### PR TITLE
webgpu: Add conv2dByMatMul

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -617,8 +617,37 @@ export class WebGPUBackend extends KernelBackend {
     return this.binaryCompareOp(a, b, binary_op.GREATER_EQUAL);
   }
 
+  private conv2dByMatMul(
+      x: Tensor4D, filter: Tensor4D,
+      convInfo: backend_util.Conv2DInfo): Tensor4D {
+    const xShape = x.shape;
+    const isChannelsLast = convInfo.dataFormat === 'channelsLast';
+    const transposeA = false;
+    const transposeB = false;
+
+    const targetShape = isChannelsLast ? xShape[0] * xShape[1] * xShape[2] :
+                                         xShape[0] * xShape[2] * xShape[3];
+    const xReshaped = this.reshape(x, [1, targetShape, convInfo.inChannels]);
+    const filterReshaped =
+        this.reshape(filter, [1, convInfo.inChannels, convInfo.outChannels]);
+
+    return this.reshape(
+        this.batchMatMul(
+            xReshaped as Tensor3D, filterReshaped as Tensor3D, transposeA,
+            transposeB),
+        convInfo.outShape);
+  }
+
   conv2d(x: Tensor4D, filter: Tensor4D, convInfo: backend_util.Conv2DInfo):
       Tensor4D {
+    if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
+        convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
+        convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
+        (convInfo.padInfo.type === 'SAME' ||
+         convInfo.padInfo.type === 'VALID')) {
+      return this.conv2dByMatMul(x, filter, convInfo);
+    }
+
     const output = Tensor.make(convInfo.outShape, {}, x.dtype, this);
     let program: Conv2DMMProgram|Conv2DNaiveProgram;
 

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
@@ -133,7 +133,7 @@ export class MatMulPackedProgram implements WebGPUProgram {
         `coordsInBounds(ivec2(row, col), ivec2(dimInner, dimBOuter)) ?
           B[row * dimBOuter + col] : 0`;
 
-    this.dispatchLayout = {x: [1], y: [2], z: [0]};
+    this.dispatchLayout = {x: [2], y: [1], z: [0]};
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [workPerThread, workPerThread, 1]);

--- a/tfjs-backend-webgpu/src/kernels/matmul_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_webgpu.ts
@@ -81,7 +81,7 @@ export class MatMulProgram implements WebGPUProgram {
   ]) {
     const bShape = [outputShape[0], aShape[2], outputShape[2]];
     this.outputShape = outputShape;
-    this.dispatchLayout = {x: [1], y: [2], z: [0]};
+    this.dispatchLayout = {x: [2], y: [1], z: [0]};
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 

--- a/tfjs-backend-webgpu/src/kernels/maxpool_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/maxpool_webgpu.ts
@@ -33,7 +33,7 @@ export class MaxPoolProgram implements WebGPUProgram {
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;
 
-    this.dispatchLayout = {x: [1], y: [2], z: [0, 3]};
+    this.dispatchLayout = {x: [2], y: [1], z: [0, 3]};
 
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);

--- a/tfjs-backend-webgpu/src/kernels/resize_bilinear_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/resize_bilinear_webgpu.ts
@@ -32,7 +32,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
       newWidth: number, alignCorners: boolean) {
     this.outputShape = [inputShape[0], newHeight, newWidth, inputShape[3]];
 
-    this.dispatchLayout = {x: [1], y: [2], z: [0, 3]};
+    this.dispatchLayout = {x: [2], y: [1], z: [0, 3]};
 
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);


### PR DESCRIPTION
PERF

With this change, the PoseNet demo increases 1 fps.

Meanwhile, this patch unifies the behavior between
dispatchLayout and dispatch thread identification values.
y -> column
x -> row

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2242)
<!-- Reviewable:end -->
