### PR TITLE
[WASM] Support integer inputs for bilinear resizing and crop and resizing.

### DIFF
--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
@@ -32,12 +32,11 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 
-void ResizeBilinear(int x_id, const DType dtype, int batch, int old_height,
-                    int old_width, int num_channels, int new_height,
-                    int new_width, int align_corners, int out_id) {
+void ResizeBilinear(int x_id, int batch, int old_height, int old_width,
+                    int num_channels, int new_height, int new_width,
+                    int align_corners, int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& out_info = backend::get_tensor_info_out(out_id);
-  std::vector<void*> inputs_buf;
 
   const float* x_buf = x_info.f32();
   float* out_buf = out_info.f32_write();

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
@@ -32,11 +32,12 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 
-void ResizeBilinear(int x_id, int batch, int old_height, int old_width,
-                    int num_channels, int new_height, int new_width,
-                    int align_corners, int out_id) {
+void ResizeBilinear(int x_id, const DType dtype, int batch, int old_height,
+                    int old_width, int num_channels, int new_height,
+                    int new_width, int align_corners, int out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& out_info = backend::get_tensor_info_out(out_id);
+  std::vector<void*> inputs_buf;
 
   const float* x_buf = x_info.f32();
   float* out_buf = out_info.f32_write();

--- a/tfjs-backend-wasm/src/kernels/Cast.ts
+++ b/tfjs-backend-wasm/src/kernels/Cast.ts
@@ -28,8 +28,9 @@ interface CastAttrs extends NamedAttrMap {
   dtype: DataType;
 }
 
-function cast(
-    args: {inputs: CastInputs, attrs: CastAttrs, backend: BackendWasm}) {
+export function cast(
+    args: {inputs: CastInputs, attrs: CastAttrs, backend: BackendWasm}):
+    TensorInfo {
   const {inputs: {x}, attrs: {dtype}, backend} = args;
   const out = backend.makeOutput(x.shape, dtype);
   const inVals = backend.typedArrayFromHeap(x);

--- a/tfjs-backend-wasm/src/kernels/CropAndResize.ts
+++ b/tfjs-backend-wasm/src/kernels/CropAndResize.ts
@@ -73,11 +73,11 @@ function cropAndResize(args: {
   const outShape = [numBoxes, cropHeight, cropWidth, images.shape[3]];
 
   let imagesData = backend.dataIdMap.get(images.dataId);
-  let castedDataId;
+  let castedData;
   if (images.dtype !== 'float32') {
-    castedDataId =
+    castedData =
         cast({backend, inputs: {x: images}, attrs: {dtype: 'float32'}});
-    imagesData = backend.dataIdMap.get(castedDataId.dataId);
+    imagesData = backend.dataIdMap.get(castedData.dataId);
   }
 
   const imagesId = imagesData.id;
@@ -95,8 +95,8 @@ function cropAndResize(args: {
       InterpolationMethod[method as {} as keyof typeof InterpolationMethod],
       extrapolationValue, outId);
 
-  if (castedDataId != null) {
-    backend.disposeData(castedDataId.dataId);
+  if (castedData != null) {
+    backend.disposeData(castedData.dataId);
   }
 
   return out;

--- a/tfjs-backend-wasm/src/kernels/CropAndResize.ts
+++ b/tfjs-backend-wasm/src/kernels/CropAndResize.ts
@@ -18,6 +18,7 @@
 import {NamedAttrMap, NamedTensorInfoMap, registerKernel, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
+import {cast} from './Cast';
 
 interface CropAndResizeInputs extends NamedTensorInfoMap {
   images: TensorInfo;
@@ -71,11 +72,19 @@ function cropAndResize(args: {
   const [cropHeight, cropWidth] = cropSize as [number, number];
   const outShape = [numBoxes, cropHeight, cropWidth, images.shape[3]];
 
-  const imagesId = backend.dataIdMap.get(images.dataId).id;
+  let imagesData = backend.dataIdMap.get(images.dataId);
+  let castedDataId;
+  if (images.dtype !== 'float32') {
+    castedDataId =
+        cast({backend, inputs: {x: images}, attrs: {dtype: 'float32'}});
+    imagesData = backend.dataIdMap.get(castedDataId.dataId);
+  }
+
+  const imagesId = imagesData.id;
   const boxesId = backend.dataIdMap.get(boxes.dataId).id;
   const boxIndId = backend.dataIdMap.get(boxInd.dataId).id;
 
-  const out = backend.makeOutput(outShape, images.dtype);
+  const out = backend.makeOutput(outShape, 'float32');
   const outId = backend.dataIdMap.get(out.dataId).id;
 
   const imagesShapeBytes = new Uint8Array(new Int32Array(images.shape).buffer);
@@ -85,6 +94,11 @@ function cropAndResize(args: {
       cropWidth,
       InterpolationMethod[method as {} as keyof typeof InterpolationMethod],
       extrapolationValue, outId);
+
+  if (castedDataId != null) {
+    backend.disposeData(castedDataId.dataId);
+  }
+
   return out;
 }
 

--- a/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
+++ b/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
@@ -63,10 +63,10 @@ function resizeBilinear(args: {
   const outShape = [batch, newHeight, newWidth, numChannels];
 
   let xData = backend.dataIdMap.get(x.dataId);
-  let castedDataId;
+  let castedData;
   if (xData.dtype !== 'float32') {
-    castedDataId = cast({backend, inputs: {x}, attrs: {dtype: 'float32'}});
-    xData = backend.dataIdMap.get(castedDataId.dataId);
+    castedData = cast({backend, inputs: {x}, attrs: {dtype: 'float32'}});
+    xData = backend.dataIdMap.get(castedData.dataId);
   }
   const xId = xData.id;
 
@@ -80,8 +80,8 @@ function resizeBilinear(args: {
       xId, batch, oldHeight, oldWidth, numChannels, newHeight, newWidth,
       alignCorners ? 1 : 0, outId);
 
-  if (castedDataId != null) {
-    backend.disposeData(castedDataId.dataId);
+  if (castedData != null) {
+    backend.disposeData(castedData.dataId);
   }
 
   return out;

--- a/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
+++ b/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
@@ -69,7 +69,6 @@ function resizeBilinear(args: {
     xData = backend.dataIdMap.get(castedDataId.dataId);
   }
   const xId = xData.id;
-  const dtype = xData.dtype;
 
   const out = backend.makeOutput(outShape, 'float32');
   if (util.sizeFromShape(x.shape) === 0) {

--- a/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
+++ b/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
@@ -20,7 +20,6 @@ import {NamedAttrMap, NamedTensorInfoMap, registerKernel, TensorInfo, util} from
 import {BackendWasm} from '../backend_wasm';
 
 import {cast} from './Cast';
-import {CppDType} from './types';
 
 interface ResizeBilinearInputs extends NamedTensorInfoMap {
   x: TensorInfo;
@@ -33,14 +32,13 @@ interface ResizeBilinearAttrs extends NamedAttrMap {
 }
 
 let wasmResizeBilinear: (
-    xId: number, dtype: number, batch: number, oldHeight: number,
-    oldWidth: number, numChannels: number, newHeight: number, newWidth: number,
+    xId: number, batch: number, oldHeight: number, oldWidth: number,
+    numChannels: number, newHeight: number, newWidth: number,
     alignCorners: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
   wasmResizeBilinear = backend.wasm.cwrap('ResizeBilinear', null /*void*/, [
     'number',  // xId
-    'number',  // dtype
     'number',  // batch
     'number',  // oldHeight
     'number',  // oldWidth
@@ -80,8 +78,8 @@ function resizeBilinear(args: {
   const outId = backend.dataIdMap.get(out.dataId).id;
 
   wasmResizeBilinear(
-      xId, CppDType[dtype], batch, oldHeight, oldWidth, numChannels, newHeight,
-      newWidth, alignCorners ? 1 : 0, outId);
+      xId, batch, oldHeight, oldWidth, numChannels, newHeight, newWidth,
+      alignCorners ? 1 : 0, outId);
 
   if (castedDataId != null) {
     backend.disposeData(castedDataId.dataId);

--- a/tfjs-core/src/backends/cpu/backend_cpu.ts
+++ b/tfjs-core/src/backends/cpu/backend_cpu.ts
@@ -3561,8 +3561,8 @@ export class MathBackendCPU extends KernelBackend {
     const numBoxes = boxes.shape[0];
 
     const [cropHeight, cropWidth] = cropSize;
-    const output = ops.buffer(
-        [numBoxes, cropHeight, cropWidth, numChannels], images.dtype);
+    const output =
+        ops.buffer([numBoxes, cropHeight, cropWidth, numChannels], 'float32');
 
     const boxVals = this.readSync(boxes.dataId) as TypedArray;
     const boxIndVals = this.readSync(boxIndex.dataId) as TypedArray;

--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -2195,7 +2195,7 @@ export class MathBackendWebGL extends KernelBackend {
         new ResizeBilinearPackedProgram(
             x.shape, newHeight, newWidth, alignCorners) :
         new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
-    return this.compileAndRun(program, [x]);
+    return this.compileAndRun(program, [x.toFloat()]);
   }
 
   resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):

--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -2195,7 +2195,7 @@ export class MathBackendWebGL extends KernelBackend {
         new ResizeBilinearPackedProgram(
             x.shape, newHeight, newWidth, alignCorners) :
         new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
-    return this.compileAndRun(program, [x.toFloat()]);
+    return this.compileAndRun(program, [x], 'float32');
   }
 
   resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):

--- a/tfjs-core/src/backends/webgl/backend_webgl.ts
+++ b/tfjs-core/src/backends/webgl/backend_webgl.ts
@@ -2260,7 +2260,7 @@ export class MathBackendWebGL extends KernelBackend {
       extrapolationValue: number): Tensor4D {
     const program = new CropAndResizeProgram(
         image.shape, boxes.shape, cropSize, method, extrapolationValue);
-    return this.compileAndRun(program, [image, boxes, boxIndex]);
+    return this.compileAndRun(program, [image, boxes, boxIndex], 'float32');
   }
 
   depthToSpace(x: Tensor4D, blockSize: number, dataFormat: 'NHWC'|'NCHW'):

--- a/tfjs-core/src/ops/image_ops.ts
+++ b/tfjs-core/src/ops/image_ops.ts
@@ -271,7 +271,7 @@ function cropAndResize_(
     method?: 'bilinear'|'nearest',
     extrapolationValue?: number,
     ): Tensor4D {
-  const $image = convertToTensor(image, 'image', 'cropAndResize', 'float32');
+  const $image = convertToTensor(image, 'image', 'cropAndResize');
   const $boxes = convertToTensor(boxes, 'boxes', 'cropAndResize', 'float32');
   const $boxInd = convertToTensor(boxInd, 'boxInd', 'cropAndResize', 'int32');
   method = method || 'bilinear';

--- a/tfjs-core/src/ops/image_ops_test.ts
+++ b/tfjs-core/src/ops/image_ops_test.ts
@@ -220,74 +220,97 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
   it('1x1-bilinear', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);
-
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [1, 1], 'bilinear', 0);
+
     expect(output.shape).toEqual([1, 1, 1, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [2.5]);
   });
   it('1x1-nearest', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [1, 1], 'nearest', 0);
+
     expect(output.shape).toEqual([1, 1, 1, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [4.0]);
   });
   it('1x1Flipped-bilinear', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([1, 1, 0, 0], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [1, 1], 'bilinear', 0);
+
     expect(output.shape).toEqual([1, 1, 1, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [2.5]);
   });
   it('1x1Flipped-nearest', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([1, 1, 0, 0], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [1, 1], 'nearest', 0);
+
     expect(output.shape).toEqual([1, 1, 1, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [4.0]);
   });
   it('3x3-bilinear', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', 0);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [1, 1.5, 2, 2, 2.5, 3, 3, 3.5, 4]);
   });
   it('3x3-nearest', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'nearest', 0);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [1, 2, 2, 3, 4, 4, 3, 4, 4]);
   });
   it('3x3Flipped-bilinear', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([1, 1, 0, 0], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', 0);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [4, 3.5, 3, 3, 2.5, 2, 2, 1.5, 1]);
   });
   it('3x3Flipped-nearest', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([1, 1, 0, 0], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'nearest', 0);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [4, 4, 3, 4, 4, 3, 2, 2, 1]);
   });
   it('3x3to2x2-bilinear', async () => {
@@ -296,9 +319,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const boxes: tf.Tensor2D =
         tf.tensor2d([0, 0, 1, 1, 0, 0, 0.5, 0.5], [2, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0, 0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [2, 2], 'bilinear', 0);
+
     expect(output.shape).toEqual([2, 2, 2, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [1, 3, 7, 9, 1, 2, 4, 5]);
   });
   it('3x3to2x2-nearest', async () => {
@@ -307,9 +333,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const boxes: tf.Tensor2D =
         tf.tensor2d([0, 0, 1, 1, 0, 0, 0.5, 0.5], [2, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0, 0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [2, 2], 'nearest', 0);
+
     expect(output.shape).toEqual([2, 2, 2, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [1, 3, 7, 9, 1, 2, 4, 5]);
   });
   it('3x3to2x2Flipped-bilinear', async () => {
@@ -318,9 +347,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const boxes: tf.Tensor2D =
         tf.tensor2d([1, 1, 0, 0, 0.5, 0.5, 0, 0], [2, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0, 0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [2, 2], 'bilinear', 0);
+
     expect(output.shape).toEqual([2, 2, 2, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [9, 7, 3, 1, 5, 4, 2, 1]);
   });
   it('3x3to2x2Flipped-nearest', async () => {
@@ -329,18 +361,24 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const boxes: tf.Tensor2D =
         tf.tensor2d([1, 1, 0, 0, 0.5, 0.5, 0, 0], [2, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0, 0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [2, 2], 'nearest', 0);
+
     expect(output.shape).toEqual([2, 2, 2, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [9, 7, 3, 1, 5, 4, 2, 1]);
   });
   it('3x3-BoxisRectangular', async () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1.5], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', 0);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(
         await output.data(), [1, 1.75, 0, 2, 2.75, 0, 3, 3.75, 0]);
   });
@@ -348,9 +386,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1.5], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'nearest', 0);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), [1, 2, 0, 3, 4, 0, 3, 4, 0]);
   });
   it('2x2to3x3-Extrapolated', async () => {
@@ -358,9 +399,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([-1, -1, 1, 1], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', val);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(
         await output.data(), [val, val, val, val, 1, 2, val, 3, 4]);
   });
@@ -369,9 +413,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([-1, -1, 1, 1], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', val);
+
     expect(output.shape).toEqual([1, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(
         await output.data(), [val, val, val, val, 1, 2, val, 3, 4]);
   });
@@ -380,9 +427,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const image: tf.Tensor4D = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([], [0, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', val);
+
     expect(output.shape).toEqual([0, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(await output.data(), []);
   });
   it('MultipleBoxes-DifferentBoxes', async () => {
@@ -391,9 +441,12 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     const boxes: tf.Tensor2D =
         tf.tensor2d([0, 0, 1, 1.5, 0, 0, 1.5, 1], [2, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0, 1], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', 0);
+
     expect(output.shape).toEqual([2, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(
         await output.data(),
         [1, 1.75, 0, 2, 2.75, 0, 3, 3.75, 0, 5, 5.5, 6, 6.5, 7, 7.5, 0, 0, 0]);
@@ -403,11 +456,30 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
         tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1.5, 0, 0, 2, 1], [2, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0, 1], 'int32');
+
     const output =
         tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'nearest', 0);
+
     expect(output.shape).toEqual([2, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
     expectArraysClose(
         await output.data(),
         [1, 2, 0, 3, 4, 0, 3, 4, 0, 5, 6, 6, 7, 8, 8, 0, 0, 0]);
+  });
+  it('int32 image returns float output', async () => {
+    const image: tf.Tensor4D =
+        tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1], 'int32');
+    const boxes: tf.Tensor2D =
+        tf.tensor2d([0, 0, 1, 1.5, 0, 0, 1.5, 1], [2, 4]);
+    const boxInd: tf.Tensor1D = tf.tensor1d([0, 1], 'int32');
+
+    const output =
+        tf.image.cropAndResize(image, boxes, boxInd, [3, 3], 'bilinear', 0);
+
+    expect(output.shape).toEqual([2, 3, 3, 1]);
+    expect(output.dtype).toBe('float32');
+    expectArraysClose(
+        await output.data(),
+        [1, 1.75, 0, 2, 2.75, 0, 3, 3.75, 0, 5, 5.5, 6, 6.5, 7, 7.5, 0, 0, 0]);
   });
 });

--- a/tfjs-core/src/ops/resize_bilinear_test.ts
+++ b/tfjs-core/src/ops/resize_bilinear_test.ts
@@ -56,8 +56,10 @@ describeWithFlags('resizeBilinear', ALL_ENVS, () => {
     const input = tf.tensor3d([1, 2, 3, 4, 5], [1, 5, 1], 'int32');
     const output = input.resizeBilinear([1, 10]);
 
+    expect(output.shape).toEqual([1, 10, 1]);
     expect(output.dtype).toBe('float32');
-    expectArraysClose(await output.data(), [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5]);
+    expectArraysClose(
+      await output.data(), [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5]);
   });
 
   it('matches tensorflow w/ random numbers alignCorners=false', async () => {

--- a/tfjs-core/src/ops/resize_bilinear_test.ts
+++ b/tfjs-core/src/ops/resize_bilinear_test.ts
@@ -52,6 +52,14 @@ describeWithFlags('resizeBilinear', ALL_ENVS, () => {
       1.62451875, 1.83673334, 1.13944793, 2.01993227, 2.01919961, 2.67524052]);
   });
 
+  it('works for ints', async () => {
+    const input = tf.tensor3d([1, 2, 3, 4, 5], [1, 5, 1], 'int32');
+    const output = input.resizeBilinear([1, 10]);
+
+    expect(output.dtype).toBe('float32');
+    expectArraysClose(await output.data(), [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5]);
+  });
+
   it('matches tensorflow w/ random numbers alignCorners=false', async () => {
     const input = tf.tensor3d(
         [


### PR DESCRIPTION
We do this by first casting the input to float32. This happens in V8 so should be very fast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2480)
<!-- Reviewable:end -->
