### PR TITLE
[WIP] Add nonMaxSuppression kernel

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -20,9 +20,6 @@
 import './flags_webgpu';
 
 import {backend_util, DataStorage, DataType, engine, env, findBackend, KernelBackend, Rank, RecursiveArray, ShapeMap, slice_util, sumOutType, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TimingInfo, util} from '@tensorflow/tfjs-core';
-// TODO(xing.xu): use nonMaxSuppressionV3 from backend_util:
-// tslint:disable-next-line: no-imports-from-dist
-import {nonMaxSuppressionImpl} from '@tensorflow/tfjs-core/dist/backends/non_max_suppression_impl';
 import {Glslang} from '@webgpu/glslang/dist/web-devel/glslang.onefile';
 
 import {BufferManager} from './buffer_manager';
@@ -1100,7 +1097,7 @@ export class WebGPUBackend extends KernelBackend {
 
     const boxesVals = boxes.dataSync();
     const scoresVals = scores.dataSync();
-    return nonMaxSuppressionImpl(
+    return backend_util.nonMaxSuppressionV3(
         boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
   }
 

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -20,6 +20,9 @@
 import './flags_webgpu';
 
 import {backend_util, DataStorage, DataType, engine, env, findBackend, KernelBackend, Rank, RecursiveArray, ShapeMap, slice_util, sumOutType, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TimingInfo, util} from '@tensorflow/tfjs-core';
+// TODO(xing.xu): use nonMaxSuppressionV3 from backend_util:
+// tslint:disable-next-line: no-imports-from-dist
+import {nonMaxSuppressionImpl} from '@tensorflow/tfjs-core/dist/backends/non_max_suppression_impl';
 import {Glslang} from '@webgpu/glslang/dist/web-devel/glslang.onefile';
 
 import {BufferManager} from './buffer_manager';
@@ -1086,6 +1089,19 @@ export class WebGPUBackend extends KernelBackend {
     }
 
     return this.compileAndRun(program, [a, b], output);
+  }
+
+  nonMaxSuppression(
+      boxes: Tensor2D, scores: Tensor1D, maxOutputSize: number,
+      iouThreshold: number, scoreThreshold: number): Tensor1D {
+    console.warn(
+        'tf.nonMaxSuppression() in WebGPU locks the UI thread. ' +
+        'Call tf.nonMaxSuppressionAsync() instead');
+
+    const boxesVals = boxes.dataSync();
+    const scoresVals = scores.dataSync();
+    return nonMaxSuppressionImpl(
+        boxesVals, scoresVals, maxOutputSize, iouThreshold, scoreThreshold);
   }
 
   fromPixels(

--- a/tfjs-backend-webgpu/src/kernels/non_max_suppression_v5.ts
+++ b/tfjs-backend-webgpu/src/kernels/non_max_suppression_v5.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, NamedAttrMap, NamedTensorInfoMap, registerKernel, TensorInfo} from '@tensorflow/tfjs-core';
+import {WebGPUBackend} from '../backend_webgpu';
+
+interface NonMaxSuppressionWithScoreInputs extends NamedTensorInfoMap {
+  boxes: TensorInfo;
+  scores: TensorInfo;
+}
+
+interface NonMaxSuppressionWithScoreAttrs extends NamedAttrMap {
+  maxOutputSize: number;
+  iouThreshold: number;
+  scoreThreshold: number;
+  softNmsSigma: number;
+}
+
+registerKernel({
+  kernelName: 'NonMaxSuppressionV5',
+  backendName: 'webgpu',
+  kernelFunc: ({inputs, backend, attrs}) => {
+    console.warn(
+        'tf.nonMaxSuppression() in webgpu locks the UI thread. ' +
+        'Call tf.nonMaxSuppressionAsync() instead');
+
+    const {boxes, scores} = inputs as NonMaxSuppressionWithScoreInputs;
+    const {maxOutputSize, iouThreshold, scoreThreshold, softNmsSigma} =
+        attrs as NonMaxSuppressionWithScoreAttrs;
+
+    const gpuBackend = backend as WebGPUBackend;
+
+    const boxesVals =
+        gpuBackend.readSync(boxes.dataId) as backend_util.TypedArray;
+    const scoresVals =
+        gpuBackend.readSync(scores.dataId) as backend_util.TypedArray;
+
+    const maxOutputSizeVal = maxOutputSize;
+    const iouThresholdVal = iouThreshold;
+    const scoreThresholdVal = scoreThreshold;
+    const softNmsSigmaVal = softNmsSigma;
+
+    const {selectedIndices, selectedScores} = backend_util.nonMaxSuppressionV5(
+        boxesVals, scoresVals, maxOutputSizeVal, iouThresholdVal,
+        scoreThresholdVal, softNmsSigmaVal);
+
+    return [selectedIndices, selectedScores];
+  }
+});

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -143,7 +143,13 @@ const TEST_FILTERS: TestFilter[] = [
                           // 'CanvasRenderingContext2D': The source width is 0
     ]
   },
