### PR TITLE
[benchmarks] Add missing modelFormat field to fit() results

### DIFF
--- a/integration_tests/benchmarks/models/models_benchmarks.ts
+++ b/integration_tests/benchmarks/models/models_benchmarks.ts
@@ -363,7 +363,7 @@ describe('TF.js Layers Benchmarks', () => {
         model = await loadGraphModel(modelName);
       } else {
         throw new Error(
-            `Unsupported modelFormat: ${JSON.stringify(modelFormat)}`);
+            `Unsupported modelFormat for model "${modelName}": ${JSON.stringify(modelFormat)}`);
       }
 
       const functionNames = Object.keys(taskGroupLog) as ModelFunctionName[];

--- a/integration_tests/benchmarks/models/models_benchmarks.ts
+++ b/integration_tests/benchmarks/models/models_benchmarks.ts
@@ -363,7 +363,8 @@ describe('TF.js Layers Benchmarks', () => {
         model = await loadGraphModel(modelName);
       } else {
         throw new Error(
-            `Unsupported modelFormat for model "${modelName}": ${JSON.stringify(modelFormat)}`);
+            `Unsupported modelFormat for model "${modelName}": ` +
+            `${JSON.stringify(modelFormat)}`);
       }
 
       const functionNames = Object.keys(taskGroupLog) as ModelFunctionName[];

--- a/integration_tests/benchmarks/python/benchmarks.py
+++ b/integration_tests/benchmarks/python/benchmarks.py
@@ -159,6 +159,7 @@ def benchmark_and_serialize_model(model_name,
     # Collect and format the data for fit().
     task_logs['fit'] = {  # For schema, see 'ModelTrainingBenchmarkRun` in types.ts.
       'taskType': 'model',
+      'modelFormat': 'GraphModel' if export_saved_model else 'LayersModel',
       'modelName': model_name,
       'modelDescription': description,
       'functionName': 'fit',


### PR DESCRIPTION
- Also add a slight improvement to error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1653)
<!-- Reviewable:end -->
