### PR TITLE
[WASM] Add useful accessors on TensorInfo

### DIFF
--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -40,6 +40,10 @@ const TensorInfo &get_tensor_info(const int tensor_id) {
   return data.at(tensor_id);
 }
 
+TensorInfo &get_tensor_info_out(const int tensor_id) {
+  return data.at(tensor_id);
+}
+
 int xnn_operator_count = 0;
 
 // Registers a disposal callback for a tensor id with a given callback function.

--- a/tfjs-backend-wasm/src/cc/backend.h
+++ b/tfjs-backend-wasm/src/cc/backend.h
@@ -64,6 +64,8 @@ namespace backend {
 // Returns the tensor information object associated with a given tensor_id
 // bucket.
 const TensorInfo &get_tensor_info(int tensor_id);
+// Same as above, but gives write access to the tensor info.
+TensorInfo &get_tensor_info_out(int tensor_id);
 
 // Registers a function callback to be called when a tensor with a given ID is
 // disposed.

--- a/tfjs-backend-wasm/src/cc/backend.h
+++ b/tfjs-backend-wasm/src/cc/backend.h
@@ -33,6 +33,24 @@ struct TensorInfo {
   // Total number of elements.
   const int size;
 
+  const float *f32() const {
+    return reinterpret_cast<const float *>(memory_offset);
+  }
+
+  float *f32_write() { return reinterpret_cast<float *>(memory_offset); }
+
+  const int *i32() const {
+    return reinterpret_cast<const int *>(memory_offset);
+  }
+
+  int *i32_write() { return reinterpret_cast<int *>(memory_offset); }
+
+  const bool *b() const {
+    return reinterpret_cast<const bool *>(memory_offset);
+  }
+
+  bool *b_write() { return reinterpret_cast<bool *>(memory_offset); }
+
   // Delete the copy constructor to avoid copying.
   TensorInfo(const TensorInfo &) = delete;
   void operator=(const TensorInfo &) = delete;

--- a/tfjs-backend-wasm/src/cc/binary.h
+++ b/tfjs-backend-wasm/src/cc/binary.h
@@ -35,33 +35,27 @@ inline void binary_f32(const int a_id, const int b_id, const int out_id,
                        float operation(float, float)) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = backend::get_tensor_info(out_id);
-  binary_impl<float>(
-      reinterpret_cast<const float*>(a_info.memory_offset), a_info.size,
-      reinterpret_cast<const float*>(b_info.memory_offset), b_info.size,
-      reinterpret_cast<float*>(out_info.memory_offset), operation);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  binary_impl<float>(a_info.f32(), a_info.size, b_info.f32(), b_info.size,
+                     out_info.f32_write(), operation);
 }
 
 inline void binary_i32(const int a_id, const int b_id, const int out_id,
                        int operation(int, int)) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = backend::get_tensor_info(out_id);
-  binary_impl<int>(
-      reinterpret_cast<const int*>(a_info.memory_offset), a_info.size,
-      reinterpret_cast<const int*>(b_info.memory_offset), b_info.size,
-      reinterpret_cast<int*>(out_info.memory_offset), operation);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  binary_impl<int>(a_info.i32(), a_info.size, b_info.i32(), b_info.size,
+                   out_info.i32_write(), operation);
 }
 
 inline void binary_bool(const int a_id, const int b_id, const int out_id,
                         bool operation(bool, bool)) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = backend::get_tensor_info(out_id);
-  binary_impl<bool>(
-      reinterpret_cast<const bool*>(a_info.memory_offset), a_info.size,
-      reinterpret_cast<const bool*>(b_info.memory_offset), b_info.size,
-      reinterpret_cast<bool*>(out_info.memory_offset), operation);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  binary_impl<bool>(a_info.b(), a_info.size, b_info.b(), b_info.size,
+                    out_info.b_write(), operation);
 }
 
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/binary.h
+++ b/tfjs-backend-wasm/src/cc/binary.h
@@ -35,7 +35,7 @@ inline void binary_f32(const int a_id, const int b_id, const int out_id,
                        float operation(float, float)) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
   binary_impl<float>(a_info.f32(), a_info.size, b_info.f32(), b_info.size,
                      out_info.f32_write(), operation);
 }
