### PR TITLE
Add slice5d and slice6d methods.

### DIFF
--- a/tfjs-core/src/ops/slice.ts
+++ b/tfjs-core/src/ops/slice.ts
@@ -16,7 +16,7 @@
  */
 
 import {ENGINE} from '../engine';
-import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, Tensor6D} from '../tensor';
+import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {Rank, TensorLike} from '../types';
 import * as util from '../util';
@@ -79,37 +79,6 @@ function slice4d_(
       $x.rank === 4,
       () =>
           `slice4d expects a rank-4 tensor, but got a rank-${$x.rank} tensor`);
-  return slice($x, begin, size);
-}
-
-/**
- * Extracts a 5D slice from a 5D array starting at coordinates `begin` and
- * is of size `size`. See `slice` for details.
- */
-function slice5d_(
-    x: Tensor5D|TensorLike, begin: [number, number, number, number, number],
-    size: [number, number, number, number, number]): Tensor5D {
-  const $x = convertToTensor(x, 'x', 'slice5d');
-  util.assert(
-      $x.rank === 5,
-      () =>
-          `slice5d expects a rank-5 tensor, but got a rank-${$x.rank} tensor`);
-  return slice($x, begin, size);
-}
-
-/**
- * Extracts a 6D slice from a 6D array starting at coordinates `begin` and
- * is of size `size`. See `slice` for details.
- */
-function slice6d_(
-    x: Tensor6D|TensorLike,
-    begin: [number, number, number, number, number, number],
-    size: [number, number, number, number, number, number]): Tensor6D {
-  const $x = convertToTensor(x, 'x', 'slice6d');
-  util.assert(
-      $x.rank === 6,
-      () =>
-          `slice6d expects a rank-6 tensor, but got a rank-${$x.rank} tensor`);
   return slice($x, begin, size);
 }
 
@@ -211,5 +180,3 @@ export const slice1d = op({slice1d_});
 export const slice2d = op({slice2d_});
 export const slice3d = op({slice3d_});
 export const slice4d = op({slice4d_});
-export const slice5d = op({slice5d_});
-export const slice6d = op({slice6d_});

--- a/tfjs-core/src/ops/slice.ts
+++ b/tfjs-core/src/ops/slice.ts
@@ -16,7 +16,7 @@
  */
 
 import {ENGINE} from '../engine';
-import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
+import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, Tensor6D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {Rank, TensorLike} from '../types';
 import * as util from '../util';
@@ -79,6 +79,37 @@ function slice4d_(
       $x.rank === 4,
       () =>
           `slice4d expects a rank-4 tensor, but got a rank-${$x.rank} tensor`);
+  return slice($x, begin, size);
+}
+
+/**
+ * Extracts a 5D slice from a 5D array starting at coordinates `begin` and
+ * is of size `size`. See `slice` for details.
+ */
+function slice5d_(
+    x: Tensor5D|TensorLike, begin: [number, number, number, number, number],
+    size: [number, number, number, number, number]): Tensor5D {
+  const $x = convertToTensor(x, 'x', 'slice5d');
+  util.assert(
+      $x.rank === 5,
+      () =>
+          `slice5d expects a rank-5 tensor, but got a rank-${$x.rank} tensor`);
+  return slice($x, begin, size);
+}
+
+/**
+ * Extracts a 6D slice from a 6D array starting at coordinates `begin` and
+ * is of size `size`. See `slice` for details.
+ */
+function slice6d_(
+    x: Tensor6D|TensorLike,
+    begin: [number, number, number, number, number, number],
+    size: [number, number, number, number, number, number]): Tensor6D {
+  const $x = convertToTensor(x, 'x', 'slice6d');
+  util.assert(
+      $x.rank === 6,
+      () =>
+          `slice6d expects a rank-6 tensor, but got a rank-${$x.rank} tensor`);
   return slice($x, begin, size);
 }
 
@@ -180,3 +211,5 @@ export const slice1d = op({slice1d_});
 export const slice2d = op({slice2d_});
 export const slice3d = op({slice3d_});
 export const slice4d = op({slice4d_});
