### PR TITLE
Fix bugs in release and publish scripts.

### DIFF
--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -125,7 +125,7 @@ async function main() {
 
     console.log(chalk.magenta.bold(`~~~ Publishing ${pkg} to npm ~~~`));
     shell.cd(pkg);
-    $('YARN_REGISTRY="https://registry.npmjs.org/" yarn publish');
+    $('YARN_REGISTRY="https://registry.npmjs.org/" yarn npm-publish');
     console.log(`Yay! Published ${pkg} to npm.`);
 
     shell.cd('..');

--- a/scripts/tag-version.js
+++ b/scripts/tag-version.js
@@ -27,7 +27,7 @@ if (dirName.endsWith('/')) {
 const packageJsonFile = dirName + '/package.json';
 if (!fs.existsSync(packageJsonFile)) {
   console.log(
-      packageJsonFile, 'does not exist. Please call this script as follows:');
+    packageJsonFile, 'does not exist. Please call this script as follows:');
   console.log('./scripts/tag-version.js DIR_NAME');
   process.exit(1);
 }
@@ -37,26 +37,9 @@ var exec = require('child_process').exec;
 var version = JSON.parse(fs.readFileSync(packageJsonFile, 'utf8')).version;
 var tag = `${dirName}-v${version}`;
 
-exec(`git tag ${tag}`, (err, stdout, stderr) => {
-  console.log('\x1b[36m%s\x1b[0m', 'git tag command stdout:');
-  console.log(stdout);
-  console.log('\x1b[31m%s\x1b[0m', 'git tag command stderr:');
-  console.log(stderr);
-
+exec(`git tag ${tag} && git push --tags`, (err, stdout, stderr) => {
   if (err) {
     throw new Error(`Could not git tag with ${tag}: ${err.message}.`);
   }
   console.log(`Successfully tagged with ${tag}.`);
-});
-
-exec(`git push --tags`, (err, stdout, stderr) => {
-  console.log('\x1b[36m%s\x1b[0m', 'git push tags command stdout:');
-  console.log(stdout);
-  console.log('\x1b[41m%s\x1b[0m', 'git push tags command stderr:');
-  console.log(stderr);
-
-  if (err) {
-    throw new Error(`Could not push git tags: ${err.message}.`);
-  }
-  console.log(`Successfully pushed tags.`);
 });

--- a/tfjs-converter/package.json
+++ b/tfjs-converter/package.json
@@ -63,6 +63,7 @@
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",
+    "publish-npm": "npm publish",
     "test": "yarn && yarn build-deps && yarn gen-json --test && ts-node run_tests.ts",
     "test-ci": "yarn && yarn build-deps-ci && yarn build-ci && yarn lint && ts-node run_tests.ts",
     "test-snippets": "ts-node ./scripts/test_snippets.ts",

--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -60,6 +60,7 @@
     "format-all": "clang-format -i -style=Google --glob=src/**/*.ts",
     "link-local": "yalc link",
     "publish-local": "rimraf dist/ && yarn build && rollup -c && yalc push",
+    "publish-npm": "npm publish",
     "lint": "tslint -p . -t verbose",
     "coverage": "KARMA_COVERAGE=1 karma start --browsers='Chrome' --singleRun",
     "test": "karma start",

--- a/tfjs-data/package.json
+++ b/tfjs-data/package.json
@@ -50,6 +50,7 @@
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
     "publish-local": "rimraf dist/ && yarn build-npm && yalc push",
+    "publish-npm": "npm publish",
     "test": "yarn && yarn build-deps && ts-node src/test_node.ts",
     "test-browsers": "karma start --browsers='Chrome,Firefox'",
     "test-ci": "yarn && yarn build-deps-ci && yarn build-ci && yarn lint && ts-node src/test_node.ts",

--- a/tfjs-layers/package.json
+++ b/tfjs-layers/package.json
@@ -48,6 +48,7 @@
     "format": "./tools/clang_format_ts.sh",
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",
+    "publish-npm": "npm publish",
     "test": "yarn && yarn build-deps && karma start",
     "test-ci": "./scripts/test-ci.sh",
     "test-snippets": "ts-node ./scripts/test_snippets.ts",

--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -42,6 +42,7 @@
     "prep-gpu": "./prep-gpu.sh",
     "prep-gpu-windows": "./prep-gpu-windows.bat",
     "publish-local": "yarn prep && yalc push",
+    "publish-npm": "npm publish",
     "test": "yarn && yarn build-deps && yarn build && ts-node src/run_tests.ts",
     "test-ci": "./scripts/test-ci.sh",
     "test-ts-integration": "./scripts/test-ts-integration.sh",

--- a/tfjs-node/package.json
+++ b/tfjs-node/package.json
@@ -40,6 +40,7 @@
     "lint": "tslint -p . -t verbose",
     "prep": "cd node_modules/@tensorflow/tfjs-core && yarn && yarn build",
     "publish-local": "yarn prep && yalc push",
+    "publish-npm": "npm publish",
     "test": "yarn && yarn build-deps && yarn build && ts-node src/run_tests.ts",
     "test-ci": "./scripts/test-ci.sh",
     "test-ts-integration": "./scripts/test-ts-integration.sh",

--- a/tfjs/package.json
+++ b/tfjs/package.json
@@ -65,6 +65,7 @@
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",
+    "publish-npm": "npm publish",
     "lint": "tslint -p . -t verbose",
     "test": "yarn && yarn build-deps && yarn build && ts-node ./scripts/release_notes/run_tests.ts && karma start",
     "test-ci": "./scripts/test-ci.sh"


### PR DESCRIPTION
Tried the new release scripts, this PR fixes below issues:
1. Change from `yarn publish` to `yarn publish-npm`. Context: yarn publish does not work, it throws error: "Can't answer a question unless a user TTY", same issue is discussed in https://github.com/lerna/lerna/issues/1200. The reason is because yarn publish has an interactive cli, which makes it impossible to use for automation process. Tried the yarn --non-interactive publish method discussed in the thread, doesn't work either. So change to yarn publish-npm, tested locally using npm whoami as a substitute. Yarn 2.x has `yarn npm publish` natively. So once we upgrade to yarn 2.x, we don't need to have publish-npm: "npm publish" in each package.json.
  
2. Combined tag version steps. Context: This script is called from the publish-npm.ts. It didn't throw any errors. But actually, only the first step that creates the tag succeed, the second step that pushes the tag didn't get executed. Combining the two steps works. It is something related to child processes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2952)
<!-- Reviewable:end -->