-  {include: 'nonMaxSuppression', excludes: []},
+  {
+    include: 'nonMaxSuppression',
+    excludes: [
+      'select from three clusters with SoftNMS',  // nonMaxSuppressionV5 is not
+                                                  // yet implemented.
+    ]
+  },
   {
     include: 'argmax',
     excludes: [

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -143,6 +143,7 @@ const TEST_FILTERS: TestFilter[] = [
                           // 'CanvasRenderingContext2D': The source width is 0
     ]
   },
+  {include: 'nonMaxSuppression', excludes: []},
   {
     include: 'argmax',
     excludes: [

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -143,13 +143,7 @@ const TEST_FILTERS: TestFilter[] = [
                           // 'CanvasRenderingContext2D': The source width is 0
     ]
   },
-  {
-    include: 'nonMaxSuppression',
-    excludes: [
-      'select from three clusters with SoftNMS',  // nonMaxSuppressionV5 is not
-                                                  // yet implemented.
-    ]
-  },
+  {include: 'nonMaxSuppression', excludes: []},
   {
     include: 'argmax',
     excludes: [

--- a/tfjs-core/src/backends/backend_util.ts
+++ b/tfjs-core/src/backends/backend_util.ts
@@ -31,6 +31,8 @@ export * from '../ops/concat_util';
 export * from '../ops/conv_util';
 export {Activation, FusedConv2DConfig} from '../ops/fused_util';
 export * from '../ops/reduce_util';
+export {nonMaxSuppressionV3, nonMaxSuppressionV5} from './non_max_suppression_impl';
+
 export {BackendValues, TypedArray, upcastType, PixelData} from '../types';
 export {MemoryInfo, TimingInfo} from '../engine';
 


### PR DESCRIPTION
FIX https://github.com/tensorflow/tfjs/issues/2361

This only works when nonMaxSuppression is used alone. If it is used with other operators, it may fail due to "WebGPU readSync is only available for CPU-resident tensors". Below case can be used to reproduce this: 
```
    it('select from three clusters, scores generated by div', async () => {
      const boxes = tf.tensor2d(
          [
            0, 0,  1, 1,  0, 0.1,  1, 1.1,  0, -0.1, 1, 0.9,
            0, 10, 1, 11, 0, 10.1, 1, 11.1, 0, 100,  1, 101
          ],
          [6, 4]);
      const a = tf.tensor1d([0, 1, -2, -4, 4, -4]);
      const b = tf.tensor1d([0.15, 0.2, 0.25, 0.5, 0.7, 1.2]);
      const scores = a.div(b) as tf.Tensor1D;
      const maxOutputSize = 2;
      const iouThreshold = 0.5;
      const scoreThreshold = 0;
      const indices = tf.image.nonMaxSuppression(
          boxes, scores, maxOutputSize, iouThreshold, scoreThreshold);

      expect(indices.shape).toEqual([2]);
      expectArraysEqual(await indices.data(), [4, 1]);
    });
  });
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2616)
<!-- Reviewable:end -->
