### PR TITLE
[tfjs-vis] Update barchart & histrogram tooltips

### DIFF
--- a/tfjs-vis/src/render/barchart.ts
+++ b/tfjs-vis/src/render/barchart.ts
@@ -101,7 +101,10 @@ export async function barchart(
       }
     },
     'data': {'values': values, 'name': 'values'},
-    'mark': 'bar',
+    'mark': {
+      'type': 'bar',
+      'tooltip': true,
+    },
     'encoding': {
       'x': {'field': 'index', 'type': xType, 'axis': xAxis},
       'y': {'field': 'value', 'type': yType, 'axis': yAxis}
@@ -124,8 +127,8 @@ const defaultOpts = {
   fontSize: 11,
 };
 
-// We keep a map of containers to chart instances in order to reuse the instance
-// where possible.
+// We keep a map of containers to chart instances in order to reuse the
+// instance where possible.
 const instances: Map<HTMLElement, InstanceInfo> =
     new Map<HTMLElement, InstanceInfo>();
 

--- a/tfjs-vis/src/render/histogram.ts
+++ b/tfjs-vis/src/render/histogram.ts
@@ -95,7 +95,10 @@ export async function histogram(
       'resize': true,
     },
     'data': {'values': filtered},
-    'mark': 'bar',
+    'mark': {
+      'type': 'bar',
+      'tooltip': true,
+    },
     'config': {
       'axis': {
         'labelFontSize': options.fontSize,


### PR DESCRIPTION
Tooltips were on by default for these charts in earlier versions of vega-lite.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.