### PR TITLE
Remove unnecessarily mutable exports from tfjs-converter

### DIFF
--- a/tfjs-converter/src/operations/executors/arithmetic_executor.ts
+++ b/tfjs-converter/src/operations/executors/arithmetic_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/basic_math_executor.ts
+++ b/tfjs-converter/src/operations/executors/basic_math_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue, getTensor} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/convolution_executor.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor =
+export const executeOp: InternalOpExecutor =
     (node: Node, tensorMap: NamedTensorsMap,
      context: ExecutionContext): tfc.Tensor[] => {
       switch (node.op) {

--- a/tfjs-converter/src/operations/executors/creation_executor.ts
+++ b/tfjs-converter/src/operations/executors/creation_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/evaluation_executor.ts
+++ b/tfjs-converter/src/operations/executors/evaluation_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor =
+export const executeOp: InternalOpExecutor =
     (node: Node, tensorMap: NamedTensorsMap,
      context: ExecutionContext): tfc.Tensor[] => {
       switch (node.op) {

--- a/tfjs-converter/src/operations/executors/graph_executor.ts
+++ b/tfjs-converter/src/operations/executors/graph_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue, getTensor} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/image_executor.ts
+++ b/tfjs-converter/src/operations/executors/image_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/logical_executor.ts
+++ b/tfjs-converter/src/operations/executors/logical_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/matrices_executor.ts
+++ b/tfjs-converter/src/operations/executors/matrices_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/normalization_executor.ts
+++ b/tfjs-converter/src/operations/executors/normalization_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/reduction_executor.ts
+++ b/tfjs-converter/src/operations/executors/reduction_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/slice_join_executor.ts
+++ b/tfjs-converter/src/operations/executors/slice_join_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {

--- a/tfjs-converter/src/operations/executors/spectral_executor.ts
+++ b/tfjs-converter/src/operations/executors/spectral_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue} from './utils';
 
-export let executeOp: InternalOpExecutor =
+export const executeOp: InternalOpExecutor =
     (node: Node, tensorMap: NamedTensorsMap,
      context: ExecutionContext): tfc.Tensor[] => {
       switch (node.op) {

--- a/tfjs-converter/src/operations/executors/transformation_executor.ts
+++ b/tfjs-converter/src/operations/executors/transformation_executor.ts
@@ -23,7 +23,7 @@ import {InternalOpExecutor, Node} from '../types';
 
 import {getParamValue, split} from './utils';
 
-export let executeOp: InternalOpExecutor = (node: Node,
+export const executeOp: InternalOpExecutor = (node: Node,
                                             tensorMap: NamedTensorsMap,
                                             context: ExecutionContext):
                                                tfc.Tensor[] => {


### PR DESCRIPTION
Mutable ESM exports can be difficult to reason about and are often not necessary.

Remove them in places that can use export const instead.

(At Google internally we forbid them and we are now cleaning up existing usages.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2509)
<!-- Reviewable:end -->
