### PR TITLE
[WASM] Selectively link XNNPACK operators

### DIFF
--- a/tfjs-backend-wasm/WORKSPACE
+++ b/tfjs-backend-wasm/WORKSPACE
@@ -8,7 +8,7 @@ emsdk_configure(name = "emsdk")
 
 git_repository(
   name = "xnnpack",
-  commit = "0c57d2a08ca62c3020a2acdb4acfe825ed2b2657",
+  commit = "f6839e1355032ee6c78833e1693876d4cdb01436",
   remote = "https://github.com/google/XNNPACK.git",
 )
 

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -35,7 +35,7 @@ tfjs_cc_library(
   hdrs = ["backend.h"],
   deps = [
     ":util",
-    "@xnnpack//:XNNPACK",
+    "@xnnpack//:xnnpack_operators_nhwc_f32",
   ],
 )
 


### PR DESCRIPTION
Link with `:xnnpack_operators_nhwc_f32` target which includes only FP32
operators in NHWC layout. This removes global references to quantized
and SpNCHW micro-kernels, and lets the linker remove them from the WAsm
binary. This modification reduce the size of tfjs-backend-wasm.wasm by
18% (58KB->49KB).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2213)
<!-- Reviewable:end -->
