### PR TITLE
Remove a few unnecessarily mutable exports from tfjs-core

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -1102,4 +1102,4 @@ function getOrMakeEngine(): Engine {
   return ns._tfengine;
 }
 
-export let ENGINE = getOrMakeEngine();
+export const ENGINE = getOrMakeEngine();

--- a/tfjs-core/src/jasmine_util.ts
+++ b/tfjs-core/src/jasmine_util.ts
@@ -210,7 +210,7 @@ export interface TestEnv {
   isDataSync?: boolean;
 }
 
-export let TEST_ENVS: TestEnv[] = [];
+export const TEST_ENVS: TestEnv[] = [];
 
 // Whether a call to setTestEnvs has been called so we turn off
 // registration. This allows command line overriding or programmatic
@@ -218,7 +218,8 @@ export let TEST_ENVS: TestEnv[] = [];
 let testEnvSet = false;
 export function setTestEnvs(testEnvs: TestEnv[]) {
   testEnvSet = true;
-  TEST_ENVS = testEnvs;
+  TEST_ENVS.length = 0;
+  TEST_ENVS.push(...testEnvs);
 }
 
 export function registerTestEnv(testEnv: TestEnv) {


### PR DESCRIPTION
Mutable ESM exports can be difficult to reason about and are often not necessary.

Remove them in a few places that can use `export const` instead.

(At Google internally we forbid them and we are now cleaning up existing usages.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2498)
<!-- Reviewable:end -->
