### PR TITLE
webgpu: Increase work per thread for maxpool

### DIFF
--- a/tfjs-backend-webgpu/src/benchmark_ops_test.ts
+++ b/tfjs-backend-webgpu/src/benchmark_ops_test.ts
@@ -159,7 +159,7 @@ describeWebGPU('Ops benchmarks', () => {
   it('maxPool', async () => {
     const x = tf.randomNormal<tf.Rank.R4>([1, 131, 131, 64]);
 
-    await time(() => tf.maxPool(x, 2, 1, 'same'));
+    await time(() => tf.maxPool(x, 2, 1, 'same'), null, true, 10, 10);
   });
 
   it('prelu', async () => {

--- a/tfjs-backend-webgpu/src/kernels/maxpool_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/maxpool_webgpu.ts
@@ -104,6 +104,6 @@ export class MaxPoolProgram implements WebGPUProgram {
         }
       }
     `;
-    this.shaderKey = 'maxpool';
+    this.shaderKey = `maxpool${this.workPerThread}`;
   }
 }


### PR DESCRIPTION
PERF

With this change, maxPool[1, 131, 131, 64] has 50%~90% speedup
on different platforms.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2628)
<!-- Reviewable:end -->
