### PR TITLE
modularise clone op

### DIFF
--- a/tfjs-core/src/gradients/Identity_grad.ts
+++ b/tfjs-core/src/gradients/Identity_grad.ts
@@ -14,21 +14,14 @@
  * limitations under the License.
  * =============================================================================
  */
-import {broadcastToGradConfig} from './gradients/BroadcastTo_grad';
-import {identityGradConfig} from './gradients/Identity_grad';
-import {squareGradConfig} from './gradients/Square_grad';
-import {squaredDifferenceGradConfig} from './gradients/SquaredDifference_grad';
-import {GradConfig} from './kernel_registry';
-import {registerGradient} from './kernel_registry';
 
-// Export all kernel configs here so that the package can auto register them
-const gradConfigs: GradConfig[] = [
-  squareGradConfig,
-  squaredDifferenceGradConfig,
-  broadcastToGradConfig,
-  identityGradConfig,
-];
+import {Identity} from '../kernel_names';
+import {GradConfig} from '../kernel_registry';
+import {Tensor} from '../tensor';
 
-for (const gradientConfig of gradConfigs) {
-  registerGradient(gradientConfig);
-}
+export const identityGradConfig: GradConfig = {
+  kernelName: Identity,
+  gradFunc: (dy: Tensor) => {
+    return {x: () => dy.toFloat()};
+  }
+};

--- a/tfjs-core/src/kernel_names.ts
+++ b/tfjs-core/src/kernel_names.ts
@@ -44,6 +44,9 @@ export interface BroadCastToAttrs {
   inputShape: number[];  // for gradient
 }
 
+export const Identity = 'Identity';
+export type IdentityInputs = Pick<NamedTensorInfoMap, 'x'>;
+
 /**
  * TensorFlow.js-only kernels
  */

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -19,8 +19,6 @@ import {NamedGradientMap} from './tape';
 import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
 
-// String used to register backend agnostic kernels.
-export const BACKEND_AGNOSTIC = '';
 const kernelRegistry: Map<string, KernelConfig> = new Map();
 const gradRegistry: Map<string, GradConfig> = new Map();
 
@@ -90,13 +88,7 @@ export interface NamedAttrMap {
 export function getKernel(
     kernelName: string, backendName: string): KernelConfig {
   const key = makeKey(kernelName, backendName);
-  if (kernelRegistry.has(key)) {
-    return kernelRegistry.get(key);
-  } else {
-    // Check for a backend agnostic kernel
-    const backendAgnosticKey = makeKey(kernelName, BACKEND_AGNOSTIC);
-    return kernelRegistry.get(backendAgnosticKey);
-  }
+  return kernelRegistry.get(key);
 }
 
 /**

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -94,7 +94,7 @@ export function getKernel(
     return kernelRegistry.get(key);
   } else {
     // Check for a backend agnostic kernel
-    const backendAgnosticKey = makeKey(kernelName, '');
+    const backendAgnosticKey = makeKey(kernelName, BACKEND_AGNOSTIC);
     return kernelRegistry.get(backendAgnosticKey);
   }
 }

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -19,6 +19,8 @@ import {NamedGradientMap} from './tape';
 import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
 
+// String used to register backend agnostic kernels.
+export const BACKEND_AGNOSTIC = '';
 const kernelRegistry: Map<string, KernelConfig> = new Map();
 const gradRegistry: Map<string, GradConfig> = new Map();
 
@@ -88,7 +90,13 @@ export interface NamedAttrMap {
 export function getKernel(
     kernelName: string, backendName: string): KernelConfig {
   const key = makeKey(kernelName, backendName);
-  return kernelRegistry.get(key);
+  if (kernelRegistry.has(key)) {
+    return kernelRegistry.get(key);
+  } else {
+    // Check for a backend agnostic kernel
+    const backendAgnosticKey = makeKey(kernelName, '');
+    return kernelRegistry.get(backendAgnosticKey);
+  }
 }
 
 /**

--- a/tfjs-core/src/ops/array_ops.ts
+++ b/tfjs-core/src/ops/array_ops.ts
@@ -26,29 +26,6 @@ import {op} from './operation';
 import {zeros, zerosLike} from './tensor_ops';
 
 /**
- * Creates a new tensor with the same values and shape as the specified
- * tensor.
- *
- * ```js
- * const x = tf.tensor([1, 2]);
- *
- * x.clone().print();
- * ```
- *
- * @param x The tensor to clone.
- */
-/** @doc {heading: 'Tensors', subheading: 'Creation'} */
-function clone_<T extends Tensor>(x: T|TensorLike): T {
-  const $x = convertToTensor(x, 'x', 'clone', null);
-  const der = (dy: T) => {
-    return {$x: () => dy.toFloat()};
-  };
-  return ENGINE.runKernelFunc(
-      () => ENGINE.makeTensorFromDataId($x.dataId, $x.shape, $x.dtype) as T,
-      {$x}, der);
-}
-
-/**
  * Create an identity matrix.
  *
  * @param numRows Number of rows.
@@ -928,7 +905,6 @@ export {
 
 export const batchToSpaceND = op({batchToSpaceND_});
 export const cast = op({cast_});
-export const clone = op({clone_});
 export const cumsum = op({cumsum_});
 export const depthToSpace = op({depthToSpace_});
 export const expandDims = op({expandDims_});

--- a/tfjs-core/src/ops/clone.ts
+++ b/tfjs-core/src/ops/clone.ts
@@ -39,16 +39,12 @@ import {op} from './operation';
 /** @doc {heading: 'Tensors', subheading: 'Creation'} */
 function clone_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'clone', null);
