### PR TITLE
update the tensorflow deps to 2.1.0

### DIFF
--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,4 +1,4 @@
-h5py==2.8.0
+h5py>=2.8.0
 numpy>=1.16.4
 six>=1.12.0
 tensorflow==2.1.0rc2

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,7 +1,7 @@
 h5py==2.8.0
-numpy==1.16.4
-six==1.11.0
-tensorflow==2.0.0
+numpy>=1.16.4
+six>=1.12.0
+tensorflow==2.1.0rc2
 tensorflow-hub==0.5.0
 gast==0.2.2
 PyInquirer==1.0.3

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.8.0
 numpy>=1.16.4
 six>=1.12.0
-tensorflow==2.1.0rc2
+tensorflow-cpu==2.1.0
 tensorflow-hub==0.7.0
 gast==0.2.2
 PyInquirer==1.0.3

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,7 +1,7 @@
 h5py==2.8.0
 numpy==1.16.4
 six==1.11.0
-tensorflow==1.15.0
+tensorflow==2.0.0
 tensorflow-hub==0.5.0
 gast==0.2.2
 PyInquirer==1.0.3

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -2,6 +2,6 @@ h5py==2.8.0
 numpy>=1.16.4
 six>=1.12.0
 tensorflow==2.1.0rc2
-tensorflow-hub==0.5.0
+tensorflow-hub==0.7.0
 gast==0.2.2
 PyInquirer==1.0.3

--- a/tfjs-converter/python/setup.py
+++ b/tfjs-converter/python/setup.py
@@ -21,9 +21,9 @@ from tensorflowjs import version
 DIR_NAME = os.path.dirname(__file__)
 
 def _get_requirements(file):
