### PR TITLE
[wasm] Use xnnpack for Add/Sub/Mul/Relu/Relu6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -130,6 +130,7 @@
     "forward_list": "cpp",
     "typeindex": "cpp",
     "*.inc": "cpp",
-    "hash_map": "cpp"
+    "hash_map": "cpp",
+    "__refstring": "cpp"
   }
 }

--- a/tfjs-backend-wasm/notes.txt
+++ b/tfjs-backend-wasm/notes.txt
@@ -1,4 +1,0 @@
-Perf improvements:
-- Detector (15.8ms --> 14.3ms) (~1.10X)
-- Mesh (9.2ms --> 8.2ms) (~1.12X)
-- MobileNet (103ms --> 101ms) (~1X)

--- a/tfjs-backend-wasm/notes.txt
+++ b/tfjs-backend-wasm/notes.txt
@@ -1,0 +1,4 @@
+Perf improvements:
+- Detector (15.8ms --> 14.3ms) (~1.10X)
+- Mesh (9.2ms --> 8.2ms) (~1.12X)
+- MobileNet (103ms --> 101ms) (~1X)

--- a/tfjs-backend-wasm/scripts/cpplint.js
+++ b/tfjs-backend-wasm/scripts/cpplint.js
@@ -26,27 +26,25 @@ const ignoreCode = true;
 const commandOpts = null;
 
 let pythonVersion = exec('python --version', commandOpts, ignoreCode);
