### PR TITLE
cast the condition param of Where op to bool type

### DIFF
--- a/tfjs-converter/src/operations/executors/dynamic_executor.ts
+++ b/tfjs-converter/src/operations/executors/dynamic_executor.ts
@@ -44,7 +44,8 @@ export async function executeOp(
     }
     case 'Where': {
       return [await tfc.whereAsync(
-          getParamValue('condition', node, tensorMap, context) as tfc.Tensor)];
+          (getParamValue('condition', node, tensorMap, context) as tfc.Tensor)
+              .asType('bool'))];
     }
     case 'ListDiff': {
       return tfc.setdiff1dAsync(

--- a/tfjs-converter/src/operations/executors/dynamic_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/dynamic_executor_test.ts
@@ -117,7 +117,13 @@ describe('dynamic', () => {
         spyOn(tfc, 'whereAsync').and.callThrough();
 
         const result = executeOp(node, {input1}, context);
-        expect(tfc.whereAsync).toHaveBeenCalledWith(input1[0]);
+        expect((tfc.whereAsync as jasmine.Spy).calls.mostRecent().args[0].dtype)
+            .toEqual('bool');
+        expect((tfc.whereAsync as jasmine.Spy)
+                   .calls.mostRecent()
+                   .args[0]
+                   .arraySync())
+            .toEqual(1);
         expect(result instanceof Promise).toBeTruthy();
       });
       it('should match json def', () => {


### PR DESCRIPTION
tfjs where op requires the condition param to be of bool type, while TF does not have this requirement.
Cast the type for condition param to ensure compatibility.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2214)
<!-- Reviewable:end -->
