### PR TITLE
[Core] Test WEBGL_PACK=false on CI

### DIFF
--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -29,7 +29,8 @@ yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1 --flag
 npm-run-all -p -c --aggregate-output \
   "run-browserstack --browsers=bs_safari_mac,bs_ios_11,bs_android_9 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu" \
   "run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac" \
-  "run-browserstack --browsers=bs_chrome_mac,win_10_chrome,bs_android_9 --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'"
+  "run-browserstack --browsers=bs_chrome_mac,win_10_chrome,bs_android_9 --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
+  "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_PACK\": false}'" \
 
 ### The next section tests TF.js in a webworker.
 # Make a dist/tf-core.min.js file to be imported by the web worker.


### PR DESCRIPTION
Significantly increase test coverage for our WebGL backend by testing the `WEBGL_PACK=false` condition on browserstack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2294)
<!-- Reviewable:end -->
