### PR TITLE
webgpu: Use DataStorage class for storing tensor map.

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -22,6 +22,7 @@ import './flags_webgpu';
 import {backend_util, DataStorage, DataType, ENV, KernelBackend, Rank, RecursiveArray, ShapeMap, Tensor, Tensor2D, Tensor3D, Tensor4D, TimingInfo, util} from '@tensorflow/tfjs-core';
 // TODO(annxingyuan): import ENGINE from core directly once 1.3.0 is
 // released.
+// tslint:disable-next-line: no-imports-from-dist
 import {ENGINE} from '@tensorflow/tfjs-core/dist/engine';
 import * as shaderc from '@webgpu/shaderc';
 

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -20,8 +20,7 @@
 import './flags_webgpu';
 
 import {backend_util, DataStorage, DataType, ENV, KernelBackend, Rank, RecursiveArray, ShapeMap, Tensor, Tensor2D, Tensor3D, Tensor4D, TimingInfo, util} from '@tensorflow/tfjs-core';
-// TODO(annxingyuan): import ENGINE from core directly once 1.3.0 is
-// released.
+// TODO(annxingyuan): get ENGINE from tf.engine() once core 1.3.0 is released.
 // tslint:disable-next-line: no-imports-from-dist
 import {ENGINE} from '@tensorflow/tfjs-core/dist/engine';
 import * as shaderc from '@webgpu/shaderc';

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -19,7 +19,10 @@
 
 import './flags_webgpu';
 
-import {backend_util, DataMover, DataType, ENV, KernelBackend, Rank, RecursiveArray, ShapeMap, Tensor, Tensor2D, Tensor3D, Tensor4D, TimingInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, DataStorage, DataType, ENV, KernelBackend, Rank, RecursiveArray, ShapeMap, Tensor, Tensor2D, Tensor3D, Tensor4D, TimingInfo, util} from '@tensorflow/tfjs-core';
+// TODO(annxingyuan): import ENGINE from core directly once 1.3.0 is
+// released.
+import {ENGINE} from '@tensorflow/tfjs-core/dist/engine';
 import * as shaderc from '@webgpu/shaderc';
 
 import {BufferManager} from './buffer_manager';
@@ -93,7 +96,7 @@ export class WebGPUBackend extends KernelBackend {
   private binaryCache: {[key: string]: WebGPUBinary};
   private fromPixels2DContext: CanvasRenderingContext2D;
   private bufferManager: BufferManager;
-  private tensorMap = new WeakMap<DataId, TensorInfo>();
+  private tensorMap: DataStorage<TensorInfo>;
 
   private tensorDisposalQueue: DataId[] = [];
   private uniformDisposalQueue: BufferInfo[] = [];
@@ -118,14 +121,11 @@ export class WebGPUBackend extends KernelBackend {
     this.compileOpts = opts;
 
     this.bufferManager = new BufferManager(this.device);
+    this.tensorMap = new DataStorage(this, ENGINE);
   }
 
   floatPrecision(): 32 {
     return 32;
-  }
-
-  setDataMover(dataMover: DataMover): void {
-    // TODO: tfjs team to implement this. Call GPUBuffer.destroy()
   }
 
   flushDisposalQueue() {

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -210,4 +210,20 @@ describeWebGPU('backend webgpu', () => {
         await backend.read(t.dataId), new Float32Array([4, 5, 6]));
     expect(bufferManager.getNumUsedBuffers()).toBe(0);
   });
+
+  it('should be possible to move data from webgl to webgpu', async () => {
+    tf.setBackend('webgl');
+    const a = tf.randomNormal([1, 65, 65, 256]);
+    const b = tf.randomNormal([1, 65, 65, 256]);
+    const c = tf.add(a, b);
+    await c.data();
+
+    const f = async () => {
+      tf.setBackend('webgpu');
+      const d = tf.add(a, b);
+      await d.data();
+    };
+
+    expect(f).not.toThrow();
+  });
 });

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -121,7 +121,7 @@ describeWebGPU('backend webgpu', () => {
     tf.ENV.set('WEBGPU_IMMEDIATE_EXECUTION_ENABLED', savedFlag);
   });
 
