### PR TITLE
webgpu: Fix the delayed mode error

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -131,7 +131,10 @@ export class WebGPUBackend extends KernelBackend {
   }
 
   flushDisposalQueue() {
-    this.tensorDisposalQueue.forEach(d => this.maybeReleaseBuffer(d));
+    this.tensorDisposalQueue.forEach(d => {
+      this.maybeReleaseBuffer(d);
+      this.tensorMap.delete(d);
+    });
     this.uniformDisposalQueue.forEach(
         d => this.bufferManager.releaseBuffer(d.buffer, d.byteSize, d.usage));
 
@@ -146,6 +149,7 @@ export class WebGPUBackend extends KernelBackend {
 
     if (this.commandQueueOwnedIds.has(dataId)) {
       this.tensorDisposalQueue.push(dataId);
+      return;
     } else {
       this.maybeReleaseBuffer(dataId);
     }


### PR DESCRIPTION
When we used DataStorage class for storing tensor map, below error was
exposed:
Uncaught (in promise) TypeError: Cannot read property 'backend' of
undefined
    at t.moveData (engine.ts:381)
    at t.get (backend.ts:58)
    at WebGPUBackend.maybeReleaseBuffer (backend_webgpu.ts:177)

The root case is that we always called 'this.tensorMap.delete(dataId)'
in disposeData function. However, in delayed mode, only when we really
flush DisposalQueue, we can call tensorMap.delete. Otherwise, the tensor id
is deleted before the buffer value is released and above error will be triggerd.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2402)
<!-- Reviewable:end -->
