### PR TITLE
[core] use ModelTensorInfo in MetaGraphInfo

### DIFF
--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -56,7 +56,7 @@ import * as util from './util';
 import {version} from './version';
 import * as webgl from './webgl';
 
-export {InferenceModel, MetaGraphInfo, ModelPredictConfig, ModelTensorInfo, SavedModelTensorInfo, SignatureDefInfo} from './model_types';
+export {InferenceModel, MetaGraphInfo, ModelPredictConfig, ModelTensorInfo, SignatureDefInfo} from './model_types';
 // Optimizers.
 export {AdadeltaOptimizer} from './optimizers/adadelta_optimizer';
 export {AdagradOptimizer} from './optimizers/adagrad_optimizer';

--- a/tfjs-core/src/model_types.ts
+++ b/tfjs-core/src/model_types.ts
@@ -113,17 +113,7 @@ export interface MetaGraphInfo {
  */
 export interface SignatureDefInfo {
   [key: string]: {
-    inputs: {[key: string]: SavedModelTensorInfo};
-    outputs: {[key: string]: SavedModelTensorInfo};
+    inputs: {[key: string]: ModelTensorInfo};
+    outputs: {[key: string]: ModelTensorInfo};
   };
-}
-
-/**
- * Interface for SavedModel/GraphModel signature input/output Tensor
- * info.
- */
-export interface SavedModelTensorInfo {
-  dtype: string;
-  shape: number[];
-  name: string;
 }


### PR DESCRIPTION
Remove `SavedModelTensorInfo` type. It's `dtype` field is different from `ModelTensorInfo`. In tfjs-node, the `dtype` field in SavedModel proto will be mapped to fields in `ModelTensorInfo` (int32, float32, boolean, complex64, string).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2379)
<!-- Reviewable:end -->
