### PR TITLE
Update the gl.canvas type to include OffscreenCanvas to prep for ts3.6

### DIFF
--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -2687,7 +2687,9 @@ export class MathBackendWebGL extends KernelBackend {
       return;
     }
     this.textureManager.dispose();
-    if (this.canvas != null && this.canvas instanceof HTMLCanvasElement) {
+    if (this.canvas != null &&
+        (typeof (HTMLCanvasElement) !== 'undefined' &&
+         this.canvas instanceof HTMLCanvasElement)) {
       this.canvas.remove();
     } else {
       this.canvas = null;

--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -231,7 +231,7 @@ export class MathBackendWebGL extends KernelBackend {
   private dataRefCount = new WeakMap<DataId, number>();
   private numBytesInGPU = 0;
 
-  private canvas: HTMLCanvasElement;
+  private canvas: HTMLCanvasElement|OffscreenCanvas;
   private fromPixels2DContext: CanvasRenderingContext2D|
       OffscreenCanvasRenderingContext2D;
 
@@ -2687,7 +2687,7 @@ export class MathBackendWebGL extends KernelBackend {
       return;
     }
     this.textureManager.dispose();
-    if (this.canvas != null && this.canvas.remove != null) {
+    if (this.canvas != null && this.canvas instanceof HTMLCanvasElement) {
       this.canvas.remove();
     } else {
       this.canvas = null;


### PR DESCRIPTION
There are still build failures in 3.6 because WebGLRenderingContext2 is included in the 3.6 types but we import a third_party package for this type.

Because we can't yet upgrade to 3.6 for real (google internal compiler isn't there yet) we just do this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2250)
<!-- Reviewable:end -->
