### PR TITLE
Lazily instantiate the TextEncoder in platform_browser

### DIFF
--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -19,16 +19,6 @@ import {ENV} from '../environment';
 import {Platform} from './platform';
 
 export class PlatformBrowser implements Platform {
-  private textEncoder: TextEncoder;
-
-  constructor() {
-
-    // Workaround for IE11 compatibility
-    // More info: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
-    if (!isIE()) {
-      this.textEncoder = new TextEncoder();
-    }
-  }
 
   fetch(path: string, init?: RequestInit): Promise<Response> {
     return fetch(path, init);
@@ -40,22 +30,11 @@ export class PlatformBrowser implements Platform {
 
   encode(text: string, encoding: string): Uint8Array {
     if (encoding !== 'utf-8' && encoding !== 'utf8') {
-        throw new Error(
-            `Browser's encoder only supports utf-8, but got ${encoding}`);
-      }
-   if (!isIE()) {
-      return this.textEncoder.encode(text);
-    } else {
-        // Workaround for IE11 compatibility
-        const utf8 = unescape(encodeURIComponent(text));
-        const result = new Uint8Array(utf8.length);
-        for (let i = 0; i < utf8.length; i++) {
-          result[i] = utf8.charCodeAt(i);
-        }
-      return result;
+      throw new Error(
+          `Browser's encoder only supports utf-8, but got ${encoding}`);
     }
+    return new TextEncoder.encode(text);
   }
-
   decode(bytes: Uint8Array, encoding: string): string {
     return new TextDecoder(encoding).decode(bytes);
   }
@@ -63,14 +42,4 @@ export class PlatformBrowser implements Platform {
 
 if (ENV.get('IS_BROWSER')) {
   ENV.setPlatform('browser', new PlatformBrowser());
-}
-
-/**
- * Tests if the user is in an Internet Explorer browser window.
- */
-function isIE() {
-  const ua = navigator.userAgent;
-  const msie = ua.indexOf('MSIE '); // IE 10 or older
-  const trident = ua.indexOf('Trident/'); //IE 11
-  return (msie > 0 || trident > 0);
 }

--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -33,7 +33,7 @@ export class PlatformBrowser implements Platform {
       throw new Error(
           `Browser's encoder only supports utf-8, but got ${encoding}`);
     }
-    return new TextEncoder.encode(text);
+    return new TextEncoder().encode(text);
   }
   decode(bytes: Uint8Array, encoding: string): string {
     return new TextDecoder(encoding).decode(bytes);

--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
+
 import {ENV} from '../environment';
 import {Platform} from './platform';
 
@@ -21,9 +22,12 @@ export class PlatformBrowser implements Platform {
   private textEncoder: TextEncoder;
 
   constructor() {
-    // According to the spec, the built-in encoder can do only UTF-8 encoding.
-    // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
-    this.textEncoder = new TextEncoder();
+
+    // Workaround for IE11 compatibility
+    // More info: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
+    if (!isIE()) {
+      this.textEncoder = new TextEncoder();
+    }
   }
 
   fetch(path: string, init?: RequestInit): Promise<Response> {
@@ -36,11 +40,22 @@ export class PlatformBrowser implements Platform {
 
   encode(text: string, encoding: string): Uint8Array {
     if (encoding !== 'utf-8' && encoding !== 'utf8') {
-      throw new Error(
-          `Browser's encoder only supports utf-8, but got ${encoding}`);
+        throw new Error(
+            `Browser's encoder only supports utf-8, but got ${encoding}`);
+      }
+   if (!isIE()) {
+      return this.textEncoder.encode(text);
+    } else {
+        // Workaround for IE11 compatibility
+        const utf8 = unescape(encodeURIComponent(text));
+        const result = new Uint8Array(utf8.length);
+        for (let i = 0; i < utf8.length; i++) {
+          result[i] = utf8.charCodeAt(i);
+        }
+      return result;
     }
-    return this.textEncoder.encode(text);
   }
+
   decode(bytes: Uint8Array, encoding: string): string {
     return new TextDecoder(encoding).decode(bytes);
   }
@@ -48,4 +63,14 @@ export class PlatformBrowser implements Platform {
 
 if (ENV.get('IS_BROWSER')) {
   ENV.setPlatform('browser', new PlatformBrowser());
+}
+
+/**
+ * Tests if the user is in an Internet Explorer browser window.
+ */
+function isIE() {
+  const ua = navigator.userAgent;
+  const msie = ua.indexOf('MSIE '); // IE 10 or older
+  const trident = ua.indexOf('Trident/'); //IE 11
+  return (msie > 0 || trident > 0);
 }

--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -20,6 +20,14 @@ import {Platform} from './platform';
 
 export class PlatformBrowser implements Platform {
 
+  private textEncoder: TextEncoder;
+
+  constructor() {
+  // According to the spec, the built-in encoder can do only UTF-8 encoding.
+  // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
+  this.textEncoder = null;
+  }
+
   fetch(path: string, init?: RequestInit): Promise<Response> {
     return fetch(path, init);
   }
@@ -33,7 +41,10 @@ export class PlatformBrowser implements Platform {
       throw new Error(
           `Browser's encoder only supports utf-8, but got ${encoding}`);
     }
-    return new TextEncoder().encode(text);
+    if (this.textEncoder == null) {
+      this.textEncoder = new TextEncoder();
+    }
+    return this.textEncoder().encode(text);
   }
   decode(bytes: Uint8Array, encoding: string): string {
     return new TextDecoder(encoding).decode(bytes);

--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -44,7 +44,7 @@ export class PlatformBrowser implements Platform {
     if (this.textEncoder == null) {
       this.textEncoder = new TextEncoder();
     }
-    return this.textEncoder().encode(text);
+    return this.textEncoder.encode(text);
   }
   decode(bytes: Uint8Array, encoding: string): string {
     return new TextDecoder(encoding).decode(bytes);

--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -20,13 +20,9 @@ import {Platform} from './platform';
 
 export class PlatformBrowser implements Platform {
 
-  private textEncoder: TextEncoder;
-
-  constructor() {
   // According to the spec, the built-in encoder can do only UTF-8 encoding.
   // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/TextEncoder
-  this.textEncoder = null;
-  }
+  private textEncoder: TextEncoder;
 
   fetch(path: string, init?: RequestInit): Promise<Response> {
     return fetch(path, init);


### PR DESCRIPTION
Microsoft IE does not support TextEncoder in browser, so a workaround is needed to ensure it doesn't break tests which implement multiple browsers.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2032)
<!-- Reviewable:end -->
