### PR TITLE
No need to copy node native addon

### DIFF
--- a/integration_tests/validate_converter.sh
+++ b/integration_tests/validate_converter.sh
@@ -62,8 +62,6 @@ if [[ "${IS_TFJS_NODE}" == "1" ]]; then
 
   cd ..
   yarn yalc link '@tensorflow/tfjs-node'
-  rm -rf .yalc/@tensorflow/tfjs-node/build
-  cp -r tfjs-node/build/Release .yalc/@tensorflow/tfjs-node/build
 else
   # Download the tfjs repositories, build them, and link them.
   if [[ ! -d "tfjs-core" ]]; then

--- a/integration_tests/yarn.lock
+++ b/integration_tests/yarn.lock
@@ -433,9 +433,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "12.0.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
-  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
+  version "12.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.4.tgz#e0b5ac3ccbf183cd3c230967c323632d6cf927ae"
+  integrity sha512-ZKrDzI6KhrqtLpccI1YxMh4d+qzNnftNtp6iL9c4mLTNgzguFu7VR7pXH/C/MfzikMeoXjvISL9mlIGNGGDXDg==
 
 "@types/node@^10.1.0":
   version "10.14.10"


### PR DESCRIPTION
The node native addon is updated with `yarn yalc link`, so there is no need to copy `tfjs-node/build/Release`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1747)
<!-- Reviewable:end -->
