### PR TITLE
Add MetaGraphInfo in tfjs-core/model_types.ts

### DIFF
--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -26,17 +26,15 @@
 
 // Engine is the global singleton that needs to be initialized before the rest
 // of the app.
-import './engine';
-// Register backend-agnostic flags.
-import './flags';
-
+// Import all kernels from cpu.
+import './backends/cpu/all_kernels';
+import './backends/cpu/backend_cpu';
 // backend_cpu.ts and backend_webgl.ts are standalone files and should be
 // explicitly included here.
 import './backends/webgl/backend_webgl';
-import './backends/cpu/backend_cpu';
-// Import all kernels from cpu.
-import './backends/cpu/all_kernels';
-
+import './engine';
+// Register backend-agnostic flags.
+import './flags';
 import './platforms/platform_browser';
 import './platforms/platform_node';
 
@@ -45,6 +43,7 @@ import * as backend_util from './backends/backend_util';
 import * as io from './io/io';
 import * as math from './math';
 import * as browser from './ops/browser';
+import * as ops from './ops/ops';
 import * as serialization from './serialization';
 import {setOpHandler} from './tensor';
 import * as tensor_util from './tensor_util';
@@ -53,38 +52,35 @@ import * as util from './util';
 import {version} from './version';
 import * as webgl from './webgl';
 
-export {InferenceModel, ModelPredictConfig} from './model_types';
+// Backend specific.
+export {BackendTimingInfo, DataMover, DataStorage, KernelBackend} from './backends/backend';
+// Top-level method exports.
+export {nextFrame} from './browser_util';
+export {MemoryInfo, TimingInfo} from './engine';
+export {env, ENV, Environment} from './environment';
+
+export * from './globals';
+export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
+export * from './kernel_registry';
+export {InferenceModel, MetaGraphInfo, ModelPredictConfig, SavedModelTensorInfo, SignatureDefInfo} from './model_types';
+export {Reduction} from './ops/loss_ops';
+export {LSTMCellFunc} from './ops/lstm';
+export * from './ops/ops';
 // Optimizers.
 export {AdadeltaOptimizer} from './optimizers/adadelta_optimizer';
 export {AdagradOptimizer} from './optimizers/adagrad_optimizer';
-export {AdamOptimizer} from './optimizers/adam_optimizer';
 export {AdamaxOptimizer} from './optimizers/adamax_optimizer';
+export {AdamOptimizer} from './optimizers/adam_optimizer';
 export {MomentumOptimizer} from './optimizers/momentum_optimizer';
 export {Optimizer} from './optimizers/optimizer';
 export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
+export {Platform} from './platforms/platform';
 export {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, variable, Variable} from './tensor';
 export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
-export {DataType, DataTypeMap, DataValues, Rank, RecursiveArray, ShapeMap, TensorLike} from './types';
-
-export * from './ops/ops';
-export {LSTMCellFunc} from './ops/lstm';
-export {Reduction} from './ops/loss_ops';
-
 export * from './train';
-export * from './globals';
-export * from './kernel_registry';
-export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
-
-export {TimingInfo, MemoryInfo} from './engine';
-export {Environment, env, ENV} from './environment';
-export {Platform} from './platforms/platform';
-
+export {DataType, DataTypeMap, DataValues, Rank, RecursiveArray, ShapeMap, TensorLike} from './types';
 export {version as version_core};
