### PR TITLE
[node] Update libtensorflow version to 1.15.0

### DIFF
--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -58,7 +58,7 @@
     "adm-zip": "^0.4.11",
     "google-protobuf": "^3.9.2",
     "https-proxy-agent": "^2.2.1",
-    "node-pre-gyp": "0.13.0",
+    "node-pre-gyp": "0.14.0",
     "progress": "^2.0.0",
     "rimraf": "^2.6.2",
     "tar": "^4.4.6"

--- a/tfjs-node/package.json
+++ b/tfjs-node/package.json
@@ -55,7 +55,7 @@
     "adm-zip": "^0.4.11",
     "google-protobuf": "^3.9.2",
     "https-proxy-agent": "^2.2.1",
-    "node-pre-gyp": "0.13.0",
+    "node-pre-gyp": "0.14.0",
     "progress": "^2.0.0",
     "rimraf": "^2.6.2",
     "tar": "^4.4.6"

--- a/tfjs-node/scripts/deps-constants.js
+++ b/tfjs-node/scripts/deps-constants.js
@@ -17,17 +17,18 @@
 const os = require('os');
 const path = require('path');
 const module_path_napi = require('../package.json').binary.module_path;
-const modulePath = module_path_napi.replace('{napi_build_version}', process.versions.napi);
+const modulePath =
+    module_path_napi.replace('{napi_build_version}', process.versions.napi);
 
 /** Version of the libtensorflow shared library to depend on. */
-const LIBTENSORFLOW_VERSION = '1.14.0';
+const LIBTENSORFLOW_VERSION = '1.15.0';
 
 /** Get the MAJOR.MINOR-only version of libtensorflow. */
 function getLibTensorFlowMajorDotMinorVersion() {
   const items = LIBTENSORFLOW_VERSION.split('.');
   if (items.length < 3) {
     throw new Error(
-      `Invalid version string for libtensorflow: ${LIBTENSORFLOW_VERSION}`);
+        `Invalid version string for libtensorflow: ${LIBTENSORFLOW_VERSION}`);
   }
   return `${items[0]}.${items[1]}`;
 }
