### PR TITLE
Only run prep-gpu.sh in cloudbuild and build-npm

### DIFF
--- a/tfjs-node-gpu/cloudbuild.yml
+++ b/tfjs-node-gpu/cloudbuild.yml
@@ -1,9 +1,17 @@
 steps:
+# Prepare tfjs-node-gpu folder, copy files from tfjs-node.
+- name: 'node:10'
+  dir: 'tfjs-node-gpu'
+  id: 'prep-gpu'
+  entrypoint: 'yarn'
+  args: ['prep-gpu']
+
 # Install common dependencies.
 - name: 'node:10'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
+  waitFor: ['prep-gpu']
 
 # Install tfjs-node dependencies.
 - name: 'node:10'

--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "build-npm": "./scripts/build-npm.sh",
+    "build-npm": "prep-gpu && ./scripts/build-npm.sh",
     "build-addon": "./scripts/build-and-upload-addon.sh",
     "build-addon-from-source": "node-pre-gyp install --build-from-source",
     "clean-deps": "rm -rf deps && rm -rf lib",
@@ -27,7 +27,7 @@
     "link-local": "yalc link",
     "lint": "tslint -p . -t verbose",
     "prep": "cd node_modules/@tensorflow/tfjs-core && yarn && yarn build",
-    "preinstall": "./prep-gpu.sh",
+    "prep-gpu": "./prep-gpu.sh",
     "publish-local": "yarn prep && yalc push",
     "test": "ts-node src/run_tests.ts",
     "test-ci": "./scripts/test-ci.sh",
@@ -68,6 +68,7 @@
     "napi_versions": [
       3,
       4
-    ]
+    ],
+    "package_name": "GPU-windows-1.2.10.zip"
   }
 }

--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "build-npm": "prep-gpu && ./scripts/build-npm.sh",
+    "build-npm": "yarn prep-gpu && ./scripts/build-npm.sh",
     "build-addon": "./scripts/build-and-upload-addon.sh",
     "build-addon-from-source": "node-pre-gyp install --build-from-source",
     "clean-deps": "rm -rf deps && rm -rf lib",
@@ -68,7 +68,6 @@
     "napi_versions": [
       3,
       4
-    ],
-    "package_name": "GPU-windows-1.2.10.zip"
+    ]
   }
 }

--- a/tfjs-node/scripts/ensure-cpu-gpu-packages-align.js
+++ b/tfjs-node/scripts/ensure-cpu-gpu-packages-align.js
@@ -31,7 +31,7 @@ process.on('unhandledRejection', e => {
  */
 const FIELDS_TO_IGNORE = [
   'name', 'scripts/install', 'scripts/test', 'scripts/prepare', 'scripts/prep',
-  'scripts/upload-windows-addon'
+  'scripts/upload-windows-addon', 'scripts/build-npm'
 ];
 
 const cpuPackageKeys = Object.keys(cpuPackage);


### PR DESCRIPTION
The preinstall command `prep-gpu.sh` should not be included in published npm package, and it can not run on windows. 

Only run it in cloudbuild for test, and when building npm package. For local development, engineers should manually run it to copy files from tfjs-node.

fix: https://github.com/tensorflow/tfjs/issues/2150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2151)
<!-- Reviewable:end -->
