### PR TITLE
webgpu: fix browser load issue when testing on Windows

### DIFF
--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -14,9 +14,9 @@
     "link-local": "yalc link",
     "unlink-local": "yalc remove",
     "lint": "tslint -p . -t verbose",
-    "test": "karma start --browsers='chrome_webgpu' --excludeTest='src/benchmark_ops_test.ts'",
+    "test": "karma start --browsers=chrome_webgpu --excludeTest='src/benchmark_ops_test.ts'",
     "test-ci": "./scripts/test-ci.sh",
-    "benchmark": "karma start --grep=benchmark --browsers='chrome_webgpu'"
+    "benchmark": "karma start --grep=benchmark --browsers=chrome_webgpu"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
ISSUE

Fixed error "Cannot load browser 'chrome_webgpu': it is not registered!" when
using `yarn test` or `yarn benchmark` on Windows platform

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2372)
<!-- Reviewable:end -->
