### PR TITLE
Add build timeout and log dir settings to top-level cloudbuild.yml

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -39,3 +39,10 @@ steps:
   id: 'tfjs-react-native'
   args: ['./scripts/run-build.sh', 'tfjs-react-native']
   waitFor: ['diff']
+
+# General settings.
+timeout: 1800s
+logsBucket: 'gs://tfjs-build-logs'
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
Add build timeout and log dir settings to top-level cloudbuild.yml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1815)
<!-- Reviewable:end -->
