### PR TITLE
webgpu: Use (16, 1, 1) as the work group size for binary and unary ops

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
@@ -40,7 +40,7 @@ export class BinaryOpProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A', 'B'];
   workPerThread = 4;
-  workGroupSize: [number, number, number] = [1, 1, 1];
+  workGroupSize: [number, number, number] = [16, 1, 1];
 
   constructor(op: string, aShape: number[], bShape: number[]) {
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -32,7 +32,7 @@ export class UnaryOpProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A'];
   workPerThread = 4;
-  workGroupSize: [number, number, number] = [1, 1, 1];
+  workGroupSize: [number, number, number] = [16, 1, 1];
 
   constructor(outputShape: number[], op: string) {
     this.outputShape = outputShape;


### PR DESCRIPTION
With this change, the add benchmark has close to 100% speedup.
And PoseNet+ResNet demo improves from 3 fps to 6 fps.

We should try to avoid using (1, 1, 1) as the default work group size.

PERF

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2013)
<!-- Reviewable:end -->
