### PR TITLE
Add depthwiseConv2D op for webgpu

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -29,6 +29,7 @@ import {BinaryOpProgram} from './kernels/binary_op_webgpu';
 import {ConcatProgram} from './kernels/concat_webgpu';
 import {Conv2DMMProgram} from './kernels/conv2d_mm_webgpu';
 import {Conv2DNaiveProgram} from './kernels/conv2d_naive_webgpu';
+import {DepthwiseConv2DProgram} from './kernels/depthwise_conv2d_webgpu';
 import {MatMulPackedProgram} from './kernels/matmul_packed_webgpu';
 import {MatMulProgram} from './kernels/matmul_webgpu';
 import {MaxPoolProgram} from './kernels/maxpool_webgpu';
@@ -556,6 +557,13 @@ export class WebGPUBackend extends KernelBackend {
 
     return this.compileAndRun(program, [x, filter], output, dimensions) as
         Tensor4D;
+  }
+
+  depthwiseConv2D(
+      x: Tensor4D, filter: Tensor4D,
+      convInfo: backend_util.Conv2DInfo): Tensor4D {
+    const program = new DepthwiseConv2DProgram(convInfo);
+    return this.compileAndRun(program, [x, filter]);
   }
 
   private argMinMaxReduce(x: Tensor, axis: number, reduceType: 'min'|'max'):

--- a/tfjs-backend-webgpu/src/benchmark_ops_test.ts
+++ b/tfjs-backend-webgpu/src/benchmark_ops_test.ts
@@ -125,4 +125,14 @@ describeWebGPU('Ops benchmarks', () => {
 
     await time(() => tf.conv2d(a, b, 1, 'same'));
   });
+
+  it('depthwiseconv2d', async () => {
+    const x = tf.randomNormal<tf.Rank.R4>([1, 128, 128, 1]);
+    const w = tf.tensor4d(
+        [0.303873, 0.229223, 0.144333, 0.803373],
+        [2, 2, 1, 1],
+    );
+
+    await time(() => tf.depthwiseConv2d(x, w, 1, 'valid'));
+  });
 });

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_webgpu.ts
@@ -67,11 +67,6 @@ export class Conv2DMMProgram implements WebGPUProgram {
     this.userCode = `
         ${matMulSource}
 
-        bool coordIsValid(ivec4 coord, ivec4 shape) {
-          return all(greaterThanEqual(coord, ivec4(0))) &&
-              all(lessThan(coord, shape));
-        }
-
         int batch;
 
         float mm_readA(uint row, uint col) {

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -30,7 +30,7 @@ const env = jasmine.getEnv();
 const INCLUDE_LIST: string[] = [
   'matmul', 'add ', 'subtract ', 'mul ', 'conv2d', 'pad', 'pool', 'maxPool',
   'floor divide ', 'resizeBilinear', 'relu', 'transpose', 'concat', 'argmax',
-  'fromPixels'
+  'fromPixels', 'depthwise'
 ];
 /** Tests that have these substrings in their name will be excluded. */
 const EXCLUDE_LIST: string[] = [

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -136,6 +136,11 @@ const SHADER_PREFIX = `#version 450
     }
     return res;
   }
+
+  bool coordIsValid(ivec4 coord, ivec4 shape) {
+    return all(greaterThanEqual(coord, ivec4(0))) &&
+        all(lessThan(coord, shape));
+  }
 `;
 
 const SAMPLING_SNIPPETS = `


### PR DESCRIPTION
Bencmmark:

| Backend |Mean time   |Min time   |
|---|---|---|
|CPU   |1.041 ms   |0.760 ms   |
|WebGL 1   |12.942 ms   |9.250 ms   |
|WebGL 2   |10.862 ms   |5.965 ms   |
|WebGL GPU   |4.423 ms   |3.950 ms   |

Test device: Chrome 78.0.3887/Macbook Pro/Intel Core I5/Mojave

Add benchmark:
```
const x = tf.randomNormal<tf.Rank.R4>([1, 128, 128, 1]);
const w = tf.tensor4d(
    [0.303873, 0.229223, 0.144333, 0.803373],
    [2, 2, 1, 1],
);
await time(() => tf.depthwiseConv2d(x, w, 1, 'valid'));
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1843)
<!-- Reviewable:end -->
