### PR TITLE
improve indexedDB error logging

### DIFF
--- a/tfjs-core/src/io/indexed_db.ts
+++ b/tfjs-core/src/io/indexed_db.ts
@@ -178,7 +178,12 @@ export class BrowserIndexedDB implements IOHandler {
               // If the put-model request fails, roll back the info entry as
               // well.
               infoStore = infoTx.objectStore(INFO_STORE_NAME);
-              const deleteInfoRequest = infoStore.delete(this.modelPath);
+              let deleteInfoRequest;
+              try {
+                deleteInfoRequest = infoStore.delete(this.modelPath);
+              } catch (error) {
+                return reject(putModelRequest.error)
+              }
               deleteInfoRequest.onsuccess = () => {
                 db.close();
                 return reject(putModelRequest.error);


### PR DESCRIPTION
In some cases where the saving of the model to indexedDB failed, the roll-back of the info entry also fails without calling `deleteInfoRequest.onerror`. This results in a not very helpful error message to the developer:

<img width="656" alt="Screenshot 2020-01-27 at 14 07 27" src="https://user-images.githubusercontent.com/11681746/73177139-7d8d9600-410e-11ea-8bae-aa1c7d5fe7ab.png">

This PR makes the actual error message clear to the developer by returning the error on the roll-back:

<img width="653" alt="Screenshot 2020-01-27 at 14 10 12" src="https://user-images.githubusercontent.com/11681746/73177237-ce04f380-410e-11ea-9aeb-d0f35ccdbb60.png">

It took me some time to figure out why saving my model to indexedDB was failing. I think this will improve debugging when failing to save to the indexedDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2701)
<!-- Reviewable:end -->
