### PR TITLE
[tfjs-node] Upgrade libtensorflow version

### DIFF
--- a/tfjs-node/scripts/deps-constants.js
+++ b/tfjs-node/scripts/deps-constants.js
@@ -22,7 +22,7 @@ const modulePath =
     module_path_napi.replace('{napi_build_version}', process.versions.napi);
 
 /** Version of the libtensorflow shared library to depend on. */
-const LIBTENSORFLOW_VERSION = '1.15.0';
+const LIBTENSORFLOW_VERSION = '2.1.0';
 
 /** Map the os.arch() to arch string in a file name */
 const ARCH_MAPPING = {


### PR DESCRIPTION
1.15.0 --> 2.1.0

Without this update, the latest versions of tfjs-node (Python) tensorflow
depend on different CUDA versions (10.0 vs. 10.1), which causes
confusion and inconvenience to users who use TF in both languages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2714)
<!-- Reviewable:end -->
