### PR TITLE
[WIP]webgpu: Don't use Int32Array.from

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -939,7 +939,7 @@ export class WebGPUBackend extends KernelBackend {
     const output = this.makeOutputArray(outShape, 'int32');
 
     const info = this.tensorMap.get(output.dataId);
-    info.values = Int32Array.from(pixelArray);
+    info.values = new Int32Array(pixelArray);
     this.maybeReleaseBuffer(output.dataId);
 
     this.uploadToGPU(output.dataId);


### PR DESCRIPTION
PERF

Per testing, we find that Int32Array.from is very slow on windows.
If we use 'new Int32Array' to replace 'Int32Array.from', the fromPixels
can speed up 3x-5x on different windows platforms. With this change,
the posenet demo can speedup 2x-3x on plaforms that fromPixels are
bottleneck.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2430)
<!-- Reviewable:end -->
