### PR TITLE
[Core] Fix bug with WEBGL_PACK=false and uploading packed tensor

### DIFF
--- a/tfjs-core/src/backends/webgl/webgl_ops_test.ts
+++ b/tfjs-core/src/backends/webgl/webgl_ops_test.ts
@@ -741,7 +741,6 @@ describeWithFlags('slice a packed texture', WEBGL_ENVS, () => {
   });
 });
 
-// TODO(annyuan, smilkov) Make this test pass for WEBGL_PACK=false.
 describeWithFlags('pointwise conv2d packed', WEBGL_ENVS, () => {
   beforeAll(() => {
     tf.env().set('WEBGL_SIZE_UPLOAD_UNIFORM', 0);


### PR DESCRIPTION
Fix a bug with WEBGL_PACK=false and uploading packed tensor. Also fix a bug in how we count data ids in the backend. This makes all but 1 test to pass with WEBGL_PACK false.

Since I'm out of battery, will address the remaining unit test in another PR where I will enable WEBGL_PACK false for CI testing. The remaining test is NOT critical - it is related to debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2291)
<!-- Reviewable:end -->
