### PR TITLE
[WASM] Fix bug where we try to set more memory on WASM heap than malloc'd

### DIFF
--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -83,7 +83,8 @@ export class BackendWasm extends KernelBackend {
 
     if (values != null) {
       this.wasm.HEAPU8.set(
-          new Uint8Array((values as backend_util.TypedArray).buffer),
+          new Uint8Array(
+              (values as backend_util.TypedArray).buffer, 0, numBytes),
           memoryOffset);
     }
   }

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -26,6 +26,15 @@ setTestEnvs([{name: 'test-wasm', backendName: 'wasm', isDataSync: true}]);
  */
 const TEST_FILTERS: TestFilter[] = [
   {
+    startsWith: 'tensor ',
+    excludes: [
+      'complex',     // Complex numbers not supported yet
+      'derivative',  // Gradients not yet supported.
+      // Downcasting broken, see: https://github.com/tensorflow/tfjs/issues/2590
+      'Tensor2D float32 -> bool', 'Tensor2D int32 -> bool'
+    ]
+  },
+  {
     include: 'add ',
     excludes: [
       'gradient',                        // Gradient is missing.

--- a/tfjs-core/src/tensor_test.ts
+++ b/tfjs-core/src/tensor_test.ts
@@ -1534,8 +1534,8 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const a = new Float32Array([1, 2, 3, 4, 5]);
     const b = a.subarray(0, 2);
     const t = tf.tensor1d(b);
-    expect(t.shape).toEqual([3]);
-    expectArraysClose(await t.data(), [1, 2, 3]);
+    expect(t.shape).toEqual([2]);
+    expectArraysClose(await t.data(), [1, 2]);
   });
 });
 

--- a/tfjs-core/src/tensor_test.ts
+++ b/tfjs-core/src/tensor_test.ts
@@ -1529,6 +1529,14 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const a = tf.ones([2, 2], 'complex64');
     expectArraysClose(await a.data(), [1, 0, 1, 0, 1, 0, 1, 0]);
   });
+
+  it('can create a tensor where values.size != buffer.size', async () => {
+    const a = new Float32Array([1, 2, 3, 4, 5]);
+    const b = a.subarray(0, 2);
+    const t = tf.tensor1d(b);
+    expect(t.shape).toEqual([3]);
+    expectArraysClose(await t.data(), [1, 2, 3]);
+  });
 });
 
 describeWithFlags('tensor debug mode', ALL_ENVS, () => {


### PR DESCRIPTION
If a values TypedArray is passed to the WASM backend we:
1) malloc bytes based on the shape, dtype
2) set the buffer based on the values buffer size.

However, the values buffer size could not match the size of the values array itself because values can be a view of a larger buffer (e.g. with Array.subarray()).

This makes sure we only set into the WASM heap the number of bytes we've actually malloc'd.

The unit test I wrote to catch this is now in core (as all backends need this to be true) and I verified it crashes the page without the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2591)
<!-- Reviewable:end -->
