### PR TITLE
Add resource loader for reading resources

### DIFF
--- a/tfjs-converter/python/setup.py
+++ b/tfjs-converter/python/setup.py
@@ -58,6 +58,7 @@ setuptools.setup(
         'tensorflowjs.version',
         'tensorflowjs.quantization',
         'tensorflowjs.read_weights',
+        'tensorflowjs.resource_loader',
         'tensorflowjs.wizard',
         'tensorflowjs.write_weights',
         'tensorflowjs.converters',

--- a/tfjs-converter/python/tensorflowjs/BUILD
+++ b/tfjs-converter/python/tensorflowjs/BUILD
@@ -133,6 +133,7 @@ py_test(
     name = "resource_loader_test",
     srcs = ["resource_loader_test.py"],
     srcs_version = "PY2AND3",
+    data = [":op_list_jsons"],
     deps = [
         ":resource_loader",
         "//tensorflowjs:expect_numpy_installed",

--- a/tfjs-converter/python/tensorflowjs/BUILD
+++ b/tfjs-converter/python/tensorflowjs/BUILD
@@ -86,6 +86,12 @@ py_library(
 )
 
 py_library(
+    name = "resource_loader",
+    srcs = ["resource_loader.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_library(
     name = "version",
     srcs = ["version.py"],
     srcs_version = "PY2AND3",

--- a/tfjs-converter/python/tensorflowjs/BUILD
+++ b/tfjs-converter/python/tensorflowjs/BUILD
@@ -129,6 +129,16 @@ py_test(
     ],
 )
 
+py_test(
+    name = "resource_loader_test",
+    srcs = ["resource_loader_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":resource_loader",
+        "//tensorflowjs:expect_numpy_installed",
+    ],
+)
+
 # A filegroup BUILD target that includes all the op list json files in the
 # the op_list/ folder. The op_list folder itself is a symbolic link to the
 # actual op_list folder under src/.

--- a/tfjs-converter/python/tensorflowjs/BUILD
+++ b/tfjs-converter/python/tensorflowjs/BUILD
@@ -136,7 +136,6 @@ py_test(
     data = [":op_list_jsons"],
     deps = [
         ":resource_loader",
-        "//tensorflowjs:expect_numpy_installed",
     ],
 )
 

--- a/tfjs-converter/python/tensorflowjs/converters/BUILD
+++ b/tfjs-converter/python/tensorflowjs/converters/BUILD
@@ -128,6 +128,7 @@ py_library(
         "//tensorflowjs:expect_numpy_installed",
         "//tensorflowjs:expect_tensorflow_installed",
         "//tensorflowjs:expect_tensorflow_hub_installed",
+        "//tensorflowjs:resource_loader",
         "//tensorflowjs:version",
         "//tensorflowjs:write_weights",
     ],

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -39,6 +39,7 @@ from tensorflowjs import write_weights
 from tensorflowjs.converters import common
 from tensorflowjs.converters import fold_batch_norms
 from tensorflowjs.converters import fuse_prelu
+from tensorflowjs import resource_loader
 
 # enable eager execution for v2 APIs
 tf.compat.v1.enable_eager_execution()
@@ -86,11 +87,10 @@ def validate(nodes, skip_op_check, strip_debug_ops):
   if skip_op_check:
     return set()
   ops = []
-  op_list_path = os.path.abspath(os.path.join(
-      os.path.dirname(os.path.abspath(__file__)), '..', 'op_list'))
-  for filename in os.listdir(op_list_path):
+  for filename in resource_loader.list_dir('op_list'):
     if os.path.splitext(filename)[1] == '.json':
-      with open(os.path.join(op_list_path, filename)) as json_data:
+      with resource_loader.open_file(os.path.join('op_list',
+                                                  filename)) as json_data:
         ops += json.load(json_data)
 
   names = {x['tfOpName'] for x in ops}

--- a/tfjs-converter/python/tensorflowjs/resource_loader.py
+++ b/tfjs-converter/python/tensorflowjs/resource_loader.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Resource management library."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+
+def open_file(path):
+  """Opens the file at given path, where path is relative to tensorflowjs/.
+
+  Args:
+    path: a string resource path relative to tensorflowjs/.
+
+  Returns:
+    An open file of that resource.
+
+  Raises:
+    IOError: If the path is not found, or the resource can't be opened.
+  """
+  path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
+  return open(path)
+
+
+def list_dir(path):
+  """List the files inside a dir where path is relative to tensorflowjs/.
+
+  Args:
+    path: a string path to a resource directory relative to tensorflowjs/.
+
+  Returns:
+    A list of files inside that directory.
+
+  Raises:
+    IOError: If the path is not found, or the resource can't be read.
+  """
+  path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
+  return os.listdir(path)

--- a/tfjs-converter/python/tensorflowjs/resource_loader_test.py
+++ b/tfjs-converter/python/tensorflowjs/resource_loader_test.py
@@ -18,13 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import os
-import shutil
 import unittest
-
-import tempfile
-
-import numpy as np
 
 from tensorflowjs import resource_loader
 
@@ -33,8 +27,8 @@ class ResourceLoaderTest(unittest.TestCase):
   def testListingFilesInOpList(self):
     files = resource_loader.list_dir('op_list')
     self.assertGreater(len(files), 0)
-    for file in files:
-      self.assertTrue(file.endswith('.json'))
+    for filename in files:
+      self.assertTrue(filename.endswith('.json'))
 
   def testReadingFileInOpList(self):
     with resource_loader.open_file('op_list/arithmetic.json') as f:

--- a/tfjs-converter/python/tensorflowjs/resource_loader_test.py
+++ b/tfjs-converter/python/tensorflowjs/resource_loader_test.py
@@ -1,0 +1,47 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import json
+import os
+import shutil
+import unittest
+
+import tempfile
+
+import numpy as np
+
+from tensorflowjs import resource_loader
+
+class ResourceLoaderTest(unittest.TestCase):
+
+  def testListingFilesInOpList(self):
+    files = resource_loader.list_dir('op_list')
+    self.assertTrue(len(files) > 0)
+    for file in files:
+      self.assertTrue(file.endswith('.json'))
+
+  def testReadingFileInOpList(self):
+    with resource_loader.open_file('op_list/arithmetic.json') as f:
+      data = json.load(f)
+      first_op = data[0]
+      self.assertTrue('tfOpName' in first_op)
+      self.assertTrue('category' in first_op)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tfjs-converter/python/tensorflowjs/resource_loader_test.py
+++ b/tfjs-converter/python/tensorflowjs/resource_loader_test.py
@@ -32,7 +32,7 @@ class ResourceLoaderTest(unittest.TestCase):
 
   def testListingFilesInOpList(self):
     files = resource_loader.list_dir('op_list')
-    self.assertTrue(len(files) > 0)
+    self.assertGreater(len(files), 0)
     for file in files:
       self.assertTrue(file.endswith('.json'))
 
@@ -40,8 +40,12 @@ class ResourceLoaderTest(unittest.TestCase):
     with resource_loader.open_file('op_list/arithmetic.json') as f:
       data = json.load(f)
       first_op = data[0]
-      self.assertTrue('tfOpName' in first_op)
-      self.assertTrue('category' in first_op)
+      self.assertIn('tfOpName', first_op)
+      self.assertIn('category', first_op)
+
+  def testReadingNonExistentFileRaisesError(self):
+    with self.assertRaises(IOError):
+      resource_loader.open_file('___non_existent')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
In order to read data files inside a par archive (internal Google packaging), we need to use a resource loader. Externally a simple `open()` and `os.listdir()` works.

This PR adds the resource loader library which internally will be replaced by a different implementation via copybara.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2067)
<!-- Reviewable:end -->
