### PR TITLE
Fix JSCompiler error (add @suppress on module objects)

### DIFF
--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -15,6 +15,12 @@
  * =============================================================================
  */
 
+/**
+ * @fileoverview
+ * @suppress {partialAlias} Optimization disabled due to use of module object.
+ *     See http://go/js-practices/namespaces#avoid-objects.
+ */
+
 // Engine is the global singleton that needs to be initialized before the rest
 // of the app.
 import './engine';

--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -17,8 +17,11 @@
 
 /**
  * @fileoverview
- * @suppress {partialAlias} Optimization disabled due to use of module object.
- *     See http://go/js-practices/namespaces#avoid-objects.
+ * @suppress {partialAlias} Optimization disabled due to passing the module
+ * object into a function below:
+ *
+ *   import * as ops from './ops/ops';
+ *   setOpHandler(ops);
  */
 
 // Engine is the global singleton that needs to be initialized before the rest


### PR DESCRIPTION
JSCompiler already warns/errors if you use a module object, e.g.
`import * as mod from ...;`
as a regular JS object that can be passed around, e.g.
`foo(mod);`
because doing so disables an optimization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2125)
<!-- Reviewable:end -->
