### PR TITLE
Throw a better error message when using negative begin indexing.

### DIFF
--- a/tfjs-core/src/ops/slice.ts
+++ b/tfjs-core/src/ops/slice.ts
@@ -131,6 +131,10 @@ function slice_<R extends Rank, T extends Tensor<R>>(
   } else {
     begin_ = begin.slice();
   }
+  begin_.forEach(d => {
+    util.assert(
+        d !== -1, () => 'slice() does not support negative begin indexing.');
+  });
   let size_: number[];
   if (size == null) {
     size_ = new Array($x.rank).fill(-1);

--- a/tfjs-core/src/ops/slice.ts
+++ b/tfjs-core/src/ops/slice.ts
@@ -149,7 +149,10 @@ function slice_<R extends Rank, T extends Tensor<R>>(
     if (d >= 0) {
       return d;
     } else {
-      util.assert(d === -1, () => 'Bad value in size');
+      util.assert(
+          d === -1,
+          () => `Negative size values should be exactly -1 but got ` +
+              `${d} for the slice() size at index ${i}.`);
       return $x.shape[i] - begin_[i];
     }
   });

--- a/tfjs-core/src/ops/slice_test.ts
+++ b/tfjs-core/src/ops/slice_test.ts
@@ -513,6 +513,13 @@ describeWithFlags('slice ergonomics', ALL_ENVS, () => {
 
     expect(tf.slice(b, 0).dtype).toEqual('float32');
   });
+
+  it('throws when begin is negative', async () => {
+    const a = [[1, 2], [3, 4]];  // 2x2
+    expect(() => tf.slice(a, [-1, 1], [
+      1, 1
+    ])).toThrowError(/slice\(\) does not support negative begin indexing./);
+  });
 });
 
 describeWithFlags('shallow slicing', ALL_ENVS, () => {


### PR DESCRIPTION
See https://github.com/tensorflow/magenta-js/pull/342

TensorFlow nor TensorFlow.js support this (though numpy does, and will call tf.strided_slice which does support that type of indexing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1965)
<!-- Reviewable:end -->
