### PR TITLE
[webgpu] Fix memory leak in buffer manager

### DIFF
--- a/tfjs-backend-webgpu/src/buffer_manager.ts
+++ b/tfjs-backend-webgpu/src/buffer_manager.ts
@@ -93,7 +93,7 @@ export class BufferManager {
   }
 
   dispose() {
-    if (this.freeBuffers == null && this.usedBuffers) {
+    if (this.freeBuffers == null && this.usedBuffers == null) {
       return;
     }
 

--- a/tfjs-backend-webgpu/src/buffer_manager.ts
+++ b/tfjs-backend-webgpu/src/buffer_manager.ts
@@ -93,21 +93,21 @@ export class BufferManager {
   }
 
   dispose() {
-    if (this.freeBuffers == null) {
+    if (this.freeBuffers == null && this.usedBuffers) {
       return;
     }
 
-    for (const key in this.freeBuffers) {
-      this.freeBuffers.get(key).forEach(buff => {
+    this.freeBuffers.forEach((buffers, key) => {
+      buffers.forEach(buff => {
         buff.destroy();
       });
-    }
+    });
 
-    for (const key in this.usedBuffers) {
-      this.usedBuffers.get(key).forEach(buff => {
+    this.usedBuffers.forEach((buffers, key) => {
+      buffers.forEach(buff => {
         buff.destroy();
       });
-    }
+    });
 
     this.freeBuffers = null;
     this.usedBuffers = null;


### PR DESCRIPTION
key in this.freeBuffers will lead to NOP, so it will not destroy any buffer.
Below sample can be used to verify this.

```
let freeBuffers: Map<string, number[]> = new Map();
let values: number[];

values = [1, 2, 3];
freeBuffers.set('a', values);
values = [4, 5, 6];
freeBuffers.set('b', values);

// The correct way to iterate over map.
for (freeBuffers.forEach((buffers, key) => {
    buffers.forEach(buff => {
    console.log(buff);
  });
}

// The incorrect way to iterate over map.
for (const key in freeBuffers) {
    freeBuffers.get(key).forEach(buff => {
      console.log(buff);
    });
}
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2525)
<!-- Reviewable:end -->
