### PR TITLE
Add a CI for checking the WASM .wasm and .js size

### DIFF
--- a/scripts/bundle-size-util.js
+++ b/scripts/bundle-size-util.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+const {exec} = require('./test-util');
+
+function getFileSizeBytes(filename) {
+  const gzipFilename = `${filename}.gzip`;
+  exec(`gzip -c ${filename} > ${gzipFilename}`, {silent: true});
+  const fileSizeBytes =
+      +(exec(`ls -l ${filename} | awk '{print $5}'`, {silent: true}));
+  const gzipFileSizeBytes =
+      +(exec(`ls -l ${gzipFilename} | awk '{print $5}'`, {silent: true}));
+  return {fileSizeBytes, gzipFileSizeBytes};
+}
+
+function showDiff(newSize, masterSize) {
+  const diffBytes = newSize - masterSize;
+  const diffPercent = (100 * diffBytes / masterSize).toFixed(2);
+  const sign = diffBytes > 0 ? '+' : '';
+
+  const charWidth = 7;
+  const diffKiloBytes =
+      (sign + (diffBytes / 1024).toFixed(2)).padStart(charWidth, ' ');
+  const masterKiloBytes =
+      ((masterSize / 1024).toFixed(2)).padStart(charWidth, ' ');
+  const newKiloBytes = ((newSize / 1024).toFixed(2)).padStart(charWidth, ' ');
+
+  console.log(`  diff:   ${diffKiloBytes} K  (${sign}${diffPercent}%)`);
+  console.log(`  master: ${masterKiloBytes} K`);
+  console.log(`  change: ${newKiloBytes} K`);
+}
+
+exports.getFileSizeBytes = getFileSizeBytes;
+exports.showDiff = showDiff;

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -13,20 +13,20 @@ steps:
   args: ['install']
   waitFor: ['yarn-common']
 
-# Build the project.
-- name: 'node:10'
-  dir: 'tfjs-backend-wasm'
-  entrypoint: 'yarn'
-  id: 'build'
-  args: ['build-ci']
-  waitFor: ['yarn']
-
 # Run lint.
 - name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'lint'
   args: ['lint']
+  waitFor: ['yarn']
+
+# Build the project.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build-ci']
   waitFor: ['yarn']
 
 # Run browser tests.

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -13,13 +13,29 @@ steps:
   args: ['install']
   waitFor: ['yarn-common']
 
+# Build the project.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build-ci']
+  waitFor: ['yarn']
+
+# Run lint.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  entrypoint: 'yarn'
+  id: 'lint'
+  args: ['lint']
+  waitFor: ['yarn']
+
 # Run browser tests.
 - name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-wasm'
-  args: ['test-ci']
-  waitFor: ['yarn']
+  args: ['test-browser-ci']
+  waitFor: ['build']
   env: ['BROWSERSTACK_USERNAME=deeplearnjs1']
   secretEnv: ['BROWSERSTACK_KEY']
 
@@ -29,15 +45,15 @@ steps:
   entrypoint: 'yarn'
   id: 'test-cc'
   args: ['test-cc']
-  waitFor: ['yarn']
+  waitFor: ['build']
 
-# bundle size check
+# Check bundle size.
 - name: 'node:10'
   dir: 'tfjs-backend-wasm'
   id: 'test-bundle-size'
   entrypoint: 'yarn'
   args: ['test-bundle-size']
-  waitFor: ['yarn']
+  waitFor: ['build']
 
 # General configuration
 secrets:

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -13,7 +13,7 @@ steps:
   args: ['install']
   waitFor: ['yarn-common']
 
-# Run tests.
+# Run browser tests.
 - name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
@@ -22,6 +22,22 @@ steps:
   waitFor: ['yarn']
   env: ['BROWSERSTACK_USERNAME=deeplearnjs1']
   secretEnv: ['BROWSERSTACK_KEY']
+
+# Run C++ tests.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  entrypoint: 'yarn'
+  id: 'test-cc'
+  args: ['test-cc']
+  waitFor: ['yarn']
+
+# bundle size check
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  id: 'test-bundle-size'
+  entrypoint: 'yarn'
+  args: ['test-bundle-size']
+  waitFor: ['yarn']
 
 # General configuration
 secrets:

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -48,12 +48,12 @@ steps:
   waitFor: ['build']
 
 # Check bundle size.
