### PR TITLE
[tfjs-converter] Allow custom shard size for more conversion pairs

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -126,6 +126,7 @@ saved a tf.keras model in the SavedModel format.
 |`--signature_name`   | Only applicable to TensorFlow SavedModel and Hub module conversion, signature to load. Defaults to `serving_default` for SavedModel and `default` for Hub module. See https://www.tensorflow.org/hub/common_signatures/.|
 |`--strip_debug_ops`   | Strips out TensorFlow debug operations `Print`, `Assert`, `CheckNumerics`. Defaults to `True`.|
 |`--quantization_bytes`  | How many bytes to optionally quantize/compress the weights to. Valid values are 1 and 2. which will quantize int32 and float32 to 1 or 2 bytes respectively. The default (unquantized) size is 4 bytes.|
+|`--weight_shard_size_bytes` | Shard size (in bytes) of the weight files. Only supported when `output_format` is `tfjs_layers_model` or `tfjs_graph_model`. Default size is 4 MB (4194304 bytes).|
 |<nobr>`--output_node_names`</nobr>| Only applicable to Frozen Model. The names of the output nodes, separated by commas.|
 
 __Note: If you want to convert TensorFlow session bundle, you can install older versions of the tensorflowjs pip package, i.e. `pip install tensorflowjs==0.8.6`.__

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -519,7 +519,7 @@ def get_arg_parser():
       type=int,
       default=None,
       help='Shard size (in bytes) of the weight files. Currently applicable '
-      'only to output_format=tfjs_layers_model.')
+      'only when output_format is tfjs_layers_model or tfjs_graph_model.')
   parser.add_argument(
       '--output_node_names',
       type=str,

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -104,7 +104,8 @@ def dispatch_keras_h5_to_tfjs_graph_model_conversion(
     h5_path, output_dir=None,
     quantization_dtype=None,
     skip_op_check=False,
-    strip_debug_ops=False):
+    strip_debug_ops=False,
+    weight_shard_size_bytes=1024 * 1024 * 4):
   """
   Convert a keras HDF5-format model to tfjs GraphModel artifacts.
 
@@ -117,6 +118,8 @@ def dispatch_keras_h5_to_tfjs_graph_model_conversion(
       (Default: `None`).
     skip_op_check: Bool whether to skip the op check.
     strip_debug_ops: Bool whether to allow unsupported debug ops.
+    weight_shard_size_bytes: Shard size (in bytes) of the weight files.
+      The size of each weight file will be <= this value.
   """
 
   if not os.path.exists(h5_path):
@@ -138,7 +141,8 @@ def dispatch_keras_h5_to_tfjs_graph_model_conversion(
       saved_model_tags='serve',
       quantization_dtype=quantization_dtype,
       skip_op_check=skip_op_check,
-      strip_debug_ops=strip_debug_ops)
+      strip_debug_ops=strip_debug_ops,
+      weight_shard_size_bytes=weight_shard_size_bytes)
 
   # Clean up the temporary SavedModel directory.
   shutil.rmtree(temp_savedmodel_dir)
@@ -146,7 +150,8 @@ def dispatch_keras_h5_to_tfjs_graph_model_conversion(
 
 def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     keras_saved_model_path, output_dir, quantization_dtype=None,
-    split_weights_by_layer=False):
+    split_weights_by_layer=False,
+    weight_shard_size_bytes=1024 * 1024 * 4):
   """Converts keras model saved in the SavedModel format to tfjs format.
 
   Note that the SavedModel format exists in keras, but not in
@@ -166,6 +171,8 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     split_weights_by_layer: Whether to split the weights into separate weight
       groups (corresponding to separate binary weight files) layer by layer
       (Default: `False`).
+    weight_shard_size_bytes: Shard size (in bytes) of the weight files.
+      The size of each weight file will be <= this value.
   """
   with tf.Graph().as_default(), tf.compat.v1.Session():
     model = tf.keras.models.load_model(keras_saved_model_path)
@@ -179,7 +186,8 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
         temp_h5_path,
         output_dir,
         quantization_dtype=quantization_dtype,
-        split_weights_by_layer=split_weights_by_layer)
+        split_weights_by_layer=split_weights_by_layer,
+        weight_shard_size_bytes=weight_shard_size_bytes)
 
     # Delete temporary .h5 file.
     os.remove(temp_h5_path)
