### PR TITLE
webgpu: Lazily upload tensor data to SSBOs.

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -128,7 +128,9 @@ export class WebGPUBackend extends KernelBackend {
 
   flushDisposalQueue() {
     this.disposalQueue.forEach(d => {
-      this.releaseBuffer(d.buffer, d.byteSize, d.usage);
+      if (d.buffer != null) {
+        this.releaseBuffer(d.buffer, d.byteSize, d.usage);
+      }
     });
 
     this.disposalQueue = [];
@@ -143,9 +145,11 @@ export class WebGPUBackend extends KernelBackend {
     if (this.commandQueueOwnedIds.has(dataId)) {
       this.disposalQueue.push(info.bufferInfo);
     } else {
-      this.releaseBuffer(
-          info.bufferInfo.buffer, info.bufferInfo.byteSize,
-          info.bufferInfo.usage);
+      if (info.bufferInfo.buffer != null) {
+        this.releaseBuffer(
+            info.bufferInfo.buffer, info.bufferInfo.byteSize,
+            info.bufferInfo.usage);
+      }
     }
 
     this.tensorMap.delete(dataId);
@@ -169,9 +173,7 @@ export class WebGPUBackend extends KernelBackend {
 
   private releaseBuffer(
       buffer: GPUBuffer, byteSize: number, usage: GPUBufferUsage) {
-    if (buffer != null) {
-      this.bufferManager.releaseBuffer(buffer, byteSize, usage);
-    }
+    this.bufferManager.releaseBuffer(buffer, byteSize, usage);
   }
 
   register(dataId: object, shape: number[], dtype: DataType): void {
@@ -224,9 +226,11 @@ export class WebGPUBackend extends KernelBackend {
     const values = mapped.slice(0);
 
     staging.unmap();
-    this.releaseBuffer(
-        staging, info.bufferInfo.byteSize,
-        GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
+    if (staging != null) {
+      this.releaseBuffer(
+          staging, info.bufferInfo.byteSize,
+          GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
+    }
 
     return values;
   }

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -734,9 +734,9 @@ export class WebGPUBackend extends KernelBackend {
         if (this.fromPixels2DContext == null) {
           this.fromPixels2DContext =
               document.createElement('canvas').getContext('2d');
-          this.fromPixels2DContext.canvas.width = pixels.width;
-          this.fromPixels2DContext.canvas.height = pixels.height;
-        }
+            }
+        this.fromPixels2DContext.canvas.width = pixels.width;
+        this.fromPixels2DContext.canvas.height = pixels.height;
         this.fromPixels2DContext.drawImage(
             pixels, 0, 0, pixels.width, pixels.height);
         pixels = this.fromPixels2DContext.canvas;

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -171,11 +171,12 @@ export class WebGPUBackend extends KernelBackend {
   }
 
   private maybeReleaseBuffer(dataId: DataId) {
-    const {bufferInfo} = this.tensorMap.get(dataId);
-    if (bufferInfo.buffer != null) {
+    const info = this.tensorMap.get(dataId);
+    if (info != null && info.bufferInfo.buffer != null) {
       this.bufferManager.releaseBuffer(
-          bufferInfo.buffer, bufferInfo.byteSize, bufferInfo.usage);
-      bufferInfo.buffer = null;
+          info.bufferInfo.buffer, info.bufferInfo.byteSize,
+          info.bufferInfo.usage);
+      info.bufferInfo.buffer = null;
     }
   }
 

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -433,9 +433,10 @@ export class WebGPUBackend extends KernelBackend {
       return {
         // Returning dtype from tensorMap because it reflects dtype
         // of underlying buffer, rather than abstract dtype.
-        dtype: this.tensorMap.get(input.dataId).dtype, shape: input.shape,
-            name: program.variableNames[i]
-      }
+        dtype: this.tensorMap.get(input.dataId).dtype,
+        shape: input.shape,
+        name: program.variableNames[i]
+      };
     });
     this.uploadToGPU(output.dataId);
     const {bindGroupLayout, pipeline} = this.getAndSavePipeline(key, () => {

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -44,7 +44,7 @@ describeWebGPU('backend webgpu', () => {
 
     expect(endNumBytes - startNumBytes).toEqual(48);
     expect(endNumTensors - startNumTensors).toEqual(2);
-    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(24);
+    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(0);
 
     tf.test_util.expectArraysClose(
         dData, new Float32Array([9, 12, 15, 19, 26, 33]));
@@ -73,7 +73,7 @@ describeWebGPU('backend webgpu', () => {
 
     expect(endNumBytes - startNumBytes).toEqual(48);
     expect(endNumTensors - startNumTensors).toEqual(2);
-    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(48);
+    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(24);
 
     tf.test_util.expectArraysClose(
         dData, new Float32Array([9, 12, 15, 19, 26, 33]));

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -185,25 +185,25 @@ describeWebGPU('backend webgpu', () => {
     const bufferManager = backend.getBufferManager();
     const t = tf.Tensor.make([3], {}, 'float32');
     backend.write(t.dataId, new Float32Array([1, 2, 3]));
+
+    expect(bufferManager.getNumUsedBuffers()).toBe(0);
+
     backend.getBuffer(t.dataId);
     expect(bufferManager.getNumUsedBuffers()).toBe(1);
-    // overwrite.
+
     backend.write(t.dataId, new Float32Array([4, 5, 6]));
     expect(bufferManager.getNumUsedBuffers()).toBe(0);
+
     tf.test_util.expectArraysClose(
         await backend.read(t.dataId), new Float32Array([4, 5, 6]));
+
+    expect(bufferManager.getNumUsedBuffers()).toBe(0);
+
     backend.getBuffer(t.dataId);
     expect(bufferManager.getNumUsedBuffers()).toBe(1);
+
     tf.test_util.expectArraysClose(
         await backend.read(t.dataId), new Float32Array([4, 5, 6]));
     expect(bufferManager.getNumUsedBuffers()).toBe(0);
-  });
-
-  it('lol', async () => {
-    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
-    const c = tf.tensor2d([1, 2, 3, 4, 2, 5], [2, 3]);
-
-    const r = tf.div(a, c);
-    tf.test_util.expectArraysClose(await r.data(), [1, 1, 1, 1, 2.5, 6 / 5]);
   });
 });


### PR DESCRIPTION
This PR is needed for https://github.com/tensorflow/tfjs/pull/2061

#### Changes
- Do not create SSBO upon registration of tensor, instead only create SSBOs as part of `compileAndRun`.
- Ensure data exists either on CPU or GPU but not both.
- Reset dimensions of canvas for `fromPixels` every time it's called.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2085)
<!-- Reviewable:end -->
