### PR TITLE
lock the tensorflow version to 2.1.0 to avoid flaky TF nightly

### DIFF
--- a/tfjs/integration_tests/python/requirements.txt
+++ b/tfjs/integration_tests/python/requirements.txt
@@ -1,2 +1,2 @@
 tensorflowjs>=1.3.1.1
-tf-nightly>=2.1.0.dev20191008
+tensorflow==2.1.0


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2712)
<!-- Reviewable:end -->