@@ -321,7 +329,8 @@ def dispatch_tfjs_layers_model_to_tfjs_graph_conversion(
     output_dir_path,
     quantization_dtype=None,
     skip_op_check=False,
-    strip_debug_ops=False):
+    strip_debug_ops=False,
+    weight_shard_size_bytes=1024 * 1024 * 4):
   """Converts a TensorFlow.js Layers Model to TensorFlow.js Graph Model.
 
   This conversion often benefits speed of inference, due to the graph
@@ -336,6 +345,8 @@ def dispatch_tfjs_layers_model_to_tfjs_graph_conversion(
       (Default: `None`).
     skip_op_check: Bool whether to skip the op check.
     strip_debug_ops: Bool whether to allow unsupported debug ops.
+    weight_shard_size_bytes: Shard size (in bytes) of the weight files.
+      The size of each weight file will be <= this value.
 
   Raises:
     ValueError, if `config_json_path` is not a path to a valid JSON
@@ -369,7 +380,8 @@ def dispatch_tfjs_layers_model_to_tfjs_graph_conversion(
       temp_h5_path, output_dir_path,
       quantization_dtype=quantization_dtype,
       skip_op_check=skip_op_check,
-      strip_debug_ops=strip_debug_ops)
+      strip_debug_ops=strip_debug_ops,
+      weight_shard_size_bytes=weight_shard_size_bytes)
 
   # Clean up temporary HDF5 file.
   os.remove(temp_h5_path)
@@ -570,20 +582,23 @@ def convert(arguments):
     dispatch_keras_h5_to_tfjs_layers_model_conversion(
         args.input_path, output_dir=args.output_path,
         quantization_dtype=quantization_dtype,
-        split_weights_by_layer=args.split_weights_by_layer)
+        split_weights_by_layer=args.split_weights_by_layer,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   elif (input_format == common.KERAS_MODEL and
         output_format == common.TFJS_GRAPH_MODEL):
     dispatch_keras_h5_to_tfjs_graph_model_conversion(
         args.input_path, output_dir=args.output_path,
         quantization_dtype=quantization_dtype,
         skip_op_check=args.skip_op_check,
-        strip_debug_ops=args.strip_debug_ops)
+        strip_debug_ops=args.strip_debug_ops,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   elif (input_format == common.KERAS_SAVED_MODEL and
         output_format == common.TFJS_LAYERS_MODEL):
     dispatch_keras_saved_model_to_tensorflowjs_conversion(
         args.input_path, args.output_path,
         quantization_dtype=quantization_dtype,
-        split_weights_by_layer=args.split_weights_by_layer)
+        split_weights_by_layer=args.split_weights_by_layer,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   elif (input_format == common.TF_SAVED_MODEL and
         output_format == common.TFJS_GRAPH_MODEL):
     tf_saved_model_conversion_v2.convert_tf_saved_model(
@@ -592,7 +607,8 @@ def convert(arguments):
         saved_model_tags=args.saved_model_tags,
         quantization_dtype=quantization_dtype,
         skip_op_check=args.skip_op_check,
-        strip_debug_ops=args.strip_debug_ops)
+        strip_debug_ops=args.strip_debug_ops,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   elif (input_format == common.TF_HUB_MODEL and
         output_format == common.TFJS_GRAPH_MODEL):
     tf_saved_model_conversion_v2.convert_tf_hub_module(
@@ -601,7 +617,8 @@ def convert(arguments):
         saved_model_tags=args.saved_model_tags,
         quantization_dtype=quantization_dtype,
         skip_op_check=args.skip_op_check,
-        strip_debug_ops=args.strip_debug_ops)
+        strip_debug_ops=args.strip_debug_ops,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   elif (input_format == common.TFJS_LAYERS_MODEL and
         output_format == common.KERAS_MODEL):
     dispatch_tensorflowjs_to_keras_h5_conversion(args.input_path,
@@ -622,14 +639,16 @@ def convert(arguments):
         args.input_path, args.output_path,
         quantization_dtype=_parse_quantization_bytes(args.quantization_bytes),
         skip_op_check=args.skip_op_check,
-        strip_debug_ops=args.strip_debug_ops)
+        strip_debug_ops=args.strip_debug_ops,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   elif (input_format == common.TF_FROZEN_MODEL and
         output_format == common.TFJS_GRAPH_MODEL):
     tf_saved_model_conversion_v2.convert_tf_frozen_model(
         args.input_path, args.output_node_names, args.output_path,
         quantization_dtype=_parse_quantization_bytes(args.quantization_bytes),
         skip_op_check=args.skip_op_check,
-        strip_debug_ops=args.strip_debug_ops)
+        strip_debug_ops=args.strip_debug_ops,
+        weight_shard_size_bytes=weight_shard_size_bytes)
   else:
     raise ValueError(
         'Unsupported input_format - output_format pair: %s - %s' %

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -553,12 +553,18 @@ def convert(arguments):
       args.input_format, args.output_format)
 
   weight_shard_size_bytes = 1024 * 1024 * 4
-  if args.weight_shard_size_bytes:
+  if args.weight_shard_size_bytes is not None:
     if (output_format not in
         (common.TFJS_LAYERS_MODEL, common.TFJS_GRAPH_MODEL)):
       raise ValueError(
           'The --weight_shard_size_bytes flag is only supported when '
           'output_format is tfjs_layers_model or tfjs_graph_model.')
+
+    if not (isinstance(args.weight_shard_size_bytes, int) and
+            args.weight_shard_size_bytes > 0):
+      raise ValueError(
+          'Expected weight_shard_size_bytes to be a positive integer, '
+          'but got %s' % args.weight_shard_size_bytes)
     weight_shard_size_bytes = args.weight_shard_size_bytes
 
   quantization_dtype = (

--- a/tfjs-converter/python/tensorflowjs/converters/converter.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter.py
@@ -544,14 +544,6 @@ def convert(arguments):
     raise ValueError(
         'Missing output_path argument. For usage, use the --help flag.')
 
-  weight_shard_size_bytes = 1024 * 1024 * 4
-  if args.weight_shard_size_bytes:
-    if  args.output_format != common.TFJS_LAYERS_MODEL:
-      raise ValueError(
-          'The --weight_shard_size_bytes flag is only supported under '
-          'output_format=tfjs_layers_model.')
-    weight_shard_size_bytes = args.weight_shard_size_bytes
-
   if args.input_path is None:
     raise ValueError(
         'Error: The input_path argument must be set. '
@@ -559,6 +551,15 @@ def convert(arguments):
 
   input_format, output_format = _standardize_input_output_formats(
       args.input_format, args.output_format)
+
+  weight_shard_size_bytes = 1024 * 1024 * 4
+  if args.weight_shard_size_bytes:
+    if (output_format not in
+        (common.TFJS_LAYERS_MODEL, common.TFJS_GRAPH_MODEL)):
+      raise ValueError(
+          'The --weight_shard_size_bytes flag is only supported when '
+          'output_format is tfjs_layers_model or tfjs_graph_model.')
+    weight_shard_size_bytes = args.weight_shard_size_bytes
 
   quantization_dtype = (
       quantization.QUANTIZATION_BYTES_TO_DTYPES[args.quantization_bytes]

--- a/tfjs-converter/python/tensorflowjs/converters/converter_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/converter_test.py
@@ -154,9 +154,9 @@ class ConvertH5WeightsTest(unittest.TestCase):
   def testConvertSavedKerasModeltoTfLayersModelSharded(self):
     with tf.Graph().as_default(), tf.compat.v1.Session():
       sequential_model = keras.models.Sequential([
-        keras.layers.Dense(
-            3, input_shape=(2,), use_bias=True, kernel_initializer='ones',
-            name='Dense1')])
+          keras.layers.Dense(
+              3, input_shape=(2,), use_bias=True, kernel_initializer='ones',
+              name='Dense1')])
       h5_path = os.path.join(self._tmp_dir, 'SequentialModel.h5')
       sequential_model.save(h5_path)
 

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -565,7 +565,7 @@ def convert_tf_hub_module_v1(module_path, output_dir,
                    quantization_dtype=quantization_dtype,
                    skip_op_check=skip_op_check,
                    strip_debug_ops=strip_debug_ops,
-                   shard_size_bytes=weight_shard_size_bytes)
+                   weight_shard_size_bytes=weight_shard_size_bytes)
   finally:
     # Clean up the temp files.
     if os.path.exists(frozen_file):

--- a/tfjs-converter/python/tensorflowjs/converters/wizard.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard.py
@@ -478,8 +478,15 @@ def run(dryrun):
           'name': common.WEIGHT_SHARD_SIZE_BYTES,
           'message': 'Please enter shard size (in bytes) of the weight files?',
           'default': str(4 * 1024 * 1024),
-          'when': lambda answers: value_in_list(answers, common.OUTPUT_FORMAT,
-                                                (common.TFJS_LAYERS_MODEL))
+          'validate':
+              lambda size: ('Please enter a positive integer' if not
+                            (size.isdigit() and int(size) > 0) else True),
+          'when': lambda answers: (value_in_list(answers, common.OUTPUT_FORMAT,
+                                                 (common.TFJS_LAYERS_MODEL,
+                                                  common.TFJS_GRAPH_MODEL)) or
+                                   value_in_list(answers, common.INPUT_FORMAT,
+                                                 (common.TF_SAVED_MODEL,
+                                                  common.TF_HUB_MODEL)))
       },
       {
           'type': 'confirm',

--- a/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard_test.py
@@ -185,6 +185,7 @@ class CliTest(unittest.TestCase):
                'saved_model_tags': 'test',
                'signature_name': 'test_default',
                'quantization_bytes': 2,
+               'weight_shard_size_bytes': '4194304',
                'skip_op_check': False,
                'strip_debug_ops': True,
                'output_path': 'tmp/web_model'}
@@ -192,6 +193,7 @@ class CliTest(unittest.TestCase):
     self.assertEqual(['--input_format=tf_saved_model',
                       '--quantization_bytes=2', '--saved_model_tags=test',
                       '--signature_name=test_default', '--strip_debug_ops=True',
+                      '--weight_shard_size_bytes=4194304',
                       'tmp/saved_model', 'tmp/web_model'],
                      wizard.generate_arguments(options))
 
@@ -201,6 +203,7 @@ class CliTest(unittest.TestCase):
                'input_path': 'tmp/saved_model',
                'saved_model_tags': 'test',
                'signature_name': 'test_default',
+               'weight_shard_size_bytes': '100',
                'quantization_bytes': 1,
                'skip_op_check': True,
                'strip_debug_ops': False,
@@ -210,17 +213,20 @@ class CliTest(unittest.TestCase):
                       '--output_format=tfjs_layers_model',
                       '--quantization_bytes=1', '--saved_model_tags=test',
                       '--signature_name=test_default', '--skip_op_check',
-                      '--strip_debug_ops=False', 'tmp/saved_model',
-                      'tmp/web_model'],
+                      '--strip_debug_ops=False',
+                      '--weight_shard_size_bytes=100',
+                      'tmp/saved_model', 'tmp/web_model'],
                      wizard.generate_arguments(options))
 
   def testGenerateCommandForKerasModel(self):
     options = {'input_format': 'keras',
                'input_path': 'tmp/model.HD5',
+               'weight_shard_size_bytes': '100',
                'quantization_bytes': 1,
                'output_path': 'tmp/web_model'}
 
     self.assertEqual(['--input_format=keras', '--quantization_bytes=1',
+                      '--weight_shard_size_bytes=100',
                       'tmp/model.HD5', 'tmp/web_model'],
                      wizard.generate_arguments(options))
 
@@ -229,11 +235,14 @@ class CliTest(unittest.TestCase):
                'output_format': 'keras',
                'input_path': 'tmp/model.json',
                'quantization_bytes': 1,
+               'weight_shard_size_bytes': '100',
                'output_path': 'tmp/web_model'}
 
     self.assertEqual(['--input_format=tfjs_layers_model',
                       '--output_format=keras',
-                      '--quantization_bytes=1', 'tmp/model.json',
+                      '--quantization_bytes=1',
+                      '--weight_shard_size_bytes=100',
+                      'tmp/model.json',
                       'tmp/web_model'],
                      wizard.generate_arguments(options))
 

--- a/tfjs-converter/python/tensorflowjs/write_weights.py
+++ b/tfjs-converter/python/tensorflowjs/write_weights.py
@@ -397,7 +397,7 @@ def _assert_weight_groups_valid(weight_groups):
 
 
 def _assert_shard_size_bytes_valid(shard_size_bytes):
-  if shard_size_bytes < 0:
+  if shard_size_bytes <= 0:
     raise ValueError(
         'shard_size_bytes must be greater than 0, but got %s' %
         shard_size_bytes)


### PR DESCRIPTION
Previously, only the tfjs_layers_model to tfjs_layers_model conversion pair worked with the `weight_shard_size_bytes` flag. This PR allows the flag to be used for any conversion where the output_format is `tfjs_layers_model` or `tfjs_graph_model`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2774)
<!-- Reviewable:end -->
