### PR TITLE
[tfjs-converter] Strip unused ops during model conversion

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -360,8 +360,8 @@ def convert_tf_saved_model(saved_model_dir,
     output_node_names.append(output_tensor.name.split(':')[0])
 
   # TensorFlow doesn't encode the saved model version in the graph in a reliable
-  # way. Try to freeze the graph using V1 utils. If that fails, freeze the
-  # graph using V2 utils.
+  # way. Try to freeze the graph using V2 utils. If that fails, freeze the
+  # graph using V1 utils.
   try:
     frozen_graph = _freeze_saved_model_v2(concrete_func)
   except BaseException:

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -303,8 +303,9 @@ def _strip_unused_nodes(frozen_graph, concrete_func, output_node_names):
     # them from the graph, so we need to ignore those.
     try:
       op = frozen_graph.get_operation_by_name(op_name)
-      if op.type != 'Const': input_node_names.append(op_name)
-    except:
+      if op.type != 'Const':
+        input_node_names.append(op_name)
+    except KeyError:
       # The original input was removed when the graph was frozen.
       continue
   stripped_graph_def = TransformGraph(


### PR DESCRIPTION
Strip unused ops based on the `(input_nodes, output_nodes)` pair from the signature def.

Before this change, the converter fails with a list of unsupported ops even if those ops are not used by the subgraph as defined by the `SignatureDef`, because the stripping was only based on output_nodes (input nodes were ignored).

After this change, the converter succeeds in converting AutoML models without having to specify the `--skip_op_check`, and resulted in following size reduction of `model.json`:
- AutoML Image classification model 172K --> 152K (-11%)
- AutoML Object Detection 294K --> 278K (-5.5%)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2058)
<!-- Reviewable:end -->
