### PR TITLE
made visibility public

### DIFF
--- a/tfjs-converter/python/tensorflowjs/BUILD
+++ b/tfjs-converter/python/tensorflowjs/BUILD
@@ -1,5 +1,7 @@
 package(
-  default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//tensorflowjs:__subpackages__",
+    ],
 )
 
 licenses(["notice"])  # Apache 2.0

--- a/tfjs-converter/python/tensorflowjs/BUILD
+++ b/tfjs-converter/python/tensorflowjs/BUILD
@@ -1,7 +1,5 @@
 package(
-    default_visibility = [
-        "//tensorflowjs:__subpackages__",
-    ],
+  default_visibility = ["//visibility:public"],
 )
 
 licenses(["notice"])  # Apache 2.0

--- a/tfjs-converter/python/tensorflowjs/converters/BUILD
+++ b/tfjs-converter/python/tensorflowjs/converters/BUILD
@@ -1,7 +1,5 @@
 package(
-    default_visibility = [
-        "//tensorflowjs:__subpackages__",
-    ],
+    default_visibility = ["//visibility:public"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/tfjs-converter/python/tensorflowjs/converters/BUILD
+++ b/tfjs-converter/python/tensorflowjs/converters/BUILD
@@ -1,5 +1,7 @@
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//tensorflowjs:__subpackages__",
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -161,6 +163,7 @@ py_library(
         "//tensorflowjs:version",
         "//tensorflowjs:write_weights",
     ],
+    visibility = ["//visibility:public"],
 )
 
 py_test(


### PR DESCRIPTION
Update visibility of converter python build files to public
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2893)
<!-- Reviewable:end -->