-if(pythonVersion['stderr'].includes('Python 2')) {
+if (pythonVersion['stderr'].includes('Python 2')) {
   python2Cmd = 'python';
 } else {
   pythonVersion = exec('python2 --version', commandOpts, ignoreCode);
-  if(pythonVersion.code === 0) {
+  if (pythonVersion.code === 0) {
     python2Cmd = 'python2';
   }
 }
 
-if(python2Cmd != null) {
+if (python2Cmd != null) {
   const result = shell.find('src/cc').filter(
-    fileName => fileName.endsWith('.cc') || fileName.endsWith('.h'));
-
-  console.log(`C++ linting files:`);
-  console.log(result);
+      fileName => fileName.endsWith('.cc') || fileName.endsWith('.h'));
 
   const cwd = process.cwd() + '/' + CC_FILEPATH;
   const filenameArgument = result.join(' ');
 
   exec(`${python2Cmd} tools/cpplint.py --root ${cwd} ${filenameArgument}`);
 } else {
-  console.warn('No python2.x version found - please install python2. ' +
-  'cpplint.py only works correctly with python 2.x.');
+  console.warn(
+      'No python2.x version found - please install python2. ' +
+      'cpplint.py only works correctly with python 2.x.');
 }

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -49,7 +49,8 @@ tfjs_cc_library(
 
 tfjs_cc_library(
   name = "binary",
-  srcs = ["binary.h"],
+  hdrs = ["binary.h"],
+  srcs = ["binary.cc"],
   deps = [
     ":backend",
   ],

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -96,6 +96,16 @@ tfjs_cc_library(
 )
 
 tfjs_cc_library(
+  name = "clamp_impl",
+  hdrs = ["clamp_impl.h"],
+  srcs = ["clamp_impl.cc"],
+  deps = [
+    ":backend",
+    ":util"
+  ],
+)
+
+tfjs_cc_library(
   name = "all_kernels",
   deps = [
     ":Abs",
@@ -361,6 +371,7 @@ tfjs_cc_library(
   srcs = ["kernels/Relu.cc"],
   deps = [
     ":backend",
+    ":clamp_impl",
     ":unary",
   ],
 )
@@ -370,6 +381,7 @@ tfjs_cc_library(
   srcs = ["kernels/Relu6.cc"],
   deps = [
     ":backend",
+    ":clamp_impl",
     ":unary",
   ],
 )

--- a/tfjs-backend-wasm/src/cc/binary.cc
+++ b/tfjs-backend-wasm/src/cc/binary.cc
@@ -1,0 +1,80 @@
+/* Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#include "src/cc/binary.h"
+
+#include <xnnpack.h>
+#include <limits>
+#include <unordered_map>
+
+#include "src/cc/backend.h"
+#include "src/cc/util.h"
+
+namespace {
+// The operator cache maps the create_op_type to the xnn_operator_t
+// instantiated for this set of weights.
+std::unordered_map<tfjs::wasm::xnn_create_binary_op, xnn_operator_t> op_cache;
+}  // namespace
+
+namespace tfjs {
+namespace wasm {
+
+void binary_xnn_f32(const int a_id, const size_t* a_shape_ptr,
+                    const int a_shape_len, const int b_id,
+                    const size_t* b_shape_ptr, const int b_shape_len,
+                    const int out_id, xnn_create_binary_op create_op,
+                    xnn_setup_binary_op setup_op) {
+  auto& a_info = backend::get_tensor_info(a_id);
+  auto& b_info = backend::get_tensor_info(b_id);
+  auto& out_info = backend::get_tensor_info_out(out_id);
+  const float* a_buf = a_info.f32();
+  const float* b_buf = b_info.f32();
+  float* out_buf = out_info.f32_write();
+
+  xnn_operator_t binary_op = nullptr;
+
+  auto cache_result = op_cache.find(create_op);
+  if (cache_result == op_cache.end()) {
+    const float sum_min = -std::numeric_limits<float>::infinity(),
+                sum_max = std::numeric_limits<float>::infinity();
+    const int flags = 0;
+    xnn_status status = create_op(sum_min, sum_max, flags, &binary_op);
+    if (status != xnn_status_success) {
+      util::warn(
+          "XNN status for xnn_create_*_nd_f32 is not successful. Got "
+          "status %d. Use -c dbg to see XNN logs.");
+      return;
+    }
+    op_cache.insert({create_op, binary_op});
+    backend::xnn_operator_count++;
+  } else {
+    binary_op = cache_result->second;
+  }
+  const int batch_size = out_info.size;
+  xnn_status status =
+      setup_op(binary_op, a_shape_len, a_shape_ptr, b_shape_len, b_shape_ptr,
+               a_buf, b_buf, out_buf, nullptr /* thread pool */);
+  if (status != xnn_status_success) {
+    util::warn(
+        "XNN status for xnn_setup_*_nd_f32 is not successful. Got "
+        "status %d. Use -c dbg to see XNN logs.",
+        status);
+    return;
+  }
+
+  xnn_run_operator(binary_op, nullptr /* thread pool */);
+}
+
+}  // namespace wasm
+}  // namespace tfjs

--- a/tfjs-backend-wasm/src/cc/binary.cc
+++ b/tfjs-backend-wasm/src/cc/binary.cc
@@ -22,8 +22,7 @@
 #include "src/cc/util.h"
 
 namespace {
-// The operator cache maps the create_op_type to the xnn_operator_t
-// instantiated for this set of weights.
+// Maps an `xnn_create_*_nd_f32` function pointer to an instantiated operator.
 std::unordered_map<tfjs::wasm::xnn_create_binary_op, xnn_operator_t> op_cache;
 }  // namespace
 

--- a/tfjs-backend-wasm/src/cc/binary.h
+++ b/tfjs-backend-wasm/src/cc/binary.h
@@ -15,6 +15,7 @@
 #ifndef BINARY_H_
 #define BINARY_H_
 
+#include <xnnpack.h>
 #include <algorithm>
 
 #include "src/cc/backend.h"
@@ -57,6 +58,18 @@ inline void binary_bool(const int a_id, const int b_id, const int out_id,
   binary_impl<bool>(a_info.b(), a_info.size, b_info.b(), b_info.size,
                     out_info.b_write(), operation);
 }
+
+typedef xnn_status (*xnn_create_binary_op)(float, float, uint32_t,
+                                           xnn_operator_t*);
+typedef xnn_status (*xnn_setup_binary_op)(xnn_operator_t, size_t, const size_t*,
+                                          size_t, const size_t*, const float*,
+                                          const float*, float*, pthreadpool_t);
+
+void binary_xnn_f32(const int a_id, const size_t* a_shape_ptr,
+                    const int a_shape_len, const int b_id,
+                    const size_t* b_shape_ptr, const int b_shape_len,
+                    const int out_id, xnn_create_binary_op create_op,
+                    xnn_setup_binary_op setup_op);
 
 }  // namespace wasm
 }  // namespace tfjs

