### PR TITLE
[wasm] Fix the `build-npm.sh` script

### DIFF
--- a/tfjs-backend-wasm/scripts/build-npm.sh
+++ b/tfjs-backend-wasm/scripts/build-npm.sh
@@ -16,9 +16,10 @@
 
 set -e
 
-yarn rimraf dist/
 yarn
-yarn build
+yarn rimraf dist/
+yarn tsc
+./scripts/build-wasm.sh
 yarn rollup -c
 
 echo "Stored standalone library at dist/tf-backend-wasm(.min).js"

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -191,7 +191,7 @@ const TEST_FILTERS: TestFilter[] = [
   {include: 'pad ', excludes: ['complex', 'zerosLike']},
   {include: 'clip', excludes: ['gradient']},
   {include: 'addN'},
-  {include: 'nonMaxSuppression'},
+  {include: 'nonMaxSuppression', excludes: ['SoftNMS']},
   {include: 'argmax', excludes: ['gradient']},
   {include: 'exp '},
   {include: 'unstack'},


### PR DESCRIPTION
DEV

Make sure the `build-npm.sh` doesn't revert the tfjs-core version in package.json.
Also skip the newly added SoftNMS test since we don't support soft in wasm yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2533)
<!-- Reviewable:end -->
