### PR TITLE
[WASM] Depend on EMSDK env variable and improve docs

### DIFF
--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -1,9 +1,21 @@
 # Emscripten installation
 
-Install emscripten [here](https://emscripten.org/docs/getting_started/downloads.html).
+Install emscripten by following the instructions [here](https://emscripten.org/docs/getting_started/downloads.html).
 
-Make sure the "emsdk" directory is in your home directory at ~/emsdk and also
-in your PATH.
+# Prepare the environment
+
+Before developing, make sure the environment variable `EMSDK` points to the
+emscripten directory (e.g. `~/emsdk`). Emscripten provides a script that does
+the setup for you:
+
+Cd into the emsdk directory and run:
+
+```sh
+source ./emsdk_env.sh
+```
+
+For details, see instructions
+[here](https://emscripten.org/docs/getting_started/downloads.html#installation-instructions).
 
 # Building
 

--- a/tfjs-backend-wasm/toolchain/cc_toolchain_config.bzl
+++ b/tfjs-backend-wasm/toolchain/cc_toolchain_config.bzl
@@ -163,7 +163,10 @@ cc_toolchain_config = rule(
 )
 
 def _emsdk_impl(ctx):
-    path = "%s/emsdk" % ctx.os.environ["HOME"]
+    if "EMSDK" not in ctx.os.environ or ctx.os.environ["EMSDK"].strip() == "":
+      fail("The environment variable EMSDK is not found. " +
+           "Did you run source ./emsdk_env.sh ?")
+    path = ctx.os.environ["EMSDK"]
     ctx.symlink(path, "emsdk")
     ctx.file("BUILD", """
 filegroup(


### PR DESCRIPTION
Instead of expecting the emsdk installation to be in the user's homedir, rely on the EMSDK environmental variable, which is setup by the emsdk environment script.