### PR TITLE
[WASM] Use XNNPack for ResizeBilinear.

### DIFF
--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -16,7 +16,7 @@
     "cpplint": "./scripts/cpplint.js",
     "lint": "tslint -p . -t verbose && yarn cpplint",
     "link-core-master": "./scripts/link-core-master.js && yarn",
-    "test": "yarn link-core-master && ./scripts/build-wasm.sh && karma start",
+    "test": "yarn link-core-master && yarn build-core && ./scripts/build-wasm.sh && karma start",
     "test-node": "ts-node src/test_node.ts",
     "test-bundle-size": "./scripts/test-bundle-size.js",
     "test-cc": "bazel test //src/cc:cc_tests --test_output=all",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -266,9 +266,9 @@ tfjs_cc_library(
 tfjs_cc_library(
   name = "ResizeBilinear",
   srcs = ["kernels/ResizeBilinear.cc"],
+  hdrs = ["kernels/ResizeBilinear.h"],
   deps = [
     ":backend",
-    ":interpolate_bilinear_impl",
     ":util",
   ],
 )
@@ -546,3 +546,12 @@ tfjs_unit_test(
     ":ClipByValue",
   ]
 )
+
+tfjs_unit_test(
+  name = "ResizeBilinear_test",
+  srcs = ["kernels/ResizeBilinear_test.cc"],
+  deps = [
+    ":ResizeBilinear",
+  ]
+)
+

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
@@ -22,8 +22,9 @@
 #include <map>
 #include <vector>
 
-#include "src/cc/backend.h"
+#include "src/cc/kernels/ResizeBilinear.h"
 
