### PR TITLE
webgpu: Fix argMax benchmark doesn't work

### DIFF
--- a/tfjs-backend-webgpu/src/benchmark_ops_test.ts
+++ b/tfjs-backend-webgpu/src/benchmark_ops_test.ts
@@ -79,7 +79,7 @@ describeWebGPU('Ops benchmarks', () => {
   }
 
   it('argMax', async () => {
-    const n = 50;
+    const n = 2;
     const doTest = async (axis: number) => {
       const tensors = new Array(n);
       const maxes = new Array(n);
@@ -97,7 +97,7 @@ describeWebGPU('Ops benchmarks', () => {
             for (const t of maxes) {
               t.dispose();
             }
-          });
+          }, false, 50, n);
     };
 
     await doTest(0);


### PR DESCRIPTION
BUG

Fix below error message when you run 'yarn benchmark':
  TypeError: Cannot read property 'data' of undefined

The error is because we want to test 50 sets of data. However, we used the
default 'reps' which is 1, that will result only the first element of
maxes is valid. So we will get above error message for the following
elements in maxes.
Meanwhile, decrease n to 2 to avoid out of time.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2087)
<!-- Reviewable:end -->
