### PR TITLE
[tfjs-converter] Add weight shard arg to save_keras_model

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion.py
@@ -308,7 +308,8 @@ def write_artifacts(topology,
     json.dump(model_json, f)
 
 
-def save_keras_model(model, artifacts_dir, quantization_dtype=None):
+def save_keras_model(model, artifacts_dir, quantization_dtype=None,
+                     weight_shard_size_bytes=1024 * 1024 * 4):
   r"""Save a Keras model and its weights in TensorFlow.js format.
 
   Args:
@@ -327,6 +328,8 @@ def save_keras_model(model, artifacts_dir, quantization_dtype=None):
       If the directory does not exist, this function will attempt to create it.
     quantization_dtype: An optional numpy dtype to quantize weights to for
         compression. Only np.uint8 and np.uint16 are supported.
+    weight_shard_size_bytes: Shard size (in bytes) of the weight files.
+      The size of each weight file will be <= this value.
 
   Raises:
     ValueError: If `artifacts_dir` already exists as a file (not a directory).
@@ -341,5 +344,6 @@ def save_keras_model(model, artifacts_dir, quantization_dtype=None):
     os.makedirs(artifacts_dir)
   write_artifacts(
       topology_json, weight_groups, artifacts_dir,
-      quantization_dtype=quantization_dtype)
+      quantization_dtype=quantization_dtype,
+      weight_shard_size_bytes=weight_shard_size_bytes)
   os.remove(temp_h5_path)


### PR DESCRIPTION
Weight shard size should be customizable through usage of the `tfjs.converters.save_keras_model` Python method. Right now, custom weight shards are only allowed through the converter CLI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2889)
<!-- Reviewable:end -->
