### PR TITLE
Generate an ES Module bundle, too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "An open-source machine learning framework.",
   "private": false,
   "main": "dist/index",
-  "jsnext:main": "dist-es6/index.js",
-  "module": "dist-es6/index.js",
+  "jsnext:main": "dist/tf.esm.js",
+  "module": "dist/tf.esm.js",
   "jsdelivr": "dist/tf.min.js",
   "unpkg": "dist/tf.min.js",
   "types": "dist/index.d.ts",
@@ -40,11 +40,11 @@
     "rollup-plugin-json": "~3.0.0",
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.13.0",
+    "rollup-plugin-uglify": "^3.0.0",
     "shelljs": "~0.8.1",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",
     "typescript": "2.7.2",
-    "uglify-js": "~3.0.28",
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,44 +20,83 @@ import typescript from 'rollup-plugin-typescript2';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 import json from 'rollup-plugin-json';
+import uglify from 'rollup-plugin-uglify';
 
-export default {
-  input: 'src/index.ts',
-  plugins: [
-    typescript(),
-    node(),
-    // Polyfill require() from dependencies.
-    commonjs({
-      ignore: ["crypto"],
-      include: 'node_modules/**',
-      namedExports: {
-        './node_modules/seedrandom/index.js': ['alea'],
-        './src/data/compiled_api.js': ['tensorflow'],
-        './node_modules/protobufjs/minimal.js': ['roots', 'Reader', 'util']
-      },
-    }),
-    json(),
-    // We need babel to compile the compiled_api.js generated proto file from es6 to es5.
-    babel()
-  ],
-  output: {
-    extend: true,
-    banner: `// @tensorflow/tfjs Copyright ${(new Date).getFullYear()} Google`,
-    file: 'dist/tf.js',
-    format: 'umd',
-    name: 'tf',
-    globals: {
-      'crypto': 'crypto'
+const copyright =  `// @tensorflow/tfjs Copyright ${(new Date).getFullYear()} Google`;
+
+function minify() {
+  return uglify({
+    output: {
+      preamble: copyright
     }
-  },
-  external: ['crypto'],
-  onwarn: warning => {
-    let {code} = warning;
-    if (code === 'CIRCULAR_DEPENDENCY' ||
-        code === 'CIRCULAR' ||
-        code === 'THIS_IS_UNDEFINED') {
-      return;
+  });
+}
+
+function config({plugins = [], output = {}}) {
+  return {
+    input: 'src/index.ts',
+    plugins: [
+      typescript(),
+      node(),
+      // Polyfill require() from dependencies.
+      commonjs({
+        ignore: ["crypto"],
+        include: 'node_modules/**',
+        namedExports: {
+          './node_modules/seedrandom/index.js': ['alea'],
+          './src/data/compiled_api.js': ['tensorflow'],
+          './node_modules/protobufjs/minimal.js': ['roots', 'Reader', 'util']
+        },
+      }),
+      json(),
+      // We need babel to compile the compiled_api.js generated proto file from es6 to es5.
+      babel(),
+      ...plugins
+    ],
+    output: {
+      banner: copyright,
+      ...output
+    },
+    external: ['crypto'],
+    onwarn: warning => {
+      let {code} = warning;
+      if (code === 'CIRCULAR_DEPENDENCY' ||
+          code === 'CIRCULAR' ||
+          code === 'THIS_IS_UNDEFINED') {
+        return;
+      }
+      console.warn('WARNING: ', warning.toString());
     }
-    console.warn('WARNING: ', warning.toString());
-  }
-};
+  };
+}
+
+export default [
+  config({
+    output: {
+      format: 'umd',
+      name: 'tf',
+      extend: true,
+      file: 'dist/tf.js'
+    }
+  }),
+  config({
+    plugins: [
+      minify()
+    ],
+    output: {
+      format: 'umd',
+      name: 'tf',
+      extend: true,
+      file: 'dist/tf.min.js'
+    }
+  }),
+  config({
+    plugins: [
+      minify()
+    ],
+    output: {
+      format: 'es',
+      file: 'dist/tf.esm.js'
+    }
+  })
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ function minify() {
   });
 }
 
-function config({plugins = [], output = {}}) {
+function config({plugins = [], output = {}, external = []}) {
   return {
     input: 'src/index.ts',
     plugins: [
@@ -57,7 +57,10 @@ function config({plugins = [], output = {}}) {
       banner: copyright,
       ...output
     },
-    external: ['crypto'],
+    external: [
+      'crypto',
+      ...external
+    ],
     onwarn: warning => {
       let {code} = warning;
       if (code === 'CIRCULAR_DEPENDENCY' ||
@@ -96,7 +99,17 @@ export default [
     ],
     output: {
       format: 'es',
-      file: 'dist/tf.esm.js'
-    }
+      file: 'dist/tf.esm.js',
+      globals: {
+        '@tensorflow/tfjs-core': 'tf',
+        '@tensorflow/tfjs-layers': 'tf',
+        '@tensorflow/tfjs-converter': 'tf'
+      }
+    },
+    external: [
+      '@tensorflow/tfjs-core',
+      '@tensorflow/tfjs-layers',
+      '@tensorflow/tfjs-converter'
+    ]
   })
 ];

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -21,6 +21,5 @@ rimraf dist/
 yarn
 yarn build
 rollup -c
-uglifyjs dist/tf.js -c -m -o dist/tf.min.js
 echo "Stored standalone library at dist/tf(.min).js"
 npm pack

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,9 +1406,9 @@ commander@^2.12.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
-commander@~2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commander@~2.14.1:
   version "2.14.1"
@@ -4583,6 +4583,12 @@ rollup-plugin-typescript2@0.13.0:
     rollup-pluginutils "^2.0.1"
     tslib "^1.9.0"
 
+rollup-plugin-uglify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz#a34eca24617709c6bf1778e9653baafa06099b86"
+  dependencies:
+    uglify-es "^3.3.7"
+
 rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
@@ -5281,6 +5287,13 @@ typescript@2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
+uglify-es@^3.3.7:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -5289,13 +5302,6 @@ uglify-js@^2.6:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
-
-uglify-js@~3.0.28:
-  version "3.0.28"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.28.tgz#96b8495f0272944787b5843a1679aa326640d5f7"
-  dependencies:
-    commander "~2.11.0"
-    source-map "~0.5.1"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Fixes #367.

This produces a single ES module bundle with no dependencies. If you prefer, it might be slightly better to retain the dependencies on the other Tensorflow packages (*e.g.*, tfjs-converter). That way if you import those other packages directly as well as tfjs, you don’t get duplicate code. (This would require that the other Tensorflow packages likewise publish an ES module bundle as in this PR.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/368)
<!-- Reviewable:end -->
