### PR TITLE
core: Fuse relu6 activation

### DIFF
--- a/tfjs-core/src/backends/cpu/backend_cpu.ts
+++ b/tfjs-core/src/backends/cpu/backend_cpu.ts
@@ -56,6 +56,8 @@ function mapActivation(
     return backend.relu(x);
   } else if (activation === 'elu') {
     return backend.elu(x);
+  } else if (activation === 'relu6') {
+    return backend.relu6(x);
   } else if (activation === 'prelu') {
     return backend.prelu(x, preluActivationWeights);
   }

--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -181,6 +181,11 @@ function mapActivationToShaderProgram(
       return unary_packed_op.ELU;
     }
     return unary_op.ELU;
+  } else if (activation === 'relu6') {
+    if (packed) {
+      return unary_packed_op.RELU6;
+    }
+    return unary_op.RELU6;
   } else if (activation === 'prelu') {
     if (packed) {
       return binaryop_packed_gpu.PRELU;

--- a/tfjs-core/src/ops/fused_test.ts
+++ b/tfjs-core/src/ops/fused_test.ts
@@ -56,6 +56,19 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     expectArraysClose(await c.data(), [0, 8, -0.9502, 20]);
   });
 
+  fit('A x B with relu6', async () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+    const transposeA = false;
+    const transposeB = false;
+
+    const c = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: null, activation: 'relu6'});
+
+    expect(c.shape).toEqual([2, 2]);
+    expectArraysClose(await c.data(), [0, 6, 0, 6]);
+  });
+
   it('A x B with prelu', async () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);

--- a/tfjs-core/src/ops/fused_test.ts
+++ b/tfjs-core/src/ops/fused_test.ts
@@ -56,7 +56,7 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     expectArraysClose(await c.data(), [0, 8, -0.9502, 20]);
   });
 
-  fit('A x B with relu6', async () => {
+  it('A x B with relu6', async () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
     const transposeA = false;

--- a/tfjs-core/src/ops/fused_util.ts
+++ b/tfjs-core/src/ops/fused_util.ts
@@ -18,7 +18,7 @@
 import {Tensor, Tensor3D, Tensor4D} from '../tensor';
 import {Conv2DInfo} from './conv_util';
 
-export type Activation = 'linear'|'relu'|'prelu'|'elu';
+export type Activation = 'linear'|'relu'|'prelu'|'elu'|'relu6';
 
 export type FusedBatchMatMulConfig = {
   a: Tensor3D,


### PR DESCRIPTION
This fixes https://github.com/tensorflow/tfjs/issues/2036

#### Changes
- Add `relu6` to fusable activations.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.