--- a/tfjs-backend-wasm/src/cc/clamp_impl.cc
+++ b/tfjs-backend-wasm/src/cc/clamp_impl.cc
@@ -1,0 +1,76 @@
+/* Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#include "src/cc/clamp_impl.h"
+
+#include <xnnpack.h>
+#include <map>
+#include <tuple>
+
+#include "src/cc/backend.h"
+#include "src/cc/util.h"
+
+namespace {
+// These values are keys to creating the xnn clamp operator. We use
+// std::tuple since it implements the compare operator needed for std::map.
+typedef std::tuple<float, float> CacheKey;
+// The operator cache maps the params of xnn_create_clamp_nc_f32 to an operator.
+std::map<CacheKey, xnn_operator_t> op_cache;
+}  // namespace
+
+namespace tfjs {
+namespace wasm {
+
+void xnn_clamp(const int x_id, const int out_id, const float min,
+               const float max) {
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& out_info = backend::get_tensor_info_out(out_id);
+  const float* x_buf = x_info.f32();
+  float* out_buf = out_info.f32_write();
+
+  xnn_operator_t op = nullptr;
+  CacheKey cache_key = {min, max};
+  const auto& cache_result = op_cache.find(cache_key);
+  if (cache_result == op_cache.end()) {
+    const size_t channels = 1, input_stride = 1, output_stride = 1, flags = 1;
+    xnn_status status = xnn_create_clamp_nc_f32(
+        channels, input_stride, output_stride, min, max, flags, &op);
+    if (status != xnn_status_success) {
+      util::warn(
+          "XNN status for xnn_create_clamp_nc_f32 is not successful. "
+          "Got status %d. Use -c dbg to see XNN logs.",
+          status);
+      return;
+    }
+    op_cache.emplace(cache_key, op);
+    backend::xnn_operator_count++;
+  } else {
+    op = cache_result->second;
+  }
+
+  const size_t batch_size = out_info.size;
+  xnn_status status = xnn_setup_clamp_nc_f32(op, batch_size, x_buf, out_buf,
+                                             nullptr /* thread pool */);
+  if (status != xnn_status_success) {
+    util::warn(
+        "XNN status for xnn_setup_clamp_nc_f32 is not successful. "
+        "Got status %d. Use -c dbg to see XNN logs.",
+        status);
+  }
+
+  xnn_run_operator(op, nullptr /* thread pool */);
+}
+
+}  // namespace wasm
+}  // namespace tfjs

--- a/tfjs-backend-wasm/src/cc/clamp_impl.cc
+++ b/tfjs-backend-wasm/src/cc/clamp_impl.cc
@@ -67,6 +67,7 @@ void xnn_clamp(const int x_id, const int out_id, const float min,
         "XNN status for xnn_setup_clamp_nc_f32 is not successful. "
         "Got status %d. Use -c dbg to see XNN logs.",
         status);
+    return;
   }
 
   xnn_run_operator(op, nullptr /* thread pool */);

--- a/tfjs-backend-wasm/src/cc/clamp_impl.h
+++ b/tfjs-backend-wasm/src/cc/clamp_impl.h
@@ -12,26 +12,16 @@
  * limitations under the License.
  * ===========================================================================*/
 
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
-
-#include "src/cc/clamp_impl.h"
+#ifndef CLAMP_IMPL_H_
+#define CLAMP_IMPL_H_
 
 namespace tfjs {
 namespace wasm {
-// We use C-style API to interface with Javascript.
-extern "C" {
 
-#ifdef __EMSCRIPTEN__
-EMSCRIPTEN_KEEPALIVE
-#endif
-void Relu6(const int x_id, const int out_id) {
-  const float min = 0;
-  const float max = 6;
-  xnn_clamp(x_id, out_id, min, max);
-}
+void xnn_clamp(const int x_id, const int out_id, const float min,
+               const float max);
 
-}  // extern "C"
 }  // namespace wasm
 }  // namespace tfjs
+
+#endif  // CLAMP_IMPL_H_

--- a/tfjs-backend-wasm/src/cc/kernels/Add.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Add.cc
@@ -16,6 +16,9 @@
 #include <emscripten.h>
 #endif
 
+#include <xnnpack.h>
+#include <limits>
+
 #include "src/cc/backend.h"
 #include "src/cc/binary.h"
 #include "src/cc/util.h"
