### PR TITLE
Resolve to absolute paths before reading json files

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -87,7 +87,7 @@ def validate(nodes, skip_op_check, strip_debug_ops):
     return set()
   ops = []
   op_list_path = os.path.abspath(os.path.join(
-      os.path.dirname(os.path.abspath(__file__)), '../op_list/'))
+      os.path.dirname(os.path.abspath(__file__)), '..', 'op_list'))
   for filename in os.listdir(op_list_path):
     if os.path.splitext(filename)[1] == '.json':
       with open(os.path.join(op_list_path, filename)) as json_data:

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -86,8 +86,8 @@ def validate(nodes, skip_op_check, strip_debug_ops):
   if skip_op_check:
     return set()
   ops = []
-  op_list_path = os.path.join(
-      os.path.dirname(os.path.abspath(__file__)), '../op_list/')
+  op_list_path = os.path.abspath(os.path.join(
+      os.path.dirname(os.path.abspath(__file__)), '../op_list/'))
   for filename in os.listdir(op_list_path):
     if os.path.splitext(filename)[1] == '.json':
       with open(os.path.join(op_list_path, filename)) as json_data:


### PR DESCRIPTION
BUG

The problem arises when building a par (Python Archive) internally, that depends on our converter tool. This resulted in the following error:

```
.../third_party/py/tensorflowjs/converters/tf_saved_model_conversion_v2.py", line 91, in validate
    for filename in os.listdir(op_list_path):
NotADirectoryError: [Errno 20] Not a directory: '.../third_party/py/tensorflowjs/converters/../op_list/'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2052)
<!-- Reviewable:end -->
