### PR TITLE
[WASM] Update cdn link to point to the .js file.

### DIFF
--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -30,7 +30,7 @@ tf.setBackend('wasm').then(() => main());
 <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs"></script>
 
 <!-- Adds the WASM backend to the global backend registry -->
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm/dist/tf-backend-wasm.js"></script>
 <script>
 tf.setBackend('wasm').then(() => main());
 </script>


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/2683

Without this the CDN 404s because it tries to fetch the .wasm path relative to the base jsdelivr link (jsdelivr does not redirect).

The alternative is we use tf.setWasmPath here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2690)
<!-- Reviewable:end -->