@@ -24,6 +27,44 @@ namespace {
 template <class T>
 inline T add(T a, T b) {
   return a + b;
+}
+
+xnn_operator_t add_op = nullptr;
+void xnn_add(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
+             const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
+             const int out_id) {
+  auto& a_info = tfjs::backend::get_tensor_info(a_id);
+  auto& b_info = tfjs::backend::get_tensor_info(b_id);
+  auto& out_info = tfjs::backend::get_tensor_info_out(out_id);
+  const float* a_buf = a_info.f32();
+  const float* b_buf = b_info.f32();
+  float* out_buf = out_info.f32_write();
+  if (add_op == nullptr) {
+    const float sum_min = -std::numeric_limits<float>::infinity(),
+                sum_max = std::numeric_limits<float>::infinity();
+    const int flags = 0;
+    xnn_status status = xnn_create_add_nd_f32(sum_min, sum_max, flags, &add_op);
+    if (status != xnn_status_success) {
+      tfjs::util::warn(
+          "XNN status for xnn_create_add_nd_f32 is not successful. Got "
+          "status %d. Use -c dbg to see XNN logs.");
+      return;
+    }
+    tfjs::backend::xnn_operator_count++;
+  }
+  const int batch_size = out_info.size;
+  xnn_status status = xnn_setup_add_nd_f32(
+      add_op, a_shape_len, a_shape_ptr, b_shape_len, b_shape_ptr, a_buf, b_buf,
+      out_buf, nullptr /* thread pool */);
+  if (status != xnn_status_success) {
+    tfjs::util::warn(
+        "XNN status for xnn_setup_add_nd_f32 is not successful. Got "
+        "status %d. Use -c dbg to see XNN logs.",
+        status);
+    return;
+  }
+
+  xnn_run_operator(add_op, nullptr /* thread pool */);
 }
 }  // namespace
 
