### PR TITLE
Fix integration test.

### DIFF
--- a/tfjs-node-gpu/cloudbuild.yml
+++ b/tfjs-node-gpu/cloudbuild.yml
@@ -13,53 +13,13 @@ steps:
   args: ['install']
   waitFor: ['prep-gpu']
 
-# Build core from master.
-- name: 'node:10'
-  dir: 'tfjs-node-gpu'
-  id: 'build-core'
-  entrypoint: 'yarn'
-  args: ['build-core-ci']
-  waitFor: ['yarn-common']
-
-# Build layers from master.
-- name: 'node:10'
-  dir: 'tfjs-node-gpu'
-  id: 'build-layers'
-  entrypoint: 'yarn'
-  args: ['build-layers-ci']
-  waitFor: ['build-core']
-
-# Build converter from master.
-- name: 'node:10'
-  dir: 'tfjs-node-gpu'
-  id: 'build-converter'
-  entrypoint: 'yarn'
-  args: ['build-converter-ci']
-  waitFor: ['build-core']
-
-# Build data from master.
-- name: 'node:10'
-  dir: 'tfjs-node-gpu'
-  id: 'build-data'
-  entrypoint: 'yarn'
-  args: ['build-data-ci']
-  waitFor: ['build-layers', 'build-converter']
-
-# Build union package from master.
-- name: 'node:10'
-  dir: 'tfjs-node-gpu'
-  id: 'build-union'
-  entrypoint: 'yarn'
-  args: ['build-union-ci']
-  waitFor: ['build-data']
-
 # Install tfjs-node dependencies.
 - name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
-  waitFor: ['build-union']
+  waitFor: ['yarn-common']
 
 # Unit tests.
 - name: 'node:10'

--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -24,6 +24,8 @@
     "build-data-ci": "cd ../tfjs-data && yarn && yarn build-ci",
     "build-union": "cd ../tfjs && yarn && yarn build",
     "build-union-ci": "cd ../tfjs && yarn && yarn build-ci",
+    "build-deps": "yarn build-core && yarn build-layers && yarn build-converter && yarn build-data && yarn build-union",
+    "build-deps-ci": "yarn build-core-ci && yarn build-layers-ci && yarn build-converter-ci && yarn build-data-ci && yarn build-union-ci",
     "build-npm": "yarn prep-gpu && ./scripts/build-npm.sh",
     "build-addon": "./scripts/build-and-upload-addon.sh",
     "build-addon-from-source": "node-pre-gyp install --build-from-source",
@@ -41,7 +43,7 @@
     "prep-gpu": "./prep-gpu.sh",
     "prep-gpu-windows": "./prep-gpu-windows.bat",
     "publish-local": "yarn prep && yalc push",
-    "test": "yarn link-master && yarn && yarn build-core && yarn build-layers && yarn build-converter && yarn build-data && yarn build-union && ts-node src/run_tests.ts",
+    "test": "yarn link-master && yarn && yarn build-deps && ts-node src/run_tests.ts",
     "test-ci": "./scripts/test-ci.sh",
     "test-ts-integration": "./scripts/test-ts-integration.sh",
     "upload-windows-addon": "prep-gpu-windows.bat && ./scripts/build-and-upload-windows-addon-gpu.bat"

--- a/tfjs-node/cloudbuild.yml
+++ b/tfjs-node/cloudbuild.yml
@@ -11,7 +11,7 @@ steps:
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
-  waitFor: ['build-union']
+  waitFor: ['yarn-common']
 
 # Unit tests.
 - name: 'node:10'

--- a/tfjs-node/cloudbuild.yml
+++ b/tfjs-node/cloudbuild.yml
@@ -5,46 +5,6 @@ steps:
   entrypoint: 'yarn'
   args: ['install']
 
