### PR TITLE
webgpu: Fix the compile error in conv2d_naive shader

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
@@ -44,18 +44,19 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
         () => 'TODO: Dilation is unimplemented');
 
     this.userCode = `
-      float readInp(uint batch, uint row, uint col, uint chan) {
+      float readInp(int batch, int row, int col, int chan) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        return coordIsValid(coord, xShape) ? getX(coord) : 0;
+        return coordIsValid(coord, xShape) ?
+          getX(batch, row, col, chan) : 0;
       }
 
-      float readFilt(uint row, uint col, uint xChannel, uint outChannel) {
-        ivec4 shape = ivec4(filterDims, xShape[3], outShape[3]);
-        return coordIsValid(coord, shape) ? 
+      float readFilt(int row, int col, int xChannel, int outChannel) {
+        ivec4 coord = ivec4(row, col, xChannel, outChannel);
+        return coordIsValid(coord, wShape) ?
           getW(row, col, xChannel, outChannel) : 0;
       }
 
-      void writeResult(uint batch, uint row, uint col, uint chan, float value) {
+      void writeResult(int batch, int row, int col, int chan, float value) {
         ivec4 coord = ivec4(batch, row, col, chan);
         if (coordIsValid(coord, outShape)) {
           setOutput(batch, row, col, chan, value);


### PR DESCRIPTION
BUG

When switch to the naive method of conv2d, below error will be met:
Error: Shader compilation failed: file:124: error: 'getX' : no matching overloaded function found.
Error: Shader compilation failed: file:131: error: 'getW' : no matching overloaded function found.

The fixing uses the right get* methods. And uses int instead of uint as the parameter type.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2002)
<!-- Reviewable:end -->
