### PR TITLE
Update link to tf.data Python API; Make BrowserStack FireFox test pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ four packages:
   [Keras](https://keras.io/).
 - [TensorFlow.js Data](https://github.com/tensorflow/tfjs-data),
   a simple API to load and prepare data analogous to
-  [tf.data](https://www.tensorflow.org/guide/datasets_for_estimators).
+  [tf.data](https://www.tensorflow.org/guide/datasets).
 - [TensorFlow.js Converter](https://github.com/tensorflow/tfjs-converter),
   tools to import a TensorFlow SavedModel to TensorFlow.js
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -45,7 +45,10 @@ module.exports = function(config) {
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: 'latest',
+        // TODO(cais): Restore 'latest' to browser_version once ongoing
+        // instability in BrowserStack + OS X + FireFox is resolved.
+        // https://github.com/tensorflow/tfjs/issues/1620
+        browser_version: '66.0',
         os: 'OS X',
         os_version: 'Sierra'
       },


### PR DESCRIPTION
Work around ongoing BrowserStack instability surrounding FireFox on OS X.

Re https://github.com/tensorflow/tfjs/issues/1620

DOC
DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1622)
<!-- Reviewable:end -->
