### PR TITLE
[WASM] Update to latest XNNPACK and fix a potential bug in conv2d

### DIFF
--- a/tfjs-backend-wasm/WORKSPACE
+++ b/tfjs-backend-wasm/WORKSPACE
@@ -8,9 +8,9 @@ emsdk_configure(name = "emsdk")
 
 git_repository(
   name = "xnnpack",
-  commit = "63ba2ed105d9256340d104077eda0f27bcbce992",
+  commit = "866f7b3916e2d420d93209523928e87c156e6e17",
   remote = "https://github.com/google/XNNPACK.git",
-  shallow_since = "1572542929 -0700",
+  shallow_since = "1574298137 -0800",
 )
 
 # The libraries below are transitive dependencies of XNNPACK that we need to

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -190,7 +190,7 @@ async function init(): Promise<{wasm: BackendWasmModule}> {
       registerTensor: wasm.cwrap(
           'register_tensor', null,
           [
-            'number',  // dataId
+            'number',  // id
             'number',  // size
             'number',  // memoryOffset
           ]),

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -69,15 +69,13 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void init() { xnn_initialize(); }
+void init() { xnn_initialize(nullptr); }
 
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
 void register_tensor(const int tensor_id, const int size, void *memory_offset) {
-  TensorInfo info = {memory_offset, size};
-  // We move info to avoid a copy.
-  data.emplace(tensor_id, std::move(info));
+  data.emplace(tensor_id, TensorInfo{memory_offset, size});
 }
 
 #ifdef __EMSCRIPTEN__

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2D_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2D_test.cc
@@ -203,9 +203,8 @@ TEST(CONV2D, transposed_filter_lifetime) {
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
   EXPECT_EQ(out, (std::vector<float>{133, 204, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-  // tfjs::wasm::dispose_data(weights0_id);
-  // tfjs::wasm::dispose_data(weights1_id);
-  // ASSERT_EQ(0, tfjs::backend::xnn_operator_count);
+  tfjs::wasm::dispose_data(weights1_id);
+  ASSERT_EQ(0, tfjs::backend::xnn_operator_count);
 
   tfjs::wasm::dispose();
 }


### PR DESCRIPTION
Update to latest XNNPACK and defend against a potential bug in conv2d where we release the memory behind the `transposed_filter` after the scope ends.

The only reason this is not a bug in practice is because xnnpack makes a copy of the filter, but that is internal detail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2421)
<!-- Reviewable:end -->
