### PR TITLE
[tfjs-core] Fix caching on cpu with async reads

### DIFF
--- a/tfjs-core/src/backends/webgl/backend_webgl_test.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl_test.ts
@@ -508,7 +508,7 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
 
 describeWithFlags('caching on cpu', WEBGL_ENVS, () => {
   it('caches on cpu after async read', async () => {
-    const backend = new MathBackendWebGL(null);
+    const backend = new MathBackendWebGL();
     tf.registerBackend('cache-on-cpu', () => backend);
     tf.setBackend('cache-on-cpu');
 
@@ -521,7 +521,7 @@ describeWithFlags('caching on cpu', WEBGL_ENVS, () => {
   });
 
   it('caches on cpu after sync read', () => {
-    const backend = new MathBackendWebGL(null);
+    const backend = new MathBackendWebGL();
     tf.registerBackend('cache-on-cpu', () => backend);
     tf.setBackend('cache-on-cpu');
 

--- a/tfjs-core/src/backends/webgl/backend_webgl_test.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl_test.ts
@@ -506,6 +506,34 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
   });
 });
 
+describeWithFlags('caching on cpu', WEBGL_ENVS, () => {
+  it('caches on cpu after async read', async () => {
+    const backend = new MathBackendWebGL(null);
+    tf.registerBackend('cache-on-cpu', () => backend);
+    tf.setBackend('cache-on-cpu');
+
+    const t = tf.square(2);
+    await t.data();
+    const info = backend.getDataInfo(t.dataId);
+    expect(info.values).not.toBe(null);
+
+    tf.removeBackend('cache-on-cpu');
+  });
+
+  it('caches on cpu after sync read', () => {
+    const backend = new MathBackendWebGL(null);
+    tf.registerBackend('cache-on-cpu', () => backend);
+    tf.setBackend('cache-on-cpu');
+
+    const t = tf.square(2);
+    t.dataSync();
+    const info = backend.getDataInfo(t.dataId);
+    expect(info.values).not.toBe(null);
+
+    tf.removeBackend('cache-on-cpu');
+  });
+});
+
 describe('WebGL backend has sync init', () => {
   it('can do matmul without waiting for ready', async () => {
     tf.registerBackend('my-webgl', () => {

--- a/tfjs-core/src/backends/webgl/backend_webgl_test.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tf from '../../index';
-import {describeWithFlags} from '../../jasmine_util';
+import {Constraints, describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose, expectArraysEqual} from '../../test_util';
 import {decodeString, encodeString} from '../../util';
 
@@ -506,7 +506,14 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
   });
 });
 
-describeWithFlags('caching on cpu', WEBGL_ENVS, () => {
+const WEBGL_WITHOUT_CPU_FORWARD: Constraints = {
+  predicate: testEnv => {
+    return testEnv.backendName === 'webgl' &&
+        !testEnv.flags['WEBGL_CPU_FORWARD'];
+  }
+};
+
+describeWithFlags('caching on cpu', WEBGL_WITHOUT_CPU_FORWARD, () => {
   it('caches on cpu after async read', async () => {
     const backend = new MathBackendWebGL();
     tf.registerBackend('cache-on-cpu', () => backend);

--- a/tfjs-core/src/ops/image_ops.ts
+++ b/tfjs-core/src/ops/image_ops.ts
@@ -191,8 +191,8 @@ async function nonMaxSuppressionAsync_(
   iouThreshold = inputs.iouThreshold;
   scoreThreshold = inputs.scoreThreshold;
 
-  const boxesVals = await $boxes.data();
-  const scoresVals = await $scores.data();
+  const [boxesVals, scoresVals] =
+      await Promise.all([$boxes.data(), $scores.data()]);
   const res = nonMaxSuppressionImpl(
       boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
   if ($boxes !== boxes) {


### PR DESCRIPTION
BUG, PERF

This PR fixes a bug introduced in https://github.com/tensorflow/tfjs-core/pull/1798

The values were not cached after an async read, which has performance implications.

The inference of an AutoML object detection model including post-processing changed from 107ms to 80ms. The reason could be an accumulation of repeated reads done by the converter executor when we call `model.executeAsync()`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/1974)
<!-- Reviewable:end -->