@@ -44,7 +44,7 @@ inline void binary_i32(const int a_id, const int b_id, const int out_id,
                        int operation(int, int)) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
   binary_impl<int>(a_info.i32(), a_info.size, b_info.i32(), b_info.size,
                    out_info.i32_write(), operation);
 }
@@ -53,7 +53,7 @@ inline void binary_bool(const int a_id, const int b_id, const int out_id,
                         bool operation(bool, bool)) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
   binary_impl<bool>(a_info.b(), a_info.size, b_info.b(), b_info.size,
                     out_info.b_write(), operation);
 }

--- a/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
@@ -37,11 +37,11 @@ void BatchMatMul(const int a_id, const int b_id, const int shared_dim,
                  const int out_id) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* a_buf = reinterpret_cast<const float*>(a_info.memory_offset);
-  const float* b_buf = reinterpret_cast<const float*>(b_info.memory_offset);
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  const float* a_buf = a_info.f32();
+  const float* b_buf = b_info.f32();
+  float* out_buf = out_info.f32_write();
 
   const int size = left_dim * right_dim;
 

--- a/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
@@ -37,7 +37,7 @@ void BatchMatMul(const int a_id, const int b_id, const int shared_dim,
                  const int out_id) {
   auto& a_info = backend::get_tensor_info(a_id);
   auto& b_info = backend::get_tensor_info(b_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* a_buf = a_info.f32();
   const float* b_buf = b_info.f32();

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2D.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2D.cc
@@ -74,11 +74,11 @@ void Conv2D(const int x_id, const int batch_size, const int input_height,
             const int output_channels, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& filter_info = backend::get_tensor_info(filter_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* x_buf = reinterpret_cast<float*>(x_info.memory_offset);
-  const float* filter_buf = reinterpret_cast<float*>(filter_info.memory_offset);
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  const float* x_buf = x_info.f32();
+  const float* filter_buf = filter_info.f32();
+  float* out_buf = out_info.f32_write();
 
   xnn_operator_t conv2d_op = nullptr;
 

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2D.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2D.cc
@@ -74,7 +74,7 @@ void Conv2D(const int x_id, const int batch_size, const int input_height,
             const int output_channels, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& filter_info = backend::get_tensor_info(filter_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* x_buf = x_info.f32();
   const float* filter_buf = filter_info.f32();

--- a/tfjs-backend-wasm/src/cc/kernels/FusedBatchNorm.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedBatchNorm.cc
@@ -34,7 +34,7 @@ void FusedBatchNorm(const int x_id, const int mean_id, const int variance_id,
   auto& x_info = backend::get_tensor_info(x_id);
   auto& mean_info = backend::get_tensor_info(mean_id);
   auto& variance_info = backend::get_tensor_info(variance_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* x_buf = x_info.f32();
   const int x_size = x_info.size;

--- a/tfjs-backend-wasm/src/cc/kernels/FusedBatchNorm.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedBatchNorm.cc
@@ -34,45 +34,43 @@ void FusedBatchNorm(const int x_id, const int mean_id, const int variance_id,
   auto& x_info = backend::get_tensor_info(x_id);
   auto& mean_info = backend::get_tensor_info(mean_id);
   auto& variance_info = backend::get_tensor_info(variance_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* x_buf = reinterpret_cast<const float*>(x_info.memory_offset);
+  const float* x_buf = x_info.f32();
   const int x_size = x_info.size;
-  const float* mean_buf =
-      reinterpret_cast<const float*>(mean_info.memory_offset);
+  const float* mean_buf = mean_info.f32();
   const int mean_size = mean_info.size;
-  const float* variance_buf =
-      reinterpret_cast<const float*>(variance_info.memory_offset);
+  const float* variance_buf = variance_info.f32();
   const int variance_size = variance_info.size;
 
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  float* out_buf = out_info.f32_write();
 
   int offset_i = 0;
   int mean_i = 0;
   int scale_i = 0;
   int variance_i = 0;
 
-  float scale_buf_default[1] = {1};
-  float* scale_buf;
+  const float scale_buf_default[1] = {1};
+  const float* scale_buf;
   int scale_size;
   if (scale_id < 0) {
     scale_buf = scale_buf_default;
     scale_size = 1;
   } else {
     auto& scale_info = backend::get_tensor_info(scale_id);
-    scale_buf = reinterpret_cast<float*>(scale_info.memory_offset);
+    scale_buf = scale_info.f32();
     scale_size = scale_info.size;
   }
 
-  float offset_buf_default[1] = {0};
-  float* offset_buf;
+  const float offset_buf_default[1] = {0};
+  const float* offset_buf;
   int offset_size;
   if (offset_id < 0) {
     offset_buf = offset_buf_default;
     offset_size = 1;
   } else {
     auto& offset_info = backend::get_tensor_info(offset_id);
-    offset_buf = reinterpret_cast<float*>(offset_info.memory_offset);
+    offset_buf = offset_info.f32();
     offset_size = offset_info.size;
   }
 

--- a/tfjs-backend-wasm/src/cc/kernels/Max.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Max.cc
@@ -28,12 +28,12 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void Max(const int x_id, const int reduce_size, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* x_buf = reinterpret_cast<const float*>(x_info.memory_offset);
+  const float* x_buf = x_info.f32();
   const int x_size = x_info.size;
 
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  float* out_buf = out_info.f32_write();
   const int out_size = out_info.size;
 
   float* x_offset = const_cast<float*>(x_buf);

--- a/tfjs-backend-wasm/src/cc/kernels/Max.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Max.cc
@@ -28,7 +28,7 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void Max(const int x_id, const int reduce_size, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* x_buf = x_info.f32();
   const int x_size = x_info.size;
@@ -36,7 +36,7 @@ void Max(const int x_id, const int reduce_size, const int out_id) {
   float* out_buf = out_info.f32_write();
   const int out_size = out_info.size;
 
-  float* x_offset = const_cast<float*>(x_buf);
+  const float* x_offset = x_buf;
 
   for (int i = 0; i < out_size; ++i) {
     const int offset = i * reduce_size;
@@ -44,7 +44,7 @@ void Max(const int x_id, const int reduce_size, const int out_id) {
 
     const float* x_iter_end = x_offset + reduce_size;
 
-    for (float* x = x_offset; x < x_iter_end; ++x) {
+    for (const float* x = x_offset; x < x_iter_end; ++x) {
       float value = *x;
       if (value > max) {
         max = value;

--- a/tfjs-backend-wasm/src/cc/kernels/Min.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Min.cc
@@ -28,12 +28,12 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void Min(const int x_id, const int reduce_size, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* x_buf = reinterpret_cast<float*>(x_info.memory_offset);
+  const float* x_buf = x_info.f32();
   const int x_size = x_info.size;
 
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  float* out_buf = out_info.f32_write();
   const int out_size = out_info.size;
 
   float* x_offset = const_cast<float*>(x_buf);

--- a/tfjs-backend-wasm/src/cc/kernels/Min.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Min.cc
@@ -28,7 +28,7 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 void Min(const int x_id, const int reduce_size, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* x_buf = x_info.f32();
   const int x_size = x_info.size;
@@ -36,7 +36,7 @@ void Min(const int x_id, const int reduce_size, const int out_id) {
   float* out_buf = out_info.f32_write();
   const int out_size = out_info.size;
 
-  float* x_offset = const_cast<float*>(x_buf);
+  const float* x_offset = x_buf;
 
   for (int i = 0; i < out_size; ++i) {
     const int offset = i * reduce_size;
@@ -44,7 +44,7 @@ void Min(const int x_id, const int reduce_size, const int out_id) {
 
     const float* x_iter_end = x_offset + reduce_size;
 
-    for (float* x = x_offset; x < x_iter_end; ++x) {
+    for (const float* x = x_offset; x < x_iter_end; ++x) {
       float value = *x;
       if (value < min) {
         min = value;

--- a/tfjs-backend-wasm/src/cc/kernels/Prelu.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Prelu.cc
@@ -51,12 +51,11 @@ EMSCRIPTEN_KEEPALIVE
 void Prelu(const int x_id, const int weights_id, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& weights_info = backend::get_tensor_info(weights_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* x_buf = reinterpret_cast<const float*>(x_info.memory_offset);
-  const float* weights_buf =
-      reinterpret_cast<float*>(weights_info.memory_offset);
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  const float* x_buf = x_info.f32();
+  const float* weights_buf = weights_info.f32();
+  float* out_buf = out_info.f32_write();
 
   xnn_operator_t prelu_op = nullptr;
 

--- a/tfjs-backend-wasm/src/cc/kernels/Prelu.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Prelu.cc
@@ -51,7 +51,7 @@ EMSCRIPTEN_KEEPALIVE
 void Prelu(const int x_id, const int weights_id, const int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& weights_info = backend::get_tensor_info(weights_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* x_buf = x_info.f32();
   const float* weights_buf = weights_info.f32();

--- a/tfjs-backend-wasm/src/cc/kernels/Transpose.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Transpose.cc
@@ -283,7 +283,7 @@ void Transpose(const int x_id, const int* x_shape_ptr, const int x_shape_length,
   auto x_shape = std::vector<int>(x_shape_ptr, x_shape_ptr + x_shape_length);
   auto perm = std::vector<int>(perm_ptr, perm_ptr + perm_length);
   auto& x_info = backend::get_tensor_info(x_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   switch (dtype) {
     case DType::float32:

--- a/tfjs-backend-wasm/src/cc/kernels/Transpose.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Transpose.cc
@@ -283,23 +283,17 @@ void Transpose(const int x_id, const int* x_shape_ptr, const int x_shape_length,
   auto x_shape = std::vector<int>(x_shape_ptr, x_shape_ptr + x_shape_length);
   auto perm = std::vector<int>(perm_ptr, perm_ptr + perm_length);
   auto& x_info = backend::get_tensor_info(x_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
   switch (dtype) {
     case DType::float32:
-      transpose<float>(reinterpret_cast<const float*>(x_info.memory_offset),
-                       x_shape, perm,
-                       reinterpret_cast<float*>(out_info.memory_offset));
+      transpose<float>(x_info.f32(), x_shape, perm, out_info.f32_write());
       break;
     case DType::int32:
-      transpose<int>(reinterpret_cast<const int*>(x_info.memory_offset),
-                     x_shape, perm,
-                     reinterpret_cast<int*>(out_info.memory_offset));
+      transpose<int>(x_info.i32(), x_shape, perm, out_info.i32_write());
       break;
     case DType::boolean:
-      transpose<bool>(reinterpret_cast<const bool*>(x_info.memory_offset),
-                      x_shape, perm,
-                      reinterpret_cast<bool*>(out_info.memory_offset));
+      transpose<bool>(x_info.b(), x_shape, perm, out_info.b_write());
       break;
     default:
       util::warn("Transpose for tensor id %d failed. Unknown dtype %d", x_id,

--- a/tfjs-backend-wasm/src/cc/unary.h
+++ b/tfjs-backend-wasm/src/cc/unary.h
@@ -20,7 +20,7 @@ namespace wasm {
 
 inline void unary(const int x_id, const int out_id, float operation(float)) {
   auto& a_info = backend::get_tensor_info(x_id);
-  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
+  auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* a_buf = a_info.f32();
   float* out_buf = out_info.f32_write();

--- a/tfjs-backend-wasm/src/cc/unary.h
+++ b/tfjs-backend-wasm/src/cc/unary.h
@@ -20,10 +20,10 @@ namespace wasm {
 
 inline void unary(const int x_id, const int out_id, float operation(float)) {
   auto& a_info = backend::get_tensor_info(x_id);
-  auto& out_info = backend::get_tensor_info(out_id);
+  auto& out_info = const_cast<TensorInfo&>(backend::get_tensor_info(out_id));
 
-  const float* a_buf = reinterpret_cast<const float*>(a_info.memory_offset);
-  float* out_buf = reinterpret_cast<float*>(out_info.memory_offset);
+  const float* a_buf = a_info.f32();
+  float* out_buf = out_info.f32_write();
 
   for (int i = 0; i < a_info.size; ++i) {
     out_buf[i] = operation(a_buf[i]);


### PR DESCRIPTION
To improve code ergonomics, add methods to access the typed pointers on `TensorInfo` avoiding `reinterpret_cast` in user-code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2342)
<!-- Reviewable:end -->
