### PR TITLE
Enable CI testing for the WASM backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ package-lock.json
 release-notes.md
 tensorflow-tfjs-*.tgz
 tfjs-backend-wasm/dist
-tfjs-backend-wasm/wasm-out
+tfjs-backend-wasm/wasm-out/*.js
+tfjs-backend-wasm/wasm-out/*.wasm
 yalc.lock
 yarn-error.log

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -64,6 +64,13 @@ steps:
   args: ['./scripts/run-build.sh', 'tfjs-backend-webgpu']
   waitFor: ['diff']
 
+# WASM.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'tfjs-backend-wasm'
+  args: ['./scripts/run-build.sh', 'tfjs-backend-wasm']
+  waitFor: ['diff']
+
 # React Native.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'

--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -1,6 +1,13 @@
 # Emscripten installation
 
-Install emscripten by following the instructions [here](https://emscripten.org/docs/getting_started/downloads.html).
+Install the Emscripten SDK (version 1.38.41):
+
+```sh
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install 1.38.41
+./emsdk activate 1.38.41
+```
 
 # Prepare the environment
 

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -1,0 +1,37 @@
+steps:
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install wasm dependencies.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  id: 'yarn'
+  entrypoint: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  entrypoint: 'yarn'
+  id: 'test-wasm'
+  args: ['test-ci']
+  waitFor: ['yarn']
+  env: ['BROWSERSTACK_USERNAME=deeplearnjs1']
+  secretEnv: ['BROWSERSTACK_KEY']
+
+# General configuration
+secrets:
+- kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
+  secretEnv:
+    BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
+timeout: 1800s
+logsBucket: 'gs://tfjs-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/tfjs-backend-wasm/karma.conf.js
+++ b/tfjs-backend-wasm/karma.conf.js
@@ -61,7 +61,7 @@ module.exports = function(config) {
       '/base/node_modules/karma-typescript/dist/client/tfjs-backend-wasm.wasm':
           '/base/wasm-out/tfjs-backend-wasm.wasm',
     },
-    reporters: ['progress', 'karma-typescript'],
+    reporters: ['dots', 'karma-typescript'],
     port: 9876,
     colors: true,
     autoWatch: true,

--- a/tfjs-backend-wasm/karma.conf.js
+++ b/tfjs-backend-wasm/karma.conf.js
@@ -66,7 +66,25 @@ module.exports = function(config) {
     colors: true,
     autoWatch: true,
     browsers: ['Chrome'],
+    browserStack: {
+      username: process.env.BROWSERSTACK_USERNAME,
+      accessKey: process.env.BROWSERSTACK_KEY
+    },
     singleRun: false,
-    client: {jasmine: {random: false}, args: args}
+    captureTimeout: 120000,
+    reportSlowerThan: 500,
+    browserNoActivityTimeout: 180000,
+    client: {jasmine: {random: false}, args: args},
+    customLaunchers: {
+      // For browserstack configs see:
+      // https://www.browserstack.com/automate/node
+      bs_chrome_mac: {
+        base: 'BrowserStack',
+        browser: 'chrome',
+        browser_version: 'latest',
+        os: 'OS X',
+        os_version: 'High Sierra'
+      }
+    }
   })
 }

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -11,7 +11,8 @@
     "build": "rimraf dist/ && ./scripts/build-wasm.sh && tsc && cp wasm-out/*.wasm dist/",
     "build-npm": "./scripts/build-npm.sh",
     "lint": "tslint -p . -t verbose",
-    "test": "./scripts/build-wasm.sh && karma start"
+    "test": "./scripts/build-wasm.sh && karma start",
+    "test-ci": "./scripts/test-ci.sh"
   },
   "peerDependencies": {
     "@tensorflow/tfjs-core": "~1.2.7"

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -14,11 +14,19 @@
 # limitations under the License.
 # =============================================================================
 
-set -euo pipefail
+set -e
 
-export EM_EXCLUSIVE_CACHE_ACCESS=1
-export EMCC_SKIP_SANITY_CHECK=1
-export EMCC_WASM_BACKEND=0
+# Install emsdk
+git clone --depth=1 --single-branch https://github.com/emscripten-core/emsdk.git
+cd emsdk
+# Need to tell emsdk where to write the .emscripten file.
+export HOME='/root'
+./emsdk install 1.38.41
+./emsdk activate 1.38.41
+source ./emsdk_env.sh
+cd ..
 
-# Run emscripten to compile and link
-python external/emsdk/emsdk/fastcomp/emscripten/emcc.py "$@"
+yarn
+yarn lint
+yarn build
+yarn karma start --browsers=bs_chrome_mac

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -29,4 +29,4 @@ cd ..
 yarn
 yarn lint
 yarn build
-yarn karma start --browsers=bs_chrome_mac
+yarn karma start --singleRun --browsers=bs_chrome_mac


### PR DESCRIPTION
- Enable CI testing for the WASM backend
- Improve documentation to depend on EMSDK 1.38.41 since 1.38.42 and later brake bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2086)
<!-- Reviewable:end -->
