### PR TITLE
[WASM] Add `NonMaxSuppressionV3`

### DIFF
--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -122,6 +122,12 @@ export class BackendWasm extends KernelBackend {
     return {unreliable: false};
   }
 
+  /**
+   * Make a tensor info for the output of an op. If `memoryOffset` is not
+   * present, this method allocates memory on the WASM heap. If `memoryOffset`
+   * is present, the memory was allocated elsewhere (in c++) and we just record
+   * the pointer where that memory lives.
+   */
   makeOutput(shape: number[], dtype: DataType, memoryOffset?: number):
       TensorInfo {
     let dataId: {};

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -122,8 +122,18 @@ export class BackendWasm extends KernelBackend {
     return {unreliable: false};
   }
 
-  makeOutput(shape: number[], dtype: DataType): TensorInfo {
-    const dataId = this.write(null /* values */, shape, dtype);
+  makeOutput(shape: number[], dtype: DataType, memoryOffset?: number):
+      TensorInfo {
+    let dataId: {};
+    if (memoryOffset == null) {
+      dataId = this.write(null /* values */, shape, dtype);
+    } else {
+      dataId = {};
+      const id = this.dataIdNextNumber++;
+      this.dataIdMap.set(dataId, {id, memoryOffset, shape, dtype});
+      const size = util.sizeFromShape(shape);
+      this.wasm.tfjs.registerTensor(id, size, memoryOffset);
+    }
     return {dataId, shape, dtype};
   }
 

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -86,6 +86,7 @@ tfjs_cc_library(
     ":FusedConv2D",
     ":Div",
     ":Mul",
+    ":NonMaxSuppressionV3",
     ":PadV2",
     ":Prelu",
     ":FusedBatchNorm",
@@ -214,6 +215,15 @@ tfjs_cc_library(
   deps = [
     ":backend",
     ":binary",
+    ":util",
+  ],
+)
+
+tfjs_cc_library(
+  name = "NonMaxSuppressionV3",
+  srcs = ["kernels/NonMaxSuppressionV3.cc"],
+  deps = [
+    ":backend",
     ":util",
   ],
 )

--- a/tfjs-backend-wasm/src/cc/kernels/NonMaxSuppressionV3.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/NonMaxSuppressionV3.cc
@@ -1,0 +1,88 @@
+/* Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "src/cc/backend.h"
+#include "src/cc/util.h"
+
+namespace {
+
+float compute_iou(const float* boxes, const int i, const int j) { return 0.0; }
+
+}  // namespace
+
+namespace tfjs {
+namespace wasm {
+// We use C-style API to interface with Javascript.
+extern "C" {
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int* NonMaxSuppressionV3(const int boxes_id, const int scores_id,
+                         const int max_out_size, const int iou_threshold,
+                         const int score_threshold) {
+  auto& boxes_info = backend::get_tensor_info(boxes_id);
+  auto& scores_info = backend::get_tensor_info_out(scores_id);
+  const float* boxes = boxes_info.f32();
+  const float* scores = scores_info.f32();
+  const int num_boxes = boxes_info.size / 4;
+  std::vector<int> box_indices;
+  for (size_t i = 0; i < num_boxes; ++i) {
+    if (scores[i] > score_threshold) {
+      box_indices.push_back(i);
+    }
+  }
+  // Sort by scores.
+  std::sort(
+      box_indices.begin(), box_indices.end(),
+      [&scores](const int i, const int j) { return scores[i] > scores[j]; });
+
+  std::vector<int> selected;
+  for (size_t i = 0; i < box_indices.size(); ++i) {
+    const int box_i = box_indices[i];
+    bool ignore_candidate = false;
+    for (size_t j = selected.size() - 1; j >= 0; --j) {
+      const int box_j = selected[j];
+      const float iou = compute_iou(boxes, box_i, box_j);
+      if (iou >= iou_threshold) {
+        ignore_candidate = true;
+        break;
+      }
+    }
+    if (!ignore_candidate) {
+      selected.push_back(box_i);
+      if (selected.size() >= max_out_size) {
+        break;
+      }
+    }
+  }
+  int* data = (int*)malloc(selected.size() * sizeof(int));
+  std::memcpy(data, selected.data(), selected.size() * sizeof(int));
+  int result[2] = {(int)data, selected.size()};
+  return result;
+}
+
+}  // extern "C"
+}  // namespace wasm
+}  // namespace tfjs

--- a/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV3.ts
+++ b/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV3.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {NamedAttrMap, NamedTensorInfoMap, registerKernel, TensorInfo} from '@tensorflow/tfjs-core';
+
+import {BackendWasm} from '../backend_wasm';
+
+interface NonMaxSuppressionInputs extends NamedTensorInfoMap {
+  boxes: TensorInfo;
+  scores: TensorInfo;
+}
+
+interface NonMaxSuppressionAttrs extends NamedAttrMap {
+  maxOutputSize: number;
+  iouThreshold: number;
+  scoreThreshold: number;
+}
+
+let wasmFunc: (
+    boxesId: number, scoresId: number, maxOutputSize: number,
+    iouThreshold: number, scoreThreshold: number, outId: number) => void;
+
+function setup(backend: BackendWasm): void {
+  wasmFunc = backend.wasm.cwrap('NonMaxSuppressionV3', null /*void*/, [
+    'number',  // boxesId
+    'number',  // scoresId
+    'number',  // maxOutputSize
+    'number',  // iouThreshold
+    'number',  // scoreThreshold
+    'number'   // outId
+  ]);
+}
+
+function kernelFunc(args: {
+  backend: BackendWasm,
+  inputs: NonMaxSuppressionInputs,
+  attrs: NonMaxSuppressionAttrs
+}): TensorInfo {
+  const {backend, inputs, attrs} = args;
+  const {iouThreshold, maxOutputSize, scoreThreshold} = attrs;
+  const {boxes, scores} = inputs;
+
+  const numBoxes = boxes.shape[0];
+
+  const boxesId = backend.dataIdMap.get(boxes.dataId).id;
+  const scoresId = backend.dataIdMap.get(scores.dataId).id;
+
+  const out = backend.makeOutput(outShape, images.dtype);
+  const outId = backend.dataIdMap.get(out.dataId).id;
+
+  wasmFunc(
+      boxesId, scoresId, maxOutputSize, iouThreshold, scoreThreshold, outId);
+  return out;
+}
+
+registerKernel({
+  kernelName: 'NonMaxSuppressionV3',
+  backendName: 'wasm',
+  setupFunc: setup,
+  kernelFunc,
+});

--- a/tfjs-backend-wasm/src/kernels/all_kernels.ts
+++ b/tfjs-backend-wasm/src/kernels/all_kernels.ts
@@ -33,6 +33,7 @@ import './FusedConv2D';
 import './Max';
 import './Min';
 import './Mul';
+import './NonMaxSuppressionV3';
 import './PadV2';
 import './Prelu';
 import './Reshape';

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -184,6 +184,7 @@ const TEST_FILTERS: TestFilter[] = [
   {include: 'pad ', excludes: ['complex', 'zerosLike']},
   {include: 'clip', excludes: ['gradient']},
   {include: 'addN'},
+  {include: 'nonMaxSuppression'},
 ];
 
 const customInclude = (testName: string) => {

--- a/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
+++ b/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
@@ -20,9 +20,9 @@ export interface BackendWasmModule extends EmscriptenModule {
   // Using the tfjs namespace to avoid conflict with emscripten's API.
   tfjs: {
     init(): void,
-    registerTensor(dataId: number, size: number, memoryOffset: number): void,
+    registerTensor(id: number, size: number, memoryOffset: number): void,
     // Disposes the data behind the data bucket.
-    disposeData(dataId: number): void,
+    disposeData(id: number): void,
     // Disposes the backend and all of its associated data.
     dispose(): void,
   }

--- a/tfjs-core/src/ops/image_ops.ts
+++ b/tfjs-core/src/ops/image_ops.ts
@@ -171,10 +171,12 @@ function nonMaxSuppression_(
   iouThreshold = inputs.iouThreshold;
   scoreThreshold = inputs.scoreThreshold;
 
+  const attrs = {maxOutputSize, iouThreshold, scoreThreshold};
   return ENGINE.runKernelFunc(
       b => b.nonMaxSuppression(
           $boxes, $scores, maxOutputSize, iouThreshold, scoreThreshold),
-      {$boxes});
+      {boxes: $boxes, scores: $scores}, null /* grad */, 'NonMaxSuppressionV3',
+      attrs);
 }
 
 /** This is the async version of `nonMaxSuppression` */


### PR DESCRIPTION
Note. We don't know the output size until we've done the computation, which means in this case we allocate the memory in c++ and give the pointer back to js for bookkeeping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2414)
<!-- Reviewable:end -->
