### PR TITLE
replace the weights node name with scaled weights node

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms.py
@@ -201,8 +201,8 @@ def fold_batch_norms(input_graph_def):
             scaled_weights, weights.dtype.type, weights.shape)))
     # Replace the weights node with scaled weights node
     for i, weights_node in enumerate(conv_op.input):
-          if weights_node == weights_op.name:
-            conv_op.input[i] = scaled_weights_op.name
+      if weights_node == weights_op.name:
+        conv_op.input[i] = scaled_weights_op.name
 
     new_conv_op = node_def_pb2.NodeDef()
     new_conv_op.CopyFrom(conv_op)

--- a/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms.py
@@ -194,11 +194,16 @@ def fold_batch_norms(input_graph_def):
         it.iternext()
     scaled_weights_op = node_def_pb2.NodeDef()
     scaled_weights_op.op = "Const"
-    scaled_weights_op.name = weights_op.name
+    scaled_weights_op.name = conv_op.name + '_weights'
     scaled_weights_op.attr["dtype"].CopyFrom(weights_op.attr["dtype"])
     scaled_weights_op.attr["value"].CopyFrom(
         attr_value_pb2.AttrValue(tensor=tensor_util.make_tensor_proto(
             scaled_weights, weights.dtype.type, weights.shape)))
+    # Replace the weights node with scaled weights node
+    for i, weights_node in enumerate(conv_op.input):
+          if weights_node == weights_op.name:
+            conv_op.input[i] = scaled_weights_op.name
+
     new_conv_op = node_def_pb2.NodeDef()
     new_conv_op.CopyFrom(conv_op)
     offset_op = node_def_pb2.NodeDef()

--- a/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms_test.py
@@ -210,7 +210,7 @@ def _generate_fused_batchnorm(data_format, conv2d_func, count=1):
   gamma_op = constant_op.constant(
       np.array([1.0, 2.0]), shape=[2], dtype=dtypes.float32)
   ops.get_default_graph().graph_def_versions.producer = 9
-  for x in range(count):
+  for _ in range(count):
     conv_op = conv2d_func(
         input_op,
         weights_op, [1, 1, 1, 1],

--- a/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms_test.py
@@ -148,44 +148,7 @@ class FoldBatchNormsTest(tf.test.TestCase):
         ("NCHW", nn_ops.depthwise_conv2d_native)
     ]:
       with tf.compat.v1.Session() as sess:
