### PR TITLE
[WIP] Disable shader key and shader cache

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -339,10 +339,8 @@ export class WebGPUBackend extends KernelBackend {
 
   private getAndSavePipeline(
       key: string, getBinary: () => webgpu_program.WebGPUBinary) {
-    if (!(key in this.binaryCache)) {
-      this.binaryCache[key] = getBinary();
-    }
-    return this.binaryCache[key];
+    // TODO(xing.xu): This cache is buggy. Enable this at a better place.
+    return this.binaryCache[key] = getBinary();
   }
 
   private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType):
@@ -940,6 +938,16 @@ export class WebGPUBackend extends KernelBackend {
 
   sigmoid<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.SIGMOID);
+    return this.compileAndRun(program, [x]);
+  }
+
+  square<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SQUARE);
+    return this.compileAndRun(program, [x]);
+  }
+
+  neg<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.NEG);
     return this.compileAndRun(program, [x]);
   }
 

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -28,6 +28,8 @@ export const ELU = `return (x >= 0.0) ? x : (exp(x) - 1.0);`;
 
 export const SIGMOID = `return 1.0 / (1.0 + exp(-1.0 * a));`;
 export const ABS = `return abs(a);`;
+export const SQUARE = `return a * a;`;
+export const NEG = `return -a;`;
 
 export class UnaryOpProgram implements WebGPUProgram {
   outputShape: number[];

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -113,10 +113,9 @@ const TEST_FILTERS: TestFilter[] = [
   {
     include: 'div',
     excludes: [
-      'broadcast 2D + 1D',               // Actual != expected.
-      'upcasts when dtypes dont match',  // Actual != expected.
-      'gradient',                        // square, sum not yet implemented.
-      'divNoNan'                         // Equal not yet implemented.
+      'upcasts when dtypes dont match',     // Actual != expected.'
+      'gradient: 1d<int32> with 1d<bool>',  // Actual != expected.
+      'divNoNan'                            // Equal not yet implemented.
     ]
   },
   {


### PR DESCRIPTION
FIX

What happens:
Run case one by one (yarn test --grep=), pass. But when run several together. Some case may fail.

Example case:
Case may be failed due to cache reasons(div/Arithmetic_test.ts):
'gradient: Tensor1D with int32',               // Actual != expected.
'gradient: Tensor2D',                          // Actual != expected.
'gradient: Tensor2D / Tensor2D w/ broadcast',  // Actual != expected.

Root cause:
This problem is introduced by two reasons:
1), makeShaderKey called before the real shader generated(compileProgram and makeShader).
Which means, two different shaders may possibly share the same shader key.

2), The shader key optimization(https://github.com/tensorflow/tfjs/pull/2451), which use
several key properties of the shader instead of the full shader source as shader key.
For most case, especially all properties are self-contained in the shader`s WebGPUProgram
file, this works. But when some properties are originated from the shader_preprocessor.ts,
two different shader may be collided with the same shader key.

Currently the fix is to disable the shader key and shader cache first.
The follow up todo is: https://github.com/tensorflow/tfjs/issues/2669.

Also add square and neg operators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2670)
<!-- Reviewable:end -->