@@ -41,10 +42,10 @@ let destLibTensorFlowFrameworkName = depsLibTensorFlowFrameworkName;
 
 if (os.platform() === 'win32') {
   depsLibTensorFlowName = 'tensorflow.dll';
-  depsLibTensorFlowFrameworkName = ''; // Not supported on Windows
+  depsLibTensorFlowFrameworkName = '';  // Not supported on Windows
 
   destLibTensorFlowName = depsLibTensorFlowName;
-  destLibTensorFlowFrameworkName = ''; // Not supported on Windows
+  destLibTensorFlowFrameworkName = '';  // Not supported on Windows
 } else if (os.platform() === 'darwin') {
   depsLibTensorFlowName += '.dylib';
   depsLibTensorFlowFrameworkName += '.dylib';
@@ -66,7 +67,7 @@ const depsLibPath = path.join(depsPath, 'lib');
 
 const depsLibTensorFlowPath = path.join(depsLibPath, depsLibTensorFlowName);
 const depsLibTensorFlowFrameworkPath =
-  path.join(depsLibPath, depsLibTensorFlowFrameworkName);
+    path.join(depsLibPath, depsLibTensorFlowFrameworkName);
 
 module.exports = {
   depsPath,

--- a/tfjs-node/scripts/install.js
+++ b/tfjs-node/scripts/install.js
@@ -30,7 +30,7 @@ const {
   modulePath
 } = require('./deps-constants.js');
 const resources = require('./resources');
-const {addonName} = require('./get-addon-name.js');
+const { addonName } = require('./get-addon-name.js');
 
 const exists = util.promisify(fs.exists);
 const mkdir = util.promisify(fs.mkdir);
@@ -38,7 +38,7 @@ const rename = util.promisify(fs.rename);
 const rimrafPromise = util.promisify(rimraf);
 
 const BASE_URI =
-    'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
+  'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
 const CPU_DARWIN = `cpu-darwin-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const CPU_LINUX = `cpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const GPU_LINUX = `gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
@@ -48,8 +48,8 @@ const GPU_WINDOWS = `gpu-windows-x86_64-${LIBTENSORFLOW_VERSION}.zip`;
 // TODO(kreeger): Update to TensorFlow 1.13:
 // https://github.com/tensorflow/tfjs/issues/1369
 const TF_WIN_HEADERS_URI =
-    `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
-    `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
+  `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
+  `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
 
 const platform = os.platform();
 let libType = process.argv[2] === undefined ? 'cpu' : process.argv[2];
@@ -59,7 +59,7 @@ let packageJsonFile;
 
 async function setPackageJsonFile() {
   packageJsonFile =
-      JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
+    JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
 }
 
 async function updateAddonName() {
@@ -83,7 +83,7 @@ function getPlatformLibtensorflowUri() {
     if (os.arch() === 'arm') {
       // TODO(kreeger): Handle arm64 as well:
       targetUri =
-          'https://storage.googleapis.com/tf-builds/libtensorflow_r1_14_linux_arm.tar.gz';
+        'https://storage.googleapis.com/tf-builds/libtensorflow_r1_14_linux_arm.tar.gz';
     } else {
       if (libType === 'gpu') {
         targetUri += GPU_LINUX;
@@ -135,43 +135,27 @@ async function downloadLibtensorflow(callback) {
 
   console.warn('* Downloading libtensorflow');
   resources.downloadAndUnpackResource(
-      getPlatformLibtensorflowUri(), depsPath, async () => {
-        if (platform === 'win32') {
-          // Some windows libtensorflow zip files are missing structure and the
-          // eager headers. Check, restructure, and download resources as
-          // needed.
-          const depsIncludePath = path.join(depsPath, 'include');
-          if (!await exists(depsLibTensorFlowPath)) {
-            // Verify that tensorflow.dll exists
-            const libtensorflowDll = path.join(depsPath, 'tensorflow.dll');
-            if (!await exists(libtensorflowDll)) {
-              throw new Error('Could not find libtensorflow.dll');
-            }
-
-            await ensureDir(depsLibPath);
-            await rename(libtensorflowDll, depsLibTensorFlowPath);
+    getPlatformLibtensorflowUri(), depsPath, async () => {
+      if (platform === 'win32') {
+        // Some windows libtensorflow zip files are missing structure and the
+        // eager headers. Check, restructure, and download resources as
+        // needed.
+        if (!await exists(depsLibTensorFlowPath)) {
+          // Verify that tensorflow.dll exists
+          const libtensorflowDll = path.join(depsPath, 'tensorflow.dll');
+          if (!await exists(libtensorflowDll)) {
+            throw new Error('Could not find libtensorflow.dll');
           }
 
-          // The shipped headers for Windows libtensorflow are old - remove and
-          // download the latest:
-          if (await exists(depsIncludePath)) {
-            await rimrafPromise(depsIncludePath);
-          }
-
-          // Download the C headers only and unpack:
-          resources.downloadAndUnpackResource(
-              TF_WIN_HEADERS_URI, depsPath, () => {
-                if (callback !== undefined) {
-                  callback();
-                }
-              });
-        } else {
-          // No other work is required on other platforms.
-          if (callback !== undefined) {
-            callback();
-          }
+          await ensureDir(depsLibPath);
+          await rename(libtensorflowDll, depsLibTensorFlowPath);
         }
-      });
+      }
+      // No other work is required on other platforms.
+      if (callback !== undefined) {
+        callback();
+      }
+    });
 }
 
 /**

--- a/tfjs-node/scripts/install.js
+++ b/tfjs-node/scripts/install.js
@@ -45,12 +45,6 @@ const GPU_LINUX = `gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const CPU_WINDOWS = `cpu-windows-x86_64-${LIBTENSORFLOW_VERSION}.zip`;
 const GPU_WINDOWS = `gpu-windows-x86_64-${LIBTENSORFLOW_VERSION}.zip`;
 
-// TODO(kreeger): Update to TensorFlow 1.13:
-// https://github.com/tensorflow/tfjs/issues/1369
-const TF_WIN_HEADERS_URI =
-    `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
-    `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
-
 const platform = os.platform();
 let libType = process.argv[2] === undefined ? 'cpu' : process.argv[2];
 let forceDownload = process.argv[3] === undefined ? undefined : process.argv[3];

--- a/tfjs-node/scripts/install.js
+++ b/tfjs-node/scripts/install.js
@@ -30,7 +30,7 @@ const {
   modulePath
 } = require('./deps-constants.js');
 const resources = require('./resources');
-const { addonName } = require('./get-addon-name.js');
+const {addonName} = require('./get-addon-name.js');
 
 const exists = util.promisify(fs.exists);
 const mkdir = util.promisify(fs.mkdir);
@@ -38,7 +38,7 @@ const rename = util.promisify(fs.rename);
 const rimrafPromise = util.promisify(rimraf);
 
 const BASE_URI =
-  'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
+    'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
 const CPU_DARWIN = `cpu-darwin-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const CPU_LINUX = `cpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
 const GPU_LINUX = `gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz`;
@@ -48,8 +48,8 @@ const GPU_WINDOWS = `gpu-windows-x86_64-${LIBTENSORFLOW_VERSION}.zip`;
 // TODO(kreeger): Update to TensorFlow 1.13:
 // https://github.com/tensorflow/tfjs/issues/1369
 const TF_WIN_HEADERS_URI =
-  `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
-  `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
+    `https://storage.googleapis.com/tf-builds/tensorflow-headers-` +
+    `${getLibTensorFlowMajorDotMinorVersion()}.zip`;
 
 const platform = os.platform();
 let libType = process.argv[2] === undefined ? 'cpu' : process.argv[2];
@@ -59,7 +59,7 @@ let packageJsonFile;
 
 async function setPackageJsonFile() {
   packageJsonFile =
-    JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
+      JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
 }
 
 async function updateAddonName() {
@@ -83,7 +83,7 @@ function getPlatformLibtensorflowUri() {
     if (os.arch() === 'arm') {
       // TODO(kreeger): Handle arm64 as well:
       targetUri =
-        'https://storage.googleapis.com/tf-builds/libtensorflow_r1_14_linux_arm.tar.gz';
+          'https://storage.googleapis.com/tf-builds/libtensorflow_r1_14_linux_arm.tar.gz';
     } else {
       if (libType === 'gpu') {
         targetUri += GPU_LINUX;
@@ -135,27 +135,27 @@ async function downloadLibtensorflow(callback) {
 
   console.warn('* Downloading libtensorflow');
   resources.downloadAndUnpackResource(
-    getPlatformLibtensorflowUri(), depsPath, async () => {
-      if (platform === 'win32') {
-        // Some windows libtensorflow zip files are missing structure and the
-        // eager headers. Check, restructure, and download resources as
-        // needed.
-        if (!await exists(depsLibTensorFlowPath)) {
-          // Verify that tensorflow.dll exists
-          const libtensorflowDll = path.join(depsPath, 'tensorflow.dll');
-          if (!await exists(libtensorflowDll)) {
-            throw new Error('Could not find libtensorflow.dll');
-          }
+      getPlatformLibtensorflowUri(), depsPath, async () => {
+        if (platform === 'win32') {
+          // Some windows libtensorflow zip files are missing structure and the
+          // eager headers. Check, restructure, and download resources as
+          // needed.
+          if (!await exists(depsLibTensorFlowPath)) {
+            // Verify that tensorflow.dll exists
+            const libtensorflowDll = path.join(depsPath, 'tensorflow.dll');
+            if (!await exists(libtensorflowDll)) {
+              throw new Error('Could not find libtensorflow.dll');
+            }
 
-          await ensureDir(depsLibPath);
-          await rename(libtensorflowDll, depsLibTensorFlowPath);
+            await ensureDir(depsLibPath);
+            await rename(libtensorflowDll, depsLibTensorFlowPath);
+          }
         }
-      }
-      // No other work is required on other platforms.
-      if (callback !== undefined) {
-        callback();
-      }
-    });
+        // No other work is required on other platforms.
+        if (callback !== undefined) {
+          callback();
+        }
+      });
 }
 
 /**

--- a/tfjs-node/yarn.lock
+++ b/tfjs-node/yarn.lock
@@ -1082,6 +1082,14 @@ minipass@^2.2.1, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.8.6:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
@@ -1130,10 +1138,10 @@ node-fetch@~2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-pre-gyp@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
-  integrity sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==
+node-pre-gyp@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -1144,7 +1152,7 @@ node-pre-gyp@0.13.0:
     rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^4"
+    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -1753,7 +1761,20 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-tar@^4, tar@^4.4.6:
+tar@^4.4.2:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
+tar@^4.4.6:
   version "4.4.10"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
   integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==


### PR DESCRIPTION
1. update libtensorflow to 1.15.0, which delivers NonMaxSuppresionV5 (cc: @lina128 )
2. new libtensorflow delivers headers for windows, so no need to download header files from separate address
3. update node-pre-gyp version

This has been tested on Linux/Mac/Windows for both CPU/GPU

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2552)
<!-- Reviewable:end -->
