### PR TITLE
Fix flaky dropout test

### DIFF
--- a/tfjs-layers/src/layers/core_test.ts
+++ b/tfjs-layers/src/layers/core_test.ts
@@ -106,7 +106,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
             if (rate === 0 || !training) {
               expect(nKept).toEqual(numel);
             } else {
-              expect(nKept).toBeLessThan(numel);
+              expect(nKept).toBeLessThanOrEqual(numel);
             }
           });
         }
@@ -764,11 +764,8 @@ describeMathCPUAndGPU('Masking Layer: Tensor', () => {
   it('3D, default maskValue', () => {
     const model = tfl.sequential();
     model.add(tfl.layers.masking({inputShape: [3, 2]}));
-    model.add(tfl.layers.simpleRNN({
-      units: 1,
-      recurrentInitializer: 'ones',
-      kernelInitializer: 'ones'
-    }));
+    model.add(tfl.layers.simpleRNN(
+        {units: 1, recurrentInitializer: 'ones', kernelInitializer: 'ones'}));
 
     const xs = tensor3d([[[1, 1], [1, 0], [0, 0]]]);
     const ys = model.predict(xs) as Tensor;
@@ -796,11 +793,8 @@ describeMathCPUAndGPU('Masking Layer: Tensor', () => {
   it('3D, custom maskValue', () => {
     const model = tfl.sequential();
     model.add(tfl.layers.masking({maskValue: -1, inputShape: [3, 2]}));
-    model.add(tfl.layers.simpleRNN({
-      units: 1,
-      recurrentInitializer: 'ones',
-      kernelInitializer: 'ones'
-    }));
+    model.add(tfl.layers.simpleRNN(
+        {units: 1, recurrentInitializer: 'ones', kernelInitializer: 'ones'}));
 
     const xs = tensor3d([[[1, 1], [1, -1], [-1, -1]]]);
     const ys = model.predict(xs) as Tensor;

--- a/tfjs-layers/src/layers/core_test.ts
+++ b/tfjs-layers/src/layers/core_test.ts
@@ -53,6 +53,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
     const trainingValues = [false, true];
     const dropoutRates = [0, 0.5];
     const noiseShapes = [null, inputShape, [2, 3, 1]];
+    const seed = 0;
 
     for (const training of trainingValues) {
       for (const rate of dropoutRates) {
@@ -61,7 +62,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
               `noiseShape=${JSON.stringify(noiseShape)}`;
           it(testTitle, () => {
             const x = ones(inputShape);
-            const dropoutLayer = tfl.layers.dropout({rate, noiseShape});
+            const dropoutLayer = tfl.layers.dropout({rate, noiseShape, seed});
             const y = dropoutLayer.apply(x, {training}) as Tensor;
             expect(x.dtype).toEqual(y.dtype);
             expect(x.shape).toEqual(y.shape);
@@ -106,7 +107,7 @@ describeMathCPUAndGPU('Dropout Layer', () => {
             if (rate === 0 || !training) {
               expect(nKept).toEqual(numel);
             } else {
-              expect(nKept).toBeLessThanOrEqual(numel);
+              expect(nKept).toBeLessThan(numel);
             }
           });
         }


### PR DESCRIPTION
It is not that unlikely to get ~20 heads in a row in 0.5 probability of flip.

Fixes https://github.com/tensorflow/tfjs/issues/1894

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1895)
<!-- Reviewable:end -->
