### PR TITLE
support FusedDepthwiseConv2dNative op

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/fuse_depthwise_conv2d.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fuse_depthwise_conv2d.py
@@ -76,7 +76,6 @@ def _add_fused_contraction_node(contraction, bias_add, activation,
 
   if activation:
     fused_op.attr['fused_ops'].list.s.extend([activation.op.encode('ascii')])
-    fused_op.attr['num_args'].i = fused_op.attr['num_args'].i + 1
     nodes_to_skip[activation.name] = True
     activation.input[:] = [contraction.name]
     inputs_to_remove.append(activation)

--- a/tfjs-converter/python/tensorflowjs/converters/fuse_depthwise_conv2d_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fuse_depthwise_conv2d_test.py
@@ -97,6 +97,6 @@ class FuseDepthwiseConv2dTest(tf.test.TestCase):
     self.assertEqual(depthwise_conv2d_count, 1)
     self.assertEqual(
         depthwise_conv2d.attr['fused_ops'].list.s, [b'BiasAdd', b'Relu'])
-    self.assertEqual(depthwise_conv2d.attr['num_args'].i, 2)
+    self.assertEqual(depthwise_conv2d.attr['num_args'].i, 1)
 if __name__ == '__main__':
   tf.test.main()

--- a/tfjs-converter/python/tensorflowjs/op_list/convolution.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/convolution.json
@@ -464,7 +464,7 @@
     "inputs": [
       {
         "start": 0,
-        "name": "input",
+        "name": "x",
         "type": "tensor"
       },
       {

--- a/tfjs-converter/src/operations/executors/convolution_executor.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor.ts
@@ -72,18 +72,18 @@ export let executeOp: InternalOpExecutor =
           if (isBiasAdd) {
             if (isPrelu && numArgs !== 2) {
               throw new Error(
-                  'Fused Conv2d and DepthwiseConv2d with BiasAdd and Prelu ' +
+                  'FusedConv2d and DepthwiseConv2d with BiasAdd and Prelu ' +
                   'must have two extra arguments: bias and alpha.');
             }
             if (!isPrelu && numArgs !== 1) {
               throw new Error(
-                  'Fused Conv2d and DepthwiseConv2d with BiasAdd must have ' +
+                  'FusedConv2d and DepthwiseConv2d with BiasAdd must have ' +
                   'one extra argument: bias.');
             }
           }
           if (isBatchNorm) {
             throw new Error(
-                'Fused Conv2d with FusedBatchNorm is not supported.');
+                'FusedConv2d and DepthwiseConv2d with FusedBatchNorm is not supported.');
           }
           const stride =
               getParamValue('strides', node, tensorMap, context) as number[];

--- a/tfjs-converter/src/operations/executors/convolution_executor.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor.ts
@@ -23,199 +23,204 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
-                                            tensorMap: NamedTensorsMap,
-                                            context: ExecutionContext):
-                                               tfc.Tensor[] => {
-  switch (node.op) {
-    case 'Conv1D': {
-      const stride =
-          getParamValue('stride', node, tensorMap, context) as number;
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const dataFormat =
-          (getParamValue('dataFormat', node, tensorMap, context) as string)
-              .toUpperCase();
-      const dilation =
-          getParamValue('dilation', node, tensorMap, context) as number;
-      return [tfc.conv1d(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor3D,
-          getParamValue('filter', node, tensorMap, context) as tfc.Tensor3D,
-          stride, pad as 'valid' | 'same', dataFormat as 'NWC' | 'NCW',
-          dilation)];
-    }
-    case 'Conv2D': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const dataFormat =
-          (getParamValue('dataFormat', node, tensorMap, context) as string)
-              .toUpperCase();
-      const dilations =
-          getParamValue('dilations', node, tensorMap, context) as number[];
-      return [tfc.conv2d(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
-              tfc.Tensor4D,
-          getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
-          [stride[1], stride[2]], pad as 'valid' | 'same',
-          dataFormat as 'NHWC' | 'NCHW', [dilations[1], dilations[2]])];
-    }
-    case '_FusedConv2D': {
-      const [extraOp, activationFunc] =
-          (getParamValue('fusedOps', node, tensorMap, context) as string[]);
-
-      const isBiasAdd = extraOp === 'biasadd';
-      const isPrelu = activationFunc === 'prelu';
-      const isBatchNorm = extraOp === 'fusedbatchnorm';
-
-      const numArgs =
-          (getParamValue('numArgs', node, tensorMap, context) as number);
-      if (isBiasAdd) {
-        if (isPrelu && numArgs !== 2) {
-          throw new Error(
-              'Fused Conv2d with BiasAdd and Prelu must have two ' +
-              'extra arguments: bias and alpha.');
+export let executeOp: InternalOpExecutor =
+    (node: Node, tensorMap: NamedTensorsMap,
+     context: ExecutionContext): tfc.Tensor[] => {
+      switch (node.op) {
+        case 'Conv1D': {
+          const stride =
+              getParamValue('stride', node, tensorMap, context) as number;
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const dataFormat =
+              (getParamValue('dataFormat', node, tensorMap, context) as string)
+                  .toUpperCase();
+          const dilation =
+              getParamValue('dilation', node, tensorMap, context) as number;
+          return [tfc.conv1d(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor3D,
+              getParamValue('filter', node, tensorMap, context) as tfc.Tensor3D,
+              stride, pad as 'valid' | 'same', dataFormat as 'NWC' | 'NCW',
+              dilation)];
         }
-        if (!isPrelu && numArgs !== 1) {
-          throw new Error(
-              'Fused Conv2d with BiasAdd must have one extra argument: bias.');
+        case 'Conv2D': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const dataFormat =
+              (getParamValue('dataFormat', node, tensorMap, context) as string)
+                  .toUpperCase();
+          const dilations =
+              getParamValue('dilations', node, tensorMap, context) as number[];
+          return [tfc.conv2d(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
+                  tfc.Tensor4D,
+              getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
+              [stride[1], stride[2]], pad as 'valid' | 'same',
+              dataFormat as 'NHWC' | 'NCHW', [dilations[1], dilations[2]])];
         }
+        case '_FusedConv2D':
+        case 'FusedDepthwiseConv2dNative': {
+          const [extraOp, activationFunc] =
+              (getParamValue('fusedOps', node, tensorMap, context) as string[]);
+
+          const isBiasAdd = extraOp === 'biasadd';
+          const isPrelu = activationFunc === 'prelu';
+          const isBatchNorm = extraOp === 'fusedbatchnorm';
+
+          const numArgs =
+              (getParamValue('numArgs', node, tensorMap, context) as number);
+          if (isBiasAdd) {
+            if (isPrelu && numArgs !== 2) {
+              throw new Error(
+                  'Fused Conv2d and DepthwiseConv2d with BiasAdd and Prelu ' +
+                  'must have two extra arguments: bias and alpha.');
+            }
+            if (!isPrelu && numArgs !== 1) {
+              throw new Error(
+                  'Fused Conv2d and DepthwiseConv2d with BiasAdd must have ' +
+                  'one extra argument: bias.');
+            }
+          }
+          if (isBatchNorm) {
+            throw new Error(
+                'Fused Conv2d with FusedBatchNorm is not supported.');
+          }
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const dataFormat =
+              (getParamValue('dataFormat', node, tensorMap, context) as string)
+                  .toUpperCase();
+          const dilations =
+              getParamValue('dilations', node, tensorMap, context) as number[];
+          const [biasArg, preluArg] =
+              getParamValue('args', node, tensorMap, context) as tfc.Tensor[];
+          const kernelMethod = node.op === '_FusedConv2D' ?
+              tfc.fused.conv2d :
+              tfc.fused.depthwiseConv2d;
+          return [kernelMethod({
+            x: getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
+                tfc.Tensor4D,
+            filter: getParamValue('filter', node, tensorMap, context) as
+                tfc.Tensor4D,
+            strides: [stride[1], stride[2]],
+            pad: pad as 'valid' | 'same',
+            dataFormat: dataFormat as 'NHWC' | 'NCHW',
+            dilations: [dilations[1], dilations[2]],
+            bias: biasArg,
+            activation: activationFunc as tfc.fused.Activation,
+            preluActivationWeights: preluArg
+          })];
+        }
+        case 'Conv2DBackpropInput':
+        case 'Conv2dTranspose': {
+          const shape = getParamValue(
+                            'outputShape', node, tensorMap,
+                            context) as [number, number, number] |
+              [number, number, number, number];
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          return [tfc.conv2dTranspose(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
+                  tfc.Tensor4D,
+              getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
+              shape, [stride[1], stride[2]], pad as 'valid' | 'same')];
+        }
+        case 'DepthwiseConv2dNative':
+        case 'DepthwiseConv2d': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const dilations =
+              getParamValue('dilations', node, tensorMap, context) as number[];
+          const dataFormat =
+              (getParamValue('dataFormat', node, tensorMap, context) as string)
+                  .toUpperCase();
+
+          return [tfc.depthwiseConv2d(
+              getParamValue('input', node, tensorMap, context) as tfc.Tensor3D |
+                  tfc.Tensor4D,
+              getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
+              [stride[1], stride[2]], pad as 'valid' | 'same',
+              dataFormat as 'NHWC' | 'NCHW', [dilations[1], dilations[2]])];
+        }
+        case 'Conv3D': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const dataFormat =
+              (getParamValue('dataFormat', node, tensorMap, context) as string)
+                  .toUpperCase();
+          const dilations =
+              getParamValue('dilations', node, tensorMap, context) as number[];
+          return [tfc.conv3d(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor4D |
+                  tfc.Tensor<tfc.Rank.R5>,
+              getParamValue('filter', node, tensorMap, context) as
+                  tfc.Tensor<tfc.Rank.R5>,
+              [stride[1], stride[2], stride[3]], pad as 'valid' | 'same',
+              dataFormat as 'NDHWC' | 'NCDHW',
+              [dilations[1], dilations[2], dilations[3]])];
+        }
+
+        case 'AvgPool': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const kernelSize =
+              getParamValue('kernelSize', node, tensorMap, context) as number[];
+
+          return [tfc.avgPool(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
+                  tfc.Tensor4D,
+              [kernelSize[1], kernelSize[2]], [stride[1], stride[2]],
+              pad as 'valid' | 'same')];
+        }
+
+        case 'MaxPool': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const kernelSize =
+              getParamValue('kernelSize', node, tensorMap, context) as number[];
+
+          return [tfc.maxPool(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
+                  tfc.Tensor4D,
+              [kernelSize[1], kernelSize[2]], [stride[1], stride[2]],
+              pad as 'valid' | 'same')];
+        }
+
+        case 'AvgPool3D': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const kernelSize =
+              getParamValue('kernelSize', node, tensorMap, context) as number[];
+
+          return [tfc.avgPool3d(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor5D,
+              [kernelSize[1], kernelSize[2], kernelSize[3]],
+              [stride[1], stride[2], stride[3]], pad as 'valid' | 'same')];
+        }
+
+        case 'MaxPool3D': {
+          const stride =
+              getParamValue('strides', node, tensorMap, context) as number[];
+          const pad = getParamValue('pad', node, tensorMap, context);
+          const kernelSize =
+              getParamValue('kernelSize', node, tensorMap, context) as number[];
+
+          return [tfc.maxPool3d(
+              getParamValue('x', node, tensorMap, context) as tfc.Tensor5D,
+              [kernelSize[1], kernelSize[2], kernelSize[3]],
+              [stride[1], stride[2], stride[3]], pad as 'valid' | 'same')];
+        }
+
+        default:
+          throw TypeError(`Node type ${node.op} is not implemented`);
       }
-      if (isBatchNorm) {
-        throw new Error('Fused Conv2d with FusedBatchNorm is not supported.');
-      }
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const dataFormat =
-          (getParamValue('dataFormat', node, tensorMap, context) as string)
-              .toUpperCase();
-      const dilations =
-          getParamValue('dilations', node, tensorMap, context) as number[];
-      const [biasArg, preluArg] =
-          getParamValue('args', node, tensorMap, context) as tfc.Tensor[];
-      return [tfc.fused.conv2d({
-        x: getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
-            tfc.Tensor4D,
-        filter: getParamValue('filter', node, tensorMap, context) as
-            tfc.Tensor4D,
-        strides: [stride[1], stride[2]],
-        pad: pad as 'valid' | 'same',
-        dataFormat: dataFormat as 'NHWC' | 'NCHW',
-        dilations: [dilations[1], dilations[2]],
-        bias: biasArg,
-        activation: activationFunc as tfc.fused.Activation,
-        preluActivationWeights: preluArg
-      })];
-    }
-    case 'Conv2DBackpropInput':
-    case 'Conv2dTranspose': {
-      const shape = getParamValue(
-                        'outputShape', node, tensorMap,
-                        context) as [number, number, number] |
-          [number, number, number, number];
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      return [tfc.conv2dTranspose(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
-              tfc.Tensor4D,
-          getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
-          shape, [stride[1], stride[2]], pad as 'valid' | 'same')];
-    }
-    case 'DepthwiseConv2dNative':
-    case 'DepthwiseConv2d': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const dilations =
-          getParamValue('dilations', node, tensorMap, context) as number[];
-      const dataFormat =
-          (getParamValue('dataFormat', node, tensorMap, context) as string)
-              .toUpperCase();
-
-      return [tfc.depthwiseConv2d(
-          getParamValue('input', node, tensorMap, context) as tfc.Tensor3D |
-              tfc.Tensor4D,
-          getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
-          [stride[1], stride[2]], pad as 'valid' | 'same',
-          dataFormat as 'NHWC' | 'NCHW', [dilations[1], dilations[2]])];
-    }
-    case 'Conv3D': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const dataFormat =
-          (getParamValue('dataFormat', node, tensorMap, context) as string)
-              .toUpperCase();
-      const dilations =
-          getParamValue('dilations', node, tensorMap, context) as number[];
-      return [tfc.conv3d(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor4D |
-              tfc.Tensor<tfc.Rank.R5>,
-          getParamValue('filter', node, tensorMap, context) as
-              tfc.Tensor<tfc.Rank.R5>,
-          [stride[1], stride[2], stride[3]], pad as 'valid' | 'same',
-          dataFormat as 'NDHWC' | 'NCDHW',
-          [dilations[1], dilations[2], dilations[3]])];
-    }
-
-    case 'AvgPool': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const kernelSize =
-          getParamValue('kernelSize', node, tensorMap, context) as number[];
-
-      return [tfc.avgPool(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
-              tfc.Tensor4D,
-          [kernelSize[1], kernelSize[2]], [stride[1], stride[2]],
-          pad as 'valid' | 'same')];
-    }
-
-    case 'MaxPool': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const kernelSize =
-          getParamValue('kernelSize', node, tensorMap, context) as number[];
-
-      return [tfc.maxPool(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor3D |
-              tfc.Tensor4D,
-          [kernelSize[1], kernelSize[2]], [stride[1], stride[2]],
-          pad as 'valid' | 'same')];
-    }
-
-    case 'AvgPool3D': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const kernelSize =
-          getParamValue('kernelSize', node, tensorMap, context) as number[];
-
-      return [tfc.avgPool3d(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor5D,
-          [kernelSize[1], kernelSize[2], kernelSize[3]],
-          [stride[1], stride[2], stride[3]], pad as 'valid' | 'same')];
-    }
-
-    case 'MaxPool3D': {
-      const stride =
-          getParamValue('strides', node, tensorMap, context) as number[];
-      const pad = getParamValue('pad', node, tensorMap, context);
-      const kernelSize =
-          getParamValue('kernelSize', node, tensorMap, context) as number[];
-
-      return [tfc.maxPool3d(
-          getParamValue('x', node, tensorMap, context) as tfc.Tensor5D,
-          [kernelSize[1], kernelSize[2], kernelSize[3]],
-          [stride[1], stride[2], stride[3]], pad as 'valid' | 'same')];
-    }
-
-    default:
-      throw TypeError(`Node type ${node.op} is not implemented`);
-  }
-};
+    };
 
 export const CATEGORY = 'convolution';

