### PR TITLE
webgpu: Improve benchmarks page readability.

### DIFF
--- a/tfjs-backend-webgpu/benchmarks/main.css
+++ b/tfjs-backend-webgpu/benchmarks/main.css
@@ -111,9 +111,8 @@ h2 {
 }
 
 .color {
-  border-radius: 50%;
-  width: 10px;
-  height: 10px;
+  width: 20px;
+  height: 2px;
   display: inline-block;
   vertical-align: middle;
 }

--- a/tfjs-backend-webgpu/benchmarks/main.js
+++ b/tfjs-backend-webgpu/benchmarks/main.js
@@ -16,10 +16,17 @@
  */
 
 const swatches = {
-  'webgpu_min': '#FCA521',
+  'webgpu_min': '#F1523E',
   'webgpu_mean': '#F1523E',
-  'webgl_min': '#03A698',
-  'webgl_mean': '#025952'
+  'webgl_min': '#3f51b5',
+  'webgl_mean': '#3f51b5'
+};
+
+const strokes = {
+  'webgpu_min': '2',
+  'webgpu_mean': '0',
+  'webgl_min': '2',
+  'webgl_mean': '0'
 };
 
 const START_LOGGING_DATE = '2019-08-16';
@@ -32,6 +39,20 @@ for (let i = 0; i <= daysElapsed; i++) {
   const current = startDate.clone().add(i, 'days');
   files.push(`${current.format('MM_DD_YYYY')}`);
   dateFormats.push(current.format('M/DD'));
+}
+
+function getSwatchBackground(swatch, stroke) {
+  let background = swatch;
+  if (stroke > 0) {
+    background = `repeating-linear-gradient(
+      to right,
+      ${swatch},
+      ${swatch} 2px,
+      white 2px,
+      white 4px
+    );`;
+  }
+  return background;
 }
 
 Promise
@@ -143,7 +164,6 @@ Promise
               }
 
               const xIncrement = chartWidth / (test.entries.length - 1);
-
               const template =  // template trendlines
                   `<div class='test'>
             <h4 class='test-name'>${test.name}</h4>
@@ -151,8 +171,12 @@ Promise
                       Object.keys(params)
                           .map((param, i) => {
                             return `<div class='swatch'>
-                                <div class='color' style='background-color:
-                                ${swatches[param]}'></div> <div class='label'>${
+                                <div class='color' style='background:
+                                ${
+                                getSwatchBackground(
+                                    swatches[param],
+                                    strokes
+                                        [param])}'></div> <div class='label'>${
                                 param}</div>
                               </div>`;
                           })
@@ -165,8 +189,9 @@ Promise
               <svg data-index=${i} class='graph' width='${
                       chartWidth}' height='${chartHeight}'>${
                       Object.keys(params).map(
-                          (param,
-                           i) => `<path stroke='${swatches[param]}' d='M${
+                          (param, i) => `<path stroke-dasharray='${
+                              strokes[param]}' stroke='${
+                              swatches[param]}' d='M${
                               params[param]
                                   .map(
                                       (d, i) => `${i * xIncrement},${
@@ -229,8 +254,9 @@ Promise
                     .params
                     .map(
                         (d, i) => {return `<div class='label-wrapper'>
-                          <div class='color' style='background-color: ${
-                            swatches[d.name]}'></div>
+                          <div class='color' style='background: ${
+                            getSwatchBackground(
+                                swatches[d.name], strokes[d.name])}'></div>
                           <div class='label'>${d.ms}</div>
                         </div>`})
                     .join(' ')}

--- a/tfjs-backend-webgpu/benchmarks/main.js
+++ b/tfjs-backend-webgpu/benchmarks/main.js
@@ -29,13 +29,20 @@ const strokes = {
   'webgl_mean': '0'
 };
 
+const MAX_NUM_LOGS = 50;
 const START_LOGGING_DATE = '2019-08-16';
 const startDate = moment(START_LOGGING_DATE, 'YYYY-MM-DD');
 const endDate = moment();
 const files = [];
 let dateFormats = [];
-const daysElapsed = endDate.diff(startDate, 'd')
-for (let i = 0; i <= daysElapsed; i++) {
+const daysElapsed = endDate.diff(startDate, 'd');
+let interval = 1;
+
+while (daysElapsed / interval > MAX_NUM_LOGS) {
+  interval += 1;
+}
+
+for (let i = 0; i <= daysElapsed; i += interval) {
   const current = startDate.clone().add(i, 'days');
   files.push(`${current.format('MM_DD_YYYY')}`);
   dateFormats.push(current.format('M/DD'));

--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-backend-webgpu",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "jsnext:main": "dist/tf-webgpu.esm.js",


### PR DESCRIPTION
#### Changes
- Change color palette for trendlines from orange / green to red / blue for readability.
- Ensure no more than 50 data points are shown at once for a single benchmark.
- Bump version number - had to bump by two versions because I accidentally published alpha.2 already :(

This is what the new benchmarks look like:

<img width="594" alt="Screen Shot 2019-09-12 at 5 10 34 PM" src="https://user-images.githubusercontent.com/5700011/64857862-c9262400-d5f3-11e9-961e-2994cbc25ac6.png">

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.