### PR TITLE
Add command to set-url

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -207,6 +207,7 @@ async function main() {
       phase.scripts.forEach(script => $(script));
     }
 
+    $(`git remote set-url origin git@github.com:tensorflow/${repo}.git`);
     $(`git checkout -b b${newVersion}`);
     $(`git push -u origin b${newVersion}`);
     $(`git add .`);


### PR DESCRIPTION
When creating /tmp/tfjs-release/tfjs the default remote url might be `https://github.com/xxxx.git`, which does not use ssh. Set it to `git@github.com/xxxx.git` before push.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1787)
<!-- Reviewable:end -->