-
-  const der = (dy: T) => {
-    return {x: () => dy.toFloat()};
-  };
   const forward = () =>
       ENGINE.makeTensorFromDataId($x.dataId, $x.shape, $x.dtype) as T;
 
   // Note this op is called tf.identity in python. Hence the kernel name used
   // here.
-  return ENGINE.runKernelFunc(forward, {x: $x}, der, Identity);
+  return ENGINE.runKernelFunc(forward, {x: $x}, null /* grad */, Identity);
 }
 
 export const clone = op({clone_});

--- a/tfjs-core/src/ops/clone.ts
+++ b/tfjs-core/src/ops/clone.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENGINE} from '../engine';
+import {BACKEND_AGNOSTIC, GradConfig, KernelConfig, NamedTensorInfoMap, registerGradient, registerKernel} from '../kernel_registry';
+import {Tensor} from '../tensor';
+import {convertToTensor} from '../tensor_util_env';
+import {TensorLike} from '../types';
+
+import {op} from './operation';
+
+/**
+ * Creates a new tensor with the same values and shape as the specified
+ * tensor.
+ *
+ * ```js
+ * const x = tf.tensor([1, 2]);
+ *
+ * x.clone().print();
+ * ```
+ *
+ * @param x The tensor to clone.
+ */
+/** @doc {heading: 'Tensors', subheading: 'Creation'} */
+function clone_<T extends Tensor>(x: T|TensorLike): T {
+  const $x = convertToTensor(x, 'x', 'clone', null);
+  return ENGINE.runKernel(Clone, {x: $x}, {}) as T;
+}
+
+export const clone = op({clone_});
+
+/**
+ * Clone is generally not expected to be implemented by backends.
+ */
+
+// tslint:disable-next-line: variable-name
+const Clone = 'Clone';
+type CloneInputs = Pick<NamedTensorInfoMap, 'x'>;
+const cloneKernelConfig: KernelConfig = {
+  kernelName: Clone,
+  backendName: BACKEND_AGNOSTIC,  // this is a backend agnostic kernel
+  kernelFunc: ({inputs}) => {
+    const {x} = inputs as CloneInputs;
+    return ENGINE.makeTensorFromDataId(x.dataId, x.shape, x.dtype);
+  }
+};
+
+const cloneGradientConfig: GradConfig = {
+  kernelName: Clone,
+  gradFunc: (dy: Tensor) => {
+    return {x: () => dy.toFloat()};
+  }
+};
+
+registerKernel(cloneKernelConfig);
+registerGradient(cloneGradientConfig);

--- a/tfjs-core/src/ops/ops.ts
+++ b/tfjs-core/src/ops/ops.ts
@@ -17,6 +17,7 @@
 
 // Modularized ops.
 export {broadcastTo} from './broadcast_to';
+export {clone} from './clone';
 export {multinomial} from './multinomial';
 export {rand} from './rand';
 export {randomGamma} from './random_gamma';


### PR DESCRIPTION
Strawman PR for discussion:

This PR modularises the clone op. But does so differently to how most ops will be modularised. There are three distinct things here:

1. The kernel and gradient registration is done within the op file and the kernel name and interface __are not__ in kernel_names.ts. This is done under the _assumption_ that we don't expect backends to need to implement `clone` (and thus do not list it in the kernel_names file). It is also done under the assumption that we always want clone available in tfjs/tfjs-core.
2. It does not add a chained op augmentor for clone. This is under a hunch that we will want some subset of ops to always be on tensor. To my eye this includes things like cast, reshape, buffer, as2D, as3D, asType, etc (but we can make a list if we agree with this hunch with the goal of keeping it as small as possible). These would remain on the backend interface / opHandler mechanism. This is primarily with an eye to developer ergonomics (including internal code).
3. It registers a backend agnostic kernels.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2935)
<!-- Reviewable:end -->
