### PR TITLE
[WASM] Add support for buildifier and CI script.

### DIFF
--- a/tfjs-backend-wasm/BUILD
+++ b/tfjs-backend-wasm/BUILD
@@ -1,2 +1,0 @@
-# This empty BUILD file is necessary so that com_github_bazelbuild_buildtools is
-# happy.

--- a/tfjs-backend-wasm/BUILD
+++ b/tfjs-backend-wasm/BUILD
@@ -1,0 +1,2 @@
+# This empty BUILD file is necessary so that com_github_bazelbuild_buildtools is
+# happy.

--- a/tfjs-backend-wasm/WORKSPACE
+++ b/tfjs-backend-wasm/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 emsdk_configure(name = "emsdk")
 
 git_repository(
-  name = "xnnpack",
-  commit = "403b7d4f2b446f158f1209f26e64104ea772694f",
-  remote = "https://github.com/google/XNNPACK.git",
-  shallow_since = "1575578984 -0800",
+    name = "xnnpack",
+    commit = "403b7d4f2b446f158f1209f26e64104ea772694f",
+    remote = "https://github.com/google/XNNPACK.git",
+    shallow_since = "1575578984 -0800",
 )
 
 # The libraries below are transitive dependencies of XNNPACK that we need to
@@ -19,77 +19,125 @@ git_repository(
 # FP16 library, used for half-precision conversions
 http_archive(
     name = "FP16",
-    strip_prefix = "FP16-ba1d31f5eed2eb4a69e4dea3870a68c7c95f998f",
+    build_file = "@xnnpack//third_party:FP16.BUILD",
     sha256 = "9764297a339ad73b0717331a2c3e9c42a52105cd04cab62cb160e2b4598d2ea6",
+    strip_prefix = "FP16-ba1d31f5eed2eb4a69e4dea3870a68c7c95f998f",
     urls = [
         "https://github.com/Maratyszcza/FP16/archive/ba1d31f5eed2eb4a69e4dea3870a68c7c95f998f.tar.gz",
     ],
-    build_file = "@xnnpack//third_party:FP16.BUILD",
 )
 
 # FXdiv library, used for repeated integer division by the same factor
 http_archive(
     name = "FXdiv",
-    strip_prefix = "FXdiv-f8c5354679ec2597792bc70a9e06eff50c508b9a",
+    build_file = "@xnnpack//third_party:FXdiv.BUILD",
     sha256 = "7d3215bea832fe77091ec5666200b91156df6724da1e348205078346325fc45e",
+    strip_prefix = "FXdiv-f8c5354679ec2597792bc70a9e06eff50c508b9a",
     urls = [
         "https://github.com/Maratyszcza/FXdiv/archive/f8c5354679ec2597792bc70a9e06eff50c508b9a.tar.gz",
     ],
-    build_file = "@xnnpack//third_party:FXdiv.BUILD",
 )
 
 # pthreadpool library, used for parallelization
 http_archive(
     name = "pthreadpool",
-    strip_prefix = "pthreadpool-0e275fe56094626349c55a524ea8b71a85daa64b",
+    build_file = "@xnnpack//third_party:pthreadpool.BUILD",
     sha256 = "c2328fdf9e48ac9b928953bcbc442eb14402d393e4cfae0541581a3d39efca9d",
+    strip_prefix = "pthreadpool-0e275fe56094626349c55a524ea8b71a85daa64b",
     urls = [
         "https://github.com/Maratyszcza/pthreadpool/archive/0e275fe56094626349c55a524ea8b71a85daa64b.tar.gz",
     ],
-    build_file = "@xnnpack//third_party:pthreadpool.BUILD",
 )
 
 # clog library, used for logging
 http_archive(
     name = "clog",
-    strip_prefix = "cpuinfo-d5e37adf1406cf899d7d9ec1d317c47506ccb970",
+    build_file = "@xnnpack//third_party:clog.BUILD",
     sha256 = "3f2dc1970f397a0e59db72f9fca6ff144b216895c1d606f6c94a507c1e53a025",
+    strip_prefix = "cpuinfo-d5e37adf1406cf899d7d9ec1d317c47506ccb970",
     urls = [
         "https://github.com/pytorch/cpuinfo/archive/d5e37adf1406cf899d7d9ec1d317c47506ccb970.tar.gz",
     ],
-    build_file = "@xnnpack//third_party:clog.BUILD",
 )
 
 # cpuinfo library, used for detecting processor characteristics
 http_archive(
     name = "cpuinfo",
-    strip_prefix = "cpuinfo-d5e37adf1406cf899d7d9ec1d317c47506ccb970",
+    build_file = "@xnnpack//third_party:cpuinfo.BUILD",
     sha256 = "3f2dc1970f397a0e59db72f9fca6ff144b216895c1d606f6c94a507c1e53a025",
+    strip_prefix = "cpuinfo-d5e37adf1406cf899d7d9ec1d317c47506ccb970",
     urls = [
         "https://github.com/pytorch/cpuinfo/archive/d5e37adf1406cf899d7d9ec1d317c47506ccb970.tar.gz",
     ],
-    build_file = "@xnnpack//third_party:cpuinfo.BUILD",
 )
 
 # psimd library, used for fallback 128-bit SIMD micro-kernels
 http_archive(
     name = "psimd",
-    strip_prefix = "psimd-4f2c53947184b56f58607b9e777416bb63ebbde1",
+    build_file = "@xnnpack//third_party:psimd.BUILD",
     sha256 = "7d1795ebf289af26e404cff5877c284775e491414cf41d7d99ab850ceaced458",
+    strip_prefix = "psimd-4f2c53947184b56f58607b9e777416bb63ebbde1",
     urls = [
         "https://github.com/Maratyszcza/psimd/archive/4f2c53947184b56f58607b9e777416bb63ebbde1.tar.gz",
     ],
-    build_file = "@xnnpack//third_party:psimd.BUILD",
 )
 
 git_repository(
-  name = "com_google_googletest",
-  commit = "cd17fa2abda2a2e4111cdabd62a87aea16835014",
-  remote = "https://github.com/google/googletest.git"
+    name = "com_google_googletest",
+    commit = "cd17fa2abda2a2e4111cdabd62a87aea16835014",
+    remote = "https://github.com/google/googletest.git",
 )
 
 http_archive(
     name = "rules_cc",
     strip_prefix = "rules_cc-master",
     urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+)
+
+# Buildifier deps
+
+# buildifier is written in Go and hence needs rules_go to be built.
+# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "9fb16af4d4836c8222142e54c9efa0bb5fc562ffc893ce2abeac3e25daead144",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "be9296bfd64882e3c08e3283c58fcb461fa6dd3c171764fcc4cf322f60615a9b",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-master",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-master",
+    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
 )

