### PR TITLE
Remove the systemFetch export from platform_node

### DIFF
--- a/tfjs-core/src/platforms/platform_node.ts
+++ b/tfjs-core/src/platforms/platform_node.ts
@@ -24,13 +24,13 @@ export const getNodeFetch = {
   importFetch: () => require('node-fetch')
 };
 
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 let systemFetch: FetchFn;
 // These getters and setters are for testing so we don't export a mutable
 // variable.
 export function resetSystemFetch() {
   systemFetch = null;
 }
-type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 export function setSystemFetch(fetchFn: FetchFn) {
   systemFetch = fetchFn;
 }

--- a/tfjs-core/src/platforms/platform_node.ts
+++ b/tfjs-core/src/platforms/platform_node.ts
@@ -24,7 +24,19 @@ export const getNodeFetch = {
   importFetch: () => require('node-fetch')
 };
 
-export let systemFetch: (url: string, init?: RequestInit) => Promise<Response>;
+let systemFetch: FetchFn;
+// These getters and setters are for testing so we don't export a mutable
+// variable.
+export function resetSystemFetch() {
+  systemFetch = null;
+}
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+export function setSystemFetch(fetchFn: FetchFn) {
+  systemFetch = fetchFn;
+}
+export function getSystemFetch(): FetchFn {
+  return systemFetch;
+}
 
 export class PlatformNode implements Platform {
   private textEncoder: TextEncoder;

--- a/tfjs-core/src/platforms/platform_node_test.ts
+++ b/tfjs-core/src/platforms/platform_node_test.ts
@@ -42,11 +42,10 @@ describeWithFlags('PlatformNode', NODE_ENVS, () => {
 
     const platform = new PlatformNode();
 
-    const savedFetch = platform_node.systemFetch;
+    const savedFetch = platform_node.getSystemFetch();
 
     // Null out the system fetch so we force it to require node-fetch.
-    // @ts-ignore
-    platform_node.systemFetch = null;
+    platform_node.resetSystemFetch();
 
     const testFetch = {fetch: (url: string, init: RequestInit) => {}};
 
@@ -63,8 +62,7 @@ describeWithFlags('PlatformNode', NODE_ENVS, () => {
     expect(platform_node.getNodeFetch.importFetch).toHaveBeenCalled();
     expect(testFetch.fetch).toHaveBeenCalledWith('test/url', {method: 'GET'});
 
-    // @ts-ignore
-    platform_node.systemFetch = savedFetch;
+    platform_node.setSystemFetch(savedFetch);
     ENV.global.fetch = globalFetch;
   });
 


### PR DESCRIPTION
Closure doesn't like exported objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1963)
<!-- Reviewable:end -->
