### PR TITLE
[tfjs-react-native] Use dynamic import of react-native-fs

### DIFF
--- a/tfjs-react-native/README.md
+++ b/tfjs-react-native/README.md
@@ -9,10 +9,6 @@ of tfjs usage, include:
   - IOHandlers to support loading models from asyncStorage and models
     that are compiled into the app bundle.
 
-## Status
-This package is currently an **alpha release**. We welcome react native developers
-to try it and give us feedback.
-
 ## Setting up a React Native app with tfjs-react-native
 
 These instructions **assume that you are generally familiar with [react native](https://facebook.github.io/react-native/) developement**.
@@ -70,7 +66,7 @@ module.exports = {
 ### Step 4: Install TensorFlow.js and tfjs-react-native
 
 - Install @tensorflow/tfjs - `npm install @tensorflow/tfjs`
-- Install @tensorflow/tfjs-react-native - `npm install @tensorflow/tfjs-react-native@alpha`
+- Install @tensorflow/tfjs-react-native - `npm install @tensorflow/tfjs-react-native`
 
 ### Step 5: Install and configure other peerDependencies
 
@@ -126,78 +122,4 @@ The [Webcam demo folder](integration_rn59/components/webcam) has an example of a
 
 ## API Docs
 
-`tfjs-react-native` exports a number of utility functions:
-
-### asyncStorageIO(modelKey: string)
-
-```js
-async function asyncStorageExample() {
-  // Define a model
-  const model = tf.sequential();
-  model.add(tf.layers.dense({units: 5, inputShape: [1]}));
-  model.add(tf.layers.dense({units: 1}));
-  model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
-
-  // Save the model to async storage
-  await model.save(asyncStorageIO('custom-model-test'));
-  // Load the model from async storage
-  await tf.loadLayersModel(asyncStorageIO('custom-model-test'));
-}
-```
-
-The `asyncStorageIO` function returns an io handler that can be used to save and load models
-to and from AsyncStorage.
-
-### bundleResourceIO(modelArchitecture: Object, modelWeights: number)
-
-```js
-const modelJson = require('../path/to/model.json');
-const modelWeights = require('../path/to/model_weights.bin');
-async function bundleResourceIOExample() {
-  const model =
-      await tf.loadLayersModel(bundleResourceIO(modelJson, modelWeights));
-
-  const res = model.predict(tf.randomNormal([1, 28, 28, 1])) as tf.Tensor;
-}
-```
-
-The `bundleResourceIO` function returns an IOHandler that is able to **load** models
-that have been bundled with the app (apk or ipa) at compile time. It takes two
-parameters.
-
-1. modelArchitecture: This is a JavaScript object (and notably not a string). This is
-   because metro will automatically resolve `require`'s for JSON file and return parsed
-   JavaScript objects.
-
-2. modelWeights: This is the numeric id returned by the metro bundler for the binary weights file
-   via `require`. The IOHandler will be able to load the actual data from the bundle package.
-
-`bundleResourceIO` only supports non sharded models at the moment. It also cannot save models. Though you
-can use the asyncStorageIO handler to save to AsyncStorage.
-
-### decodeJpeg(contents: Uint8Array, channels?: 0 | 1 | 3)
-
-```js
-const image = require("path/to/img.jpg");
-const imageAssetPath = Image.resolveAssetSource(image);
-const response = await fetch(imageAssetPath.uri, {}, { isBinary: true });
-const rawImageData = await response.arrayBuffer();
-
-const imageTensor = decodeJpeg(rawImageData);
-```
-
-**returns** a tf.Tensor3D of the decoded image.
-
-Parameters:
-
-1. contents: raw bytes of the image as a Uint8Array
-1. channels: An optional int that indicates whether the image should be loaded as RBG (channels = 3), Grayscale (channels = 1), or autoselected based on the contents of the image (channels = 0). Defaults to 3. Currently only 3 channel RGB images are supported.
-
-### fetch(path: string, init?: RequestInit, options?: tf.io.RequestDetails)
-
-tfjs react native exports a custom fetch function that is able to correctly load binary files into
-`arrayBuffer`'s. The first two parameters are the same as regular [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). The 3rd paramater is an optional custom `options` object, it currently has one option
-
-- options.isBinary: A boolean indicating if this is request for a binary file.
-
-This is needed because the response from `fetch` as currently implemented in React Native does not support the `arrayBuffer()` call.
+[API docs are available here](https://js.tensorflow.org/api_react_native/latest/)

--- a/tfjs-react-native/integration_rn59/package.json
+++ b/tfjs-react-native/integration_rn59/package.json
@@ -19,7 +19,7 @@
     "@tensorflow-models/mobilenet": "^2.0.4",
     "@tensorflow-models/posenet": "^2.2.1",
     "@tensorflow/tfjs": "~1.5.1",
-    "@tensorflow/tfjs-react-native": "0.1.0-alpha.3",
+    "@tensorflow/tfjs-react-native": "0.2.0",
     "expo-camera": "^7.0.0",
     "expo-gl": "^7.0.0",
     "expo-gl-cpp": "^7.0.0",
@@ -28,7 +28,7 @@
     "jpeg-js": "^0.3.5",
     "react": "16.8.3",
     "react-native": "0.59.10",
-    "react-native-fs": "2.13.2",
+    "react-native-fs": "2.14.1",
     "react-native-svg": "^9.13.6",
     "react-native-unimodules": "^0.5.4",
     "rn-fetch-blob": "^0.10.15"

--- a/tfjs-react-native/integration_rn59/yarn.lock
+++ b/tfjs-react-native/integration_rn59/yarn.lock
@@ -893,10 +893,10 @@
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.1.tgz#52aab88ab64618bfb193a7fafc7443a7edaaa151"
   integrity sha512-DyuhifqflK+bdpBRLAj3RuWm1eTVe8yNX2+WH+W+wmhpjGg7Yagnar6/66JdS2h3WUFoiplCpZRAVMVw631E5g==
 
-"@tensorflow/tfjs-react-native@0.1.0-alpha.3":
-  version "0.1.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-react-native/-/tfjs-react-native-0.1.0-alpha.3.tgz#307176a58ff66f2080fbab4f43e60e5a480fc15b"
-  integrity sha512-kWpwnBinfutoMYW8tTtXVbNy2Iw8lpQDwirS9HC8tuI6566Z/xHUbX4H8NdSzZYrTBq8iZ/O0pFL4U07uGO24w==
+"@tensorflow/tfjs-react-native@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-react-native/-/tfjs-react-native-0.2.0.tgz#ad769d69aec4a4b158931cba730fc58460ce9656"
+  integrity sha512-BYfzWrzoUHijMTTE2PUX7tyfEt/2SyrBPZ+0fpHw8TyRDe99XhExiVtEdMKg0kvPWdcQvgsn8Ow2zjIeY67mrA==
   dependencies:
     base64-js "^1.3.0"
     buffer "^5.2.1"
@@ -6033,10 +6033,10 @@ react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-native-fs@2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.13.2.tgz#78257c5e461d19723b51cc369eb2e161f942676d"
-  integrity sha512-eN2HReoE/T+6r180kiXppshqJ5DsO6AngUmVbz09Qzl5EXU2zN0WfOaizKR2oD5u0XlcDrNJK7/spVH1XyQzEw==
+react-native-fs@2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.14.1.tgz#61c70a865b5b5bcb020dd4e4befd60a2c20c836f"
+  integrity sha512-ZcfiwNP+FBgvv2eRk0B62/NI58mbjszjjYvQlP352HLkUqVsK4Ld6X8fdBO1lZAz6SgitUk8WEc9NEciRIt31g==
   dependencies:
     base-64 "^0.1.0"
     utf8 "^2.1.1"

--- a/tfjs-react-native/package.json
+++ b/tfjs-react-native/package.json
@@ -59,6 +59,6 @@
     "expo-gl": "^7.0.0",
     "react": "^16.12.0",
     "react-native": ">= 0.58.0",
-    "react-native-fs": "^2.16.1"
+    "react-native-fs": "^2.14.1"
   }
 }

--- a/tfjs-react-native/src/bundle_resource_io.ts
+++ b/tfjs-react-native/src/bundle_resource_io.ts
@@ -68,11 +68,9 @@ class BundleResourceHandler implements io.IOHandler {
     const weightsAsset = Asset.fromModule(this.modelWeightsId);
     if (weightsAsset.uri.match('^http')) {
       // In debug/dev mode RN will serve these assets over HTTP
-      console.log('calling load via http asset');
       return this.loadViaHttp(weightsAsset);
     } else {
       // In release mode the assets will be on the file system.
-      console.log('calling load local asset');
       return this.loadLocalAsset(weightsAsset);
     }
   }
@@ -101,7 +99,6 @@ class BundleResourceHandler implements io.IOHandler {
 
     // tslint:disable-next-line: no-require-imports
     const RNFS = require('react-native-fs');
-    console.log('RNFS', RNFS);
 
     const modelJson = this.modelJson;
 


### PR DESCRIPTION
This should resolve https://github.com/tensorflow/tfjs/issues/2729 (once released).

Expo filesystem does not provide the functionality we need so this moves react-native-fs into a dynamic import so that managed expo apps can use the package. Managed expo apps should not hit the code path where this new require statement is used as their assets are always served from the web.

I'm also including an overdue README update.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2740)
<!-- Reviewable:end -->
