### PR TITLE
[tfjs-layers] Fix memory leak with loaded models containing nested Sequential layers

### DIFF
--- a/tfjs-layers/src/models_test.ts
+++ b/tfjs-layers/src/models_test.ts
@@ -841,6 +841,55 @@ describeMathCPU('loadLayersModel from URL', () => {
     expect(numTensors2).toEqual(numTensors0);
   });
 
+  it('loadLayersModel: no memory leak with nested LayersModel layer',
+    async() => {
+      const modelTopology =
+          JSON.parse(JSON.stringify(fakeSequentialModelWithNestedContainer))
+              .modelTopology;
+
+      const weightsManifest: io.WeightsManifestConfig = [
+        {
+          'paths': ['weight_0'],
+          'weights': [
+            {'name': `dense_1/kernel`, 'dtype': 'float32', 'shape': [4, 2]},
+            {'name': `dense_1/bias`, 'dtype': 'float32', 'shape': [2]},
+            {'name': `dense_2/kernel`, 'dtype': 'float32', 'shape': [2, 1]},
+            {'name': `dense_2/bias`, 'dtype': 'float32', 'shape': [1]}
+          ],
+        }
+      ];
+
+      spyOn(ENV.platform, 'fetch').and.callFake((path: string) => {
+        return new Promise((resolve, reject) => {
+          if (path === 'model/model.json') {
+            resolve(new Response(
+                JSON.stringify({
+                  modelTopology,
+                  weightsManifest,
+                }),
+                {'headers': {'Content-Type': JSON_TYPE}}));
+          } else if (path === 'model/weight_0') {
+            resolve(new Response(
+                new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+                {'headers': {'Content-Type': OCTET_STREAM_TYPE}}));
+          } else {
+            reject(new Error(`Invalid path: ${path}`));
+          }
+        });
+      });
+
+      const numTensors0 = memory().numTensors;
+      const model = await tfl.loadLayersModel('model/model.json');
+      const mem = await memory();
+      const numTensors1 = mem.numTensors;
+      expect(numTensors1).toEqual(numTensors0 + 4);
+
+      const disposeResult = model.dispose();
+      expect(disposeResult.numDisposedVariables).toEqual(4);
+      const numTensors2 = memory().numTensors;
+      expect(numTensors2).toEqual(numTensors0);
+    });
+
   it('load topology and weights from implicit relative http path: HDF5 format',
      async () => {
        const modelTopology =
@@ -2222,6 +2271,112 @@ const fakeSequentialModel: ModelAndWeightsConfig = {
       'name': 'test'
     },
     'backend': 'tensorflow'
+  }
+};
+
+const fakeSequentialModelWithNestedContainer: ModelAndWeightsConfig = {
+  modelTopology: {
+    'keras_version': '2.2.4',
+    'backend': 'tensorflow',
+    'model_config': {
+      'class_name': 'Model',
+      'config': {
+        'name': 'model_1',
+        'layers': [{
+          'name': 'dense_1_input',
+          'class_name': 'InputLayer',
+          'config': {
+            'batch_input_shape': [null, 4],
+            'dtype': 'float32',
+            'sparse': false,
+            'name': 'dense_1_input'
+          },
+          'inbound_nodes': []
+        }, {
+          'name': 'dense_1',
+          'class_name': 'Dense',
+          'config': {
+            'name': 'dense_1',
+            'trainable': true,
+            'batch_input_shape': [null, 4],
+            'dtype': 'float32',
+            'units': 2,
+            'activation': 'relu',
+            'use_bias': true,
+            'kernel_initializer': {
+              'class_name': 'VarianceScaling',
+              'config': {
+                'scale': 1.0,
+                'mode': 'fan_avg',
+                'distribution': 'uniform',
+                'seed': null
+              }
+            },
+            'bias_initializer': {
+              'class_name': 'Zeros',
+              'config': {}
+            },
+            'kernel_regularizer': null,
+            'bias_regularizer': null,
+            'activity_regularizer': null,
+            'kernel_constraint': null,
+            'bias_constraint': null
+          },
+          'inbound_nodes': [
+            [
+              ['dense_1_input', 0, 0, {}]
+            ]
+          ]
+        }, {
+          'name': 'sequential_2',
+          'class_name': 'Sequential',
+          'config': {
+            'name': 'sequential_2',
+            'layers': [{
+              'class_name': 'Dense',
+              'config': {
+                'name': 'dense_2',
+                'trainable': true,
+                'batch_input_shape': [null, 2],
+                'dtype': 'float32',
+                'units': 1,
+                'activation': 'softmax',
+                'use_bias': true,
+                'kernel_initializer': {
+                  'class_name': 'VarianceScaling',
+                  'config': {
+                    'scale': 1.0,
+                    'mode': 'fan_avg',
+                    'distribution': 'uniform',
+                    'seed': null
+                  }
+                },
+                'bias_initializer': {
+                  'class_name': 'Zeros',
+                  'config': {}
+                },
+                'kernel_regularizer': null,
+                'bias_regularizer': null,
+                'activity_regularizer': null,
+                'kernel_constraint': null,
+                'bias_constraint': null
+              }
+            }]
+          },
+          'inbound_nodes': [
+            [
+              ['dense_1', 0, 0, {}]
+            ]
+          ]
+        }],
+        'input_layers': [
+          ['dense_1_input', 0, 0]
+        ],
+        'output_layers': [
+          ['sequential_2', 1, 0]
+        ]
+      }
+    }
   }
 };
 


### PR DESCRIPTION
If a model loaded with loadLayersModel contains a nested Sequential layer, disposing of the main model leaves the tensors of the nested model behind. This is because the refCount of the nested model doesn't go to zero during the call to `dispose` since the refCount was incremented twice (once during submodel creation and once when the submodel is added as a layer) but only decremented once during.

This commit makes it so references to each internally constructed sub-container are tracked and disposed when the parent model is disposed to ensure that the refCount hits zero and tensors are disposed.

*Note:* Nested sequential layers constructed through the layers API still works as intended as tested by: https://github.com/tensorflow/tfjs/blob/master/tfjs-layers/src/engine/container_test.ts#L603

Original PR before re-org: https://github.com/tensorflow/tfjs-layers/pull/578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1865)
<!-- Reviewable:end -->
