### PR TITLE
[AutoML] Fix a bug when fetching `dict.txt` where path to `model.json` is relative

### DIFF
--- a/tfjs-automl/package.json
+++ b/tfjs-automl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-automl",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/tf-automl.esm.js",

--- a/tfjs-automl/src/img_classification_test.ts
+++ b/tfjs-automl/src/img_classification_test.ts
@@ -17,6 +17,7 @@
 
 import {GraphModel} from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
 import {BROWSER_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
 import * as automl from './index';

--- a/tfjs-automl/src/object_detection_test.ts
+++ b/tfjs-automl/src/object_detection_test.ts
@@ -17,6 +17,7 @@
 
 import {GraphModel} from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
 import {BROWSER_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
 import * as automl from './index';

--- a/tfjs-automl/src/test_browser.ts
+++ b/tfjs-automl/src/test_browser.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+// tslint:disable-next-line: no-imports-from-dist
 import {setTestEnvs} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
 // Increase test timeout since we are fetching the model files from GCS.

--- a/tfjs-automl/src/test_node.ts
+++ b/tfjs-automl/src/test_node.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+// tslint:disable-next-line: no-imports-from-dist
 import {setTestEnvs} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
 // tslint:disable-next-line:no-require-imports

--- a/tfjs-automl/src/util.ts
+++ b/tfjs-automl/src/util.ts
@@ -24,8 +24,10 @@ export function imageToTensor(img: ImageInput): Tensor3D {
 
 /** Loads and parses the dictionary. */
 export async function loadDictionary(modelUrl: string): Promise<string[]> {
-  const prefixUrl = modelUrl.slice(0, modelUrl.lastIndexOf('/'));
-  const dictUrl = `${prefixUrl}/dict.txt`;
+  const lastIndexOfSlash = modelUrl.lastIndexOf('/');
+  const prefixUrl =
+      lastIndexOfSlash >= 0 ? modelUrl.slice(0, lastIndexOfSlash + 1) : '';
+  const dictUrl = `${prefixUrl}dict.txt`;
   const response = await util.fetch(dictUrl);
   const text = await response.text();
   return text.trim().split('\n');

--- a/tfjs-automl/src/util_test.ts
+++ b/tfjs-automl/src/util_test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {util} from '@tensorflow/tfjs-core';
+import {loadDictionary} from './util';
+
+describe('load dictionary', () => {
+  it('relative url to model.json', async () => {
+    spyOn(util, 'fetch').and.callFake((dictUrl: string) => {
+      expect(dictUrl).toBe('dict.txt');
+      return {text: async () => 'first\nsecond\nthird'};
+    });
+    const res = await loadDictionary('model.json');
+    expect(res).toEqual(['first', 'second', 'third']);
+  });
+
+  it('relative url to model.json with a base path', async () => {
+    spyOn(util, 'fetch').and.callFake((dictUrl: string) => {
+      expect(dictUrl).toBe('base/path/dict.txt');
+      return {text: async () => 'first\nsecond\nthird'};
+    });
+    const res = await loadDictionary('base/path/model.json');
+    expect(res).toEqual(['first', 'second', 'third']);
+  });
+
+  it('absolute url to model.json', async () => {
+    spyOn(util, 'fetch').and.callFake((dictUrl: string) => {
+      expect(dictUrl).toBe('/dict.txt');
+      return {text: async () => 'first\nsecond\nthird\n'};
+    });
+    const res = await loadDictionary('/model.json');
+    expect(res).toEqual(['first', 'second', 'third']);
+  });
+
+  it('absolute url to model.json with a base path', async () => {
+    spyOn(util, 'fetch').and.callFake((dictUrl: string) => {
+      expect(dictUrl).toBe('/base/path/dict.txt');
+      return {text: async () => 'first\nsecond\nthird\n'};
+    });
+    const res = await loadDictionary('/base/path/model.json');
+    expect(res).toEqual(['first', 'second', 'third']);
+  });
+});

--- a/tfjs-automl/src/version.ts
+++ b/tfjs-automl/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.0.1-alpha.1';
+const version = '0.0.1-alpha.2';
 export {version};


### PR DESCRIPTION
BUG

Fix a bug when fetching `dict.txt` while the path to `model.json` is relative without any base path (no slashes in url).

Also bump version number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2088)
<!-- Reviewable:end -->
