### PR TITLE
fix incorrect Erf op output

### DIFF
--- a/tfjs-core/src/backends/cpu/backend_cpu.ts
+++ b/tfjs-core/src/backends/cpu/backend_cpu.ts
@@ -1517,11 +1517,12 @@ export class MathBackendCPU implements KernelBackend {
     const a4 = erf_util.ERF_A4;
     const a5 = erf_util.ERF_A5;
     for (let i = 0; i < values.length; ++i) {
-      const v = values[i];
+      const sign = Math.sign(values[i]);
+      const v = Math.abs(values[i]);
       const t = 1.0 / (1.0 + p * v);
-      resultValues[i] = 1.0 -
-          (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t *
-              Math.exp(-v * v);
+      resultValues[i] = sign * (1.0 -
+        (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t *
+        Math.exp(-v * v));
     }
     return Tensor.make(x.shape, {values: resultValues});
   }

--- a/tfjs-core/src/backends/webgl/unaryop_gpu.ts
+++ b/tfjs-core/src/backends/webgl/unaryop_gpu.ts
@@ -210,8 +210,10 @@ export const ERF = `
   float a4 = ${erf_util.ERF_A4};
   float a5 = ${erf_util.ERF_A5};
 
+  float sign = sign(x);
+  x = abs(x);
   float t = 1.0 / (1.0 + p * x);
-  return 1.0 - (((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*exp(-x*x);
+  return sign * (1.0 - (((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*exp(-x*x));
 `;
 
 export const SQUARE = `return x * x;`;

--- a/tfjs-core/src/ops/unary_ops_test.ts
+++ b/tfjs-core/src/ops/unary_ops_test.ts
@@ -3660,6 +3660,14 @@ describeWithFlags('erf', ALL_ENVS, () => {
     expectArraysClose(await result.data(), expected);
   });
 
+  it('blowup', async () => {
+    const values = [-1.4, -2.5, -3.1, -4.4];
+    const a = tf.tensor1d(values);
+    const result = tf.erf(a);
+    const expected = [-0.9522852, -0.999593, -0.9999883, -1];
+    expectArraysClose(await result.data(), expected);
+  });
+
   it('scalar', async () => {
     const a = tf.scalar(1);
     const result = tf.erf(a);


### PR DESCRIPTION
The Erf output should be between -1 and 1, but I got [-1.0235416, -7.3770967, 80427.2890625, 1.0000005] when I ran below code:
```
tf = require('@tensorflow/tfjs')
const x = tf.tensor1d([-1.4,-2.5,-3.1,-4.4]);
x.erf().print();
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2027)
<!-- Reviewable:end -->
