### PR TITLE
[converter]Temprory solution to symlink dependencies.

### DIFF
--- a/scripts/link-core-master.js
+++ b/scripts/link-core-master.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright 2019 Google LLC. All Rights Reserved.
+// Copyright 2020 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tfjs-converter/cloudbuild.yml
+++ b/tfjs-converter/cloudbuild.yml
@@ -43,7 +43,7 @@ steps:
   dir: 'tfjs-converter'
   entrypoint: 'yarn'
   id: 'build'
-  args: ['build']
+  args: ['build-ci']
   waitFor: ['gen-json']
 
 # Run javascript tests.

--- a/tfjs-converter/package.json
+++ b/tfjs-converter/package.json
@@ -15,10 +15,10 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.6.0"
+    "@tensorflow/tfjs-core": "link:../tfjs-core"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.6.0",
+    "@tensorflow/tfjs-core": "link:../tfjs-core",
     "@types/deep-equal": "^1.0.1",
     "@types/jasmine": "~2.8.6",
     "@types/long": "~3.0.32",
@@ -59,8 +59,9 @@
     "build-core-ci": "cd ../tfjs-core && yarn && yarn build-ci",
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
+    "link-core-master": "./scripts/link-core-master.js",
     "publish-local": "yarn build-npm && yalc push",
-    "test": "yarn build-core && yarn && yarn gen-json --test && ts-node run_tests.ts",
+    "test": "yarn link-core-master && yarn build-core && yarn && yarn gen-json --test && ts-node run_tests.ts",
     "test-ci": "ts-node run_tests.ts",
     "test-snippets": "ts-node ./scripts/test_snippets.ts",
     "lint": "tslint -p . -t verbose",

--- a/tfjs-converter/package.json
+++ b/tfjs-converter/package.json
@@ -59,7 +59,7 @@
     "build-core-ci": "cd ../tfjs-core && yarn && yarn build-ci",
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
-    "link-core-master": "./scripts/link-core-master.js",
+    "link-core-master": "../scripts/link-core-master.js",
     "publish-local": "yarn build-npm && yalc push",
     "test": "yarn link-core-master && yarn build-core && yarn && yarn gen-json --test && ts-node run_tests.ts",
     "test-ci": "ts-node run_tests.ts",

--- a/tfjs-converter/package.json
+++ b/tfjs-converter/package.json
@@ -54,7 +54,8 @@
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {
-    "build": "yarn gen-json --test && tsc",
+    "build": "yarn link-core-master && yarn gen-json --test && tsc",
+    "build-ci": "yarn gen-json --test && tsc",
     "build-core": "cd ../tfjs-core && yarn && yarn build",
     "build-core-ci": "cd ../tfjs-core && yarn && yarn build-ci",
     "build-npm": "./scripts/build-npm.sh",

--- a/tfjs-converter/scripts/build-npm.sh
+++ b/tfjs-converter/scripts/build-npm.sh
@@ -19,7 +19,7 @@ set -e
 
 rimraf dist/
 yarn
-yarn build
+yarn build-ci
 rollup -c
 
 # Use minified files for miniprogram

--- a/tfjs-converter/scripts/link-core-master.js
+++ b/tfjs-converter/scripts/link-core-master.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+// This script updates package.json to link core at master.
+
+const fs = require('fs');
+
+let pkg = fs.readFileSync('package.json', 'utf8');
+
+pkg = `${pkg}`.replace(
+    new RegExp(`"@tensorflow/tfjs-core": ".+"`, 'g'),
+    `"@tensorflow/tfjs-core": "link:../tfjs-core"`);
+
+fs.writeFileSync('package.json', pkg);

--- a/tfjs-converter/yarn.lock
+++ b/tfjs-converter/yarn.lock
@@ -55,17 +55,9 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@tensorflow/tfjs-core@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.6.0.tgz#8a871de73995e0efc7ea5660df018402c788d285"
-  integrity sha512-b98jn1pjRuEDVNN6/ZQMFhyYV27ZIsG9CcHSMXq1ohX6ALQQB3mwgrMeC2TEVXFl6/L2vOD8W+txuBRGKHnvpg==
-  dependencies:
-    "@types/offscreencanvas" "~2019.3.0"
-    "@types/seedrandom" "2.4.27"
-    "@types/webgl-ext" "0.0.30"
-    "@types/webgl2" "0.0.4"
-    node-fetch "~2.1.2"
-    seedrandom "2.4.3"
+"@tensorflow/tfjs-core@link:../tfjs-core":
+  version "0.0.0"
+  uid ""
 
 "@types/deep-equal@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
The symlink is changed back to pinned version after release. I thought the generated release branch won't be merged back to master, but it does. Short term solution is to apply the same strategy that WASM package use to use script to change back to symlink. Cons is, (1) people need to remember run test at least once before submit the PR, because CI won't do the link. (2) it's possible people may develop against pinned version if they don't run the test first.

Long term solution (hopefully will come soon), always keep symlink in development code and master branch. Have a dedicated release branch for bumping versions. Always publish from the release branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2834)
<!-- Reviewable:end -->
