### PR TITLE
Improve docs for initialEpochs

### DIFF
--- a/tfjs-converter/src/executor/graph_model.ts
+++ b/tfjs-converter/src/executor/graph_model.ts
@@ -26,8 +26,8 @@ import {GraphExecutor} from './graph_executor';
 export const TFHUB_SEARCH_PARAM = '?tfjs-format=file';
 export const DEFAULT_MODEL_NAME = 'model.json';
 /**
- * A `tf.GraphModel` is a directed, acyclic graph of built from
- * SavedModel GraphDef and allows inference exeuction.
+ * A `tf.GraphModel` is a directed, acyclic graph built from a
+ * SavedModel GraphDef and allows inference execution.
  *
  * A `tf.GraphModel` can only be created by loading from a model converted from
  * a [TensorFlow SavedModel](https://www.tensorflow.org/guide/saved_model) using

--- a/tfjs-layers/src/backend/tfjs_backend.ts
+++ b/tfjs-layers/src/backend/tfjs_backend.ts
@@ -113,7 +113,7 @@ export function repeat(x: Tensor, n: number): Tensor {
 }
 
 /**
- * Flatten an Tensor into 1D.
+ * Flatten a Tensor into 1D.
  * @param x Input tensor.
  * @return The result of the flattening `x`.
  */

