### PR TITLE
[tfjs-layers] fix reshape layer output shape computation

### DIFF
--- a/tfjs-layers/src/layers/core.ts
+++ b/tfjs-layers/src/layers/core.ts
@@ -518,7 +518,7 @@ export class Reshape extends Layer {
 
   computeOutputShape(inputShape: Shape): Shape {
     let anyUnknownDims = false;
-    for (let i = 0; i < inputShape.length; ++i) {
+    for (let i = 1; i < inputShape.length; ++i) {
       if (this.isUnknown(inputShape[i])) {
         anyUnknownDims = true;
         break;

--- a/tfjs-layers/src/layers/core_test.ts
+++ b/tfjs-layers/src/layers/core_test.ts
@@ -589,6 +589,17 @@ describe('Reshape Layer: Symbolic', () => {
     expect(output.inputs).toEqual([symbolicInput]);
   });
 
+  it('One unknown dimension with unknown batch size.', () => {
+    const symbolicInput =
+        new tfl.SymbolicTensor('float32', [null, 10, 4], null, [], null);
+    const targetShape = [5, null];
+    const flattenLayer = tfl.layers.reshape({targetShape});
+    const output = flattenLayer.apply(symbolicInput) as tfl.SymbolicTensor;
+    expect(output.shape).toEqual([null, 5, 8]);
+    expect(output.sourceLayer).toEqual(flattenLayer);
+    expect(output.inputs).toEqual([symbolicInput]);
+  });
+
   it('Incompatible size.', () => {
     const symbolicInput =
         new tfl.SymbolicTensor('float32', [12, 10, 4], null, [], null);


### PR DESCRIPTION
Ensure that output shape is computed correctly when input shape has an unknown batch size.

In Keras, a Reshape layer with `batch_input_shape=[None, 16]` and `target_shape=[-1, 1]` has output shape `[None, 16, 1]` as the reshape operation is being applied per batch.
In TFJS an equivalent Reshape layer would have an output shape `[None, None, 1]` thus adding an unnecessary unknown dimension. Plus this behavior was not consistent with the python implementation.