### PR TITLE
[Core] Remove `save` from kernels

### DIFF
--- a/tfjs-core/src/backends/cpu/square.ts
+++ b/tfjs-core/src/backends/cpu/square.ts
@@ -26,13 +26,10 @@ interface SquareInputs {
 registerKernel({
   kernelName: 'Square',
   backendName: 'cpu',
-  kernelFunc: ({inputs, backend, save}) => {
+  kernelFunc: ({inputs, backend}) => {
     const {x} = inputs as {} as SquareInputs;
     const cpuBackend = backend as MathBackendCPU;
     assertNotComplex(x, 'square');
-
-    // Save it for the gradient.
-    save([x]);
 
     const values = cpuBackend.data.get(x.dataId).values as Float32Array;
     const newValues = new Float32Array(values.length);

--- a/tfjs-core/src/backends/cpu/square.ts
+++ b/tfjs-core/src/backends/cpu/square.ts
@@ -15,11 +15,12 @@
  * =============================================================================
  */
 
-import {registerKernel, TensorInfo} from '../../kernel_registry';
+import {NamedTensorInfoMap, registerKernel, TensorInfo} from '../../kernel_registry';
+
 import {MathBackendCPU} from './backend_cpu';
 import {assertNotComplex} from './cpu_util';
 
-interface SquareInputs {
+interface SquareInputs extends NamedTensorInfoMap {
   x: TensorInfo;
 }
 
@@ -27,7 +28,7 @@ registerKernel({
   kernelName: 'Square',
   backendName: 'cpu',
   kernelFunc: ({inputs, backend}) => {
-    const {x} = inputs as {} as SquareInputs;
+    const {x} = inputs as SquareInputs;
     const cpuBackend = backend as MathBackendCPU;
     assertNotComplex(x, 'square');
 

--- a/tfjs-core/src/backends/webgl/square.ts
+++ b/tfjs-core/src/backends/webgl/square.ts
@@ -26,12 +26,9 @@ interface SquareInputs {
 registerKernel({
   kernelName: 'Square',
   backendName: 'webgl',
-  kernelFunc: ({inputs, backend, save}) => {
+  kernelFunc: ({inputs, backend}) => {
     const {x} = inputs as {} as SquareInputs;
     const webglBackend = backend as MathBackendWebGL;
-
-    // Save it for the gradient.
-    save([x]);
     const program = new UnaryOpProgram(x.shape, SQUARE);
     return webglBackend.runWebGLProgram(program, [x], x.dtype);
   }

--- a/tfjs-core/src/backends/webgl/square.ts
+++ b/tfjs-core/src/backends/webgl/square.ts
@@ -15,11 +15,12 @@
  * =============================================================================
  */
 
-import {registerKernel, TensorInfo} from '../../kernel_registry';
+import {NamedTensorInfoMap, registerKernel, TensorInfo} from '../../kernel_registry';
+
 import {MathBackendWebGL} from './backend_webgl';
 import {SQUARE, UnaryOpProgram} from './unaryop_gpu';
 
-interface SquareInputs {
+interface SquareInputs extends NamedTensorInfoMap {
   x: TensorInfo;
 }
 
@@ -27,7 +28,7 @@ registerKernel({
   kernelName: 'Square',
   backendName: 'webgl',
   kernelFunc: ({inputs, backend}) => {
-    const {x} = inputs as {} as SquareInputs;
+    const {x} = inputs as SquareInputs;
     const webglBackend = backend as MathBackendWebGL;
     const program = new UnaryOpProgram(x.shape, SQUARE);
     return webglBackend.runWebGLProgram(program, [x], x.dtype);

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -478,7 +478,8 @@ export class Engine implements TensorTracker, DataMover {
    * @param inputsToSave A list of tensors, inputs to save for the backprop
    *     computation.
    * @param outputsToSave A list of booleans, specifying which output to save
-   *     for the backprop computation.
+   *     for the backprop computation. These are booleans since the output
+   * tensors are not visible to the user.
    */
   runKernel(
       kernelName: string, inputs: NamedTensorMap, attrs: NamedAttrMap,
@@ -533,11 +534,8 @@ export class Engine implements TensorTracker, DataMover {
   runKernelFunc<T extends Tensor|Tensor[], I extends NamedTensorMap>(
       forwardFunc: ForwardFunc<T>, inputs: I,
       backwardsFunc?: (dy: T, saved: Tensor[]) => {[P in keyof I]: () => I[P]},
-      kernelName?: string, attrs?: NamedAttrMap, inputsToSave?: Tensor[],
-      outputsToSave?: boolean[]): T {
-    inputsToSave = inputsToSave || [];
-    outputsToSave = outputsToSave || [];
-
+      kernelName?: string, attrs?: NamedAttrMap, inputsToSave: Tensor[] = [],
+      outputsToSave: boolean[] = []): T {
     let outputs: Tensor[];
     let saved: Tensor[] = [];
     const isTapeOn = this.isTapeOn();

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -469,12 +469,16 @@ export class Engine implements TensorTracker, DataMover {
   }
 
   /**
-   * Execute a kernel with the given name and return the output tensor info.
+   * Execute a kernel with the given name and return the output tensor.
    *
    * @param kernelName The name of the kernel to execute.
-   * @param inputs A map of input names to tensor infos.
+   * @param inputs A map of input names to tensors.
    * @param attrs A map of attribute names to their values. An attribute is a
    *     primitive (non-tensor) input to the kernel.
+   * @param inputsToSave A list of tensors, inputs to save for the backprop
+   *     computation.
+   * @param outputsToSave A list of booleans, specifying which output to save
+   *     for the backprop computation.
    */
   runKernel(
       kernelName: string, inputs: NamedTensorMap, attrs: NamedAttrMap,

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -19,8 +19,6 @@ import {DataType} from './types';
 
 const kernelRegistry: Map<string, KernelConfig> = new Map();
 
-export type GradSaveFunc = (save: DataId[]) => void;
-
 export type DataId = object;
 
 /** These are extra non-tensor/primitive params passed to kernel functions. */
@@ -31,7 +29,6 @@ export type KernelFunc = (params: {
   inputs: NamedTensorInfoMap,
   backend: {},
   attrs?: NamedAttrMap,
-  save?: GradSaveFunc
 }) => TensorInfo|TensorInfo[];
 
 /** Function that gets called after the backend initializes. */

--- a/tfjs-core/src/ops/square.ts
+++ b/tfjs-core/src/ops/square.ts
@@ -41,10 +41,12 @@ function square_<T extends Tensor>(x: T|TensorLike): T {
   };
   const kernelName = 'Square';
   const attrs = {};
+  const inputsToSave = [$x];
+  const outputsToSave: boolean[] = [];
   return ENGINE.runKernelFunc((backend, save) => {
     save([$x]);
     return backend.square($x);
-  }, {x: $x}, grad, kernelName, attrs);
+  }, {x: $x}, grad, kernelName, attrs, inputsToSave, outputsToSave);
 }
 
 export const square = op({square_});


### PR DESCRIPTION
Modular kernels shouldn't deal with saving results for back-prop since back-prop is backend-agnostic operation and should happen in the logical op.

We generalize `runKernel()` to take `inputsToKeep: Tensor[]` and `outputsToKeep: boolean[]` as optional args which get passed to `runKernelFunc()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2248)
<!-- Reviewable:end -->
