### PR TITLE
support int64 for dType params

### DIFF
--- a/tfjs-converter/src/operations/operation_mapper.ts
+++ b/tfjs-converter/src/operations/operation_mapper.ts
@@ -312,6 +312,7 @@ export function parseDtypeParam(value: string|tensorflow.DataType): DataType {
     case tensorflow.DataType.DT_FLOAT:
       return 'float32';
     case tensorflow.DataType.DT_INT32:
+    case tensorflow.DataType.DT_INT64:
       return 'int32';
     case tensorflow.DataType.DT_BOOL:
       return 'bool';

--- a/tfjs-converter/src/operations/operation_mapper_test.ts
+++ b/tfjs-converter/src/operations/operation_mapper_test.ts
@@ -112,9 +112,15 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
       }
     },
     {
+      name: 'Cast',
+      op: 'Cast',
+      input: ['BiasAdd'],
+      attr: {DstT: {type: tensorflow.DataType.DT_INT64}}
+    },
+    {
       name: 'Squeeze',
       op: 'Squeeze',
-      input: ['BiasAdd'],
+      input: ['Cast'],
       attr: {squeeze_dims: {list: {i: ['1', '2']}}}
     },
     {
@@ -182,7 +188,7 @@ describe('operationMapper', () => {
       it('should convert nodes', () => {
         expect(Object.keys(convertedGraph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',
-          'BiasAdd', 'Squeeze', 'Squeeze2', 'Split', 'LogicalNot',
+          'BiasAdd', 'Cast', 'Squeeze', 'Squeeze2', 'Split', 'LogicalNot',
           'FusedBatchNorm'
         ]);
       });
@@ -236,6 +242,10 @@ describe('operationMapper', () => {
       it('should map params with deprecated name', () => {
         expect(convertedGraph.nodes['Squeeze'].attrParams['axis'].value)
             .toEqual([1, 2]);
+      });
+      it('should map params with int64 dtype', () => {
+        expect(convertedGraph.nodes['Cast'].attrParams['dtype'].value)
+            .toEqual('int32');
       });
     });
   });


### PR DESCRIPTION
There are op params that are in int64 type, we should map them to int32.
 
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2201)
<!-- Reviewable:end -->