@@ -35,11 +76,13 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Add(const int a_id, const int b_id, const DType dtype, const int out_id) {
-  auto& a_info = backend::get_tensor_info(a_id);
+void Add(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
+         const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
+         const DType dtype, const int out_id) {
   switch (dtype) {
     case DType::float32:
-      binary_f32(a_id, b_id, out_id, add<float>);
+      xnn_add(a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr, b_shape_len,
+              out_id);
       break;
     case DType::int32:
       binary_i32(a_id, b_id, out_id, add<int>);

--- a/tfjs-backend-wasm/src/cc/kernels/Add.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Add.cc
@@ -15,11 +15,8 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
-
 #include <xnnpack.h>
-#include <limits>
 
-#include "src/cc/backend.h"
 #include "src/cc/binary.h"
 #include "src/cc/util.h"
 
@@ -27,44 +24,6 @@ namespace {
 template <class T>
 inline T add(T a, T b) {
   return a + b;
-}
-
-xnn_operator_t add_op = nullptr;
-void xnn_add(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
-             const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
-             const int out_id) {
-  auto& a_info = tfjs::backend::get_tensor_info(a_id);
-  auto& b_info = tfjs::backend::get_tensor_info(b_id);
-  auto& out_info = tfjs::backend::get_tensor_info_out(out_id);
-  const float* a_buf = a_info.f32();
-  const float* b_buf = b_info.f32();
-  float* out_buf = out_info.f32_write();
-  if (add_op == nullptr) {
-    const float sum_min = -std::numeric_limits<float>::infinity(),
-                sum_max = std::numeric_limits<float>::infinity();
-    const int flags = 0;
-    xnn_status status = xnn_create_add_nd_f32(sum_min, sum_max, flags, &add_op);
-    if (status != xnn_status_success) {
-      tfjs::util::warn(
-          "XNN status for xnn_create_add_nd_f32 is not successful. Got "
-          "status %d. Use -c dbg to see XNN logs.");
-      return;
-    }
-    tfjs::backend::xnn_operator_count++;
-  }
-  const int batch_size = out_info.size;
-  xnn_status status = xnn_setup_add_nd_f32(
-      add_op, a_shape_len, a_shape_ptr, b_shape_len, b_shape_ptr, a_buf, b_buf,
-      out_buf, nullptr /* thread pool */);
-  if (status != xnn_status_success) {
-    tfjs::util::warn(
-        "XNN status for xnn_setup_add_nd_f32 is not successful. Got "
-        "status %d. Use -c dbg to see XNN logs.",
-        status);
-    return;
-  }
-
-  xnn_run_operator(add_op, nullptr /* thread pool */);
 }
 }  // namespace
 
@@ -81,8 +40,9 @@ void Add(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
          const DType dtype, const int out_id) {
   switch (dtype) {
     case DType::float32:
-      xnn_add(a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr, b_shape_len,
-              out_id);
+      binary_xnn_f32(a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr,
+                     b_shape_len, out_id, xnn_create_add_nd_f32,
+                     xnn_setup_add_nd_f32);
       break;
     case DType::int32:
       binary_i32(a_id, b_id, out_id, add<int>);

--- a/tfjs-backend-wasm/src/cc/kernels/Div.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Div.cc
@@ -35,7 +35,9 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Div(const int a_id, const int b_id, const DType dtype, const int out_id) {
+void Div(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
+         const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
+         const DType dtype, const int out_id) {
   auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:

--- a/tfjs-backend-wasm/src/cc/kernels/FloorDiv.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FloorDiv.cc
@@ -30,8 +30,9 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void FloorDiv(const int a_id, const int b_id, const DType dtype,
-              const int out_id) {
+void FloorDiv(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
+              const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
+              const DType dtype, const int out_id) {
   auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:

--- a/tfjs-backend-wasm/src/cc/kernels/Mul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Mul.cc
@@ -35,7 +35,9 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Mul(const int a_id, const int b_id, const DType dtype, const int out_id) {
+void Mul(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
+         const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
+         const DType dtype, const int out_id) {
   auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:

--- a/tfjs-backend-wasm/src/cc/kernels/Mul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Mul.cc
@@ -15,8 +15,8 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
+#include <xnnpack.h>
 
-#include "src/cc/backend.h"
 #include "src/cc/binary.h"
 #include "src/cc/util.h"
 
@@ -38,10 +38,11 @@ EMSCRIPTEN_KEEPALIVE
 void Mul(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
          const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
          const DType dtype, const int out_id) {
-  auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:
-      binary_f32(a_id, b_id, out_id, mul<float>);
+      binary_xnn_f32(a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr,
+                     b_shape_len, out_id, xnn_create_multiply_nd_f32,
+                     xnn_setup_multiply_nd_f32);
       break;
     case DType::int32:
       binary_i32(a_id, b_id, out_id, mul<int>);

--- a/tfjs-backend-wasm/src/cc/kernels/Relu.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Relu.cc
@@ -16,15 +16,9 @@
 #include <emscripten.h>
 #endif
 
-#include <cmath>
+#include <limits>
 
-#include "src/cc/backend.h"
-#include "src/cc/unary.h"
-
-namespace {
-// TODO(annxingyuan): Use XNN clamp operator.
-inline float oper(const float val) { return val < 0. ? 0. : val; }
-}  // namespace
+#include "src/cc/clamp_impl.h"
 
 namespace tfjs {
 namespace wasm {
@@ -34,7 +28,11 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Relu(const int x_id, const int out_id) { unary(x_id, out_id, oper); }
+void Relu(const int x_id, const int out_id) {
+  const float min = 0;
+  const float max = std::numeric_limits<float>::infinity();
+  xnn_clamp(x_id, out_id, min, max);
+}
 
 }  // extern "C"
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/kernels/Sub.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Sub.cc
@@ -35,7 +35,9 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Sub(const int a_id, const int b_id, const DType dtype, const int out_id) {
+void Sub(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
+         const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
+         const DType dtype, const int out_id) {
   auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:

--- a/tfjs-backend-wasm/src/cc/kernels/Sub.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Sub.cc
@@ -15,8 +15,8 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
+#include <xnnpack.h>
 
-#include "src/cc/backend.h"
 #include "src/cc/binary.h"
 #include "src/cc/util.h"
 
@@ -38,10 +38,11 @@ EMSCRIPTEN_KEEPALIVE
 void Sub(const int a_id, const size_t* a_shape_ptr, const int a_shape_len,
          const int b_id, const size_t* b_shape_ptr, const int b_shape_len,
          const DType dtype, const int out_id) {
-  auto& a_info = backend::get_tensor_info(a_id);
   switch (dtype) {
     case DType::float32:
-      binary_f32(a_id, b_id, out_id, sub<float>);
+      binary_xnn_f32(a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr,
+                     b_shape_len, out_id, xnn_create_subtract_nd_f32,
+                     xnn_setup_subtract_nd_f32);
       break;
     case DType::int32:
       binary_i32(a_id, b_id, out_id, sub<int>);

--- a/tfjs-backend-wasm/src/kernels/Add.ts
+++ b/tfjs-backend-wasm/src/kernels/Add.ts
@@ -16,4 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-registerBinaryKernel('Add');
+const supportsBroadcast = true;
+registerBinaryKernel('Add', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Div.ts
+++ b/tfjs-backend-wasm/src/kernels/Div.ts
@@ -16,4 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-registerBinaryKernel('Div');
+const supportsBroadcast = false;
+registerBinaryKernel('Div', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/FloorDiv.ts
+++ b/tfjs-backend-wasm/src/kernels/FloorDiv.ts
@@ -16,4 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-registerBinaryKernel('FloorDiv');
+const supportsBroadcast = false;
+registerBinaryKernel('FloorDiv', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Mul.ts
+++ b/tfjs-backend-wasm/src/kernels/Mul.ts
@@ -16,4 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-registerBinaryKernel('Mul');
+const supportsBroadcast = false;
+registerBinaryKernel('Mul', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Mul.ts
+++ b/tfjs-backend-wasm/src/kernels/Mul.ts
@@ -16,5 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-const supportsBroadcast = false;
+const supportsBroadcast = true;
 registerBinaryKernel('Mul', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Sub.ts
+++ b/tfjs-backend-wasm/src/kernels/Sub.ts
@@ -16,4 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-registerBinaryKernel('Sub');
+const supportsBroadcast = false;
+registerBinaryKernel('Sub', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Sub.ts
+++ b/tfjs-backend-wasm/src/kernels/Sub.ts
@@ -16,5 +16,5 @@
  */
 
 import {registerBinaryKernel} from './binary_kernel';
-const supportsBroadcast = false;
+const supportsBroadcast = true;
 registerBinaryKernel('Sub', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/binary_kernel.ts
+++ b/tfjs-backend-wasm/src/kernels/binary_kernel.ts
@@ -20,14 +20,21 @@ import {backend_util, NamedTensorInfoMap, registerKernel, TensorInfo, util} from
 import {BackendWasm} from '../backend_wasm';
 import {CppDType} from './types';
 
-export function registerBinaryKernel(kernelName: string) {
-  let wasmFunc: (aId: number, bId: number, dtype: number, outId: number) =>
-      void;
+export function registerBinaryKernel(
+    kernelName: string, supportsBroadcast: boolean) {
+  let wasmFunc:
+      (aId: number, aShape: Uint8Array, aShapeLen: number, bId: number,
+       bShape: Uint8Array, bShapeLen: number, dtype: number, outId: number) =>
+          void;
 
   function setupFunc(backend: BackendWasm): void {
     wasmFunc = backend.wasm.cwrap(kernelName, null /* void */, [
       'number',  // a_id,
+      'array',   // a_shape
+      'number',  // a_shape.length
       'number',  // b_id
+      'array',   // b_shape
+      'number',  // b_shape.length
       'number',  // dtype
       'number'   // out_id
     ]);
@@ -42,8 +49,21 @@ export function registerBinaryKernel(kernelName: string) {
 
     const newShape = backend_util.assertAndGetBroadcastShape(a.shape, b.shape);
     const out = backend.makeOutput(newShape, a.dtype);
+
     // Short-circuit zero-sized tensors.
     if (util.sizeFromShape(newShape) === 0) {
+      return out;
+    }
+
+    const aShapeBytes = new Uint8Array(new Int32Array(a.shape).buffer);
+    const bShapeBytes = new Uint8Array(new Int32Array(b.shape).buffer);
+    const outId = backend.dataIdMap.get(out.dataId).id;
+    const kernelFunc = () => wasmFunc(
+        aId, aShapeBytes, a.shape.length, bId, bShapeBytes, b.shape.length,
+        CppDType[a.dtype], outId);
+
+    if (supportsBroadcast) {
+      kernelFunc();
       return out;
     }
 
@@ -51,10 +71,8 @@ export function registerBinaryKernel(kernelName: string) {
     const bBroadcastDims = backend_util.getBroadcastDims(b.shape, newShape);
     const loopsOverAllOfA = aBroadcastDims.every((v, i) => v === i);
     const loopsOverAllOfB = bBroadcastDims.every((v, i) => v === i);
-    const outId = backend.dataIdMap.get(out.dataId).id;
-
     if (loopsOverAllOfA && loopsOverAllOfB) {
-      wasmFunc(aId, bId, CppDType[a.dtype], outId);
+      kernelFunc();
       return out;
     } else {
       throw new Error('Broadcasting along inner dims is not yet supported');

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -28,10 +28,7 @@ const TEST_FILTERS: TestFilter[] = [
   {
     include: 'add ',
     excludes: [
-      'gradient',                   // Gradient is missing.
-      'broadcast inner dim',        // Broadcast inner dim not yet supported.
-      'broadcast each with 1 dim',  // Same as above.
-      'broadcasting same rank Tensors different shape',  // Same as above.
+      'gradient',                        // Gradient is missing.
       'upcasts when dtypes dont match',  // Uses the 'complex' dtype.
       'complex',                         // Complex numbers not supported yet
     ]

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -126,15 +126,9 @@ const TEST_FILTERS: TestFilter[] = [
   {
     include: 'sub ',
     excludes: [
-      'complex',              // Complex numbers not yet implemented.
-      'gradient',             // Not yet implemented.
-      'upcasts',              // Upcasting not supported yet.
-      'broadcast inner dim',  //  Broadcasting along inner dims not supported.
-      'broadcast each with 1 dim',  //  Broadcasting along inner dims not
-                                    //  supported.
-      'broadcasting same rank Tensors different shape',  //  Broadcasting
-                                                         //  along inner dims
-                                                         //  not supported.
+      'complex',   // Complex numbers not yet implemented.
+      'gradient',  // Not yet implemented.
+      'upcasts',   // Upcasting not supported yet.
     ]
   },
   {
@@ -142,12 +136,6 @@ const TEST_FILTERS: TestFilter[] = [
     excludes: [
       'complex',   // Complex numbers not yet supported.
       'gradient',  // Gradient not defined yet.
-      'broadcasting same rank Tensors different shape',  // Broadcasting along
-                                                         // inner dims not
-                                                         // supported yet.
-      'broadcast 5D + 2D',  // Broadcasting along inner dims not supported
-                            // yet.
-      'broadcast 6D + 2D'   // Broadcasting along inner dims not supported yet.
     ]
   },
   {

--- a/tfjs-backend-wasm/yarn.lock
+++ b/tfjs-backend-wasm/yarn.lock
@@ -49,17 +49,9 @@
   resolved "https://registry.yarnpkg.com/@bazel/hide-bazel-files/-/hide-bazel-files-0.38.3.tgz#e98231d3d360d51860d9c1a7c3345b40dab4cf81"
   integrity sha512-o+dNkfDm3qxWQ8h/04cWuTcjR7qnjZi3pQGv4aklVb16oPWx2jF8BzbkwvWuIkdbOl9VnqYP0vaHzwQVJRRcIA==
 
-"@tensorflow/tfjs-core@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.4.0.tgz#045c91f93cb3ea77473b664c0d1dbad675d7f046"
-  integrity sha512-a7dHhSsBbtaxp8/1UAeYKrjY1bQxsDy/Uhj57+mTuGLAcL8CDrTOXXZzucCgs5nvQErdscp7Gp/2VCcA1xp6XQ==
-  dependencies:
-    "@types/offscreencanvas" "~2019.3.0"
-    "@types/seedrandom" "2.4.27"
-    "@types/webgl-ext" "0.0.30"
-    "@types/webgl2" "0.0.4"
-    node-fetch "~2.1.2"
-    seedrandom "2.4.3"
+"@tensorflow/tfjs-core@link:../tfjs-core":
+  version "0.0.0"
+  uid ""
 
 "@types/emscripten@~0.0.34":
   version "0.0.34"


### PR DESCRIPTION
Call into xnnpack for Add/Sub/Mul/Relu/Relu6. This provides general axis broadcast support for Add, Sub and Mul.

Perf improvements (average of 200 runs on Macbook Pro 15 2018):
- Detector (15.8ms --> 13.9ms) (~14%)
- Mesh (9.2ms --> 8.2ms) (~12%)
- PoseNet (197ms --> 179ms) (~10%)
- MobileNet (103ms --> 101ms) (~0%)

PERF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2506)
<!-- Reviewable:end -->
