### PR TITLE
[tfjs-core] Rename TensorInfo interface to ModelTensorInfo

### DIFF
--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -53,7 +53,7 @@ import * as util from './util';
 import {version} from './version';
 import * as webgl from './webgl';
 
-export {InferenceModel, MetaGraphInfo, ModelPredictConfig, SavedModelTensorInfo, SignatureDefInfo} from './model_types';
+export {InferenceModel, MetaGraphInfo, ModelPredictConfig, ModelTensorInfo, SavedModelTensorInfo, SignatureDefInfo} from './model_types';
 // Optimizers.
 export {AdadeltaOptimizer} from './optimizers/adadelta_optimizer';
 export {AdagradOptimizer} from './optimizers/adagrad_optimizer';
@@ -64,7 +64,7 @@ export {Optimizer} from './optimizers/optimizer';
 export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
 export {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, Variable} from './tensor';
-export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject, TensorInfo} from './tensor_types';
+export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
 export {DataType, DataTypeMap, DataValues, Rank, RecursiveArray, ShapeMap, TensorLike} from './types';
 
 export * from './ops/ops';

--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -64,7 +64,7 @@ export {Optimizer} from './optimizers/optimizer';
 export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
 export {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, Variable} from './tensor';
-export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
+export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject, TensorInfo} from './tensor_types';
 export {DataType, DataTypeMap, DataValues, Rank, RecursiveArray, ShapeMap, TensorLike} from './types';
 
 export * from './ops/ops';

--- a/tfjs-core/src/model_types.ts
+++ b/tfjs-core/src/model_types.ts
@@ -16,7 +16,8 @@
  */
 
 import {Tensor} from './tensor';
-import {NamedTensorMap, TensorInfo} from './tensor_types';
+import {NamedTensorMap} from './tensor_types';
+import {DataType} from './types';
 
 export interface ModelPredictConfig {
   /**
@@ -31,18 +32,30 @@ export interface ModelPredictConfig {
 }
 
 /**
+ * Interface for model input/output tensor info.
+ */
+export interface ModelTensorInfo {
+  // Name of the tensor.
+  name: string;
+  // Tensor shape information, Optional.
+  shape?: number[];
+  // Data type of the tensor.
+  dtype: DataType;
+}
+
+/**
  * Common interface for a machine learning model that can do inference.
  */
 export interface InferenceModel {
   /**
    * Return the array of input tensor info.
    */
-  readonly inputs: TensorInfo[];
+  readonly inputs: ModelTensorInfo[];
 
   /**
    * Return the array of output tensor info.
    */
-  readonly outputs: TensorInfo[];
+  readonly outputs: ModelTensorInfo[];
 
   /**
    * Execute the inference for the input tensors.

--- a/tfjs-core/src/tensor_types.ts
+++ b/tfjs-core/src/tensor_types.ts
@@ -16,7 +16,6 @@
  */
 
 import {Tensor, Variable} from './tensor';
-import {DataType} from './types';
 
 /** @docalias {[name: string]: Tensor} */
 export type NamedTensorMap = {

--- a/tfjs-core/src/tensor_types.ts
+++ b/tfjs-core/src/tensor_types.ts
@@ -45,12 +45,3 @@ export interface TensorContainerObject {
   [x: string]: TensorContainer;
 }
 export interface TensorContainerArray extends Array<TensorContainer> {}
-
-export interface TensorInfo {
-  // Name of the tensor.
-  name: string;
-  // Tensor shape information, Optional.
-  shape?: number[];
-  // Data type of the tensor.
-  dtype: DataType;
-}


### PR DESCRIPTION
Rename interface `TensorInfo` to `ModelTensorInfo` and move it from [tensor_types.ts](https://github.com/tensorflow/tfjs/blob/03cb7434f116c6a7263602def4c56cb803b16333/tfjs-core/src/tensor_types.ts#L49) to `model_types.ts`. 

This is because:
1. it is only used by `InferenceModel`
2. it needs to be exported
3. rename it so it is not conflict with `TensorInfo` in `kernel_registry.ts`

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2218)
<!-- Reviewable:end -->