--- a/tfjs-backend-wasm/WORKSPACE
+++ b/tfjs-backend-wasm/WORKSPACE
@@ -1,6 +1,6 @@
-load("//toolchain:cc_toolchain_config.bzl", "emsdk_configure")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//toolchain:cc_toolchain_config.bzl", "emsdk_configure")
 
 # Make all files under $HOME/emsdk/* visible to the toolchain. The files are
 # available as external/emsdk/emsdk/*
@@ -92,52 +92,4 @@ http_archive(
     name = "rules_cc",
     strip_prefix = "rules_cc-master",
     urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
-)
-
-# Buildifier deps
-
-# buildifier is written in Go and hence needs rules_go to be built.
-# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "9fb16af4d4836c8222142e54c9efa0bb5fc562ffc893ce2abeac3e25daead144",
-    urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
-    ],
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
-
-http_archive(
-    name = "bazel_gazelle",
-    sha256 = "be9296bfd64882e3c08e3283c58fcb461fa6dd3c171764fcc4cf322f60615a9b",
-    urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.1/bazel-gazelle-0.18.1.tar.gz",
-    ],
-)
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-gazelle_dependencies()
-
-http_archive(
-    name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
 )

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -71,7 +71,7 @@ steps:
   args: ['test-bundle-size']
   waitFor: ['build']
 
-# Check bundle size.
+# Lint bazel files.
 - name: 'node:10'
   dir: 'tfjs-backend-wasm'
   id: 'buildifier'

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -71,6 +71,14 @@ steps:
   args: ['test-bundle-size']
   waitFor: ['build']
 
+# Check bundle size.
+- name: 'node:10'
+  dir: 'tfjs-backend-wasm'
+  id: 'buildifier'
+  entrypoint: 'yarn'
+  args: ['buildifier-ci']
+  waitFor: ['yarn']
+
 # General configuration
 secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -16,7 +16,7 @@
     "build": "yarn link-core-master && yarn build-core && rimraf dist/ && tsc && ./scripts/build-wasm.sh",
     "build-ci": "./scripts/build-ci.sh",
     "build-npm": "./scripts/build-npm.sh",
