### PR TITLE
DONT COMMIT: add exports = {} to environment.ts

### DIFF
--- a/tfjs-core/src/environment.ts
+++ b/tfjs-core/src/environment.ts
@@ -17,6 +17,8 @@
 
 import {Platform} from './platforms/platform';
 
+exports = {};
+
 // Expects flags from URL in the format ?tfjsflags=FLAG1:1,FLAG2:true.
 const TENSORFLOWJS_FLAGS_PREFIX = 'tfjsflags';
 

--- a/tfjs-core/src/environment.ts
+++ b/tfjs-core/src/environment.ts
@@ -17,6 +17,8 @@
 
 import {Platform} from './platforms/platform';
 
+// tslint:disable-next-line:ban-ts-ignore see above
+// @ts-ignore
 exports = {};
 
 // Expects flags from URL in the format ?tfjsflags=FLAG1:1,FLAG2:true.


### PR DESCRIPTION
This results in a runtime error:

```
$ ts-node ./scripts/test_snippets/test_snippets.ts

/usr/local/google/home/nsthorat/tfjs-clients/mono/tfjs/tfjs-core/src/engine.ts:949
    const environment = new Environment(ns);
                        ^
TypeError: environment_1.Environment is not a constructor
    at getOrMakeEngine (/usr/local/google/home/nsthorat/tfjs-clients/mono/tfjs/tfjs-core/src/engine.ts:949:25)
    at Object.<anonymous> (/usr/local/google/home/nsthorat/tfjs-clients/mono/tfjs/tfjs-core/src/engine.ts:960:21)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Module.m._compile (/usr/local/google/home/nsthorat/tfjs-clients/mono/tfjs/tfjs-core/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/usr/local/google/home/nsthorat/tfjs-clients/mono/tfjs/tfjs-core/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2123)
<!-- Reviewable:end -->
