### PR TITLE
[layers] Create utility function that maps fusable activation name to layers identifier, and add elu activation.

### DIFF
--- a/tfjs-layers/integration_tests/tfjs2keras/package.json
+++ b/tfjs-layers/integration_tests/tfjs2keras/package.json
@@ -5,9 +5,9 @@
   "private": false,
   "license": "Apache-2.0 AND MIT",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.2.8",
-    "@tensorflow/tfjs-layers": "1.2.8",
-    "@tensorflow/tfjs-node": "1.2.8",
+    "@tensorflow/tfjs-core": "1.2.9",
+    "@tensorflow/tfjs-layers": "1.2.9",
+    "@tensorflow/tfjs-node": "1.2.9",
     "clang-format": "~1.2.2"
   },
   "scripts": {

--- a/tfjs-layers/src/layers/convolutional.ts
+++ b/tfjs-layers/src/layers/convolutional.ts
@@ -32,16 +32,6 @@ import * as generic_utils from '../utils/generic_utils';
 import {getExactlyOneShape, getExactlyOneTensor} from '../utils/types_utils';
 import {LayerVariable} from '../variables';
 
-function mapActivationToFusedKernel(activationName: string): fused.Activation {
-  if (activationName === 'relu') {
-    return 'relu';
-  }
-  if (activationName === 'linear') {
-    return 'linear';
-  }
-  return null;
-}
-
 /**
  * Transpose and cast the input before the conv2d.
  * @param x Input image tensor.
@@ -574,7 +564,7 @@ export abstract class Conv extends BaseConv {
       let outputs: Tensor;
       const biasValue = this.bias == null ? null : this.bias.read();
       const fusedActivationName =
-          mapActivationToFusedKernel(this.activation.getClassName());
+          generic_utils.mapActivationToFusedKernel(this.activation.getClassName());
 
       if (fusedActivationName != null && this.rank === 2) {
         outputs = conv2dWithBiasActivation(

--- a/tfjs-layers/src/layers/convolutional.ts
+++ b/tfjs-layers/src/layers/convolutional.ts
@@ -563,8 +563,8 @@ export abstract class Conv extends BaseConv {
       inputs = getExactlyOneTensor(inputs);
       let outputs: Tensor;
       const biasValue = this.bias == null ? null : this.bias.read();
-      const fusedActivationName =
-          generic_utils.mapActivationToFusedKernel(this.activation.getClassName());
+      const fusedActivationName = generic_utils.mapActivationToFusedKernel(
+                                            this.activation.getClassName());
 
       if (fusedActivationName != null && this.rank === 2) {
         outputs = conv2dWithBiasActivation(

--- a/tfjs-layers/src/layers/core.ts
+++ b/tfjs-layers/src/layers/core.ts
@@ -24,20 +24,10 @@ import {ActivationIdentifier} from '../keras_format/activation_config';
 import {Shape} from '../keras_format/common';
 import {getRegularizer, Regularizer, RegularizerIdentifier, serializeRegularizer} from '../regularizers';
 import {Kwargs} from '../types';
-import {assertPositiveInteger} from '../utils/generic_utils';
+import {assertPositiveInteger, mapActivationToFusedKernel} from '../utils/generic_utils';
 import {arrayProd, range} from '../utils/math_utils';
 import {getExactlyOneShape, getExactlyOneTensor} from '../utils/types_utils';
 import {LayerVariable} from '../variables';
-
-function mapActivationToFusedKernel(activationName: string): fused.Activation {
-  if (activationName === 'relu') {
-    return 'relu';
-  }
-  if (activationName === 'linear') {
-    return 'linear';
-  }
-  return null;
-}
 
 export declare interface DropoutLayerArgs extends LayerArgs {
   /** Float between 0 and 1. Fraction of the input units to drop. */

--- a/tfjs-layers/src/layers/core.ts
+++ b/tfjs-layers/src/layers/core.ts
@@ -12,7 +12,7 @@
  * TensorFlow.js Layers: Basic Layers.
  */
 
-import {any, fused, notEqual, serialization, Tensor, tidy, transpose, util} from '@tensorflow/tfjs-core';
+import {any, notEqual, serialization, Tensor, tidy, transpose, util} from '@tensorflow/tfjs-core';
 
 import {Activation as ActivationFn, getActivation, serializeActivation} from '../activations';
 import * as K from '../backend/tfjs_backend';

--- a/tfjs-layers/src/utils/generic_utils.ts
+++ b/tfjs-layers/src/utils/generic_utils.ts
@@ -10,7 +10,7 @@
 
 /* Original source: utils/generic_utils.py */
 
-import {DataType, serialization, util} from '@tensorflow/tfjs-core';
+import {DataType, serialization, util, fused} from '@tensorflow/tfjs-core';
 
 import {AssertionError, ValueError} from '../errors';
 // tslint:enable
@@ -497,4 +497,22 @@ export function debounce<T>(
     return lastResult;
   };
   return f2;
+}
+
+/**
+ * Returns the layers identifier for a fusable activation.
+ *
+ * @param activationName The name of the fusable activation.
+ */
+export function mapActivationToFusedKernel(activationName: string): fused.Activation {
+  if (activationName === 'relu') {
+    return 'relu';
+  }
+  if (activationName === 'linear') {
+    return 'linear';
+  }
+  if(activationName === 'elu') {
+    return 'elu';
+  }
+  return null;
 }

--- a/tfjs-layers/src/utils/generic_utils.ts
+++ b/tfjs-layers/src/utils/generic_utils.ts
@@ -500,9 +500,10 @@ export function debounce<T>(
 }
 
 /**
- * Returns the layers identifier for a fusable activation.
+ * Returns the fusable activation given a layers identifier.
  *
- * @param activationName The name of the fusable activation.
+ * @param activationName The layers identifier string.
+ * @return The name of the fusable activation.
  */
 export function mapActivationToFusedKernel(activationName: string):
   fused.Activation {

--- a/tfjs-layers/src/utils/generic_utils.ts
+++ b/tfjs-layers/src/utils/generic_utils.ts
@@ -504,7 +504,8 @@ export function debounce<T>(
  *
  * @param activationName The name of the fusable activation.
  */
-export function mapActivationToFusedKernel(activationName: string): fused.Activation {
+export function mapActivationToFusedKernel(activationName: string):
+  fused.Activation {
   if (activationName === 'relu') {
     return 'relu';
   }


### PR DESCRIPTION
#### Changes
- Move `mapActivationToFusedKernel` into `generic_utils`
- Add `elu` activation.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2083)
<!-- Reviewable:end -->
