### PR TITLE
Add protocol option to release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@types/node": "^12.7.5",
+    "argparse": "^1.0.10",
     "chalk": "~2.4.2",
     "clang-format": "~1.2.4",
     "shelljs": "~0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "devDependencies": {
-    "clang-format": "~1.2.4",
+    "@types/node": "^12.7.5",
     "chalk": "~2.4.2",
+    "clang-format": "~1.2.4",
     "shelljs": "~0.8.3",
     "ts-node": "~4.1.0",
     "tslint": "~5.20.0",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -31,6 +31,7 @@ import * as readline from 'readline';
 import * as shell from 'shelljs';
 import * as fs from 'fs';
 import chalk from 'chalk';
+import * as argparse from 'argparse';
 
 interface Phase {
   // The list of packages that will be updated with this change.
@@ -87,6 +88,13 @@ const PHASES: Phase[] = [
 
 const TMP_DIR = '/tmp/tfjs-release';
 
+const parser = new argparse.ArgumentParser();
+
+parser.addArgument('--git-protocol', {
+  action: 'storeTrue',
+  help: 'Use the git protocal rather than the http protocol when cloning repos.'
+});
+
 function printPhase(phaseId: number) {
   const phase = PHASES[phaseId];
   console.log(chalk.green(`Phase ${phaseId}:`));
@@ -104,6 +112,8 @@ function getPatchUpdateVersion(version: string): string {
 }
 
 async function main() {
+  const args = parser.parseArgs();
+
   PHASES.forEach((_, i) => printPhase(i));
   console.log();
 
@@ -131,11 +141,13 @@ async function main() {
   $(`rm -f -r ${dir}`);
   $(`mkdir ${dir}`);
 
+  const urlBase = args.git_protocol ? 'git@github.com:' : 'https://github.com/';
+
   if (phase.repo != null) {
-    $(`git clone https://github.com/tensorflow/${phase.repo} ${dir} --depth=1`);
+    $(`git clone ${urlBase}tensorflow/${phase.repo} ${dir} --depth=1`);
     shell.cd(dir);
   } else {
-    $(`git clone https://github.com/tensorflow/tfjs ${dir} --depth=1`);
+    $(`git clone ${urlBase}tensorflow/tfjs ${dir} --depth=1`);
     shell.cd(dir);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,7 +40,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-argparse@^1.0.7:
+argparse@^1.0.10, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@types/node@^12.7.5":
+  version "12.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
+  integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
+
 "@types/strip-bom@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"


### PR DESCRIPTION
Small tweak to release script to allow caller to use the git protocol instead https to do clones.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2073)
<!-- Reviewable:end -->