-  it('should not recycle buffers in delayed mode', () => {
+  it('should not recycle buffers in delayed mode', async () => {
     const savedFlag = tf.ENV.get('WEBGPU_IMMEDIATE_EXECUTION_ENABLED');
     tf.ENV.set('WEBGPU_IMMEDIATE_EXECUTION_ENABLED', false);
     const backend = tf.backend() as WebGPUBackend;
@@ -152,11 +152,15 @@ describeWebGPU('backend webgpu', () => {
     expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(4);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
-    tf.matMul(c2, f2);
+    const c3 = tf.matMul(c2, f2);
     const freeBuffersAfterSecondMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMatMul - freeBuffersAfterSecondMul).toEqual(0);
     expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(3);
+
+    // Tests happen within a tidy so we need to read a tensor at the end of a
+    // test in delayed mode in order to force flush the disposal queue.
+    await c3.data();
     tf.ENV.set('WEBGPU_IMMEDIATE_EXECUTION_ENABLED', savedFlag);
   });
 

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -23,7 +23,6 @@ import {setDeprecationWarningFn, Tensor} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
-
 /**
  * Enables production mode which disables correctness checks in favor of
  * performance.

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -74,7 +74,7 @@ export function disposeVariables(): void {
 }
 
 /**
- * Gets the `ENGINE` object.
+ * It returns the global engine that keeps track of all tensors and backends.
  */
 /** @doc {heading: 'Environment'} */
 export function engine(): Engine {

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -16,12 +16,13 @@
  */
 
 import {KernelBackend} from './backends/backend';
-import {ENGINE, MemoryInfo, ProfileInfo, ScopeFn, TimingInfo} from './engine';
+import {ENGINE, Engine, MemoryInfo, ProfileInfo, ScopeFn, TimingInfo} from './engine';
 import {ENV} from './environment';
 import {Platform} from './platforms/platform';
 import {setDeprecationWarningFn, Tensor} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
+
 
 /**
  * Enables production mode which disables correctness checks in favor of
@@ -71,6 +72,14 @@ setDeprecationWarningFn(deprecationWarn);
 /** @doc {heading: 'Environment'} */
 export function disposeVariables(): void {
   ENGINE.disposeVariables();
+}
+
+/**
+ * Gets the `ENGINE` object.
+ */
+/** @doc {heading: 'Environment'} */
+export function engine(): Engine {
+  return ENGINE;
 }
 
 /**

--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -65,7 +65,7 @@ export * from './train';
 export * from './globals';
 export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
 
-export {TimingInfo, MemoryInfo, ENGINE} from './engine';
+export {TimingInfo, MemoryInfo} from './engine';
 export {ENV, Environment} from './environment';
 export {Platform} from './platforms/platform';
 

--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -65,7 +65,7 @@ export * from './train';
 export * from './globals';
 export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
 
-export {TimingInfo, MemoryInfo} from './engine';
+export {TimingInfo, MemoryInfo, ENGINE} from './engine';
 export {ENV, Environment} from './environment';
 export {Platform} from './platforms/platform';
 

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -48,10 +48,6 @@ export class NodeJSKernelBackend extends KernelBackend {
     this.isUsingGpuDevice = this.binding.isUsingGpuDevice();
   }
 
-  setDataMover(dataMover: DataMover): void {
-    // TODO(kreeger, smilkov): Implement this.
-  }
-
   private getDTypeInteger(dtype: DataType): number {
     switch (dtype) {
       case 'float32':

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {backend_util, BackendTimingInfo, DataMover, DataType, fill, KernelBackend, ones, Rank, rsqrt, Scalar, scalar, ShapeMap, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, tensor3d, Tensor4D, Tensor5D, tidy, util} from '@tensorflow/tfjs-core';
+import {backend_util, BackendTimingInfo, DataType, fill, KernelBackend, ones, Rank, rsqrt, Scalar, scalar, ShapeMap, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, tensor3d, Tensor4D, Tensor5D, tidy, util} from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {EPSILON_FLOAT32} from '@tensorflow/tfjs-core/dist/backends/backend';
 // tslint:disable-next-line: no-imports-from-dist


### PR DESCRIPTION
#### Changes
- Remove obsolete `setDataMover` method from WebGPU backend.
- Export `ENGINE` in core.
- Use `DataStorage` class instead of directly creating `WeakMap` for storing tensor map. 
- Force flush disposal queue at the end of tests in delayed mode.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2095)
<!-- Reviewable:end -->