-    "buildifier": "./scripts/buildifier-ci.sh",
+    "buildifier-ci": "./scripts/buildifier-ci.sh",
     "clean": "rimraf dist/ && bazel clean --expunge",
     "cpplint": "./scripts/cpplint.js",
     "lint": "tslint -p . -t verbose && yarn cpplint",

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -8,10 +8,15 @@
   "unpkg": "dist/tf-wasm.min.js",
   "jsdelivr": "dist/tf-wasm.min.js",
   "scripts": {
+    "bazel:format": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unsorted-dict-items,unused-variable",
+    "bazel:format-check": "yarn bazel:format --mode=check",
+    "bazel:lint": "yarn bazel:format --lint=warn",
+    "bazel:lint-check": "yarn bazel:format --lint=warn --mode=check",
     "build-core": "cd ../tfjs-core && yarn && yarn build",
     "build": "yarn link-core-master && yarn build-core && rimraf dist/ && tsc && ./scripts/build-wasm.sh",
     "build-ci": "./scripts/build-ci.sh",
     "build-npm": "./scripts/build-npm.sh",
+    "buildifier": "./scripts/buildifier-ci.sh",
     "clean": "rimraf dist/ && bazel clean --expunge",
     "cpplint": "./scripts/cpplint.js",
     "lint": "tslint -p . -t verbose && yarn cpplint",
@@ -31,6 +36,7 @@
   },
   "devDependencies": {
     "@bazel/bazel": "^0.28.0",
+    "@bazel/buildifier": "0.29.0",
     "@tensorflow/tfjs-core": "link:../tfjs-core",
     "@types/emscripten": "~0.0.34",
     "@types/jasmine": "~2.8.6",

--- a/tfjs-backend-wasm/scripts/buildifier-ci.sh
+++ b/tfjs-backend-wasm/scripts/buildifier-ci.sh
@@ -20,9 +20,11 @@ if [ $? -eq 0 ]
 then
   echo
 else
-  echo && \
-  echo "'yarn bazel:format-check' failed!" && \
-  echo "Please run 'yarn bazel:format'." && \
+  echo
+  echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  echo "'yarn bazel:format-check' failed!"
+  echo "Please run 'yarn bazel:format'."
+  echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   exit 1
 fi
 
@@ -32,8 +34,10 @@ if [ $? -eq 0 ]
 then
   echo
 else
-  echo && \
-  echo "'yarn bazel:lint-check' failed!" && \
-  echo "Please run 'yarn bazel:lint'." && \
+  echo
+  echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  echo "'yarn bazel:lint-check' failed!"
+  echo "Please run 'yarn bazel:lint'."
+  echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   exit 1
 fi

--- a/tfjs-backend-wasm/scripts/buildifier-ci.sh
+++ b/tfjs-backend-wasm/scripts/buildifier-ci.sh
@@ -25,6 +25,7 @@ else
   echo "'yarn bazel:format-check' failed!"
   echo "Please run 'yarn bazel:format'."
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  echo
   exit 1
 fi
 
@@ -39,5 +40,6 @@ else
   echo "'yarn bazel:lint-check' failed!"
   echo "Please run 'yarn bazel:lint'."
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  echo
   exit 1
 fi

--- a/tfjs-backend-wasm/scripts/buildifier-ci.sh
+++ b/tfjs-backend-wasm/scripts/buildifier-ci.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+yarn bazel:format-check
+
+if [ $? -eq 0 ]
+then
+  echo
+else
+  echo && \
+  echo "'yarn bazel:format-check' failed!" && \
+  echo "Please run 'yarn bazel:format'." && \
+  exit 1
+fi
+
+yarn bazel:lint-check
+
+if [ $? -eq 0 ]
+then
+  echo
+else
+  echo && \
+  echo "'yarn bazel:lint-check' failed!" && \
+  echo "Please run 'yarn bazel:lint'." && \
+  exit 1
+fi

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -1,5 +1,5 @@
-load(":build_defs.bzl", "tfjs_cc_library", "tfjs_unit_test")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load(":build_defs.bzl", "tfjs_cc_library", "tfjs_unit_test")
 
 # Emcripten produces a much larger wasm bundle unless the cc_binary has srcs
 # explicitly pointing to files with exported methods (EMSCRIPTEN_KEEPALIVE).
@@ -7,6 +7,9 @@ KERNELS_WITH_KEEPALIVE = glob(
     ["kernels/*.cc"],
     exclude = ["**/*_test.cc"],
 )
+
+
+
 
 cc_binary(
     name = "tfjs-backend-wasm.js",
@@ -79,8 +82,8 @@ tfjs_cc_library(
 
 tfjs_cc_library(
     name = "clamp_impl",
-    hdrs = ["clamp_impl.h"],
     srcs = ["clamp_impl.cc"],
+    hdrs = ["clamp_impl.h"],
     deps = [
         ":backend",
         ":util",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -1,4 +1,3 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load(":build_defs.bzl", "tfjs_cc_library", "tfjs_unit_test")
 
 # Emcripten produces a much larger wasm bundle unless the cc_binary has srcs

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -156,6 +156,8 @@ tfjs_cc_library(
     ":FusedBatchNorm",
     ":FusedConv2D",
     ":FusedDepthwiseConv2D",
+    ":Greater",
+    ":GreaterEqual",
     ":Max",
     ":Maximum",
     ":MaxPool",
@@ -171,8 +173,6 @@ tfjs_cc_library(
     ":Sigmoid",
     ":Sub",
     ":Transpose",
-    ":Greater",
-    ":GreaterEqual",
   ]
 )
 

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -1,15 +1,16 @@
 load(":build_defs.bzl", "tfjs_cc_library", "tfjs_unit_test")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
 # Emcripten produces a much larger wasm bundle unless the cc_binary has srcs
 # explicitly pointing to files with exported methods (EMSCRIPTEN_KEEPALIVE).
 KERNELS_WITH_KEEPALIVE = glob(
-  ["kernels/*.cc"],
-  exclude = ["**/*_test.cc"],
+    ["kernels/*.cc"],
+    exclude = ["**/*_test.cc"],
 )
 
 cc_binary(
     name = "tfjs-backend-wasm.js",
-    srcs = ['backend.cc'] + KERNELS_WITH_KEEPALIVE,
+    srcs = ["backend.cc"] + KERNELS_WITH_KEEPALIVE,
     linkopts = [
         "-s ALLOW_MEMORY_GROWTH=1",
         "-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[]",
@@ -23,570 +24,574 @@ cc_binary(
         "-s MALLOC=emmalloc",
     ],
     deps = [
-        ":backend",
         ":all_kernels",
+        ":backend",
     ],
 )
 
 test_suite(
-  name = "cc_tests"
+    name = "cc_tests",
+)
+
+buildifier(
+    name = "buildifier",
 )
 
 ## Library
 
 tfjs_cc_library(
-  name = "backend",
-  srcs = ["backend.cc"],
-  hdrs = ["backend.h"],
-  deps = [
-    ":check_macros",
-    ":util",
-    "@xnnpack//:xnnpack_operators_nhwc_f32",
-  ],
+    name = "backend",
+    srcs = ["backend.cc"],
+    hdrs = ["backend.h"],
+    deps = [
+        ":check_macros",
+        ":util",
+        "@xnnpack//:xnnpack_operators_nhwc_f32",
+    ],
 )
 
 tfjs_unit_test(
-  name = "backend_tests",
-  srcs = glob(["*_test.cc"]),
-  deps = [
-    ":backend",
-    ":util",
-    ":Prelu",
-  ]
+    name = "backend_tests",
+    srcs = glob(["*_test.cc"]),
+    deps = [
+        ":Prelu",
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "binary",
-  hdrs = ["binary.h"],
-  srcs = ["binary.cc"],
-  deps = [
-    ":backend",
-  ],
+    name = "binary",
+    srcs = ["binary.cc"],
+    hdrs = ["binary.h"],
+    deps = [
+        ":backend",
+    ],
 )
 
 tfjs_cc_library(
-  name = "check_macros",
-  srcs = ["check_macros.h"],
-  deps = [
-    ":util",
-  ],
+    name = "check_macros",
+    srcs = ["check_macros.h"],
+    deps = [
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "clamp_impl",
-  hdrs = ["clamp_impl.h"],
-  srcs = ["clamp_impl.cc"],
-  deps = [
-    ":backend",
-    ":util"
-  ],
+    name = "clamp_impl",
+    srcs = ["clamp_impl.cc"],
+    hdrs = ["clamp_impl.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "conv2d_impl",
-  hdrs = ["conv2d_impl.h"],
-  srcs = ["conv2d_impl.cc"],
-  deps = [
-    ":backend",
-    ":transpose_impl",
-    ":prelu_impl",
-    ":util",
-  ],
+    name = "conv2d_impl",
+    srcs = ["conv2d_impl.cc"],
+    hdrs = ["conv2d_impl.h"],
+    deps = [
+        ":backend",
+        ":prelu_impl",
+        ":transpose_impl",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "interpolate_bilinear_impl",
-  hdrs = ["interpolate_bilinear_impl.h"],
-  srcs = ["interpolate_bilinear_impl.cc"],
-  deps = [
-    ":backend",
-    ":util"
-  ],
+    name = "interpolate_bilinear_impl",
+    srcs = ["interpolate_bilinear_impl.cc"],
+    hdrs = ["interpolate_bilinear_impl.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "prelu_impl",
-  hdrs = ["prelu_impl.h"],
-  srcs = ["prelu_impl.cc"],
-  deps = [
-    ":backend",
-    ":util"
-  ],
+    name = "prelu_impl",
+    srcs = ["prelu_impl.cc"],
+    hdrs = ["prelu_impl.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "transpose_impl",
-  hdrs = ["transpose_impl.h"],
-  srcs = ["transpose_impl.cc"],
-  deps = [":util"],
+    name = "transpose_impl",
+    srcs = ["transpose_impl.cc"],
+    hdrs = ["transpose_impl.h"],
+    deps = [":util"],
 )
 
 tfjs_cc_library(
-  name = "util",
-  hdrs = ["util.h"],
-  srcs = ["util.cc"],
+    name = "util",
+    srcs = ["util.cc"],
+    hdrs = ["util.h"],
 )
 
 tfjs_cc_library(
-  name = "unary",
-  srcs = ["unary.h"],
-  deps = [
-    ":backend",
-  ],
+    name = "unary",
+    srcs = ["unary.h"],
+    deps = [
+        ":backend",
+    ],
 )
 
 # Kernels
 
 tfjs_cc_library(
-  name = "all_kernels",
-  deps = [
-    ":Abs",
-    ":Add",
-    ":AvgPool",
-    ":AddN",
-    ":ArgMax",
-    ":BatchMatMul",
-    ":Div",
-    ":ClipByValue",
-    ":CropAndResize",
-    ":Conv2D",
-    ":DepthwiseConv2dNative",
-    ":Exp",
-    ":FloorDiv",
-    ":FusedBatchNorm",
-    ":FusedConv2D",
-    ":FusedDepthwiseConv2D",
-    ":Greater",
-    ":GreaterEqual",
-    ":Max",
-    ":Maximum",
-    ":MaxPool",
-    ":Minimum",
-    ":Min",
-    ":Mul",
-    ":NonMaxSuppressionV3",
-    ":PadV2",
-    ":Prelu",
-    ":Relu",
-    ":Relu6",
-    ":ResizeBilinear",
-    ":Sigmoid",
-    ":Sub",
-    ":Transpose",
-  ]
+    name = "all_kernels",
+    deps = [
+        ":Abs",
+        ":Add",
+        ":AddN",
+        ":ArgMax",
+        ":AvgPool",
+        ":BatchMatMul",
+        ":ClipByValue",
+        ":Conv2D",
+        ":CropAndResize",
+        ":DepthwiseConv2dNative",
+        ":Div",
+        ":Exp",
+        ":FloorDiv",
+        ":FusedBatchNorm",
+        ":FusedConv2D",
+        ":FusedDepthwiseConv2D",
+        ":Greater",
+        ":GreaterEqual",
+        ":Max",
+        ":MaxPool",
+        ":Maximum",
+        ":Min",
+        ":Minimum",
+        ":Mul",
+        ":NonMaxSuppressionV3",
+        ":PadV2",
+        ":Prelu",
+        ":Relu",
+        ":Relu6",
+        ":ResizeBilinear",
+        ":Sigmoid",
+        ":Sub",
+        ":Transpose",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Abs",
-  srcs = ["kernels/Abs.cc"],
-  deps = [
-    ":backend",
-    ":unary",
-  ],
+    name = "Abs",
+    srcs = ["kernels/Abs.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Add",
-  srcs = ["kernels/Add.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Add",
+    srcs = ["kernels/Add.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "AddN",
-  srcs = ["kernels/AddN.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "AddN",
+    srcs = ["kernels/AddN.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "ArgMax",
-  srcs = ["kernels/ArgMax.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "ArgMax",
+    srcs = ["kernels/ArgMax.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "AvgPool",
-  srcs = ["kernels/AvgPool.cc"],
-  hdrs = ["kernels/AvgPool.h"],
-  deps = [
-    ":backend",
-    ":util"
-  ]
+    name = "AvgPool",
+    srcs = ["kernels/AvgPool.cc"],
+    hdrs = ["kernels/AvgPool.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_unit_test(
-  name = "AvgPool_test",
-  srcs = ["kernels/AvgPool_test.cc"],
-  deps = [
-    ":AvgPool"
-  ]
+    name = "AvgPool_test",
+    srcs = ["kernels/AvgPool_test.cc"],
+    deps = [
+        ":AvgPool",
+    ],
 )
 
 tfjs_cc_library(
-  name = "BatchMatMul",
-  srcs = ["kernels/BatchMatMul.cc"],
-  hdrs = ["kernels/BatchMatMul.h"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "BatchMatMul",
+    srcs = ["kernels/BatchMatMul.cc"],
+    hdrs = ["kernels/BatchMatMul.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_unit_test(
-  name = "BatchMatMul_test",
-  srcs = ["kernels/BatchMatMul_test.cc"],
-  deps = [
-    ":BatchMatMul",
-  ]
+    name = "BatchMatMul_test",
+    srcs = ["kernels/BatchMatMul_test.cc"],
+    deps = [
+        ":BatchMatMul",
+    ],
 )
 
 tfjs_cc_library(
-  name = "ClipByValue",
-  hdrs = ["kernels/ClipByValue.h"],
-  srcs = ["kernels/ClipByValue.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "ClipByValue",
+    srcs = ["kernels/ClipByValue.cc"],
+    hdrs = ["kernels/ClipByValue.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_unit_test(
-  name = "ClipByValue_test",
-  srcs = ["kernels/ClipByValue_test.cc"],
-  deps = [
-    ":ClipByValue",
-  ]
+    name = "ClipByValue_test",
+    srcs = ["kernels/ClipByValue_test.cc"],
+    deps = [
+        ":ClipByValue",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Conv2D",
-  srcs = ["kernels/Conv2D.cc"],
-  hdrs = ["kernels/Conv2D.h"],
-  deps = [
-    ":conv2d_impl",
-  ],
+    name = "Conv2D",
+    srcs = ["kernels/Conv2D.cc"],
+    hdrs = ["kernels/Conv2D.h"],
+    deps = [
+        ":conv2d_impl",
+    ],
 )
 
 tfjs_unit_test(
-  name = "Conv2D_test",
-  srcs = ["kernels/Conv2D_test.cc"],
-  deps = [
-    ":Conv2D",
-  ]
+    name = "Conv2D_test",
+    srcs = ["kernels/Conv2D_test.cc"],
+    deps = [
+        ":Conv2D",
+    ],
 )
 
 tfjs_cc_library(
-  name = "CropAndResize",
-  srcs = ["kernels/CropAndResize.cc"],
-  deps = [
-    ":backend",
-    ":interpolate_bilinear_impl",
-    ":util",
-  ],
+    name = "CropAndResize",
+    srcs = ["kernels/CropAndResize.cc"],
+    deps = [
+        ":backend",
+        ":interpolate_bilinear_impl",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "DepthwiseConv2dNative",
-  srcs = ["kernels/DepthwiseConv2dNative.cc"],
-  hdrs = ["kernels/DepthwiseConv2dNative.h"],
-  deps = [
-    ":conv2d_impl",
-  ],
+    name = "DepthwiseConv2dNative",
+    srcs = ["kernels/DepthwiseConv2dNative.cc"],
+    hdrs = ["kernels/DepthwiseConv2dNative.h"],
+    deps = [
+        ":conv2d_impl",
+    ],
 )
 
 tfjs_unit_test(
-  name = "DepthwiseConv2dNative_test",
-  srcs = ["kernels/DepthwiseConv2dNative_test.cc"],
-  deps = [
-    ":DepthwiseConv2dNative",
-  ]
+    name = "DepthwiseConv2dNative_test",
+    srcs = ["kernels/DepthwiseConv2dNative_test.cc"],
+    deps = [
+        ":DepthwiseConv2dNative",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Div",
-  srcs = ["kernels/Div.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Div",
+    srcs = ["kernels/Div.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Exp",
-  srcs = ["kernels/Exp.cc"],
-  deps = [
-    ":backend",
-    ":unary",
-  ],
+    name = "Exp",
+    srcs = ["kernels/Exp.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "FloorDiv",
-  srcs = ["kernels/FloorDiv.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "FloorDiv",
+    srcs = ["kernels/FloorDiv.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "FusedBatchNorm",
-  srcs = ["kernels/FusedBatchNorm.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "FusedBatchNorm",
+    srcs = ["kernels/FusedBatchNorm.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "FusedConv2D",
-  srcs = ["kernels/FusedConv2D.cc"],
-  hdrs = ["kernels/FusedConv2D.h"],
-  deps = [
-    ":conv2d_impl",
-  ],
+    name = "FusedConv2D",
+    srcs = ["kernels/FusedConv2D.cc"],
+    hdrs = ["kernels/FusedConv2D.h"],
+    deps = [
+        ":conv2d_impl",
+    ],
 )
 
 tfjs_unit_test(
-  name = "FusedConv2D_test",
-  srcs = ["kernels/FusedConv2D_test.cc"],
-  deps = [
-    ":FusedConv2D",
-  ]
+    name = "FusedConv2D_test",
+    srcs = ["kernels/FusedConv2D_test.cc"],
+    deps = [
+        ":FusedConv2D",
+    ],
 )
 
 tfjs_cc_library(
-  name = "FusedDepthwiseConv2D",
-  srcs = ["kernels/FusedDepthwiseConv2D.cc"],
-  hdrs = ["kernels/FusedDepthwiseConv2D.h"],
-  deps = [
-    ":conv2d_impl",
-  ],
+    name = "FusedDepthwiseConv2D",
+    srcs = ["kernels/FusedDepthwiseConv2D.cc"],
+    hdrs = ["kernels/FusedDepthwiseConv2D.h"],
+    deps = [
+        ":conv2d_impl",
+    ],
 )
 
 tfjs_unit_test(
-  name = "FusedDepthwiseConv2D_test",
-  srcs = ["kernels/FusedDepthwiseConv2D_test.cc"],
-  deps = [
-    ":FusedDepthwiseConv2D",
-  ]
+    name = "FusedDepthwiseConv2D_test",
+    srcs = ["kernels/FusedDepthwiseConv2D_test.cc"],
+    deps = [
+        ":FusedDepthwiseConv2D",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Greater",
-  srcs = ["kernels/Greater.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Greater",
+    srcs = ["kernels/Greater.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "GreaterEqual",
-  srcs = ["kernels/GreaterEqual.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "GreaterEqual",
+    srcs = ["kernels/GreaterEqual.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Log",
-  srcs = ["kernels/Log.cc"],
-  deps = [
-    ":backend",
-    ":unary",
-  ],
+    name = "Log",
+    srcs = ["kernels/Log.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Max",
-  srcs = ["kernels/Max.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "Max",
+    srcs = ["kernels/Max.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Maximum",
-  srcs = ["kernels/Maximum.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Maximum",
+    srcs = ["kernels/Maximum.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "MaxPool",
-  srcs = ["kernels/MaxPool.cc"],
-  hdrs = ["kernels/MaxPool.h"],
-  deps = [
-    ":backend",
-    ":util"
-  ]
+    name = "MaxPool",
+    srcs = ["kernels/MaxPool.cc"],
+    hdrs = ["kernels/MaxPool.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_unit_test(
-  name = "MaxPool_test",
-  srcs = ["kernels/MaxPool_test.cc"],
-  deps = [
-    ":MaxPool"
-  ]
+    name = "MaxPool_test",
+    srcs = ["kernels/MaxPool_test.cc"],
+    deps = [
+        ":MaxPool",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Min",
-  srcs = ["kernels/Min.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "Min",
+    srcs = ["kernels/Min.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Minimum",
-  srcs = ["kernels/Minimum.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Minimum",
+    srcs = ["kernels/Minimum.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Mul",
-  srcs = ["kernels/Mul.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Mul",
+    srcs = ["kernels/Mul.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "NonMaxSuppressionV3",
-  srcs = ["kernels/NonMaxSuppressionV3.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "NonMaxSuppressionV3",
+    srcs = ["kernels/NonMaxSuppressionV3.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "PadV2",
-  srcs = ["kernels/PadV2.cc"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "PadV2",
+    srcs = ["kernels/PadV2.cc"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Prelu",
-  srcs = ["kernels/Prelu.cc"],
-  hdrs = ["kernels/Prelu.h"],
-  deps = [
-    ":backend",
-    ":util",
-    ":prelu_impl",
-  ],
+    name = "Prelu",
+    srcs = ["kernels/Prelu.cc"],
+    hdrs = ["kernels/Prelu.h"],
+    deps = [
+        ":backend",
+        ":prelu_impl",
+        ":util",
+    ],
 )
 
 tfjs_unit_test(
-  name = "Prelu_test",
-  srcs = ["kernels/Prelu_test.cc"],
-  deps = [
-    ":Prelu",
-  ]
+    name = "Prelu_test",
+    srcs = ["kernels/Prelu_test.cc"],
+    deps = [
+        ":Prelu",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Relu",
-  srcs = ["kernels/Relu.cc"],
-  deps = [
-    ":backend",
-    ":clamp_impl",
-    ":unary",
-  ],
+    name = "Relu",
+    srcs = ["kernels/Relu.cc"],
+    deps = [
+        ":backend",
+        ":clamp_impl",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Relu6",
-  srcs = ["kernels/Relu6.cc"],
-  deps = [
-    ":backend",
-    ":clamp_impl",
-    ":unary",
-  ],
+    name = "Relu6",
+    srcs = ["kernels/Relu6.cc"],
+    deps = [
+        ":backend",
+        ":clamp_impl",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "ResizeBilinear",
-  srcs = ["kernels/ResizeBilinear.cc"],
-  hdrs = ["kernels/ResizeBilinear.h"],
-  deps = [
-    ":backend",
-    ":util",
-  ],
+    name = "ResizeBilinear",
+    srcs = ["kernels/ResizeBilinear.cc"],
+    hdrs = ["kernels/ResizeBilinear.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
 )
 
 tfjs_unit_test(
-  name = "ResizeBilinear_test",
-  srcs = ["kernels/ResizeBilinear_test.cc"],
-  deps = [
-    ":ResizeBilinear",
-  ]
+    name = "ResizeBilinear_test",
+    srcs = ["kernels/ResizeBilinear_test.cc"],
+    deps = [
+        ":ResizeBilinear",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Sigmoid",
-  srcs = ["kernels/Sigmoid.cc"],
-  deps = [
-    ":backend",
-    ":unary",
-  ],
+    name = "Sigmoid",
+    srcs = ["kernels/Sigmoid.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Square",
-  srcs = ["kernels/Square.cc"],
-  deps = [
-    ":backend",
-    ":unary",
-  ],
+    name = "Square",
+    srcs = ["kernels/Square.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Sub",
-  srcs = ["kernels/Sub.cc"],
-  deps = [
-    ":backend",
-    ":binary",
-    ":util",
-  ],
+    name = "Sub",
+    srcs = ["kernels/Sub.cc"],
+    deps = [
+        ":backend",
+        ":binary",
+        ":util",
+    ],
 )
 
 tfjs_cc_library(
-  name = "Transpose",
-  srcs = ["kernels/Transpose.cc"],
-  deps = [
-    ":backend",
-    ":util",
-    ":transpose_impl",
-  ],
+    name = "Transpose",
+    srcs = ["kernels/Transpose.cc"],
+    deps = [
+        ":backend",
+        ":transpose_impl",
+        ":util",
+    ],
 )

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -8,9 +8,6 @@ KERNELS_WITH_KEEPALIVE = glob(
     exclude = ["**/*_test.cc"],
 )
 
-
-
-
 cc_binary(
     name = "tfjs-backend-wasm.js",
     srcs = ["backend.cc"] + KERNELS_WITH_KEEPALIVE,

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -32,10 +32,6 @@ test_suite(
     name = "cc_tests",
 )
 
-buildifier(
-    name = "buildifier",
-)
-
 ## Library
 
 tfjs_cc_library(

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -79,8 +79,8 @@ tfjs_cc_library(
 
 tfjs_cc_library(
     name = "clamp_impl",
-    srcs = ["clamp_impl.cc"],
     hdrs = ["clamp_impl.h"],
+    srcs = ["clamp_impl.cc"],
     deps = [
         ":backend",
         ":util",

--- a/tfjs-backend-wasm/src/cc/build_defs.bzl
+++ b/tfjs-backend-wasm/src/cc/build_defs.bzl
@@ -14,7 +14,7 @@ def tfjs_unit_test(name, srcs, deps = []):
         linkstatic = True,
         deps = [
             "@com_google_googletest//:gtest_main",
-        ] + deps
+        ] + deps,
     )
 
 def tfjs_cc_library(name, srcs = [], hdrs = [], deps = []):
@@ -27,9 +27,9 @@ def tfjs_cc_library(name, srcs = [], hdrs = [], deps = []):
     """
 
     native.cc_library(
-      name = name,
-      linkstatic = True,
-      srcs = srcs,
-      hdrs = hdrs,
-      deps = deps,
+        name = name,
+        linkstatic = True,
+        srcs = srcs,
+        hdrs = hdrs,
+        deps = deps,
     )

--- a/tfjs-backend-wasm/toolchain/cc_toolchain_config.bzl
+++ b/tfjs-backend-wasm/toolchain/cc_toolchain_config.bzl
@@ -172,8 +172,8 @@ cc_toolchain_config = rule(
 
 def _emsdk_impl(ctx):
     if "EMSDK" not in ctx.os.environ or ctx.os.environ["EMSDK"].strip() == "":
-      fail("The environment variable EMSDK is not found. " +
-           "Did you run source ./emsdk_env.sh ?")
+        fail("The environment variable EMSDK is not found. " +
+             "Did you run source ./emsdk_env.sh ?")
     path = ctx.os.environ["EMSDK"]
     ctx.symlink(path, "emsdk")
     ctx.file("BUILD", """

--- a/tfjs-backend-wasm/toolchain/cc_toolchain_config.bzl
+++ b/tfjs-backend-wasm/toolchain/cc_toolchain_config.bzl
@@ -1,3 +1,4 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "feature",
@@ -6,7 +7,6 @@ load(
     "tool_path",
     "with_feature_set",
 )
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 def _impl(ctx):
     tool_paths = [

--- a/tfjs-backend-wasm/yarn.lock
+++ b/tfjs-backend-wasm/yarn.lock
@@ -44,6 +44,30 @@
     "@bazel/bazel-linux_x64" "0.28.1"
     "@bazel/bazel-win32_x64" "0.28.1"
 
+"@bazel/buildifier-darwin_x64@0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-darwin_x64/-/buildifier-darwin_x64-0.29.0.tgz#13dfaf3ea4d89f9d4da00085e894e90b7d302342"
+  integrity sha512-jiQIZo5z1c8oFokD2jObrkB04Bs+7RaUJ6WlHV9BBeJiRMGfRVUBUrOF5eJPk6VB8qknIOfHvJD/Ym5XUc1Zlw==
+
+"@bazel/buildifier-linux_x64@0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-linux_x64/-/buildifier-linux_x64-0.29.0.tgz#0191fc46735a1c281878642673844f2b717cd8dc"
+  integrity sha512-sXXY0gP4oC1nC1G8Baqd7kyBL/y9/qOqftKSkDe2Y7gBoc9GslwyexwDxTSxK0Gun/4Vcvc2eRu7b83hMOxuag==
+
+"@bazel/buildifier-win32_x64@0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-win32_x64/-/buildifier-win32_x64-0.29.0.tgz#a63438c7a7d2dc593e626ed6e163e9d8ea93917a"
+  integrity sha512-hnOQfPhQNAIqbrhsHT3MWAyAZSUhKwxzEuZJZoOsGrW8fPonhKysdvfZJqfqJ6vDVYaMJKvLnSO1c9QZRhU7kQ==
+
+"@bazel/buildifier@0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier/-/buildifier-0.29.0.tgz#7984739270c8d1dd23650f87a810e1e6367188d9"
+  integrity sha512-skJ7vVff7x3tB8crBCtJji2wU09uH0uD2N30xfOpVUgsMJSXktAQMj8+RPdMBqJQ9XS5+O5lmRthR35Ua7xQXA==
+  optionalDependencies:
+    "@bazel/buildifier-darwin_x64" "0.29.0"
+    "@bazel/buildifier-linux_x64" "0.29.0"
+    "@bazel/buildifier-win32_x64" "0.29.0"
+
 "@bazel/hide-bazel-files@latest":
   version "0.38.3"
   resolved "https://registry.yarnpkg.com/@bazel/hide-bazel-files/-/hide-bazel-files-0.38.3.tgz#e98231d3d360d51860d9c1a7c3345b40dab4cf81"


### PR DESCRIPTION
The new commands:
`yarn bazel:format` and `yarn bazel:lint`.

FYI these (crazy long) scripts are the official scripts taken from this page: https://docs.bazel.build/versions/master/build-javascript.html

Here is an example of a failing cloudbuild: https://pantheon.corp.google.com/cloud-build/builds/afff2e3b-9dce-4457-9ec7-2cceefd8cced;step=9?project=learnjs-174218

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2572)
<!-- Reviewable:end -->
