### PR TITLE
[WASM] Support multiple dispose callback functions for the same tensor id.

### DIFF
--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -40,7 +40,7 @@ steps:
   secretEnv: ['BROWSERSTACK_KEY']
 
 # Run C++ tests.
-- name: 'node:10'
+- name: 'node:12'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-cc'

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -40,7 +40,7 @@ steps:
   secretEnv: ['BROWSERSTACK_KEY']
 
 # Run C++ tests.
-- name: 'node:12'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-cc'

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint -p . -t verbose && yarn cpplint",
     "test": "./scripts/build-wasm.sh && karma start",
     "test-bundle-size": "./scripts/test-bundle-size.js",
-    "test-cc": "yarn bazel test //src/cc:cc_tests --test_output=all",
+    "test-cc": "bazel test //src/cc:cc_tests --test_output=all",
     "test-browser-ci": "karma start --singleRun --browsers=bs_chrome_mac"
   },
   "peerDependencies": {

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -48,7 +48,7 @@ void register_disposal_callback(int tensor_id, DisposeFunction dispose_fn) {
     // We move callbacks to avoid a copy.
     disposal_callbacks.insert({tensor_id, std::move(callbacks)});
   } else {
-    std::vector<DisposeFunction> &callbacks = disposal_callbacks.at(tensor_id);
+    std::vector<DisposeFunction> &callbacks = disposal_callbacks[tensor_id];
     callbacks.push_back(dispose_fn);
   }
 }

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -43,15 +43,14 @@ int xnn_operator_count = 0;
 
 // Registers a disposal callback for a tensor id with a given callback function.
 void register_disposal_callback(int tensor_id, DisposeFunction dispose_fn) {
-  std::vector<DisposeFunction> callbacks;
   if (disposal_callbacks.count(tensor_id) == 0) {
-    callbacks = std::vector<DisposeFunction>{dispose_fn};
+    auto callbacks = std::vector<DisposeFunction>{dispose_fn};
+    // We move callbacks to avoid a copy.
+    disposal_callbacks.insert({tensor_id, std::move(callbacks)});
   } else {
-    callbacks = disposal_callbacks[tensor_id];
+    std::vector<DisposeFunction> &callbacks = disposal_callbacks.at(tensor_id);
     callbacks.push_back(dispose_fn);
   }
-  // We move callbacks to avoid another copy.
-  disposal_callbacks[tensor_id] = std::move(callbacks);
 }
 
 int num_tensors() { return data.size(); }

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -43,14 +43,15 @@ int xnn_operator_count = 0;
 
 // Registers a disposal callback for a tensor id with a given callback function.
 void register_disposal_callback(int tensor_id, DisposeFunction dispose_fn) {
+  std::vector<DisposeFunction> callbacks;
   if (disposal_callbacks.count(tensor_id) == 0) {
-    auto callbacks = std::vector<DisposeFunction>{dispose_fn};
-    // We move callbacks to avoid a copy.
-    disposal_callbacks.insert({tensor_id, std::move(callbacks)});
+    callbacks = std::vector<DisposeFunction>{dispose_fn};
   } else {
-    auto callbacks = disposal_callbacks.at(tensor_id);
+    callbacks = disposal_callbacks[tensor_id];
     callbacks.push_back(dispose_fn);
   }
+  // We move callbacks to avoid another copy.
+  disposal_callbacks[tensor_id] = std::move(callbacks);
 }
 
 int num_tensors() { return data.size(); }

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -71,10 +71,8 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void register_tensor(int tensor_id, int size, void *memory_offset) {
   TensorInfo info = {memory_offset, size};
-  // // We move info to avoid a copy.
-  // data.emplace(tensor_id, std::move(info));
-  data.insert({tensor_id, std::move(info)});
-  // data[tensor_id] = {memory_offset, size};
+  // We move info to avoid a copy.
+  data.emplace(tensor_id, std::move(info));
 }
 
 #ifdef __EMSCRIPTEN__

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -37,7 +37,7 @@ std::unordered_map<int, std::vector<tfjs::backend::DisposeFunction>>
 
 namespace tfjs {
 namespace backend {
-TensorInfo &get_tensor_info(int tensor_id) { return data.at(tensor_id); }
+const TensorInfo &get_tensor_info(int tensor_id) { return data.at(tensor_id); }
 
 int xnn_operator_count = 0;
 
@@ -48,7 +48,7 @@ void register_disposal_callback(int tensor_id, DisposeFunction dispose_fn) {
     // We move callbacks to avoid a copy.
     disposal_callbacks.insert({tensor_id, std::move(callbacks)});
   } else {
-    std::vector<DisposeFunction> &callbacks = disposal_callbacks[tensor_id];
+    auto &callbacks = disposal_callbacks[tensor_id];
     callbacks.push_back(dispose_fn);
   }
 }

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -71,8 +71,10 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void register_tensor(int tensor_id, int size, void *memory_offset) {
   TensorInfo info = {memory_offset, size};
-  // We move info to avoid a copy.
+  // // We move info to avoid a copy.
+  // data.emplace(tensor_id, std::move(info));
   data.insert({tensor_id, std::move(info)});
+  // data[tensor_id] = {memory_offset, size};
 }
 
 #ifdef __EMSCRIPTEN__

--- a/tfjs-backend-wasm/src/cc/backend.h
+++ b/tfjs-backend-wasm/src/cc/backend.h
@@ -32,13 +32,20 @@ struct TensorInfo {
   void *memory_offset;
   // Total number of elements.
   int size;
+
+  // Delete the copy constructor to avoid copying.
+  TensorInfo(const TensorInfo &) = delete;
+  void operator=(const TensorInfo &) = delete;
+
+  // Bring back the move constructor.
+  TensorInfo(TensorInfo &&) = default;
 };
 
 namespace tfjs {
 namespace backend {
 // Returns the tensor information object associated with a given tensor_id
 // bucket.
-TensorInfo &get_tensor_info(int tensor_id);
+const TensorInfo &get_tensor_info(int tensor_id);
 
 // Registers a function callback to be called when a tensor with a given ID is
 // disposed.

--- a/tfjs-backend-wasm/src/cc/backend_test.cc
+++ b/tfjs-backend-wasm/src/cc/backend_test.cc
@@ -29,7 +29,7 @@ TEST(BACKEND, register_tensor) {
   tfjs::wasm::register_tensor(tensor_id, size, values);
   ASSERT_EQ(1, tfjs::backend::num_tensors());
 
-  TensorInfo tensor_info = tfjs::backend::get_tensor_info(tensor_id);
+  auto& tensor_info = tfjs::backend::get_tensor_info(tensor_id);
 
   ASSERT_EQ(size, tensor_info.size);
 

--- a/tfjs-backend-wasm/src/cc/binary.h
+++ b/tfjs-backend-wasm/src/cc/binary.h
@@ -33,9 +33,9 @@ inline void binary_impl(T* a_buf, int a_size, T* b_buf, int b_size, T* out_buf,
 
 inline void binary_f32(int a_id, int b_id, int out_id,
                        float operation(float, float)) {
-  const TensorInfo& a_info = backend::get_tensor_info(a_id);
-  const TensorInfo& b_info = backend::get_tensor_info(b_id);
-  const TensorInfo& out_info = backend::get_tensor_info(out_id);
+  auto& a_info = backend::get_tensor_info(a_id);
+  auto& b_info = backend::get_tensor_info(b_id);
+  auto& out_info = backend::get_tensor_info(out_id);
   binary_impl<float>(
       reinterpret_cast<float*>(a_info.memory_offset), a_info.size,
       reinterpret_cast<float*>(b_info.memory_offset), b_info.size,
@@ -44,9 +44,9 @@ inline void binary_f32(int a_id, int b_id, int out_id,
 
 inline void binary_i32(int a_id, int b_id, int out_id,
                        int operation(int, int)) {
-  const TensorInfo& a_info = backend::get_tensor_info(a_id);
-  const TensorInfo& b_info = backend::get_tensor_info(b_id);
-  const TensorInfo& out_info = backend::get_tensor_info(out_id);
+  auto& a_info = backend::get_tensor_info(a_id);
+  auto& b_info = backend::get_tensor_info(b_id);
+  auto& out_info = backend::get_tensor_info(out_id);
   binary_impl<int>(reinterpret_cast<int*>(a_info.memory_offset), a_info.size,
                    reinterpret_cast<int*>(b_info.memory_offset), b_info.size,
                    reinterpret_cast<int*>(out_info.memory_offset), operation);
@@ -54,9 +54,9 @@ inline void binary_i32(int a_id, int b_id, int out_id,
 
 inline void binary_bool(int a_id, int b_id, int out_id,
                         bool operation(bool, bool)) {
-  const TensorInfo& a_info = backend::get_tensor_info(a_id);
-  const TensorInfo& b_info = backend::get_tensor_info(b_id);
-  const TensorInfo& out_info = backend::get_tensor_info(out_id);
+  auto& a_info = backend::get_tensor_info(a_id);
+  auto& b_info = backend::get_tensor_info(b_id);
+  auto& out_info = backend::get_tensor_info(out_id);
   binary_impl<bool>(reinterpret_cast<bool*>(a_info.memory_offset), a_info.size,
                     reinterpret_cast<bool*>(b_info.memory_offset), b_info.size,
                     reinterpret_cast<bool*>(out_info.memory_offset), operation);

--- a/tfjs-backend-wasm/src/cc/binary.h
+++ b/tfjs-backend-wasm/src/cc/binary.h
@@ -33,9 +33,9 @@ inline void binary_impl(T* a_buf, int a_size, T* b_buf, int b_size, T* out_buf,
 
 inline void binary_f32(int a_id, int b_id, int out_id,
                        float operation(float, float)) {
-  const auto a_info = backend::get_tensor_info(a_id);
-  const auto b_info = backend::get_tensor_info(b_id);
-  const auto out_info = backend::get_tensor_info(out_id);
+  const TensorInfo& a_info = backend::get_tensor_info(a_id);
+  const TensorInfo& b_info = backend::get_tensor_info(b_id);
+  const TensorInfo& out_info = backend::get_tensor_info(out_id);
   binary_impl<float>(
       reinterpret_cast<float*>(a_info.memory_offset), a_info.size,
       reinterpret_cast<float*>(b_info.memory_offset), b_info.size,
@@ -44,9 +44,9 @@ inline void binary_f32(int a_id, int b_id, int out_id,
 
 inline void binary_i32(int a_id, int b_id, int out_id,
                        int operation(int, int)) {
-  const auto a_info = backend::get_tensor_info(a_id);
-  const auto b_info = backend::get_tensor_info(b_id);
-  const auto out_info = backend::get_tensor_info(out_id);
+  const TensorInfo& a_info = backend::get_tensor_info(a_id);
+  const TensorInfo& b_info = backend::get_tensor_info(b_id);
+  const TensorInfo& out_info = backend::get_tensor_info(out_id);
   binary_impl<int>(reinterpret_cast<int*>(a_info.memory_offset), a_info.size,
                    reinterpret_cast<int*>(b_info.memory_offset), b_info.size,
                    reinterpret_cast<int*>(out_info.memory_offset), operation);
@@ -54,9 +54,9 @@ inline void binary_i32(int a_id, int b_id, int out_id,
 
 inline void binary_bool(int a_id, int b_id, int out_id,
                         bool operation(bool, bool)) {
-  const auto a_info = backend::get_tensor_info(a_id);
-  const auto b_info = backend::get_tensor_info(b_id);
-  const auto out_info = backend::get_tensor_info(out_id);
+  const TensorInfo& a_info = backend::get_tensor_info(a_id);
+  const TensorInfo& b_info = backend::get_tensor_info(b_id);
+  const TensorInfo& out_info = backend::get_tensor_info(out_id);
   binary_impl<bool>(reinterpret_cast<bool*>(a_info.memory_offset), a_info.size,
                     reinterpret_cast<bool*>(b_info.memory_offset), b_info.size,
                     reinterpret_cast<bool*>(out_info.memory_offset), operation);

--- a/tfjs-backend-wasm/src/cc/kernels/Add.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Add.cc
@@ -36,7 +36,7 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Add(int a_id, int b_id, DType dtype, int out_id) {
-  const auto a_info = backend::get_tensor_info(a_id);
+  auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:
       binary_f32(a_id, b_id, out_id, add<float>);

--- a/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
@@ -33,9 +33,9 @@ void BatchMatMul(int a_id, int b_id, int shared_dim, int left_dim,
                  int right_dim, int batch_dim, int a_batch, int a_outer_step,
                  int a_inner_step, int b_batch, int b_outer_step,
                  int b_inner_step, int out_id) {
-  const TensorInfo a_info = backend::get_tensor_info(a_id);
-  const TensorInfo b_info = backend::get_tensor_info(b_id);
-  const TensorInfo out_info = backend::get_tensor_info(out_id);
+  auto& a_info = backend::get_tensor_info(a_id);
+  auto& b_info = backend::get_tensor_info(b_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   const float* a_buf = reinterpret_cast<float*>(a_info.memory_offset);
   const float* b_buf = reinterpret_cast<float*>(b_info.memory_offset);

--- a/tfjs-backend-wasm/src/cc/kernels/Div.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Div.cc
@@ -36,7 +36,7 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Div(int a_id, int b_id, DType dtype, int out_id) {
-  const auto a_info = backend::get_tensor_info(a_id);
+  auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:
       binary_f32(a_id, b_id, out_id, div<float>);

--- a/tfjs-backend-wasm/src/cc/kernels/FusedBatchNorm.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedBatchNorm.cc
@@ -30,10 +30,10 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void FusedBatchNorm(int x_id, int mean_id, int variance_id, int offset_id,
                     int scale_id, float variance_epsilon, int out_id) {
-  const auto x_info = backend::get_tensor_info(x_id);
-  const auto mean_info = backend::get_tensor_info(mean_id);
-  const auto variance_info = backend::get_tensor_info(variance_id);
-  const auto out_info = backend::get_tensor_info(out_id);
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& mean_info = backend::get_tensor_info(mean_id);
+  auto& variance_info = backend::get_tensor_info(variance_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   float* x_buf = reinterpret_cast<float*>(x_info.memory_offset);
   int x_size = x_info.size;
@@ -56,7 +56,7 @@ void FusedBatchNorm(int x_id, int mean_id, int variance_id, int offset_id,
     scale_buf = scale_buf_default;
     scale_size = 1;
   } else {
-    const auto scale_info = backend::get_tensor_info(scale_id);
+    auto& scale_info = backend::get_tensor_info(scale_id);
     scale_buf = reinterpret_cast<float*>(scale_info.memory_offset);
     scale_size = scale_info.size;
   }
@@ -68,7 +68,7 @@ void FusedBatchNorm(int x_id, int mean_id, int variance_id, int offset_id,
     offset_buf = offset_buf_default;
     offset_size = 1;
   } else {
-    const auto offset_info = backend::get_tensor_info(offset_id);
+    auto& offset_info = backend::get_tensor_info(offset_id);
     offset_buf = reinterpret_cast<float*>(offset_info.memory_offset);
     offset_size = offset_info.size;
   }

--- a/tfjs-backend-wasm/src/cc/kernels/Max.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Max.cc
@@ -27,8 +27,8 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Max(int x_id, int reduce_size, int out_id) {
-  const auto x_info = backend::get_tensor_info(x_id);
-  const auto out_info = backend::get_tensor_info(out_id);
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   float* x_buf = reinterpret_cast<float*>(x_info.memory_offset);
   int x_size = x_info.size;

--- a/tfjs-backend-wasm/src/cc/kernels/Min.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Min.cc
@@ -27,8 +27,8 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Min(int x_id, int reduce_size, int out_id) {
-  const auto x_info = backend::get_tensor_info(x_id);
-  const auto out_info = backend::get_tensor_info(out_id);
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   float* x_buf = reinterpret_cast<float*>(x_info.memory_offset);
   int x_size = x_info.size;

--- a/tfjs-backend-wasm/src/cc/kernels/Mul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Mul.cc
@@ -36,7 +36,7 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Mul(int a_id, int b_id, DType dtype, int out_id) {
-  const auto a_info = backend::get_tensor_info(a_id);
+  auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:
       binary_f32(a_id, b_id, out_id, mul<float>);

--- a/tfjs-backend-wasm/src/cc/kernels/Prelu.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Prelu.cc
@@ -49,9 +49,9 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Prelu(int x_id, int weights_id, int out_id) {
-  const TensorInfo x_info = backend::get_tensor_info(x_id);
-  const TensorInfo weights_info = backend::get_tensor_info(weights_id);
-  const TensorInfo out_info = backend::get_tensor_info(out_id);
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& weights_info = backend::get_tensor_info(weights_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   const float* x_buf = reinterpret_cast<float*>(x_info.memory_offset);
   const float* weights_buf =

--- a/tfjs-backend-wasm/src/cc/kernels/Sub.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Sub.cc
@@ -36,7 +36,7 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 void Sub(int a_id, int b_id, DType dtype, int out_id) {
-  const auto a_info = backend::get_tensor_info(a_id);
+  auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:
       binary_f32(a_id, b_id, out_id, sub<float>);

--- a/tfjs-backend-wasm/src/cc/kernels/Transpose.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Transpose.cc
@@ -281,8 +281,8 @@ void Transpose(int x_id, int* x_shape_ptr, int x_shape_length, DType dtype,
                int out_id, int* perm_ptr, int perm_length) {
   auto x_shape = std::vector<int>(x_shape_ptr, x_shape_ptr + x_shape_length);
   auto perm = std::vector<int>(perm_ptr, perm_ptr + perm_length);
-  const TensorInfo x_info = backend::get_tensor_info(x_id);
-  const TensorInfo out_info = backend::get_tensor_info(out_id);
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   switch (dtype) {
     case DType::float32:

--- a/tfjs-backend-wasm/src/cc/unary.h
+++ b/tfjs-backend-wasm/src/cc/unary.h
@@ -19,8 +19,8 @@ namespace tfjs {
 namespace wasm {
 
 inline void unary(int x_id, int out_id, float operation(float)) {
-  const TensorInfo& a_info = backend::get_tensor_info(x_id);
-  const TensorInfo& out_info = backend::get_tensor_info(out_id);
+  auto& a_info = backend::get_tensor_info(x_id);
+  auto& out_info = backend::get_tensor_info(out_id);
 
   const float* a_buf = reinterpret_cast<float*>(a_info.memory_offset);
   float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);

--- a/tfjs-backend-wasm/src/cc/unary.h
+++ b/tfjs-backend-wasm/src/cc/unary.h
@@ -19,8 +19,8 @@ namespace tfjs {
 namespace wasm {
 
 inline void unary(int x_id, int out_id, float operation(float)) {
-  const TensorInfo a_info = backend::get_tensor_info(x_id);
-  const TensorInfo out_info = backend::get_tensor_info(out_id);
+  const TensorInfo& a_info = backend::get_tensor_info(x_id);
+  const TensorInfo& out_info = backend::get_tensor_info(out_id);
 
   const float* a_buf = reinterpret_cast<float*>(a_info.memory_offset);
   float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);

--- a/tfjs-backend-wasm/src/cc/util.h
+++ b/tfjs-backend-wasm/src/cc/util.h
@@ -105,14 +105,14 @@ inline std::vector<int> offset_to_loc(int index,
 // Returns the flat offset of an n-dim tensor given the indices and strides.
 inline int loc_to_offset(const std::vector<int>& loc,
                          const std::vector<int>& strides) {
-  int rank = loc.size();
+  size_t rank = loc.size();
   if (rank == 0) {
     return 0;
   } else if (rank == 1) {
     return loc[0];
   }
-  int index = loc[loc.size() - 1];
-  for (int i = 0; i < loc.size() - 1; ++i) {
+  size_t index = loc[loc.size() - 1];
+  for (size_t i = 0; i < loc.size() - 1; ++i) {
     index += strides[i] * loc[i];
   }
   return index;


### PR DESCRIPTION
We need to simply store the reference to the element on the map.

This PR also:

- Removes the copy constructor and assignment operator for TensorInfo. It also brings back the move constructor so that we can use it in a hash map.
- Changes all usages of TensorInfo to use a reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2321)
<!-- Reviewable:end -->
