### PR TITLE
verify weights existing, instead of the weights length

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -256,7 +256,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 1)
+    self.assertTrue('weights' in weights_manifest[0])
 
     # Check meta-data in the artifact JSON.
     self.assertEqual(model_json['format'], 'graph-model')
@@ -313,7 +313,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 1)
+    self.assertTrue('weights' in weights_manifest[0])
 
   def test_convert_saved_model_with_fused_conv2d(self):
     self._create_saved_model_with_fusable_conv2d()
@@ -443,7 +443,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 6)
+    self.assertTrue('weights' in weights_manifest[0])
 
     # Check meta-data in the artifact JSON.
     self.assertEqual(model_json['format'], 'graph-model')
@@ -481,7 +481,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 1)
+    self.assertTrue('weights' in weights_manifest[0])
     self.assertTrue(
         glob.glob(
             os.path.join(self._tmp_dir, SAVED_MODEL_DIR, 'group*-*')))
@@ -505,7 +505,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 1)
+    self.assertTrue('weights' in weights_manifest[0])
     self.assertTrue(
         glob.glob(
             os.path.join(self._tmp_dir, SAVED_MODEL_DIR, 'group*-*')))
@@ -525,7 +525,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 1)
+    self.assertTrue('weights' in weights_manifest[0])
 
     self.assertTrue(
         glob.glob(
@@ -546,7 +546,7 @@ class ConvertTest(tf.test.TestCase):
     weights_manifest = model_json['weightsManifest']
     self.assertCountEqual(weights_manifest[0]['paths'],
                           ['group1-shard1of1.bin'])
-    self.assertEqual(len(weights_manifest[0]['weights']), 1)
+    self.assertTrue('weights' in weights_manifest[0])
 
     self.assertTrue(
         glob.glob(


### PR DESCRIPTION
This fixes the internal test failure.
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2142)
<!-- Reviewable:end -->