+#include "src/cc/backend.h"
 #include "src/cc/util.h"
 
 namespace {

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
@@ -64,7 +64,6 @@ void ResizeBilinear(size_t x_id, size_t batch, size_t old_height,
 
   OperatorCacheKey cache_key = {num_channels, flags};
 
-  // We assume b is the weights and cache the xnn operator on it.
   auto operator_cache_idx = operator_cache.find(cache_key);
   if (operator_cache_idx == operator_cache.end()) {
     const size_t channels = num_channels;
@@ -94,8 +93,8 @@ void ResizeBilinear(size_t x_id, size_t batch, size_t old_height,
       x_buf, out_buf, nullptr /* thread pool */);
   if (status != xnn_status_success) {
     tfjs::util::warn(
-        "XNN status for xnn_setup_fully_connected_nc_f32 is not successful. "
-        "Got status %d. Use -c dbg to see XNN logs.",
+        "XNN status for xnn_setup_resize_bilinear2d_nhwc_f32 is not "
+        "successful. Got status %d. Use -c dbg to see XNN logs.",
         status);
     return;
   }

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstddef>
 #include <map>
+#include <tuple>
 #include <vector>
 
 #include "src/cc/kernels/ResizeBilinear.h"

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.cc
@@ -16,17 +16,30 @@
 #include <emscripten.h>
 #endif
 
+#include <xnnpack.h>
 #include <cmath>
 #include <cstddef>
+#include <map>
 #include <vector>
 
 #include "src/cc/backend.h"
-#include "src/cc/interpolate_bilinear_impl.h"
 
 #include "src/cc/util.h"
 
+namespace {
+// We use std::tuple as the cache key as it implements the compare operator
+// needed for std::map.
+typedef std::tuple<size_t, uint32_t> OperatorCacheKey;
+
+// The operator cache maps the weights id to the xnn_operator_t instantiated for
+// this set of weights.
+std::map<OperatorCacheKey, xnn_operator_t> operator_cache;
+
+}  // namespace
+
 namespace tfjs {
 namespace wasm {
+
 extern "C" {
 
 #ifdef __EMSCRIPTEN__
@@ -35,60 +48,57 @@ EMSCRIPTEN_KEEPALIVE
 
 void ResizeBilinear(size_t x_id, size_t batch, size_t old_height,
                     size_t old_width, size_t num_channels, size_t new_height,
-                    size_t new_width, size_t align_corners, size_t out_id) {
+                    size_t new_width, bool align_corners, size_t out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& out_info = backend::get_tensor_info_out(out_id);
 
   const float* x_buf = x_info.f32();
   float* out_buf = out_info.f32_write();
 
-  const std::vector<size_t> x_shape = {batch, old_height, old_width,
-                                       num_channels};
-  const auto image_strides = util::compute_strides(x_shape);
+  xnn_operator_t resize_bilinear_op = nullptr;
 
-  const float effective_input_height =
-      (align_corners > 0 && new_height > 1) ? old_height - 1 : old_height;
-  const float effective_input_width =
-      (align_corners > 0 && new_width > 1) ? old_width - 1 : old_width;
+  const uint32_t flags = XNN_FLAG_TENSORFLOW_LEGACY_MODE |
+                         (align_corners ? XNN_FLAG_ALIGN_CORNERS : 0);
 
-  const float effective_output_height =
-      (align_corners > 0 && new_height > 1) ? new_height - 1 : new_height;
-  const float effective_output_width =
-      (align_corners > 0 && new_width > 1) ? new_width - 1 : new_width;
+  OperatorCacheKey cache_key = {num_channels, flags};
 
-  const float height_scale = effective_input_height / effective_output_height;
-  const float width_scale = effective_input_width / effective_output_width;
+  // We assume b is the weights and cache the xnn operator on it.
+  auto operator_cache_idx = operator_cache.find(cache_key);
+  if (operator_cache_idx == operator_cache.end()) {
+    const size_t channels = num_channels;
+    const size_t input_pixel_stride = num_channels;
+    const size_t output_pixel_stride = num_channels;
 
-  const bool should_extrapolate = false;
-
-  const float old_height_m1 = old_height - 1;
-  const float old_width_m1 = old_width - 1;
-
-  for (size_t b = 0; b < batch; ++b) {
-    for (size_t r = 0; r < new_height; ++r) {
-      const float y_ind = height_scale * r;
-
-      float* out_buf_ptr = out_buf +
-                           b * (new_height * new_width * num_channels) +
-                           r * (new_width * num_channels);
-
-      const size_t top_ind = std::floor(y_ind);
-      const size_t bottom_ind = std::min(old_height_m1, std::ceil(y_ind));
-      const float y_lerp = y_ind - top_ind;
-
-      const size_t batch_offset = b * image_strides[0];
-
-      if (width_scale == 1 && y_lerp == 0) {
-        memcpy(out_buf_ptr, x_buf + batch_offset + top_ind * image_strides[1],
-               sizeof(float) * new_width * num_channels);
-      } else {
-        tfjs::wasm::interpolate_bilinear(
-            out_buf_ptr, x_buf, image_strides, new_width, old_width,
-            old_width_m1, old_height_m1, num_channels, should_extrapolate, 0.0,
-            batch_offset, y_ind, width_scale, 0.0, 0.0);
-      }
+    xnn_status status = xnn_create_resize_bilinear2d_nhwc_f32(
+        channels, input_pixel_stride, output_pixel_stride, flags,
+        &resize_bilinear_op);
+    if (status != xnn_status_success) {
+      tfjs::util::warn(
+          "XNN status for xnn_create_resize_bilinear2d_nhwc_f32 is not "
+          "successful. Got status %d. Use -c dbg to see XNN logs.",
+          status);
+      return;
     }
+
+    operator_cache.insert({cache_key, resize_bilinear_op});
+
+    tfjs::backend::xnn_operator_count++;
+  } else {
+    resize_bilinear_op = operator_cache_idx->second;
   }
+
+  xnn_status status = xnn_setup_resize_bilinear2d_nhwc_f32(
+      resize_bilinear_op, batch, old_height, old_width, new_height, new_width,
+      x_buf, out_buf, nullptr /* thread pool */);
+  if (status != xnn_status_success) {
+    tfjs::util::warn(
+        "XNN status for xnn_setup_fully_connected_nc_f32 is not successful. "
+        "Got status %d. Use -c dbg to see XNN logs.",
+        status);
+    return;
+  }
+
+  xnn_run_operator(resize_bilinear_op, nullptr /* thread pool */);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.h
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear.h
@@ -1,0 +1,32 @@
+/* Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#ifndef KERNELS_RESIZEBILINEAR_H_
+#define KERNELS_RESIZEBILINEAR_H_
+
+#include <cstddef>
+
+namespace tfjs {
+namespace wasm {
+extern "C" {
+
+void ResizeBilinear(size_t x_id, size_t batch, size_t old_height,
+                    size_t old_width, size_t num_channels, size_t new_height,
+                    size_t new_width, bool align_corners, size_t out_id);
+}
+
+}  // namespace wasm
+}  // namespace tfjs
+
+#endif  // KERNELS_RESIZEBILINEAR_H_

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear_test.cc
@@ -25,14 +25,14 @@ TEST(BATCH_MATMUL, xnn_operator_lifetime) {
 
   ASSERT_EQ(0, tfjs::backend::num_tensors());
 
-  size_t x0_id = 1;
-  size_t x1_id = 2;
-  size_t x_size = 4;
-  float x_values[2] = {1, 2, 2, 2};
+  const size_t x0_id = 1;
+  const size_t x1_id = 2;
+  const size_t x_size = 4;
+  float x_values[x_size] = {1, 2, 2, 2};
 
-  size_t out_id = 3;
-  size_t out_size = 8;
-  float out_values[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  const size_t out_id = 3;
+  const size_t out_size = 8;
+  float out_values[out_size] = {0, 0, 0, 0, 0, 0, 0, 0};
 
   tfjs::wasm::register_tensor(x0_id, x_size, x_values);
   tfjs::wasm::register_tensor(x1_id, x_size, x_values);
@@ -41,54 +41,53 @@ TEST(BATCH_MATMUL, xnn_operator_lifetime) {
   ASSERT_EQ(3, tfjs::backend::num_tensors());
   ASSERT_EQ(0, tfjs::backend::xnn_operator_count);
 
-  size_t batch_size = 1;
+  const size_t batch_size = 1;
   // One new xnn_operator should be created for the first call to
   // ResizeBilinear.
-  size_t old_height0 = 2;
-  size_t old_width0 = 1;
-  size_t num_channels0 = 2;
-  size_t new_height0 = 2;
-  size_t new_width0 = 2;
+  const size_t old_height0 = 2;
+  const size_t old_width0 = 1;
+  const size_t num_channels0 = 2;
+  const size_t new_height0 = 2;
+  const size_t new_width0 = 2;
   bool align_corners0 = false;
-  bool tfjs::wasm::ResizeBilinear(x0_id, batch_size, old_height0, old_width0,
-                                  num_channels0, new_height0, new_width0,
-                                  align_corners, out_id);
+  tfjs::wasm::ResizeBilinear(x0_id, batch_size, old_height0, old_width0,
+                             num_channels0, new_height0, new_width0,
+                             align_corners0, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
-  // // No new xnn_operators should be created for the second call to
-  // BatchMatMul
-  // // with the same b's.
-  // tfjs::wasm::BatchMatMul(x0_id, a_shape_ptr, a_shape.size(), b0_id,
-  //                         b_shape_ptr, b_shape.size(), false /* transpose_a
-  //                         */, false /* transpose_b */, out_id);
-  // ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
+  // No new xnn_operators should be created for the second call to
+  // ResizeBilinear with the same arguments.
+  tfjs::wasm::ResizeBilinear(x0_id, batch_size, old_height0, old_width0,
+                             num_channels0, new_height0, new_width0,
+                             align_corners0, out_id);
+  ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
-  // // One new xnn_operator should be created for another call to BatchMatMul
-  // with
-  // // new b's.
-  // tfjs::wasm::BatchMatMul(x0_id, a_shape_ptr, a_shape.size(), b1_id,
-  //                         b_shape_ptr, b_shape.size(), false /* transpose_a
-  //                         */, false /* transpose_b */, out_id);
-  // ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
+  // No new xnn_operators should be created for the second call to
+  // ResizeBilinear with a new x id but same arguments.
+  tfjs::wasm::ResizeBilinear(x1_id, batch_size, old_height0, old_width0,
+                             num_channels0, new_height0, new_width0,
+                             align_corners0, out_id);
+  ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
-  // // No new xnn_operators should be created for the next call to BatchMatMul
-  // // with the same b's.
-  // tfjs::wasm::BatchMatMul(x0_id, a_shape_ptr, a_shape.size(), b1_id,
-  //                         b_shape_ptr, b_shape.size(), false /* transpose_a
-  //                         */, false /* transpose_b */, out_id);
-  // ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
+  // One new xnn_operator should be created for another call to ResizeBilinear
+  // with a different num_channels argument.
+  const size_t old_height1 = 2;
+  const size_t old_width1 = 2;
+  const size_t num_channels1 = 1;
+  const size_t new_height1 = 2;
+  const size_t new_width1 = 4;
+  tfjs::wasm::ResizeBilinear(x0_id, batch_size, old_height1, old_width1,
+                             num_channels1, new_height1, new_width1,
+                             align_corners0, out_id);
+  ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
-  // // Disposing a's should not remove xnn operators.
-  // tfjs::wasm::dispose_data(x0_id);
-  // tfjs::wasm::dispose_data(x1_id);
-  // ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
-
-  // // Disposing b's should remove xnn operators.
-  // tfjs::wasm::dispose_data(b0_id);
-  // ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
-
-  // tfjs::wasm::dispose_data(b1_id);
-  // ASSERT_EQ(0, tfjs::backend::xnn_operator_count);
+  // One new xnn_operator should be created for another call to ResizeBilinear
+  // with a different align_corners argument
+  bool align_corners1 = true;
+  tfjs::wasm::ResizeBilinear(x0_id, batch_size, old_height1, old_width1,
+                             num_channels1, new_height1, new_width1,
+                             align_corners1, out_id);
+  ASSERT_EQ(3, tfjs::backend::xnn_operator_count);
 
   tfjs::wasm::dispose();
 }

--- a/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/ResizeBilinear_test.cc
@@ -1,0 +1,94 @@
+/* Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+#include "src/cc/backend.h"
+#include "src/cc/kernels/ResizeBilinear.h"
+
+TEST(BATCH_MATMUL, xnn_operator_lifetime) {
+  tfjs::wasm::init();
+
+  ASSERT_EQ(0, tfjs::backend::num_tensors());
+
+  size_t x0_id = 1;
+  size_t x1_id = 2;
+  size_t x_size = 4;
+  float x_values[2] = {1, 2, 2, 2};
+
+  size_t out_id = 3;
+  size_t out_size = 8;
+  float out_values[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+  tfjs::wasm::register_tensor(x0_id, x_size, x_values);
+  tfjs::wasm::register_tensor(x1_id, x_size, x_values);
+  tfjs::wasm::register_tensor(out_id, out_size, out_values);
+
+  ASSERT_EQ(3, tfjs::backend::num_tensors());
+  ASSERT_EQ(0, tfjs::backend::xnn_operator_count);
+
+  size_t batch_size = 1;
+  // One new xnn_operator should be created for the first call to
+  // ResizeBilinear.
+  size_t old_height0 = 2;
+  size_t old_width0 = 1;
+  size_t num_channels0 = 2;
+  size_t new_height0 = 2;
+  size_t new_width0 = 2;
+  bool align_corners0 = false;
+  bool tfjs::wasm::ResizeBilinear(x0_id, batch_size, old_height0, old_width0,
+                                  num_channels0, new_height0, new_width0,
+                                  align_corners, out_id);
+  ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
+
+  // // No new xnn_operators should be created for the second call to
+  // BatchMatMul
+  // // with the same b's.
+  // tfjs::wasm::BatchMatMul(x0_id, a_shape_ptr, a_shape.size(), b0_id,
+  //                         b_shape_ptr, b_shape.size(), false /* transpose_a
+  //                         */, false /* transpose_b */, out_id);
+  // ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
+
+  // // One new xnn_operator should be created for another call to BatchMatMul
+  // with
+  // // new b's.
+  // tfjs::wasm::BatchMatMul(x0_id, a_shape_ptr, a_shape.size(), b1_id,
+  //                         b_shape_ptr, b_shape.size(), false /* transpose_a
+  //                         */, false /* transpose_b */, out_id);
+  // ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
+
+  // // No new xnn_operators should be created for the next call to BatchMatMul
+  // // with the same b's.
+  // tfjs::wasm::BatchMatMul(x0_id, a_shape_ptr, a_shape.size(), b1_id,
+  //                         b_shape_ptr, b_shape.size(), false /* transpose_a
+  //                         */, false /* transpose_b */, out_id);
+  // ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
+
+  // // Disposing a's should not remove xnn operators.
+  // tfjs::wasm::dispose_data(x0_id);
+  // tfjs::wasm::dispose_data(x1_id);
+  // ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
+
+  // // Disposing b's should remove xnn operators.
+  // tfjs::wasm::dispose_data(b0_id);
+  // ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
+
+  // tfjs::wasm::dispose_data(b1_id);
+  // ASSERT_EQ(0, tfjs::backend::xnn_operator_count);
+
+  tfjs::wasm::dispose();
+}

--- a/tfjs-backend-wasm/src/kernels/Maximum.ts
+++ b/tfjs-backend-wasm/src/kernels/Maximum.ts
@@ -15,6 +15,6 @@
  * =============================================================================
  */
 
-import { registerBinaryKernel } from './binary_kernel';
+import {registerBinaryKernel} from './binary_kernel';
 const supportsBroadcast = false;
 registerBinaryKernel('Maximum', supportsBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Minimum.ts
+++ b/tfjs-backend-wasm/src/kernels/Minimum.ts
@@ -15,6 +15,6 @@
  * =============================================================================
  */
 
-import { registerBinaryKernel } from './binary_kernel';
+import {registerBinaryKernel} from './binary_kernel';
 const supportsBroadcast = false;
 registerBinaryKernel('Minimum', supportsBroadcast);


### PR DESCRIPTION
This replaces the current implementation with one that calls into XNNPack.

Benchmark numbers for x: [1, 513, 513, 3] => [257, 257] (from bodypix) on my desktop linux machine:
- Before: ~7ms
- After: ~2ms

This also fixes `yarn test` so that it calls build-core.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2554)
<!-- Reviewable:end -->
