### PR TITLE
webgpu: Add rules to use conv2dWithIm2Col

### DIFF
--- a/tfjs-backend-webgpu/src/benchmark_ops_test.ts
+++ b/tfjs-backend-webgpu/src/benchmark_ops_test.ts
@@ -146,6 +146,27 @@ describeWebGPU('Ops benchmarks', () => {
     await time(() => tf.conv2d(a, b, 1, 'same'));
   });
 
+  it('conv2d1', async () => {
+    const a = tf.randomNormal<tf.Rank.R4>([1, 15, 15, 64]);
+    const b = tf.randomNormal<tf.Rank.R4>([3, 3, 64, 256]);
+
+    await time(() => tf.conv2d(a, b, 1, 'same'), null, true, 20, 20);
+  });
+
+  it('conv2d2', async () => {
+    const a = tf.randomNormal<tf.Rank.R4>([1, 8, 8, 512]);
+    const b = tf.randomNormal<tf.Rank.R4>([3, 3, 512, 512]);
+
+    await time(() => tf.conv2d(a, b, 1, 'same'), null, true, 20, 20);
+  });
+
+  it('conv2d3', async () => {
+    const a = tf.randomNormal<tf.Rank.R4>([1, 17, 17, 256]);
+    const b = tf.randomNormal<tf.Rank.R4>([3, 3, 256, 256]);
+
+    await time(() => tf.conv2d(a, b, 2, 'valid'), null, true, 20, 20);
+  });
+
   it('depthwiseconv2d', async () => {
     const x = tf.randomNormal<tf.Rank.R4>([1, 128, 128, 1]);
     const w = tf.tensor4d(

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -42,11 +42,6 @@ ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 4);
 ENV.registerFlag('WEBGPU_CONV2D_WORK_PER_THREAD', () => 2);
 
 /**
- * Whether we will run im2col as a separate shader for convolution.
- */
-ENV.registerFlag('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', () => false);
-
-/**
  * Whether we use low power GPU. Otherwise, a high performance GPU will be
  * requested.
  */


### PR DESCRIPTION
conv2d with some input shapes is very slow on integrated GPU.
The possible reasons may be that 1) too many complicated calculations
when reading/writing data. 2) the read data is discontinuous in memory.

To some extent, running im2col as a separate shader can solve above issues.
With this change, posenet demo has 1~3 fps improvement on different i-GPU.

Issue: #2553

On i-GPU
Shapes in ResNet   Before   After
[1, 15, 15, 64]:   13.743   4.830
[1, 8, 8, 512]:    8.230    4.711
[1, 17, 17, 256]:  2.462    1.870

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2568)
<!-- Reviewable:end -->
