### PR TITLE
[tfjs-converter] Adjust tfjs-converter build script

### DIFF
--- a/tfjs-converter/package.json
+++ b/tfjs-converter/package.json
@@ -54,7 +54,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {
-    "build": "yarn gen-json --test && tsc && copyfiles -f src/data/compiled_api.* dist/src/data/",
+    "build": "yarn gen-json --test && tsc",
     "build-core": "cd ../tfjs-core && yarn && yarn build",
     "build-core-ci": "cd ../tfjs-core && yarn && yarn build-ci",
     "build-npm": "./scripts/build-npm.sh",

--- a/tfjs-converter/rollup.config.js
+++ b/tfjs-converter/rollup.config.js
@@ -54,7 +54,6 @@ function config({plugins = [], output = {}}) {
       // Polyfill require() from dependencies.
       commonjs({
         namedExports: {
-          './src/data/compiled_api.js': ['tensorflow'],
           './node_modules/protobufjs/minimal.js': ['roots', 'Reader', 'util']
         }
       }),


### PR DESCRIPTION
This commit removes the portion that copies the `compiled_api.ts` file into the `dist` folder. This seems to be leftover from when  compiled_api used to be a javascript file and not typescript. Currently, I don't really see a reason to still copy the typescript file over. Let me know if there is a reason I'm missing.

This will also prevent issues like in https://github.com/tensorflow/tfjs/issues/2400.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2789)
<!-- Reviewable:end -->