-- name: 'node:10'
-  dir: 'tfjs-backend-wasm'
-  id: 'test-bundle-size'
-  entrypoint: 'yarn'
-  args: ['test-bundle-size']
-  waitFor: ['build']
+# - name: 'node:10'
+#   dir: 'tfjs-backend-wasm'
+#   id: 'test-bundle-size'
+#   entrypoint: 'yarn'
+#   args: ['test-bundle-size']
+#   waitFor: ['build']
 
 # General configuration
 secrets:

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -9,12 +9,13 @@
   "jsdelivr": "dist/tf-wasm.min.js",
   "scripts": {
     "build": "rimraf dist/ && ./scripts/build-wasm.sh && tsc && cp wasm-out/*.wasm dist/",
+    "build-ci": "./scripts/build-ci.sh",
     "build-npm": "./scripts/build-npm.sh",
     "lint": "tslint -p . -t verbose",
     "test": "./scripts/build-wasm.sh && karma start",
     "test-bundle-size": "./scripts/test-bundle-size.js",
     "test-cc": "yarn bazel test //src/cc:cc_tests --test_output=all",
-    "test-ci": "./scripts/test-ci.sh"
+    "test-browser-ci": "karma start --singleRun --browsers=bs_chrome_mac"
   },
   "peerDependencies": {
     "@tensorflow/tfjs-core": "~1.2.7"

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -12,6 +12,7 @@
     "build-npm": "./scripts/build-npm.sh",
     "lint": "tslint -p . -t verbose",
     "test": "./scripts/build-wasm.sh && karma start",
+    "test-bundle-size": "./scripts/test-bundle-size.js",
     "test-cc": "yarn bazel test //src/cc:cc_tests --test_output=all",
     "test-ci": "./scripts/test-ci.sh"
   },

--- a/tfjs-backend-wasm/scripts/build-ci.sh
+++ b/tfjs-backend-wasm/scripts/build-ci.sh
@@ -26,6 +26,4 @@ export HOME='/root'
 source ./emsdk_env.sh
 cd ..
 
-yarn lint
 yarn build