--- a/tfjs-converter/src/operations/executors/convolution_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor_test.ts
@@ -323,4 +323,98 @@ describe('convolution', () => {
       });
     });
   });
+  describe('FusedDepthwiseConv2d', () => {
+    it('with bias and activation func', () => {
+      spyOn(tfc.fused, 'depthwiseConv2d');
+      node.op = 'FusedDepthwiseConv2dNative';
+      node.inputParams['filter'] = createTensorAttr(1);
+      node.inputParams['args'] = createTensorsAttr(2, 0);
+      node.attrParams['fusedOps'] = createStrArrayAttr(['biasadd', 'relu']);
+      node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['pad'] = createStrAttr('same');
+      node.attrParams['dataFormat'] = createStrAttr('NHWC');
+      node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['numArgs'] = createNumberAttr(1);
+      const input1 = [tfc.scalar(1.0)];
+      const input2 = [tfc.scalar(2.0)];
+      const input3 = [tfc.scalar(3.0)];
+
+      node.inputNames = ['input1', 'input2', 'input3'];
+      executeOp(node, {input1, input2, input3}, context);
+
+      expect(tfc.fused.depthwiseConv2d).toHaveBeenCalledWith({
+        x: input1[0],
+        filter: input2[0],
+        strides: [2, 2],
+        pad: 'same',
+        dataFormat: 'NHWC',
+        dilations: [2, 2],
+        bias: input3[0],
+        activation: 'relu',
+        preluActivationWeights: undefined
+      });
+    });
+
+    it('with bias and prelu activation func', () => {
+      spyOn(tfc.fused, 'depthwiseConv2d');
+      node.op = 'FusedDepthwiseConv2dNative';
+      node.inputParams['filter'] = createTensorAttr(1);
+      node.inputParams['args'] = createTensorsAttr(2, 0);
+      node.attrParams['fusedOps'] = createStrArrayAttr(['biasadd', 'prelu']);
+      node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['pad'] = createStrAttr('same');
+      node.attrParams['dataFormat'] = createStrAttr('NHWC');
+      node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['numArgs'] = createNumberAttr(2);
+      const input1 = [tfc.scalar(1.0)];
+      const input2 = [tfc.scalar(2.0)];
+      const input3 = [tfc.scalar(3.0)];
+      const input4 = [tfc.scalar(4.0)];
+      node.inputNames = ['input1', 'input2', 'input3', 'input4'];
+      executeOp(node, {input1, input2, input3, input4}, context);
+
+      expect(tfc.fused.depthwiseConv2d).toHaveBeenCalledWith({
+        x: input1[0],
+        filter: input2[0],
+        strides: [2, 2],
+        pad: 'same',
+        dataFormat: 'NHWC',
+        dilations: [2, 2],
+        bias: input3[0],
+        activation: 'prelu',
+        preluActivationWeights: input4[0]
+      });
+    });
+
+    it('bias add', () => {
+      spyOn(tfc.fused, 'depthwiseConv2d');
+      node.op = 'FusedDepthwiseConv2dNative';
+      node.inputParams['filter'] = createTensorAttr(1);
+      node.inputParams['args'] = createTensorsAttr(2, 0);
+      node.attrParams['fusedOps'] = createStrArrayAttr(['biasadd']);
+      node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['pad'] = createStrAttr('same');
+      node.attrParams['dataFormat'] = createStrAttr('NHWC');
+      node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['numArgs'] = createNumberAttr(1);
+      const input1 = [tfc.scalar(1.0)];
+      const input2 = [tfc.scalar(2.0)];
+      const input3 = [tfc.scalar(3.0)];
+
+      node.inputNames = ['input1', 'input2', 'input3'];
+      executeOp(node, {input1, input2, input3}, context);
+
+      expect(tfc.fused.depthwiseConv2d).toHaveBeenCalledWith({
+        x: input1[0],
+        filter: input2[0],
+        strides: [2, 2],
+        pad: 'same',
+        dataFormat: 'NHWC',
+        dilations: [2, 2],
+        bias: input3[0],
+        activation: undefined,
+        preluActivationWeights: undefined
+      });
+    });
+  });
 });

--- a/tfjs-converter/src/operations/op_list/convolution.ts
+++ b/tfjs-converter/src/operations/op_list/convolution.ts
@@ -242,7 +242,7 @@ export const json: OpMapper[] = [
     'tfOpName': 'FusedDepthwiseConv2dNative',
     'category': 'convolution',
     'inputs': [
-      {'start': 0, 'name': 'input', 'type': 'tensor'},
+      {'start': 0, 'name': 'x', 'type': 'tensor'},
       {'start': 1, 'name': 'filter', 'type': 'tensor'},
       {'start': 2, end: 0, 'name': 'args', 'type': 'tensors'},
     ],


### PR DESCRIPTION
Added support for FusedDepthwiseConv2dNative in GraphModel execution.
Fixed an issue with the python converter code, where the numArgs attribute is set wrong for FusedDepthwiseConv2dNative op.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2446)
<!-- Reviewable:end -->
