### PR TITLE
[WASM] Automatically format BUILD and .bzl files when saving in vscode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,14 @@
   "[cpp]": {
     "editor.formatOnSave": true
   },
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "(BUILD|.*bzl)",
+        "cmd": "yarn bazel:format && yarn bazel:lint"
+      }
+    ]
+  },
   "editor.defaultFormatter": "xaver.clang-format",
   "editor.rulers": [80],
   "clang-format.style": "Google",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -37,6 +37,7 @@ test_suite(
 tfjs_cc_library(
     name = "backend",
     srcs = ["backend.cc"],
+    hdrs = ["backend.h"],
     deps = [
         ":check_macros",
         ":util",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -37,7 +37,6 @@ test_suite(
 tfjs_cc_library(
     name = "backend",
     srcs = ["backend.cc"],
-    hdrs = ["backend.h"],
     deps = [
         ":check_macros",
         ":util",

--- a/tfjs.code-workspace
+++ b/tfjs.code-workspace
@@ -62,7 +62,9 @@
       // Formats typescript, javascript and c++ code.
       "xaver.clang-format",
       // Lints typescipt code.
-      "ms-vscode.vscode-typescript-tslint-plugin"
+      "ms-vscode.vscode-typescript-tslint-plugin",
+      // Running custom linters on save.
+      "emeraldwalk.RunOnSave"
     ]
   }
 }


### PR DESCRIPTION
This using the emeraldwalk.runonsave extension and calls our linting tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2576)
<!-- Reviewable:end -->
