### PR TITLE
core: Prevent eager unpacking of output for the packed reshape kernel.

### DIFF
--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -2583,7 +2583,10 @@ export class MathBackendWebGL implements KernelBackend {
     const program = new ReshapePackedProgram(
         afterShapeAs3D as [number, number, number],
         inputAs3D.shape as [number, number, number]);
-    return this.compileAndRun<Tensor<R>>(program, [inputAs3D])
+    const preventEagerUnpackingOfOutput = true;
+    return this
+        .compileAndRun<Tensor<R>>(
+            program, [inputAs3D], null, null, preventEagerUnpackingOfOutput)
         .reshape(afterShape);
   }
 


### PR DESCRIPTION
This fixes https://github.com/tensorflow/tfjs/issues/2044

#### Changes
- Prevent eager unpacking of output of packed reshape op. The whole purpose of packed reshape is to rearrange an input for a packed op, so we should not eagerly unpack its output, even if `WEBGL_PACK` is `false`. (Why are we dealing with packed inputs when `WEBGL_PACK` is `false` in the first place? Because matMul is always packed.)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2051)
<!-- Reviewable:end -->
