### PR TITLE
[tfjs-backend-wasm] Move the free() call into JavaScript.

### DIFF
--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -70,6 +70,7 @@ export class BackendWasm extends KernelBackend {
 
   disposeData(dataId: DataId) {
     const data = this.dataIdMap.get(dataId);
+    this.wasm._free(data.memoryOffset);
     this.wasm.tfjs.disposeData(data.id);
     this.dataIdMap.delete(dataId);
   }

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -6,7 +6,7 @@ cc_binary(
         "-s DISABLE_EXCEPTION_CATCHING=1",
         "-s FILESYSTEM=0",
         "-s EXIT_RUNTIME=0",
-        "-s EXPORTED_FUNCTIONS='[\"_malloc\"]'",
+        "-s EXPORTED_FUNCTIONS='[\"_malloc\", \"_free\"]'",
         "-s EXTRA_EXPORTED_RUNTIME_METHODS='[\"cwrap\"]'",
         "-s ENVIRONMENT=web",
         "-s MODULARIZE=1",

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -64,24 +64,7 @@ void register_tensor(int data_id, int *shape_ptr, int shape_length, DType dtype,
 }
 
 EMSCRIPTEN_KEEPALIVE
-void dispose_data(int data_id) {
-  TensorInfo info = data.at(data_id);
-  switch (info.dtype) {
-    case DType::float32:
-      free(info.buf.f32);
-      break;
-    case DType::int32:
-      free(info.buf.i32);
-      break;
-    case DType::boolean:
-      free(info.buf.b);
-      break;
-    default:
-      util::warn("Dispose for tensor id %d failed. Unknown dtype %d", data_id,
-                 info.dtype);
-  }
-  data.erase(data_id);
-}
+void dispose_data(int data_id) { data.erase(data_id); }
 
 EMSCRIPTEN_KEEPALIVE
 void dispose() {


### PR DESCRIPTION
Moving this call into JavaScript does the following:
- Makes C++ internally consistent. malloc and free both happen from JavaScript. C++'s job is not to allocate memory, just to run kernels on pointers it gets automatically.
- Allows us to be more flexible w.r.t reusing pointers for subsequent calls to models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2181)
<!-- Reviewable:end -->
