### PR TITLE
Fix document state check error suggests a Inappropriate event

### DIFF
--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -316,7 +316,7 @@ export class MathBackendWebGL implements KernelBackend {
           throw new Error(
               'The DOM is not ready yet. Please call ' +
               'tf.browser.fromPixels() once the DOM is ready. One way to ' +
-              'do that is to add an event listener for `DOMContentLoaded` ' +
+              'do that is to add an event listener for `load` ' +
               'on the document object');
         }
         //@ts-ignore


### PR DESCRIPTION
https://github.com/tensorflow/tfjs/blob/aa92053a8d7c640fe9e685e254655f417480cf0d/tfjs-core/src/backends/webgl/backend_webgl.ts#L313-L321
The error message above suggests to use `DOMContentLoaded` though, Its if condition checks `document.readyState !== 'complete'`.
Because `DOMContentLoaded` is called before `document.readyState` becomes `'complete'`.  It's  an inappropriate suggestion. 
It should suggest `load` event instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1852)
<!-- Reviewable:end -->
