### PR TITLE
update the TF deps to tf_nightly

### DIFF
--- a/tfjs/integration_tests/python/requirements.txt
+++ b/tfjs/integration_tests/python/requirements.txt
@@ -1,2 +1,2 @@
 tensorflowjs>=1.2.9
-tf-nightly-2.0-preview>=2.0.0.dev20190614
+tf-nightly>=2.0.0.dev20190614


### PR DESCRIPTION
tf-nightly-2.0-preview will no longer be available, we need to use
tf_nightly instead.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2144)
<!-- Reviewable:end -->