--- a/tfjs-layers/src/backend/tfjs_backend_test.ts
+++ b/tfjs-layers/src/backend/tfjs_backend_test.ts
@@ -34,7 +34,7 @@ describe('TensorMath', () => {
 });
 
 describe('dtype', () => {
-  it('returns float32 for an Tensor', () => {
+  it('returns float32 for a Tensor', () => {
     const x = zeros([1]);
     expect(x.dtype).toEqual('float32');
   });

--- a/tfjs-layers/src/engine/topology_test.ts
+++ b/tfjs-layers/src/engine/topology_test.ts
@@ -659,7 +659,7 @@ describeMathCPU('Layer', () => {
   describe('apply() passed 1+ Tensors', () => {
     it('returns new values for output if the same as the input.', () => {
       const anArray = ones([1]);
-      // Test with both an Tensor and an array of Tensors.
+      // Test with both a Tensor and an array of Tensors.
       for (const inputs of [anArray, [anArray, anArray]]) {
         const layer = new LayerForTest();
         const result = layer.apply(inputs) as Tensor | Tensor[];

--- a/tfjs-layers/src/engine/training.ts
+++ b/tfjs-layers/src/engine/training.ts
@@ -1084,7 +1084,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
    * model.predict(tf.ones([8, 10]), {batchSize: 4}).print();
    * ```
    *
-   * @param x The input data, as an Tensor, or an `Array` of `tf.Tensor`s if
+   * @param x The input data, as a Tensor, or an `Array` of `tf.Tensor`s if
    *   the model has multiple inputs.
    * @param args A `ModelPredictArgs` object containing optional fields.
    *
@@ -1123,7 +1123,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
    * });
    * model.predictOnBatch(tf.ones([8, 10])).print();
    * ```
-   * @param x: Input samples, as an Tensor (for models with exactly one
+   * @param x: Input samples, as a Tensor (for models with exactly one
    *   input) or an array of Tensors (for models with more than one input).
    * @return Tensor(s) of predictions
    */

--- a/tfjs-layers/src/engine/training_dataset.ts
+++ b/tfjs-layers/src/engine/training_dataset.ts
@@ -38,10 +38,7 @@ export interface ModelFitDatasetArgs<T> {
   batchesPerEpoch?: number;
 
   /**
-   * The number of times to iterate over the training dataset.
-   * Note that when used with `initialEpoch`, epochs is the index of the
-   * "final epoch". The model is not trained for a number of iterations
-   * given by epochs, but merely until the epoch of index epochs is reached.
+   * Integer number of times to iterate over the training dataset.
    */
   epochs: number;
 
@@ -144,7 +141,9 @@ export interface ModelFitDatasetArgs<T> {
 
   /**
    * Epoch at which to start training (useful for resuming a previous training
-   * run).
+   * run). When this is used, `epochs` is the index of the "final epoch".
+   * The model is not trained for a number of iterations given by `epochs`,
+   * but merely until the epoch of index `epochs` is reached.
    */
   initialEpoch?: number;
 

--- a/tfjs-layers/src/engine/training_dataset.ts
+++ b/tfjs-layers/src/engine/training_dataset.ts
@@ -39,8 +39,9 @@ export interface ModelFitDatasetArgs<T> {
 
   /**
    * The number of times to iterate over the training dataset.
-   *
-   * An integer.
+   * Note that when used with `initialEpoch`, epochs is the index of the
+   * "final epoch". The model is not trained for a number of iterations
+   * given by epochs, but merely until the epoch of index epochs is reached.
    */
   epochs: number;
 
@@ -512,7 +513,7 @@ function getStepsPerEpoch<T>(
   return stepsPerEpoch;
 }
 
-// Check if provided object is a Dataset object by checking it's .iterator
+// Check if provided object is a Dataset object by checking its .iterator
 // element.
 function isDatasetObject<T>(
     dataset:

--- a/tfjs-layers/src/engine/training_tensors.ts
+++ b/tfjs-layers/src/engine/training_tensors.ts
@@ -168,7 +168,7 @@ export function checkBatchSize(batchSize: number) {
 }
 
 /**
- * Slice an Tensor or an Array of Tensors, by start and stop indices.
+ * Slice a Tensor or an Array of Tensors, by start and stop indices.
  *
  * Porting Note: The `_slice_arrays` function in PyKeras is covered by this
  *   function and `sliceArraysByIndices()` together.
@@ -192,7 +192,7 @@ export function sliceArrays(
 }
 
 /**
- * Slice an Tensor or an Array of Tensors, by random-order indices.
+ * Slice a Tensor or an Array of Tensors, by random-order indices.
  *
  * Porting Note: The `_slice_arrays` function in PyKeras is covered by this
  *   function and `sliceArrays()` together.
@@ -476,7 +476,7 @@ export async function fitTensors(
         args.validationSplit != null && args.validationSplit > 0 &&
         args.validationSplit < 1) {
       doValidation = true;
-      // Porting Note: In tfjs-layers, inputs[0] is always an Tensor.
+      // Porting Note: In tfjs-layers, inputs[0] is always a Tensor.
       const splitAt =
           Math.floor(inputs[0].shape[0] * (1 - args.validationSplit));
       const originalBatchSize = inputs[0].shape[0];

--- a/tfjs-layers/src/engine/training_tensors.ts
+++ b/tfjs-layers/src/engine/training_tensors.ts
@@ -33,10 +33,7 @@ export interface ModelFitArgs {
   batchSize?: number;
 
   /**
-   * The number of times to iterate over the training data arrays.
-   * Note that when used with `initialEpoch`, epochs is the index of the
-   * "final epoch". The model is not trained for a number of iterations
-   * given by epochs, but merely until the epoch of index epochs is reached.
+   * Integer number of times to iterate over the training data arrays.
    */
   epochs?: number;
 
@@ -121,7 +118,9 @@ export interface ModelFitArgs {
 
   /**
    * Epoch at which to start training (useful for resuming a previous training
-   * run).
+   * run). When this is used, `epochs` is the index of the "final epoch".
+   * The model is not trained for a number of iterations given by `epochs`,
+   * but merely until the epoch of index `epochs` is reached.
    */
   initialEpoch?: number;
 

--- a/tfjs-layers/src/exports.ts
+++ b/tfjs-layers/src/exports.ts
@@ -148,8 +148,8 @@ export function sequential(config?: SequentialArgs): Sequential {
  * 1. Models created with the `tf.layers.*`, `tf.sequential`, and
  * `tf.model` APIs of TensorFlow.js and later saved with the
  * `tf.LayersModel.save` method.
- * 2. Models converted from Keras or TensorFlow tf.keras using
- *    the [tensorflowjs_converter](https://github.com/tensorflow/tfjs-converter)
+ * 2. Models converted from Keras or TensorFlow tf.keras using the
+ * [tensorflowjs_converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
  *
  * This mode is *not* applicable to TensorFlow `SavedModel`s or their converted
  * forms. For those models, use `tf.loadGraphModel`.
@@ -222,7 +222,7 @@ export function sequential(config?: SequentialArgs): Sequential {
  *   - `strict`: Require that the provided weights exactly match those required
  *     by the layers.  Default true.  Passing false means that both extra
  *     weights and missing weights will be silently ignored.
- *   - ｀onProgress｀: A function of the signature `(fraction: number) => void',
+ *   - `onProgress`: A function of the signature `(fraction: number) => void',
  *     that can be used as the progress callback for the model loading.
  * @returns A `Promise` of `tf.LayersModel`, with the topology and weights
  *     loaded.

--- a/tfjs-layers/src/models.ts
+++ b/tfjs-layers/src/models.ts
@@ -757,7 +757,7 @@ export class Sequential extends LayersModel {
    * model.predict(tf.ones([2, 10])).print();
    * ```
    *
-   * @param x The input data, as an Tensor, or an `Array` of `tf.Tensor`s if
+   * @param x The input data, as a Tensor, or an `Array` of `tf.Tensor`s if
    *   the model has multiple inputs.
    * @param conifg A `ModelPredictConfig` object containing optional fields.
    *
@@ -780,7 +780,7 @@ export class Sequential extends LayersModel {
   /**
    * Returns predictions for a single batch of samples.
    *
-   * @param x: Input samples, as an Tensor, or list of Tensors (if the model
+   * @param x: Input samples, as a Tensor, or list of Tensors (if the model
    *   has multiple inputs).
    * @return Tensor(s) of predictions
    */

--- a/tfjs-layers/src/utils/test_utils.ts
+++ b/tfjs-layers/src/utils/test_utils.ts
@@ -30,7 +30,7 @@ registerTestEnv({
 });
 
 /**
- * Expect values are close between an Tensor or number array.
+ * Expect values are close between a Tensor or number array.
  * @param actual
  * @param expected
  */


### PR DESCRIPTION
This PR fixes fixes the `epochs` docstring for  `fitDataset` to match what was changed here: https://github.com/tensorflow/tfjs/commit/439314075c3b7f17a6924ef71ec10d1908641932

Some other minor fixes were added as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2856)
<!-- Reviewable:end -->