-# Build core from master.
-- name: 'node:10'
-  dir: 'tfjs-node'
-  id: 'build-core'
-  entrypoint: 'yarn'
-  args: ['build-core-ci']
-  waitFor: ['yarn-common']
-
-# Build layers from master.
-- name: 'node:10'
-  dir: 'tfjs-node'
-  id: 'build-layers'
-  entrypoint: 'yarn'
-  args: ['build-layers-ci']
-  waitFor: ['build-core']
-
-# Build converter from master.
-- name: 'node:10'
-  dir: 'tfjs-node'
-  id: 'build-converter'
-  entrypoint: 'yarn'
-  args: ['build-converter-ci']
-  waitFor: ['build-core']
-
-# Build data from master.
-- name: 'node:10'
-  dir: 'tfjs-node'
-  id: 'build-data'
-  entrypoint: 'yarn'
-  args: ['build-data-ci']
-  waitFor: ['build-layers', 'build-converter']
-
-# Build union package from master.
-- name: 'node:10'
-  dir: 'tfjs-node'
-  id: 'build-union'
-  entrypoint: 'yarn'
-  args: ['build-union-ci']
-  waitFor: ['build-data']
-
 # Install tfjs-node dependencies.
 - name: 'node:10'
   dir: 'tfjs-node'

--- a/tfjs-node/package.json
+++ b/tfjs-node/package.json
@@ -24,6 +24,8 @@
     "build-data-ci": "cd ../tfjs-data && yarn && yarn build-ci",
     "build-union": "cd ../tfjs && yarn && yarn build",
     "build-union-ci": "cd ../tfjs && yarn && yarn build-ci",
+    "build-deps": "yarn build-core && yarn build-layers && yarn build-converter && yarn build-data && yarn build-union",
+    "build-deps-ci": "yarn build-core-ci && yarn build-layers-ci && yarn build-converter-ci && yarn build-data-ci && yarn build-union-ci",
     "build-npm": "./scripts/build-npm.sh",
     "build-addon": "./scripts/build-and-upload-addon.sh",
     "build-addon-from-source": "node-pre-gyp install --build-from-source",
@@ -39,7 +41,7 @@
     "lint": "tslint -p . -t verbose",
     "prep": "cd node_modules/@tensorflow/tfjs-core && yarn && yarn build",
     "publish-local": "yarn prep && yalc push",
-    "test": "yarn link-master && yarn && yarn build-core && yarn build-layers && yarn build-converter && yarn build-data && yarn build-union && ts-node src/run_tests.ts",
+    "test": "yarn link-master && yarn && yarn build-deps && ts-node src/run_tests.ts",
     "test-ci": "./scripts/test-ci.sh",
     "test-ts-integration": "./scripts/test-ts-integration.sh",
     "upload-windows-addon": "./scripts/build-and-upload-windows-addon.bat"

--- a/tfjs-node/scripts/test-ci.sh
+++ b/tfjs-node/scripts/test-ci.sh
@@ -10,6 +10,11 @@
 set -e
 
 yarn build-addon-from-source
+yarn build-core-ci
+yarn build-layers-ci
+yarn build-converter-ci
+yarn build-data-ci
+yarn build-union-ci
 yarn build-ci
 yarn lint
 yarn test

--- a/tfjs-node/scripts/test-ci.sh
+++ b/tfjs-node/scripts/test-ci.sh
@@ -10,11 +10,7 @@
 set -e
 
 yarn build-addon-from-source
-yarn build-core-ci
-yarn build-layers-ci
-yarn build-converter-ci
-yarn build-data-ci
-yarn build-union-ci
+yarn build-deps-ci
 yarn build-ci
 yarn lint
 yarn test


### PR DESCRIPTION
Fix integration test and refactor code. 

For any tests, it has to build dependencies first. Local and CI test of tfjs-node already have this, but integration test doesn't have. Adding build step to test-ci, which is called by integration test. Therefore, removing the same steps from cloudbuild.yml.

Also extract all the dependency builds into a yarn command.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2899)
<!-- Reviewable:end -->
