### PR TITLE
move inputsToSave and outputsToSave to gradConfig

### DIFF
--- a/tfjs-core/src/gradients/Square_grad.ts
+++ b/tfjs-core/src/gradients/Square_grad.ts
@@ -21,6 +21,7 @@ import {Tensor} from '../tensor';
 
 export const squareGradConfig: GradConfig = {
   kernelName: Square,
+  inputsToSave: ['x'],
   gradFunc: (dy: Tensor, saved: Tensor[]) => {
     const [x] = saved;
     return {x: () => dy.mul(x.toFloat().mul(2))};

--- a/tfjs-core/src/gradients/SquaredDifference_grad.ts
+++ b/tfjs-core/src/gradients/SquaredDifference_grad.ts
@@ -23,6 +23,7 @@ import {Tensor} from '../tensor';
 
 export const squaredDifferenceGradConfig: GradConfig = {
   kernelName: SquaredDifference,
+  inputsToSave: ['a', 'b'],
   gradFunc: (dy: Tensor, saved: Tensor[]) => {
     const [a, b] = saved;
     const two = scalar(2);

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -59,6 +59,8 @@ export interface KernelConfig {
 /** Config object for registering a gradient in the global registry. */
 export interface GradConfig {
   kernelName: string;
+  inputsToSave?: string[];
+  outputsToSave?: boolean[];
   gradFunc: GradFunc;
 }
 


### PR DESCRIPTION
This moves the definition of inputsToSave and outputsToSave for gradient computation onto the gradient config. 

runKernelFunc still takes inputsToSave and outputsToSave as fallbacks for ops currently using those directly. However those two params to runKernelFun are effectively deprecated.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2925)
<!-- Reviewable:end -->