-        inputs = [1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6]
-        input_op = constant_op.constant(
-            np.array(inputs),
-            shape=[1, 1, 6, 2] if data_format == "NHWC" else [1, 2, 1, 6],
-            dtype=dtypes.float32)
-        if conv2d_func == nn_ops.conv2d:
-          weights = [1, 2, 3, 4, 0.1, 0.2, 0.3, 0.4]
-          weights_op = constant_op.constant(
-              np.array(weights), shape=[1, 2, 2, 2], dtype=dtypes.float32)
-        else:
-          weights = [1, 2, 0.3, 0.4]
-          weights_op = constant_op.constant(
-              np.array(weights), shape=[1, 2, 2, 1], dtype=dtypes.float32)
-        conv_op = conv2d_func(
-            input_op,
-            weights_op, [1, 1, 1, 1],
-            padding="SAME",
-            data_format=data_format,
-            name="conv_op")
-        mean_op = constant_op.constant(
-            np.array([10, 20]), shape=[2], dtype=dtypes.float32)
-        variance_op = constant_op.constant(
-            np.array([0.25, 0.5]), shape=[2], dtype=dtypes.float32)
-        beta_op = constant_op.constant(
-            np.array([0.1, 0.6]), shape=[2], dtype=dtypes.float32)
-        gamma_op = constant_op.constant(
-            np.array([1.0, 2.0]), shape=[2], dtype=dtypes.float32)
-        ops.get_default_graph().graph_def_versions.producer = 9
-        gen_nn_ops.fused_batch_norm_v3(
-            conv_op,
-            gamma_op,
-            beta_op,
-            mean_op,
-            variance_op,
-            0.00001,
-            is_training=False,
-            data_format=data_format,
-            name="output")
+        _generate_fused_batchnorm(data_format, conv2d_func)
         original_graph_def = sess.graph_def
         original_result = sess.run(["output:0"])
       optimized_graph_def = fold_batch_norms.fold_batch_norms(
@@ -200,5 +163,69 @@ class FoldBatchNormsTest(tf.test.TestCase):
 
       for node in optimized_graph_def.node:
         self.assertNotEqual("FusedBatchNormV3", node.op)
+
+  def testFoldFusedBatchNormsWithSharedWeights(self):
+    for data_format, conv2d_func in [
+        ("NHWC", nn_ops.conv2d), ("NCHW", nn_ops.conv2d),
+        ("NHWC", nn_ops.depthwise_conv2d_native),
+        ("NCHW", nn_ops.depthwise_conv2d_native)
+    ]:
+      with tf.compat.v1.Session() as sess:
+        _generate_fused_batchnorm(data_format, conv2d_func, 2)
+        original_graph_def = sess.graph_def
+        original_result = sess.run(["output:0"])
+      optimized_graph_def = fold_batch_norms.fold_batch_norms(
+          original_graph_def)
+    with tf.compat.v1.Session() as sess:
+      _ = importer.import_graph_def(
+          optimized_graph_def, input_map={}, name="optimized")
+      optimized_result = sess.run(["optimized/output:0"])
+
+      self.assertAllClose(
+          original_result, optimized_result, rtol=1e-04, atol=1e-06)
+
+      for node in optimized_graph_def.node:
+        self.assertNotEqual("FusedBatchNormV3", node.op)
+
+def _generate_fused_batchnorm(data_format, conv2d_func, count=1):
+  inputs = [1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6]
+  input_op = constant_op.constant(
+      np.array(inputs),
+      shape=[1, 1, 6, 2] if data_format == "NHWC" else [1, 2, 1, 6],
+      dtype=dtypes.float32)
+  if conv2d_func == nn_ops.conv2d:
+    weights = [1, 2, 3, 4, 0.1, 0.2, 0.3, 0.4]
+    weights_op = constant_op.constant(
+        np.array(weights), shape=[1, 2, 2, 2], dtype=dtypes.float32)
+  else:
+    weights = [1, 2, 0.3, 0.4]
+    weights_op = constant_op.constant(
+        np.array(weights), shape=[1, 2, 2, 1], dtype=dtypes.float32)
+  mean_op = constant_op.constant(
+      np.array([10, 20]), shape=[2], dtype=dtypes.float32)
+  variance_op = constant_op.constant(
+      np.array([0.25, 0.5]), shape=[2], dtype=dtypes.float32)
+  beta_op = constant_op.constant(
+      np.array([0.1, 0.6]), shape=[2], dtype=dtypes.float32)
+  gamma_op = constant_op.constant(
+      np.array([1.0, 2.0]), shape=[2], dtype=dtypes.float32)
+  ops.get_default_graph().graph_def_versions.producer = 9
+  for x in range(count):
+    conv_op = conv2d_func(
+        input_op,
+        weights_op, [1, 1, 1, 1],
+        padding="SAME",
+        data_format=data_format,
+        name="conv_op")
+    gen_nn_ops.fused_batch_norm_v3(
+        conv_op,
+        gamma_op,
+        beta_op,
+        mean_op,
+        variance_op,
+        0.00001,
+        is_training=False,
+        data_format=data_format,
+        name="output")
 if __name__ == '__main__':
   tf.test.main()

--- a/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion.py
@@ -26,9 +26,9 @@ import json
 import os
 import tempfile
 
+import six
 import h5py
 import numpy as np
-import six
 
 from tensorflowjs import write_weights  # pylint: disable=import-error
 from tensorflowjs.converters import common


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/2055

When the batchnorm ops share the same weights, the scaled weights calculated by batchnorm folding will generate duplicated nodes.
This fix uses the conv2d op node name as the base to avoid the duplication.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2284)
<!-- Reviewable:end -->
