### PR TITLE
[tfjs-react-native] Don't flipHorizontal if using back camera on iOS

### DIFF
--- a/tfjs-react-native/src/camera/camera_stream.tsx
+++ b/tfjs-react-native/src/camera/camera_stream.tsx
@@ -306,7 +306,10 @@ export function cameraWithTensors<T extends WrappedComponentProps>(
         const height = PixelRatio.getPixelSizeForLayoutSize(
           cameraLayout.height
         );
-        const flipHorizontal = Platform.OS === 'ios' ? false : true;
+        const isFrontCamera = 
+          this.camera.props.type === Camera.Constants.Type.front;
+        const flipHorizontal = 
+          Platform.OS === 'ios' && isFrontCamera ? false : true;
 
         renderToGLView(gl, cameraTexture, { width, height }, flipHorizontal);
       };


### PR DESCRIPTION
Bugfix: On iOS, using the back camera with `cameraWithTensors` would result is a horizontally mirrored viewfinder render. Android works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2747)
<!-- Reviewable:end -->
