### PR TITLE
[tfjs-react-native] Update tfjs-react-native version for integration app

### DIFF
--- a/tfjs-react-native/integration_rn59/package.json
+++ b/tfjs-react-native/integration_rn59/package.json
@@ -19,7 +19,7 @@
     "@tensorflow-models/mobilenet": "^2.0.4",
     "@tensorflow-models/posenet": "^2.2.1",
     "@tensorflow/tfjs": "~1.5.1",
-    "@tensorflow/tfjs-react-native": "0.2.0",
+    "@tensorflow/tfjs-react-native": "0.2.3",
     "expo-camera": "^7.0.0",
     "expo-gl": "^7.0.0",
     "expo-gl-cpp": "^7.0.0",

--- a/tfjs-react-native/integration_rn59/yarn.lock
+++ b/tfjs-react-native/integration_rn59/yarn.lock
@@ -893,10 +893,10 @@
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.1.tgz#52aab88ab64618bfb193a7fafc7443a7edaaa151"
   integrity sha512-DyuhifqflK+bdpBRLAj3RuWm1eTVe8yNX2+WH+W+wmhpjGg7Yagnar6/66JdS2h3WUFoiplCpZRAVMVw631E5g==
 
-"@tensorflow/tfjs-react-native@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-react-native/-/tfjs-react-native-0.2.0.tgz#ad769d69aec4a4b158931cba730fc58460ce9656"
-  integrity sha512-BYfzWrzoUHijMTTE2PUX7tyfEt/2SyrBPZ+0fpHw8TyRDe99XhExiVtEdMKg0kvPWdcQvgsn8Ow2zjIeY67mrA==
+"@tensorflow/tfjs-react-native@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-react-native/-/tfjs-react-native-0.2.3.tgz#16f8f9467f84d1721acb43f8eb65e20cd7a4d7e8"
+  integrity sha512-Dt51xqVQ28/NVEwPY5WXnML9LPNES04/WYqZLhItJh4ivZSlLL3m1kby3tH03nrw1CUS9J2O4zGMEKsplfNLqA==
   dependencies:
     base64-js "^1.3.0"
     buffer "^5.2.1"


### PR DESCRIPTION
In the integration_rn59 app, using version 0.2.0 for `tfjs-react-native` yields the issue mentioned in #2753. This PR bumps it to the latest version so that the app can be installed.

Fixes: #2753

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2757)
<!-- Reviewable:end -->