-yarn karma start --singleRun --browsers=bs_chrome_mac

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -36,11 +36,7 @@ exec(
 
 shell.cd(dirName);
 shell.cd(wasmDirName);
-exec(`yarn`, {silent: true});
-// Try build-ci and then build-npm because build-ci doesn't exist at master
-// before this change merges.
-exec(`./scripts/build-ci.sh || ./scripts/build-npm.sh`, {silent: false});
-exec(`rollup -c`, {silent: false});
+exec(`yarn && ./scripts/build-ci.sh && yarn rollup -c`, {silent: true});
 
 const masterMinBundleSize = getFileSizeBytes(bundleFilename);
 const masterWasmSize = getFileSizeBytes(wasmFileName);

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -36,7 +36,7 @@ exec(
 
 shell.cd(dirName);
 shell.cd(wasmDirName);
-exec(`yarn && yarn build && yarn rollup -c`, {silent: false});
+exec(`yarn && ./scripts/build-ci.sh && rollup -c`, {silent: false});
 
 const masterMinBundleSize = getFileSizeBytes(bundleFilename);
 const masterWasmSize = getFileSizeBytes(wasmFileName);

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -19,7 +19,7 @@ const {exec} = require('../../scripts/test-util');
 const {showDiff, getFileSizeBytes} = require('../../scripts/bundle-size-util');
 
 // Get the bundle sizes from this change.
-exec(`yarn build-npm`, {silent: true});
+exec(`yarn rollup -c`, {silent: true});
 
 const bundleFilename = 'dist/tf-backend-wasm.min.js';
 const minBundleSize = getFileSizeBytes(bundleFilename);
@@ -36,7 +36,7 @@ exec(
 
 shell.cd(dirName);
 shell.cd(coreDirName);
-exec(`yarn && yarn build-npm`, {silent: true});
+exec(`yarn && yarn build && yarn rollup -c`, {silent: true});
 
 const masterMinBundleSize = getFileSizeBytes(bundleFilename);
 const masterWasmSize = getFileSizeBytes(wasmFileName);

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -36,7 +36,11 @@ exec(
 
 shell.cd(dirName);
 shell.cd(wasmDirName);
-exec(`yarn && ./scripts/build-ci.sh && rollup -c`, {silent: false});
+exec(`yarn`, {silent: true});
+// Try build-ci and then build-npm because build-ci doesn't exist at master
+// before this change merges.
+exec(`./scripts/build-ci.sh || ./scripts/build-npm.sh`, {silent: false});
+exec(`rollup -c`, {silent: false});
 
 const masterMinBundleSize = getFileSizeBytes(bundleFilename);
 const masterWasmSize = getFileSizeBytes(wasmFileName);

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -19,12 +19,16 @@ const {exec} = require('../../scripts/test-util');
 const {showDiff, getFileSizeBytes} = require('../../scripts/bundle-size-util');
 
 // Get the bundle sizes from this change.
-exec(`yarn rollup -c --ci`, {silent: true});
-const minSize = getFileSizeBytes('dist/tf-core.min.js');
+exec(`yarn build-npm`, {silent: true});
+
+const bundleFilename = 'dist/tf-backend-wasm.min.js';
+const minBundleSize = getFileSizeBytes(bundleFilename);
+const wasmFileName = 'dist/tfjs-backend-wasm.wasm';
+const wasmSize = getFileSizeBytes(wasmFileName);
 
 // Clone master and get the bundle size from master.
-const dirName = '/tmp/tfjs-core-bundle';
-const coreDirName = 'tfjs-core';
+const dirName = '/tmp/tfjs-backend-wasm-bundle';
+const coreDirName = 'tfjs-backend-wasm';
 exec(
     `git clone --depth=1 --single-branch ` +
         `https://github.com/tensorflow/tfjs ${dirName}`,
@@ -32,16 +36,27 @@ exec(
 
 shell.cd(dirName);
 shell.cd(coreDirName);
-exec(`yarn && yarn rollup -c --ci`, {silent: true});
+exec(`yarn && yarn build-npm`, {silent: true});
 
-const masterMinSize = getFileSizeBytes('dist/tf-core.min.js');
+const masterMinBundleSize = getFileSizeBytes(bundleFilename);
+const masterWasmSize = getFileSizeBytes(wasmFileName);
 
-console.log(`~~~~ minified bundle ~~~~`);
+console.log(`~~~~ WASM file ~~~~`);
 console.log(`==> post-gzip`)
-showDiff(minSize.gzipFileSizeBytes, masterMinSize.gzipFileSizeBytes);
+showDiff(wasmSize.gzipFileSizeBytes, masterWasmSize.gzipFileSizeBytes);
 console.log();
 console.log(`==> pre-gzip`)
-showDiff(minSize.fileSizeBytes, masterMinSize.fileSizeBytes);
+showDiff(wasmSize.fileSizeBytes, masterWasmSize.fileSizeBytes);
+console.log();
+console.log();
+
+console.log(`~~~~ minified bundle (JavaScript) ~~~~`);
+console.log(`==> post-gzip`)
+showDiff(
+    minBundleSize.gzipFileSizeBytes, masterMinBundleSize.gzipFileSizeBytes);
+console.log();
+console.log(`==> pre-gzip`)
+showDiff(minBundleSize.fileSizeBytes, masterMinBundleSize.fileSizeBytes);
 console.log();
 console.log();
 

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -28,15 +28,15 @@ const wasmSize = getFileSizeBytes(wasmFileName);
 
 // Clone master and get the bundle size from master.
 const dirName = '/tmp/tfjs-backend-wasm-bundle';
-const coreDirName = 'tfjs-backend-wasm';
+const wasmDirName = 'tfjs-backend-wasm';
 exec(
     `git clone --depth=1 --single-branch ` +
         `https://github.com/tensorflow/tfjs ${dirName}`,
     {silent: true});
 
 shell.cd(dirName);
-shell.cd(coreDirName);
-exec(`yarn && yarn build && yarn rollup -c`, {silent: true});
+shell.cd(wasmDirName);
+exec(`yarn && yarn build && yarn rollup -c`, {silent: false});
 
 const masterMinBundleSize = getFileSizeBytes(bundleFilename);
 const masterWasmSize = getFileSizeBytes(wasmFileName);

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -26,8 +26,6 @@ export HOME='/root'
 source ./emsdk_env.sh
 cd ..
 
-yarn
 yarn lint
 yarn build
-yarn test-cc
 yarn karma start --singleRun --browsers=bs_chrome_mac


### PR DESCRIPTION
Here we move some of the bundle size checking utilities from core out into the union package so we can share logic with the WASM backend.

Also this PR moves `yarn test-cc` into a separate cloud build job so that it parallelizes with the browser tests.

The bundle size output looks like this:

```
$ ./scripts/test-bundle-size.js
~~~~WASM file ~~~~
==> post-gzip
  diff:      0.00 K  (0.00%)
  master:   59.39 K
  change:   59.39 K

==> pre-gzip
  diff:      0.00 K  (0.00%)
  master:  183.49 K
  change:  183.49 K


~~~~minified bundle (JavaScript) ~~~~
==> post-gzip
  diff:      0.00 K  (0.00%)
  master:    7.58 K
  change:    7.58 K

==> pre-gzip
  diff:      0.00 K  (0.00%)
  master:   20.99 K
  change:   20.99 K
```

Today we are at 66.97K post-gzip.

As of this change the cloudbuild.yml is *disabled* for this because it relies on the new package structure. After this change I'll reenable it and fix any bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2191)
<!-- Reviewable:end -->
