### PR TITLE
the tensorflow cpu pip fails on mac

### DIFF
--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,7 +1,7 @@
 h5py==2.8.0
 numpy==1.16.4
 six==1.11.0
-tensorflow-cpu==1.15.0
+tensorflow==1.15.0
 tensorflow-hub==0.5.0
 gast==0.2.2
 PyInquirer==1.0.3


### PR DESCRIPTION
revert back to tensorflow 1.15
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2389)
<!-- Reviewable:end -->