+export const slice5d = op({slice5d_});
+export const slice6d = op({slice6d_});

--- a/tfjs-layers/src/backend/tfjs_backend.ts
+++ b/tfjs-layers/src/backend/tfjs_backend.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, Tensor5D, Tensor6D, tidy, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
+import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, Tensor5D, tidy, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
 import {checkDataFormat} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {DataFormat, Shape} from '../keras_format/common';
@@ -169,7 +169,7 @@ export function sliceAlongFirstAxis(
           size, array.shape[1], array.shape[2], array.shape[3], array.shape[4]
         ]);
       case 6:
-        return tfc.slice(array as Tensor6D, [start, 0, 0, 0, 0, 0], [
+        return tfc.slice(array, [start, 0, 0, 0, 0, 0], [
           size, array.shape[1], array.shape[2], array.shape[3], array.shape[4],
           array.shape[5]
         ]);

--- a/tfjs-layers/src/backend/tfjs_backend.ts
+++ b/tfjs-layers/src/backend/tfjs_backend.ts
@@ -13,7 +13,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, tidy, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
+import {onesLike as coreOnesLike, scalar, Tensor, Tensor1D, tensor1d, Tensor2D, Tensor3D, Tensor4D, Tensor5D, Tensor6D, tidy, where, zerosLike as coreZerosLike} from '@tensorflow/tfjs-core';
 import {checkDataFormat} from '../common';
 import {NotImplementedError, ValueError} from '../errors';
 import {DataFormat, Shape} from '../keras_format/common';
@@ -164,6 +164,15 @@ export function sliceAlongFirstAxis(
         return tfc.slice4d(
             array as Tensor4D, [start, 0, 0, 0],
             [size, array.shape[1], array.shape[2], array.shape[3]]);
+      case 5:
+        return tfc.slice(array as Tensor5D, [start, 0, 0, 0, 0], [
+          size, array.shape[1], array.shape[2], array.shape[3], array.shape[4]
+        ]);
+      case 6:
+        return tfc.slice(array as Tensor6D, [start, 0, 0, 0, 0, 0], [
+          size, array.shape[1], array.shape[2], array.shape[3], array.shape[4],
+          array.shape[5]
+        ]);
       default:
         throw new ValueError(
             `sliceAlongFirstAxis() received an unsupported tensor rank: ` +

--- a/tfjs-layers/src/backend/tfjs_backend_test.ts
+++ b/tfjs-layers/src/backend/tfjs_backend_test.ts
@@ -254,34 +254,50 @@ describeMathCPUAndGPU('batchFlatten', () => {
 
 describeMathCPUAndGPU('sliceAlongFirstAxis', () => {
   const array1DData = [10, 20, 30, 40];
-  it('1D', () => {
+  fit('1D', () => {
     const x = tensor1d(array1DData);
     expectTensorsClose(K.sliceAlongFirstAxis(x, 1, 2), tensor1d([20, 30]));
   });
 
   const array2DData = [[10, 11], [20, 21], [30, 31], [40, 41]];
-  it('2D', () => {
+  fit('2D', () => {
     const x = tensor2d(array2DData, [4, 2]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2), tensor2d([[20, 21], [30, 31]], [2, 2]));
   });
 
   const array3DData = [[[10]], [[20]], [[30]], [[40]]];
-  it('3D', () => {
+  fit('3D', () => {
     const x = tensor3d(array3DData, [4, 1, 1]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2), tensor3d([[[20]], [[30]]], [2, 1, 1]));
   });
 
   const array4DData = [[[[10]]], [[[20]]], [[[30]]], [[[40]]]];
-  it('4D', () => {
+  fit('4D', () => {
     const x = tensor4d(array4DData, [4, 1, 1, 1]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2),
         tensor4d([[[[20]]], [[[30]]]], [2, 1, 1, 1]));
   });
 
-  it('Scalar leads to error', () => {
+  const array5DData = [[[[[10]]]], [[[[20]]]], [[[[30]]]], [[[[40]]]]];
+  fit('5D', () => {
+    const x = tensor5d(array5DData, [4, 1, 1, 1, 1]);
+    expectTensorsClose(
+        K.sliceAlongFirstAxis(x, 1, 2),
+        tensor5d([[[[[20]]]], [[[[30]]]]], [2, 1, 1, 1, 1]));
+  });
+
+  const array6DData = [[[[[[10]]]]], [[[[[20]]]]], [[[[[30]]]]], [[[[[40]]]]]];
+  fit('6D', () => {
+    const x = tensor6d(array6DData, [4, 1, 1, 1, 1, 1]);
+    expectTensorsClose(
+        K.sliceAlongFirstAxis(x, 1, 2),
+        tensor6d([[[[[[20]]]]], [[[[[30]]]]]], [2, 1, 1, 1, 1, 1]));
+  });
+
+  fit('Scalar leads to error', () => {
     expect(() => {
       K.sliceAlongFirstAxis(scalar(24), 0, 1);
     }).toThrow();

--- a/tfjs-layers/src/backend/tfjs_backend_test.ts
+++ b/tfjs-layers/src/backend/tfjs_backend_test.ts
@@ -254,27 +254,27 @@ describeMathCPUAndGPU('batchFlatten', () => {
 
 describeMathCPUAndGPU('sliceAlongFirstAxis', () => {
   const array1DData = [10, 20, 30, 40];
-  fit('1D', () => {
+  it('1D', () => {
     const x = tensor1d(array1DData);
     expectTensorsClose(K.sliceAlongFirstAxis(x, 1, 2), tensor1d([20, 30]));
   });
 
   const array2DData = [[10, 11], [20, 21], [30, 31], [40, 41]];
-  fit('2D', () => {
+  it('2D', () => {
     const x = tensor2d(array2DData, [4, 2]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2), tensor2d([[20, 21], [30, 31]], [2, 2]));
   });
 
   const array3DData = [[[10]], [[20]], [[30]], [[40]]];
-  fit('3D', () => {
+  it('3D', () => {
     const x = tensor3d(array3DData, [4, 1, 1]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2), tensor3d([[[20]], [[30]]], [2, 1, 1]));
   });
 
   const array4DData = [[[[10]]], [[[20]]], [[[30]]], [[[40]]]];
-  fit('4D', () => {
+  it('4D', () => {
     const x = tensor4d(array4DData, [4, 1, 1, 1]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2),
@@ -282,7 +282,7 @@ describeMathCPUAndGPU('sliceAlongFirstAxis', () => {
   });
 
   const array5DData = [[[[[10]]]], [[[[20]]]], [[[[30]]]], [[[[40]]]]];
-  fit('5D', () => {
+  it('5D', () => {
     const x = tensor5d(array5DData, [4, 1, 1, 1, 1]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2),
@@ -290,14 +290,14 @@ describeMathCPUAndGPU('sliceAlongFirstAxis', () => {
   });
 
   const array6DData = [[[[[[10]]]]], [[[[[20]]]]], [[[[[30]]]]], [[[[[40]]]]]];
-  fit('6D', () => {
+  it('6D', () => {
     const x = tensor6d(array6DData, [4, 1, 1, 1, 1, 1]);
     expectTensorsClose(
         K.sliceAlongFirstAxis(x, 1, 2),
         tensor6d([[[[[[20]]]]], [[[[[30]]]]]], [2, 1, 1, 1, 1, 1]));
   });
 
-  fit('Scalar leads to error', () => {
+  it('Scalar leads to error', () => {
     expect(() => {
       K.sliceAlongFirstAxis(scalar(24), 0, 1);
     }).toThrow();


### PR DESCRIPTION
This fixes https://github.com/tensorflow/tfjs/issues/1985

#### Changes
- Add support for 5D / 6D tensors to `sliceAlongFirstAxis`

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2206)
<!-- Reviewable:end -->
