### PR TITLE
Update XNNPACK for faster PReLU

### DIFF
--- a/tfjs-backend-wasm/WORKSPACE
+++ b/tfjs-backend-wasm/WORKSPACE
@@ -8,9 +8,9 @@ emsdk_configure(name = "emsdk")
 
 git_repository(
     name = "xnnpack",
-    commit = "3ba868c43f19dbe230cf91d87d722191dc23da19",
+    commit = "15d1f511d37a8dad1ab7a80cfefd7014accf72ac",
     remote = "https://github.com/google/XNNPACK.git",
-    shallow_since = "1582304954 -0800",
+    shallow_since = "1582560423 -0800",
 )
 
 # The libraries below are transitive dependencies of XNNPACK that we need to

--- a/tfjs-backend-wasm/src/cc/prelu_impl.cc
+++ b/tfjs-backend-wasm/src/cc/prelu_impl.cc
@@ -58,13 +58,11 @@ void prelu(const float* x_buf, const size_t x_size, const size_t weights_id,
   if (operator_cache_idx == operator_cache.end()) {
     const size_t channels = weights_info.size;
     const size_t strides = channels;
-    const float output_min = -std::numeric_limits<float>::infinity();
-    const float output_max = std::numeric_limits<float>::infinity();
 
     const uint32_t flags = 0;
     xnn_status status =
         xnn_create_prelu_nc_f32(channels, strides, strides, weights_buf,
-                                output_min, output_max, flags, &prelu_op);
+                                flags, &prelu_op);
     if (status != xnn_status_success) {
       util::warn(
           "XNN status for xnn_create_prelu_nc_f32 is not successful. Got "


### PR DESCRIPTION
- Pull google/XNNPACK@c8230a41b2e7773661764f6385f4cb9dcdb008e6
- Update TF.js PReLU implementation to reflect changed XNNPACK API for
PReLU operator

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2787)
<!-- Reviewable:end -->
