### PR TITLE
Release and diffing change.

### DIFF
--- a/scripts/find-affected-packages.js
+++ b/scripts/find-affected-packages.js
@@ -43,22 +43,19 @@ if (commitSha == null) {
 if (branchName == null) {
   branchName = exec(`git rev-parse --abbrev-ref HEAD`).stdout.trim();
 }
+if (baseBranch == null) {
+  // For Nightly build, baseBranch is null. We use master for Nightly build.
+  baseBranch = 'master';
+}
 console.log('commitSha: ', commitSha);
 console.log('branchName: ', branchName);
 console.log('baseBranch: ', baseBranch);
 
-const toMaster = baseBranch == 'master';
-
-if (toMaster) {
-  console.log('Clone branch master.');
-  // We cannot do --depth=1 here because we need to check out an old merge base.
-  // We cannot do --single-branch here because we need multiple branches.
-  exec(`git clone https://github.com/tensorflow/tfjs ${CLONE_PATH}`);
-} else {
-  console.log(`Clone branch ${baseBranch}`);
-  exec(`git clone -b ${baseBranch} https://github.com/tensorflow/tfjs ${
-      CLONE_PATH}`);
-}
+// We cannot do --depth=1 here because we need to check out an old merge base.
+// We cannot do --single-branch here because we need multiple branches.
+console.log(`Clone branch ${baseBranch}`);
+exec(`git clone -b ${baseBranch} https://github.com/tensorflow/tfjs ${
+    CLONE_PATH}`);
 
 console.log();  // Break up the console for readability.
 
@@ -68,19 +65,16 @@ shell.cd(CLONE_PATH);
 const res = shell.exec(`git checkout ${commitSha}`, {silent: true});
 const isPullRequestFromFork = res.code !== 0;
 
-if (toMaster) {
-  // Only checkout the merge base if the pull requests comes from a
-  // tensorflow/tfjs branch. Otherwise clone master and diff against master.
-  if (!isPullRequestFromFork) {
-    console.log('PR is coming from tensorflow/tfjs. Finding the merge base...');
-    exec(`git checkout ${branchName}`);
-    const mergeBase = exec(`git merge-base master ${branchName}`).stdout.trim();
-    exec(`git fetch origin ${mergeBase}`);
-    exec(`git checkout ${mergeBase}`);
-    console.log('mergeBase: ', mergeBase);
-  } else {
-    console.log('PR is coming from a fork. Diffing against master.');
-  }
+// Only checkout the merge base if the pull requests comes from a
+// tensorflow/tfjs branch. Otherwise clone master and diff against master.
+if (!isPullRequestFromFork) {
+  console.log('PR is coming from tensorflow/tfjs. Finding the merge base...');
+  exec(`git checkout ${branchName}`);
+  const mergeBase =
+      exec(`git merge-base ${baseBranch} ${branchName}`).stdout.trim();
+  exec(`git fetch origin ${mergeBase}`);
+  exec(`git checkout ${mergeBase}`);
+  console.log('mergeBase: ', mergeBase);
 } else {
   console.log(`PR is going to diff against branch ${baseBranch}.`);
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -270,8 +270,7 @@ async function main() {
 
   const packageNames = packages.join(', ');
   const versionNames = newVersions.join(', ');
-  const timestamp = Date.now();
-  const branchName = `b${newVersions.join('-')}_${timestamp}`;
+  const branchName = `b${newVersions.join('-')}_phase${phaseInt}`;
   $(`git checkout -b ${branchName}`);
   $(`git push -u origin ${branchName}`);
   $(`git add .`);


### PR DESCRIPTION
Preparing for release process change. This PR includes below changes:
(1) Make diffing logic more generic. It introduces baseBranch, so the script no longer assume diff against master, it will diff against whatever baseBranch cloud build send. This information is ultimately from GitHub.
(2) Add a step in release script, asking which release branch to send the PR to.
(3) Generate a unique local branch for the PR each time. The branches need to be deleted afterwards.
(4) Automate pull-request to send the PR to the release branch, not master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2885)
<!-- Reviewable:end -->
