### PR TITLE
webgpu: Optimize maxpool with groupsize(4, 4, 4)

### DIFF
--- a/tfjs-backend-webgpu/src/benchmark_ops_test.ts
+++ b/tfjs-backend-webgpu/src/benchmark_ops_test.ts
@@ -135,4 +135,11 @@ describeWebGPU('Ops benchmarks', () => {
 
     await time(() => tf.depthwiseConv2d(x, w, 1, 'valid'));
   });
+
+  it('maxPool', async () => {
+    const x = tf.randomNormal<tf.Rank.R4>([1, 131, 131, 64]);
+
+    await time(() => tf.maxPool(x, 2, 1, 'same'));
+  });
+
 });

--- a/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
@@ -28,7 +28,7 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 filterDims, pad, stride;';
-  workGroupSize: [number, number, number] = [4, 8, 1];
+  workGroupSize: [number, number, number] = [4, 8, 4];
 
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;

--- a/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
@@ -26,7 +26,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 filterDims, pad, stride;';
-  workGroupSize: [number, number, number] = [4, 8, 1];
+  workGroupSize: [number, number, number] = [4, 8, 4];
 
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;

--- a/tfjs-backend-webgpu/src/kernels/maxpool_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/maxpool_webgpu.ts
@@ -28,7 +28,7 @@ export class MaxPoolProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'ivec2 pad, stride, dilation, convDims, filterDims;';
-  workGroupSize: [number, number, number] = [4, 4, 1];
+  workGroupSize: [number, number, number] = [4, 4, 4];
 
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;


### PR DESCRIPTION
PERF

With this change, maxPool [1,131,131,64] benchmark improves 35%(from 20ms to 13ms).
The PoseNet demo improves from 7fps to 8fps.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2112)
<!-- Reviewable:end -->
