### PR TITLE
incorporate sourceMappingUrls from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "rollup-plugin-commonjs": "9.1.3",
     "rollup-plugin-json": "~3.0.0",
     "rollup-plugin-node-resolve": "3.3.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-typescript2": "0.13.0",
     "rollup-plugin-uglify": "~3.0.0",
     "shelljs": "~0.8.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
 import node from 'rollup-plugin-node-resolve';
-import resolve from 'rollup-plugin-node-resolve';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import typescript from 'rollup-plugin-typescript2';
 import uglify from 'rollup-plugin-uglify';
 
@@ -59,6 +59,7 @@ function config({plugins = [], output = {}, external = []}) {
       // We need babel to compile the compiled_api.js generated proto file from
       // es6 to es5.
       babel(),
+      sourcemaps(),
       ...plugins,
     ],
     output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4574,6 +4574,13 @@ rollup-plugin-node-resolve@3.3.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
+rollup-plugin-sourcemaps@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz#62125aa94087aadf7b83ef4dfaf629b473135e87"
+  dependencies:
+    rollup-pluginutils "^2.0.1"
+    source-map-resolve "^0.5.0"
+
 rollup-plugin-typescript2@0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.13.0.tgz#5fc838657d05af82e04554832cadf06cdb32f657"


### PR DESCRIPTION
This improves the sourcemaps for the union package by allowing it to bring in the sourcemaps generated by the subpackages, as opposed to generating sourcemaps for the compiled versions of the dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/816)
<!-- Reviewable:end -->