-
-// Top-level method exports.
-export {nextFrame} from './browser_util';
-
 // Second level exports.
 export {
   browser,
@@ -98,8 +94,6 @@ export {
   tensor_util
 };
 
-// Backend specific.
-export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './backends/backend';
 
-import * as ops from './ops/ops';
+
 setOpHandler(ops);

--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -26,15 +26,15 @@
 
 // Engine is the global singleton that needs to be initialized before the rest
 // of the app.
-// Import all kernels from cpu.
-import './backends/cpu/all_kernels';
-import './backends/cpu/backend_cpu';
-// backend_cpu.ts and backend_webgl.ts are standalone files and should be
-// explicitly included here.
-import './backends/webgl/backend_webgl';
 import './engine';
 // Register backend-agnostic flags.
 import './flags';
+// backend_cpu.ts and backend_webgl.ts are standalone files and should be
+// explicitly included here.
+import './backends/webgl/backend_webgl';
+import './backends/cpu/backend_cpu';
+// Import all kernels from cpu.
+import './backends/cpu/all_kernels';
 import './platforms/platform_browser';
 import './platforms/platform_node';
 
@@ -43,7 +43,6 @@ import * as backend_util from './backends/backend_util';
 import * as io from './io/io';
 import * as math from './math';
 import * as browser from './ops/browser';
-import * as ops from './ops/ops';
 import * as serialization from './serialization';
 import {setOpHandler} from './tensor';
 import * as tensor_util from './tensor_util';
@@ -52,35 +51,38 @@ import * as util from './util';
 import {version} from './version';
 import * as webgl from './webgl';
 
-// Backend specific.
-export {BackendTimingInfo, DataMover, DataStorage, KernelBackend} from './backends/backend';
-// Top-level method exports.
-export {nextFrame} from './browser_util';
-export {MemoryInfo, TimingInfo} from './engine';
-export {env, ENV, Environment} from './environment';
-
-export * from './globals';
-export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
-export * from './kernel_registry';
 export {InferenceModel, MetaGraphInfo, ModelPredictConfig, SavedModelTensorInfo, SignatureDefInfo} from './model_types';
-export {Reduction} from './ops/loss_ops';
-export {LSTMCellFunc} from './ops/lstm';
-export * from './ops/ops';
 // Optimizers.
 export {AdadeltaOptimizer} from './optimizers/adadelta_optimizer';
 export {AdagradOptimizer} from './optimizers/adagrad_optimizer';
-export {AdamaxOptimizer} from './optimizers/adamax_optimizer';
 export {AdamOptimizer} from './optimizers/adam_optimizer';
+export {AdamaxOptimizer} from './optimizers/adamax_optimizer';
 export {MomentumOptimizer} from './optimizers/momentum_optimizer';
 export {Optimizer} from './optimizers/optimizer';
 export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
-export {Platform} from './platforms/platform';
 export {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, variable, Variable} from './tensor';
 export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
-export * from './train';
 export {DataType, DataTypeMap, DataValues, Rank, RecursiveArray, ShapeMap, TensorLike} from './types';
+
+export * from './ops/ops';
+export {LSTMCellFunc} from './ops/lstm';
+export {Reduction} from './ops/loss_ops';
+
+export * from './train';
+export * from './globals';
+export * from './kernel_registry';
+export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
+
+export {TimingInfo, MemoryInfo} from './engine';
+export {Environment, env, ENV} from './environment';
+export {Platform} from './platforms/platform';
+
 export {version as version_core};
+
+// Top-level method exports.
+export {nextFrame} from './browser_util';
+
 // Second level exports.
 export {
   browser,
@@ -94,6 +96,8 @@ export {
   tensor_util
 };
 
+// Backend specific.
+export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './backends/backend';
 
-
+import * as ops from './ops/ops';
 setOpHandler(ops);

--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -29,12 +29,14 @@
 import './engine';
 // Register backend-agnostic flags.
 import './flags';
+
 // backend_cpu.ts and backend_webgl.ts are standalone files and should be
 // explicitly included here.
 import './backends/webgl/backend_webgl';
 import './backends/cpu/backend_cpu';
 // Import all kernels from cpu.
 import './backends/cpu/all_kernels';
+
 import './platforms/platform_browser';
 import './platforms/platform_node';
 

--- a/tfjs-core/src/model_types.ts
+++ b/tfjs-core/src/model_types.ts
@@ -86,3 +86,31 @@ export interface InferenceModel {
   execute(inputs: Tensor|Tensor[]|NamedTensorMap, outputs: string|string[]):
       Tensor|Tensor[];
 }
+
+/**
+ * Interface for inspected SavedModel/GraphModel MetaGraph info.
+ */
+export interface MetaGraphInfo {
+  tags: string[];
+  signatureDefs: SignatureDefInfo;
+}
+
+/**
+ * Interface for inspected SavedModel/GraphModel SignatureDef info.
+ */
+export interface SignatureDefInfo {
+  [key: string]: {
+    inputs: {[key: string]: SavedModelTensorInfo};
+    outputs: {[key: string]: SavedModelTensorInfo};
+  };
+}
+
+/**
+ * Interface for inspected SavedModel/GraphModel signature input/output Tensor
+ * info.
+ */
+export interface SavedModelTensorInfo {
+  dtype: string;
+  shape: number[];
+  name: string;
+}

--- a/tfjs-core/src/model_types.ts
+++ b/tfjs-core/src/model_types.ts
@@ -88,7 +88,7 @@ export interface InferenceModel {
 }
 
 /**
- * Interface for inspected SavedModel/GraphModel MetaGraph info.
+ * Interface for SavedModel/GraphModel MetaGraph info.
  */
 export interface MetaGraphInfo {
   tags: string[];
@@ -96,7 +96,7 @@ export interface MetaGraphInfo {
 }
 
 /**
- * Interface for inspected SavedModel/GraphModel SignatureDef info.
+ * Interface for SavedModel/GraphModel SignatureDef info.
  */
 export interface SignatureDefInfo {
   [key: string]: {
@@ -106,7 +106,7 @@ export interface SignatureDefInfo {
 }
 
 /**
- * Interface for inspected SavedModel/GraphModel signature input/output Tensor
+ * Interface for SavedModel/GraphModel signature input/output Tensor
  * info.
  */
 export interface SavedModelTensorInfo {


### PR DESCRIPTION
The same interfaces can be used to represent the information/structure of SavedModel and GraphModel(converted from SavedModel). This PR add the interface in tfjs-core, the same place where InferenceModel is defined.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2200)
<!-- Reviewable:end -->