-    "Reads the requirements file and returns the packages"
-    with open(os.path.join(DIR_NAME, file), 'r') as requirements:
-        return requirements.readlines()
+  "Reads the requirements file and returns the packages"
+  with open(os.path.join(DIR_NAME, file), 'r') as requirements:
+    return requirements.readlines()
 
 CONSOLE_SCRIPTS = [
     'tensorflowjs_converter = tensorflowjs.converters.converter:pip_main',

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -168,7 +168,8 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
       (Default: `False`).
   """
   with tf.Graph().as_default(), tf.compat.v1.Session():
-    model = tf.keras.modelexperimental.load_from_saved_model(keras_saved_model_path)
+    model = tf.keras.modelexperimental.load_from_saved_model(
+        keras_saved_model_path)
 
     # Save model temporarily in HDF5 format.
     temp_h5_path = tempfile.mktemp(suffix='.h5')

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -156,7 +156,7 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     keras_saved_model_path: path to a folder in which the
       assets/saved_model.json can be found. This is usually a subfolder
       that is under the folder passed to
-      `keras.experimental.export_saved_model()` and has a Unix epoch time
+      `tf.keras.models.save_model()` and has a Unix epoch time
       as its name (e.g., 1542212752).
     output_dir: Output directory to which the TensorFlow.js-format model JSON
       file and weights files will be written. If the directory does not exist,
@@ -168,12 +168,11 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
       (Default: `False`).
   """
   with tf.Graph().as_default(), tf.compat.v1.Session():
-    model = tf.keras.modelexperimental.load_from_saved_model(
-        keras_saved_model_path)
+    model = tf.keras.models.load_model(keras_saved_model_path)
 
     # Save model temporarily in HDF5 format.
     temp_h5_path = tempfile.mktemp(suffix='.h5')
-    model.save(temp_h5_path)
+    model.save(temp_h5_path, save_format='h5')
     assert os.path.isfile(temp_h5_path)
 
     dispatch_keras_h5_to_tfjs_layers_model_conversion(
@@ -255,8 +254,8 @@ def dispatch_tensorflowjs_to_keras_saved_model_conversion(
 
   with tf.Graph().as_default(), tf.compat.v1.Session():
     model = keras_tfjs_loader.load_keras_model(config_json_path)
-    keras.experimental.export_saved_model(
-        model, keras_saved_model_path, serving_only=True)
+    tf.keras.models.save_model(
+        model, keras_saved_model_path)
 
 
 def dispatch_tensorflowjs_to_tensorflowjs_conversion(

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -78,7 +78,7 @@ def dispatch_keras_h5_to_tfjs_layers_model_conversion(
         'Expected path to point to an HDF5 file, but it points to a '
         'directory: %s' % h5_path)
 
-  h5_file = h5py.File(h5_path)
+  h5_file = h5py.File(h5_path, 'r')
   if 'layer_names' in h5_file.attrs:
     model_json = None
     groups = conversion.h5_weights_to_tfjs_format(

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -168,7 +168,7 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
       (Default: `False`).
   """
   with tf.Graph().as_default(), tf.compat.v1.Session():
-    model = keras.experimental.load_from_saved_model(keras_saved_model_path)
+    model = tf.keras.modelexperimental.load_from_saved_model(keras_saved_model_path)
 
     # Save model temporarily in HDF5 format.
     temp_h5_path = tempfile.mktemp(suffix='.h5')

--- a/tfjs-converter/python/tensorflowjs/converters/converter_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter_test.py
@@ -26,7 +26,7 @@ import tempfile
 import unittest
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow import keras
 
 from tensorflowjs import version

--- a/tfjs-converter/python/tensorflowjs/converters/converter_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter_test.py
@@ -335,12 +335,17 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
     model.add(keras.layers.Reshape([2, 3], input_shape=[6]))
     model.add(keras.layers.LSTM(10))
     model.add(keras.layers.Dense(1, activation='sigmoid'))
+    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.predict(tf.ones((1, 6)), steps=1)
+    tf.keras.backend.set_learning_phase(0)
     return model
 
   def _createNestedSequentialModel(self):
     model = keras.Sequential()
     model.add(keras.layers.Dense(6, input_shape=[10], activation='relu'))
     model.add(self._createSimpleSequentialModel())
+    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.predict(tf.ones((1, 10)), steps=1)
     return model
 
   def _createFunctionalModelWithWeights(self):
@@ -349,6 +354,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
     y = keras.layers.Concatenate()([input1, input2])
     y = keras.layers.Dense(4, activation='softmax')(y)
     model = keras.Model([input1, input2], y)
+    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.predict([tf.ones((1, 8)), tf.ones((1, 10))], steps=1)
     return model
 
   def testConvertTfKerasSequentialSavedAsSavedModel(self):
@@ -356,7 +363,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createSimpleSequentialModel()
       old_model_json = json.loads(model.to_json())
       old_weights = model.get_weights()
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # Convert the keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -384,14 +391,10 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
   def testConvertTfKerasSequentialCompiledAndSavedAsSavedModel(self):
     with tf.Graph().as_default(), tf.compat.v1.Session():
       model = self._createSimpleSequentialModel()
-      # Compile the model before saving.
-      model.compile(
-          loss='binary_crossentropy',
-          optimizer=tf.compat.v1.train.GradientDescentOptimizer(2.5e-3))
 
       old_model_json = json.loads(model.to_json())
       old_weights = model.get_weights()
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # Convert the keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -419,7 +422,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
   def testWrongConverterRaisesCorrectErrorMessage(self):
     with tf.Graph().as_default(), tf.compat.v1.Session():
       model = self._createSimpleSequentialModel()
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # Convert the keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -436,7 +439,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createNestedSequentialModel()
       old_model_json = json.loads(model.to_json())
       old_weights = model.get_weights()
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # Convert the keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -466,8 +469,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createFunctionalModelWithWeights()
       old_model_json = json.loads(model.to_json())
       old_weights = model.get_weights()
-      keras.experimental.export_saved_model(
-          model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # Convert the keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -495,8 +497,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
   def testConvertTfKerasSequentialSavedAsSavedModelWithQuantization(self):
     with tf.Graph().as_default(), tf.compat.v1.Session():
       model = self._createSimpleSequentialModel()
-      keras.experimental.export_saved_model(
-          model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # Convert the keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')

--- a/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fold_batch_norms_test.py
@@ -19,7 +19,8 @@ import shutil
 import tempfile
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf1
+import tensorflow.compat.v2 as tf
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import importer
@@ -40,7 +41,7 @@ class FoldBatchNormsTest(tf.test.TestCase):
     super(FoldBatchNormsTest, self).tearDown()
 
   def testFoldBatchNorms(self):
-    with tf.compat.v1.Session() as sess:
+    with tf1.Session() as sess:
       inputs = [1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6]
       input_op = constant_op.constant(
           np.array(inputs), shape=[1, 1, 6, 2], dtype=dtypes.float32)
@@ -71,7 +72,7 @@ class FoldBatchNormsTest(tf.test.TestCase):
       original_result = sess.run(["output:0"])
     optimized_graph_def = fold_batch_norms.fold_batch_norms(
         original_graph_def)
-    with tf.compat.v1.Session() as sess:
+    with tf1.Session() as sess:
       _ = importer.import_graph_def(
           optimized_graph_def, input_map={}, name="optimized")
       optimized_result = sess.run(["optimized/output:0"])
@@ -87,7 +88,7 @@ class FoldBatchNormsTest(tf.test.TestCase):
         ("NHWC", nn_ops.depthwise_conv2d_native),
         ("NCHW", nn_ops.depthwise_conv2d_native)
     ]:
-      with tf.compat.v1.Session() as sess:
+      with tf1.Session() as sess:
         inputs = [1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6]
         input_op = constant_op.constant(
             np.array(inputs),
@@ -130,7 +131,7 @@ class FoldBatchNormsTest(tf.test.TestCase):
         original_result = sess.run(["output:0"])
       optimized_graph_def = fold_batch_norms.fold_batch_norms(
           original_graph_def)
-    with tf.compat.v1.Session() as sess:
+    with tf1.Session() as sess:
       _ = importer.import_graph_def(
           optimized_graph_def, input_map={}, name="optimized")
       optimized_result = sess.run(["optimized/output:0"])
@@ -147,13 +148,13 @@ class FoldBatchNormsTest(tf.test.TestCase):
         ("NHWC", nn_ops.depthwise_conv2d_native),
         ("NCHW", nn_ops.depthwise_conv2d_native)
     ]:
-      with tf.compat.v1.Session() as sess:
+      with tf1.Session() as sess:
         _generate_fused_batchnorm(data_format, conv2d_func)
         original_graph_def = sess.graph_def
         original_result = sess.run(["output:0"])
       optimized_graph_def = fold_batch_norms.fold_batch_norms(
           original_graph_def)
-    with tf.compat.v1.Session() as sess:
+    with tf1.Session() as sess:
       _ = importer.import_graph_def(
           optimized_graph_def, input_map={}, name="optimized")
       optimized_result = sess.run(["optimized/output:0"])
@@ -170,8 +171,8 @@ class FoldBatchNormsTest(tf.test.TestCase):
         ("NHWC", nn_ops.conv2d),
         ("NHWC", nn_ops.depthwise_conv2d_native),
     ]:
-      graph = tf.Graph()
-      with tf.compat.v1.Session(graph=graph) as sess:
+      graph = tf1.Graph()
+      with tf1.Session(graph=graph) as sess:
         count = 1
         add_bias = True
         _generate_fused_batchnorm(data_format, conv2d_func, count, add_bias)
@@ -179,7 +180,7 @@ class FoldBatchNormsTest(tf.test.TestCase):
         original_result = sess.run(["output:0"])
       optimized_graph_def = fold_batch_norms.fold_batch_norms(
           original_graph_def)
-    with tf.compat.v1.Session() as sess:
+    with tf1.Session() as sess:
       _ = importer.import_graph_def(
           optimized_graph_def, input_map={}, name="optimized")
       optimized_result = sess.run(["optimized/output:0"])
@@ -200,13 +201,13 @@ class FoldBatchNormsTest(tf.test.TestCase):
         ("NHWC", nn_ops.depthwise_conv2d_native),
         ("NCHW", nn_ops.depthwise_conv2d_native)
     ]:
-      with tf.compat.v1.Session() as sess:
+      with tf1.Session() as sess:
         _generate_fused_batchnorm(data_format, conv2d_func, 2)
         original_graph_def = sess.graph_def
         original_result = sess.run(["output:0"])
       optimized_graph_def = fold_batch_norms.fold_batch_norms(
           original_graph_def)
-    with tf.compat.v1.Session() as sess:
+    with tf1.Session() as sess:
       _ = importer.import_graph_def(
           optimized_graph_def, input_map={}, name="optimized")
       optimized_result = sess.run(["optimized/output:0"])

--- a/tfjs-converter/python/tensorflowjs/converters/fuse_depthwise_conv2d_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fuse_depthwise_conv2d_test.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import tempfile
 
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 
 from tensorflowjs.converters import fuse_depthwise_conv2d
 from tensorflowjs.converters import graph_rewrite_util

--- a/tfjs-converter/python/tensorflowjs/converters/fuse_prelu_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/fuse_prelu_test.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import tempfile
 
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.core.protobuf import meta_graph_pb2
 

--- a/tfjs-converter/python/tensorflowjs/converters/generate_test_model.py
+++ b/tfjs-converter/python/tensorflowjs/converters/generate_test_model.py
@@ -22,7 +22,7 @@ import argparse
 import os
 import sys
 
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 
 tf.enable_eager_execution()
 

--- a/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion_test.py
@@ -26,8 +26,8 @@ import unittest
 
 import h5py
 import numpy as np
-import tensorflow as tf
-from tensorflow import keras
+import tensorflow.compat.v2 as tf
+from tensorflow.compat.v2 import keras
 
 from tensorflowjs import version
 from tensorflowjs.converters import keras_h5_conversion as conversion

--- a/tfjs-converter/python/tensorflowjs/converters/keras_tfjs_loader.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_tfjs_loader.py
@@ -23,7 +23,7 @@ import os
 import uuid
 
 import six
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow import keras
 
 from tensorflowjs import read_weights

--- a/tfjs-converter/python/tensorflowjs/converters/keras_tfjs_loader_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_tfjs_loader_test.py
@@ -27,7 +27,7 @@ import tempfile
 import unittest
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow import keras
 
 from tensorflowjs.converters import keras_h5_conversion

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -22,8 +22,7 @@ import shutil
 import tempfile
 import unittest
 
-import tensorflow as tf
-from tensorflow.contrib import lookup as contrib_lookup
+import tensorflow.compat.v2 as tf
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -88,7 +87,7 @@ class ConvertTest(tf.test.TestCase):
 
     graph = tf.Graph()
     with graph.as_default():
-      x = tf.placeholder('float32', [2, 2])
+      x = tf.compat.v1.placeholder('float32', [2, 2])
       w = tf.compat.v1.get_variable('w', shape=[2, 2])
       output = tf.compat.v1.matmul(x, w)
       init_op = w.initializer
@@ -96,18 +95,18 @@ class ConvertTest(tf.test.TestCase):
       # Add a hash table that is not used by the output.
       keys = tf.constant(['key'])
       values = tf.constant([1])
-      initializer = contrib_lookup.KeyValueTensorInitializer(keys, values)
-      table = contrib_lookup.HashTable(initializer, -1)
+      initializer = tf.lookup.KeyValueTensorInitializer(keys, values)
+      table = tf.lookup.StaticHashTable(initializer, -1)
 
       # Create a builder.
       save_dir = os.path.join(self._tmp_dir, SAVED_MODEL_DIR)
-      builder = tf.compat.v1.saved_model.builder.SavedModelBuilder(save_dir)
+      builder = tf.compat.v1.saved_model.builder.SavedModelBuilder(
+          save_dir)
 
       with tf.compat.v1.Session() as sess:
         # Run the initializer on `w`.
         sess.run(init_op)
-        table.init.run()
-
+        table.lookup(keys)
         builder.add_meta_graph_and_variables(
             sess, [tf.compat.v1.saved_model.tag_constants.SERVING],
             signature_def_map={
@@ -280,20 +279,21 @@ class ConvertTest(tf.test.TestCase):
     saved_model_dir = os.path.join(self._tmp_dir, FROZEN_MODEL_DIR)
     with graph.as_default():
       x = tf.constant([[37.0, -23.0], [1.0, 4.0]])
-      w = tf.Variable(tf.random_uniform([2, 2]))
+      w = tf.Variable(tf.random.uniform([2, 2]))
       y = tf.matmul(x, w)
       tf.nn.softmax(y)
       init_op = w.initializer
 
       # Create a builder
-      builder = tf.saved_model.builder.SavedModelBuilder(saved_model_dir)
+      builder = tf.compat.v1.saved_model.builder.SavedModelBuilder(
+          saved_model_dir)
 
-      with tf.Session() as sess:
+      with tf.compat.v1.Session() as sess:
         # Run the initializer on `w`.
         sess.run(init_op)
 
         builder.add_meta_graph_and_variables(
-            sess, [tf.saved_model.tag_constants.SERVING],
+            sess, [tf.compat.v1.saved_model.tag_constants.SERVING],
             signature_def_map=None,
             assets_collection=None)
 
@@ -311,7 +311,7 @@ class ConvertTest(tf.test.TestCase):
         frozen_file,
         True,
         '',
-        saved_model_tags=tf.saved_model.tag_constants.SERVING,
+        saved_model_tags=tf.compat.v1.saved_model.tag_constants.SERVING,
         input_saved_model_dir=saved_model_dir)
 
   def test_convert_saved_model_v1(self):

--- a/tfjs-converter/python/tensorflowjs/converters/wizard.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard.py
@@ -25,7 +25,7 @@ import traceback
 
 import PyInquirer
 import h5py
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow.core.framework import types_pb2
 from tensorflow.python.saved_model import loader_impl
 from tensorflowjs.converters import converter

--- a/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
@@ -70,7 +70,7 @@ class CliTest(unittest.TestCase):
     model.add(keras.layers.LSTM(10))
     model.add(keras.layers.Dense(1, activation='sigmoid'))
     save_dir = os.path.join(self._tmp_dir, SAVED_MODEL_DIR)
-    keras.experimental.export_saved_model(model, save_dir)
+    tf.keras.models.save_model(model, save_dir)
 
   def _create_saved_model(self):
     """Test a basic model with functions to make sure functions are inlined."""
@@ -172,11 +172,11 @@ class CliTest(unittest.TestCase):
   def testAvailableSignatureNames(self):
     self._create_saved_model()
     save_dir = os.path.join(self._tmp_dir, SAVED_MODEL_DIR)
-    self.assertEqual(['__saved_model_init_op', 'serving_default'],
-                     [x['value'] for x in wizard.available_signature_names(
+    self.assertEqual(sorted(['__saved_model_init_op', 'serving_default']),
+                     sorted([x['value'] for x in wizard.available_signature_names(
                          {'input_path': save_dir,
                           'input_format': 'tf_saved_model',
-                          'saved_model_tags': 'serve'})])
+                          'saved_model_tags': 'serve'})]))
 
   def testGenerateCommandForSavedModel(self):
     options = {'input_format': 'tf_saved_model',

--- a/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
@@ -21,7 +21,7 @@ import tempfile
 import json
 import os
 import shutil
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow import keras
 from tensorflow.python.eager import def_function
 from tensorflow.python.ops import variables

--- a/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
@@ -173,10 +173,11 @@ class CliTest(unittest.TestCase):
     self._create_saved_model()
     save_dir = os.path.join(self._tmp_dir, SAVED_MODEL_DIR)
     self.assertEqual(sorted(['__saved_model_init_op', 'serving_default']),
-                     sorted([x['value'] for x in wizard.available_signature_names(
-                         {'input_path': save_dir,
-                          'input_format': 'tf_saved_model',
-                          'saved_model_tags': 'serve'})]))
+                     sorted(
+                         [x['value'] for x in wizard.available_signature_names(
+                             {'input_path': save_dir,
+                              'input_format': 'tf_saved_model',
+                              'saved_model_tags': 'serve'})]))
 
   def testGenerateCommandForSavedModel(self):
     options = {'input_format': 'tf_saved_model',

--- a/tfjs-converter/python/test_nightly_pip_package.py
+++ b/tfjs-converter/python/test_nightly_pip_package.py
@@ -19,28 +19,13 @@ from __future__ import division
 from __future__ import print_function
 
 import glob
-import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
-import unittest
 
-import numpy as np
 import tensorflow.compat.v2 as tf
-from tensorflow import keras
-from tensorflow.python.eager import def_function
-from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import tensor_spec
-from tensorflow.python.ops import variables
-from tensorflow.python.tools import freeze_graph
-from tensorflow.python.training.tracking import tracking
 from tensorflow.python.saved_model.save import save
-import tensorflow_hub as hub
-
-import tensorflowjs as tfjs
 
 class APIAndShellTest(tf.test.TestCase):
   """Nightly tests for the Python API of the pip package."""

--- a/tfjs-converter/python/test_nightly_pip_package.py
+++ b/tfjs-converter/python/test_nightly_pip_package.py
@@ -28,7 +28,7 @@ import tempfile
 import unittest
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow import keras
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op

--- a/tfjs-converter/python/test_pip_package.py
+++ b/tfjs-converter/python/test_pip_package.py
@@ -28,7 +28,7 @@ import tempfile
 import unittest
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 from tensorflow import keras
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
@@ -151,20 +151,21 @@ def _create_frozen_model(save_path):
   saved_model_dir = os.path.join(save_path)
   with graph.as_default():
     x = tf.constant([[37.0, -23.0], [1.0, 4.0]])
-    w = tf.Variable(tf.random_uniform([2, 2]))
+    w = tf.Variable(tf.random.uniform([2, 2]))
     y = tf.matmul(x, w)
     tf.nn.softmax(y)
     init_op = w.initializer
 
     # Create a builder
-    builder = tf.saved_model.builder.SavedModelBuilder(saved_model_dir)
+    builder = tf.compat.v1.saved_model.builder.SavedModelBuilder(
+        saved_model_dir)
 
-    with tf.Session() as sess:
+    with tf.compat.v1.Session() as sess:
       # Run the initializer on `w`.
       sess.run(init_op)
 
       builder.add_meta_graph_and_variables(
-          sess, [tf.saved_model.tag_constants.SERVING],
+          sess, [tf.compat.v1.saved_model.tag_constants.SERVING],
           signature_def_map=None,
           assets_collection=None)
 
@@ -182,7 +183,7 @@ def _create_frozen_model(save_path):
       frozen_file,
       True,
       '',
-      saved_model_tags=tf.saved_model.tag_constants.SERVING,
+      saved_model_tags=tf.compat.v1.saved_model.tag_constants.SERVING,
       input_saved_model_dir=saved_model_dir)
 class APIAndShellTest(tf.test.TestCase):
   """Tests for the Python API of the pip package."""

--- a/tfjs-converter/python/test_pip_package.py
+++ b/tfjs-converter/python/test_pip_package.py
@@ -68,8 +68,11 @@ def _createKerasModel(layer_name_prefix, h5_path=None):
       kernel_initializer='ones',
       name=layer_name_prefix + '2')(dense1)
   model = keras.models.Model(inputs=[input_tensor], outputs=[output])
+  model.compile(optimizer='adam', loss='binary_crossentropy')
+  model.predict(tf.ones((1, 3)), steps=1)
+
   if h5_path:
-    model.save(h5_path)
+    model.save(h5_path, save_format='h5')
   return model
 
 def _createTensorFlowSavedModelV1(name_scope, save_path):
@@ -722,7 +725,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createNestedSequentialModel()
       y = model.predict(x)
 
-      keras..export_saved_model(model, self._tmp_dir)
+      keras.models.save_model(model, self._tmp_dir)
 
       # 2. Convert the keras saved model to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -939,9 +942,11 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = keras.Sequential()
       model.add(keras.layers.Dense(10, activation='relu', input_shape=[4]))
       model.add(keras.layers.Dense(1, activation='sigmoid'))
+      model.compile(optimizer='adam', loss='binary_crossentropy')
+      model.predict(tf.ones((1, 4)), steps=1)
 
       h5_path = os.path.join(self._tmp_dir, 'model.h5')
-      model.save(h5_path)
+      model.save(h5_path, save_format='h5')
 
     # 2. Convert the keras saved model to tfjs_layers_model format.
     layers_model_output_dir = os.path.join(self._tmp_dir, 'tfjs_layers')
@@ -975,9 +980,11 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = keras.Sequential()
       model.add(keras.layers.Dense(10, activation='relu', input_shape=[4]))
       model.add(keras.layers.Dense(1, activation='sigmoid'))
+      model.compile(optimizer='adam', loss='binary_crossentropy')
+      model.predict(tf.ones((1, 4)), steps=1)
 
       h5_path = os.path.join(self._tmp_dir, 'model.h5')
-      model.save(h5_path)
+      model.save(h5_path, save_format='h5')
 
     # 2. Convert the keras saved model to tfjs_layers_model format.
     layers_model_output_dir = os.path.join(self._tmp_dir, 'tfjs_layers')

--- a/tfjs-converter/python/test_pip_package.py
+++ b/tfjs-converter/python/test_pip_package.py
@@ -722,7 +722,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createNestedSequentialModel()
       y = model.predict(x)
 
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      keras..export_saved_model(model, self._tmp_dir)
 
       # 2. Convert the keras saved model to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -763,7 +763,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createFunctionalModelWithWeights()
       y = model.predict([x1, x2])
 
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # 2. Convert the keras saved model to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -804,7 +804,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       model = self._createNestedSequentialModel()
       y = model.predict(x)
 
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # 2. Convert the keras saved model to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -833,7 +833,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       weights = model.get_weights()
       total_weight_bytes = sum(np.size(w) for w in weights) * 4
 
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # 2. Convert the keras saved model to tfjs_layers_model format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
@@ -897,7 +897,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       weights = model.get_weights()
       total_weight_bytes = sum(np.size(w) for w in weights) * 4
 
-      keras.experimental.export_saved_model(model, self._tmp_dir)
+      tf.keras.models.save_model(model, self._tmp_dir)
 
       # 2. Convert the keras saved model to tfjs_layers_model format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')


### PR DESCRIPTION
Update the tensorflow imports to specifically import compat.v2, since in g3 by default it imports compat.v1

Using latest TF 2.1.0 official release

also fixed https://github.com/tensorflow/tfjs/issues/2582

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2627)
<!-- Reviewable:end -->
