### PR TITLE
fix the Concat and ConcatV2 op 

### DIFF
--- a/tfjs-converter/python/tensorflowjs/op_list/slice_join.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/slice_join.json
@@ -14,6 +14,14 @@
         "name": "axis",
         "type": "number"
       }
+    ],
+    "attrs": [
+      {
+        "tfName": "N",
+        "name": "n",
+        "type": "number",
+        "defaultValue": 2
+      }
     ]
   },
   {
@@ -30,6 +38,14 @@
         "start": 0,
         "name": "axis",
         "type": "number"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "N",
+        "name": "n",
+        "type": "number",
+        "defaultValue": 2
       }
     ]
   },

--- a/tfjs-converter/src/operations/executors/slice_join_executor.ts
+++ b/tfjs-converter/src/operations/executors/slice_join_executor.ts
@@ -30,9 +30,11 @@ export let executeOp: InternalOpExecutor = (node: Node,
   switch (node.op) {
     case 'ConcatV2':
     case 'Concat': {
+      const n = getParamValue('n', node, tensorMap, context) as number;
       const axis = getParamValue('axis', node, tensorMap, context) as number;
-      const inputs =
+      let inputs =
           getParamValue('tensors', node, tensorMap, context) as tfc.Tensor[];
+      inputs = inputs.slice(0, n);
       return [tfc.concat(inputs, axis)];
     }
     case 'GatherV2':

--- a/tfjs-converter/src/operations/executors/slice_join_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/slice_join_executor_test.ts
@@ -51,14 +51,26 @@ describe('slice join', () => {
         node.op = 'Concat';
         node.inputParams.tensors = createTensorsAttr(1, 0);
         node.inputParams.axis = createNumberAttrFromIndex(0);
+        node.attrParams.n = createNumberAttr(2);
         executeOp(node, {input1, input2, input3}, context);
 
         expect(spy).toHaveBeenCalledWith([input2[0], input3[0]], 1);
+      });
+      it('Concat when input length and n mismatch', () => {
+        const spy = spyOn(tfc, 'concat');
+        node.op = 'Concat';
+        node.inputParams.tensors = createTensorsAttr(0, -1);
+        node.inputParams.axis = createNumberAttrFromIndex(-1);
+        node.attrParams.n = createNumberAttr(1);
+        executeOp(node, {input1, input2, input3}, context);
+
+        expect(spy).toHaveBeenCalledWith([input1[0]], 3);
       });
       it('should match json def for Concat', () => {
         node.op = 'Concat';
         node.inputParams.tensors = createTensorsAttr(1, 0);
         node.inputParams.axis = createNumberAttrFromIndex(0);
+        node.attrParams.n = createNumberAttr(2);
 
         expect(validateParam(node, slice_join.json, 'Concat')).toBeTruthy();
       });
@@ -67,14 +79,26 @@ describe('slice join', () => {
         node.op = 'ConcatV2';
         node.inputParams.tensors = createTensorsAttr(0, -1);
         node.inputParams.axis = createNumberAttrFromIndex(-1);
+        node.attrParams.n = createNumberAttr(2);
         executeOp(node, {input1, input2, input3}, context);
 
         expect(spy).toHaveBeenCalledWith([input1[0], input2[0]], 3);
+      });
+      it('ConcatV2 when input length and n mismatch', () => {
+        const spy = spyOn(tfc, 'concat');
+        node.op = 'ConcatV2';
+        node.inputParams.tensors = createTensorsAttr(0, -1);
+        node.inputParams.axis = createNumberAttrFromIndex(-1);
+        node.attrParams.n = createNumberAttr(1);
+        executeOp(node, {input1, input2, input3}, context);
+
+        expect(spy).toHaveBeenCalledWith([input1[0]], 3);
       });
       it('should match json def for ConcatV2', () => {
         node.op = 'ConcatV2';
         node.inputParams.tensors = createTensorsAttr(0, -1);
         node.inputParams.axis = createNumberAttrFromIndex(-1);
+        node.attrParams.n = createNumberAttr(3);
 
         expect(validateParam(node, slice_join.json, 'ConcatV2')).toBeTruthy();
       });

--- a/tfjs-converter/src/operations/op_list/slice_join.ts
+++ b/tfjs-converter/src/operations/op_list/slice_join.ts
@@ -24,7 +24,9 @@ export const json: OpMapper[] = [
     'inputs': [
       {'start': 0, 'end': -1, 'name': 'tensors', 'type': 'tensors'},
       {'start': -1, 'name': 'axis', 'type': 'number'}
-    ]
+    ],
+    'attrs':
+        [{'tfName': 'N', 'name': 'n', 'type': 'number', 'defaultValue': 2}]
   },
   {
     'tfOpName': 'Concat',
@@ -32,7 +34,9 @@ export const json: OpMapper[] = [
     'inputs': [
       {'start': 1, 'end': 0, 'name': 'tensors', 'type': 'tensors'},
       {'start': 0, 'name': 'axis', 'type': 'number'}
-    ]
+    ],
+    'attrs': [{'tfName': 'N', 'name': 'n', 'type': 'number', 'defaultValue': 2}]
+
   },
   {
     'tfOpName': 'GatherV2',


### PR DESCRIPTION
Fix https://github.com/tensorflow/tfjs/issues/841
when the input tensor list length mismatch with the attribute param N, this seems to be the result of grappler graph optimization, where a concatV2 op has 7 input tensors when the attribute param N indicates 6. The axis is used as input tensor by mistake.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2352)
<!-- Reviewable:end -->
