### PR TITLE
Cleanup temp change after tfjs-node change is complete

### DIFF
--- a/tfjs-node/scripts/install.js
+++ b/tfjs-node/scripts/install.js
@@ -28,12 +28,9 @@ const {
   getLibTensorFlowMajorDotMinorVersion,
   LIBTENSORFLOW_VERSION,
   modulePath
-} =
-require('./deps-constants.js');
+} = require('./deps-constants.js');
 const resources = require('./resources');
-const {
-  addonName
-} = require('./get-addon-name.js');
+const {addonName} = require('./get-addon-name.js');
 
 const exists = util.promisify(fs.exists);
 const mkdir = util.promisify(fs.mkdir);
@@ -41,7 +38,7 @@ const rename = util.promisify(fs.rename);
 const rimrafPromise = util.promisify(rimraf);
 
 const BASE_URI =
-  'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
+    'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
 const CPU_DARWIN = `cpu-darwin-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const CPU_LINUX = `cpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const GPU_LINUX = `gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
@@ -51,8 +48,8 @@ const GPU_WINDOWS = `gpu-windows-x86_64-${LIBTENSORFLOW_VERSION}.zip`;
 // TODO(kreeger): Update to TensorFlow 1.13:
 // https://github.com/tensorflow/tfjs/issues/1369
 const TF_WIN_HEADERS_URI =
-  `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
-  `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
+    `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
+    `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
 
 const platform = os.platform();
 let libType = process.argv[2] === undefined ? 'cpu' : process.argv[2];
@@ -61,7 +58,8 @@ let forceDownload = process.argv[3] === undefined ? undefined : process.argv[3];
 let packageJsonFile;
 
 async function setPackageJsonFile() {
-  packageJsonFile = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
+  packageJsonFile =
+      JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
 }
 
 async function updateAddonName() {
@@ -93,7 +91,7 @@ function getPlatformLibtensorflowUri() {
     if (os.arch() === 'arm') {
       // TODO(kreeger): Handle arm64 as well:
       targetUri =
-        'https://storage.googleapis.com/tf-builds/libtensorflow_r1_14_linux_arm.tar.gz';
+          'https://storage.googleapis.com/tf-builds/libtensorflow_r1_14_linux_arm.tar.gz';
     } else {
       if (libType === 'gpu') {
         targetUri += GPU_LINUX;
@@ -145,43 +143,43 @@ async function downloadLibtensorflow(callback) {
 
   console.warn('* Downloading libtensorflow');
   resources.downloadAndUnpackResource(
-    getPlatformLibtensorflowUri(), depsPath, async () => {
-      if (platform === 'win32') {
-        // Some windows libtensorflow zip files are missing structure and the
-        // eager headers. Check, restructure, and download resources as
-        // needed.
-        const depsIncludePath = path.join(depsPath, 'include');
-        if (!await exists(depsLibTensorFlowPath)) {
-          // Verify that tensorflow.dll exists
-          const libtensorflowDll = path.join(depsPath, 'tensorflow.dll');
-          if (!await exists(libtensorflowDll)) {
-            throw new Error('Could not find libtensorflow.dll');
+      getPlatformLibtensorflowUri(), depsPath, async () => {
+        if (platform === 'win32') {
+          // Some windows libtensorflow zip files are missing structure and the
+          // eager headers. Check, restructure, and download resources as
+          // needed.
+          const depsIncludePath = path.join(depsPath, 'include');
+          if (!await exists(depsLibTensorFlowPath)) {
+            // Verify that tensorflow.dll exists
+            const libtensorflowDll = path.join(depsPath, 'tensorflow.dll');
+            if (!await exists(libtensorflowDll)) {
+              throw new Error('Could not find libtensorflow.dll');
+            }
+
+            await ensureDir(depsLibPath);
+            await rename(libtensorflowDll, depsLibTensorFlowPath);
           }
 
-          await ensureDir(depsLibPath);
-          await rename(libtensorflowDll, depsLibTensorFlowPath);
-        }
+          // The shipped headers for Windows libtensorflow are old - remove and
+          // download the latest:
+          if (await exists(depsIncludePath)) {
+            await rimrafPromise(depsIncludePath);
+          }
 
-        // The shipped headers for Windows libtensorflow are old - remove and
-        // download the latest:
-        if (await exists(depsIncludePath)) {
-          await rimrafPromise(depsIncludePath);
+          // Download the C headers only and unpack:
+          resources.downloadAndUnpackResource(
+              TF_WIN_HEADERS_URI, depsPath, () => {
+                if (callback !== undefined) {
+                  callback();
+                }
+              });
+        } else {
+          // No other work is required on other platforms.
+          if (callback !== undefined) {
+            callback();
+          }
         }
-
-        // Download the C headers only and unpack:
-        resources.downloadAndUnpackResource(
-          TF_WIN_HEADERS_URI, depsPath, () => {
-            if (callback !== undefined) {
-              callback();
-            }
-          });
-      } else {
-        // No other work is required on other platforms.
-        if (callback !== undefined) {
-          callback();
-        }
-      }
-    });
+      });
 }
 
 /**
@@ -197,6 +195,7 @@ async function build() {
       // Move libtensorflow to module path, where tfjs_binding.node locates.
       cp.exec('node scripts/deps-stage.js symlink ' + modulePath);
     }
+    revertAddonName();
   });
 }
 
@@ -217,7 +216,6 @@ async function run() {
     await cleanDeps();
     await downloadLibtensorflow(build);
   }
-  revertAddonName();
 }
 
 run();


### PR DESCRIPTION
In tfjs-node@1.2.8 the cleanup of some temp change has a race condition with node-pre-gyp installation. Move the cleanup code to callback to make sure installation works.

fix: https://github.com/tensorflow/tfjs/issues/1912

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1927)
<!-- Reviewable:end -->
