### PR TITLE
[core] Move variations of the same set of tests to nightly.

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -22,6 +22,7 @@ steps:
   id: 'tfjs-core'
   args: ['./scripts/run-build.sh', 'tfjs-core']
   waitFor: ['find-affected-packages']
+  env: ['NIGHTLY=$_NIGHTLY']
 
 # Converter.
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -17,6 +17,6 @@
 set -e
 
 DIR=$1
-if test -f "$DIR/run-ci"; then
+if [[ -f "$DIR/run-ci" || "$NIGHTLY" = true ]]; then
   gcloud builds submit . --config=$DIR/cloudbuild.yml
 fi

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -22,24 +22,24 @@ yarn test-node-ci
 
 if [ "$NIGHTLY" = true ]
 then
-# Run the first karma separately so it can download the BrowserStack binary
-# without conflicting with others.
-yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  # Run the first karma separately so it can download the BrowserStack binary
+  # without conflicting with others.
+  yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
-# Run the rest of the karma tests in parallel. These runs will reuse the
-# already downloaded binary.
-npm-run-all -p -c --aggregate-output \
-  "run-browserstack --browsers=bs_safari_mac,bs_ios_11,bs_android_9 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu" \
-  "run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac" \
-  "run-browserstack --browsers=bs_chrome_mac,win_10_chrome,bs_android_9 --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
-  "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_PACK\": false}'" \
+  # Run the rest of the karma tests in parallel. These runs will reuse the
+  # already downloaded binary.
+  npm-run-all -p -c --aggregate-output \
+    "run-browserstack --browsers=bs_safari_mac,bs_ios_11,bs_android_9 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu" \
+    "run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac" \
+    "run-browserstack --browsers=bs_chrome_mac,win_10_chrome,bs_android_9 --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
+    "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_PACK\": false}'" \
 
-### The next section tests TF.js in a webworker.
-# Make a dist/tf-core.min.js file to be imported by the web worker.
-yarn rollup -c --ci
-# Safari doesn't have offscreen canvas so test cpu in a webworker.
-# Chrome has offscreen canvas, so test webgl in a webworker.
-yarn test-webworker --browsers=bs_safari_mac,bs_chrome_mac
+  ### The next section tests TF.js in a webworker.
+  # Make a dist/tf-core.min.js file to be imported by the web worker.
+  yarn rollup -c --ci
+  # Safari doesn't have offscreen canvas so test cpu in a webworker.
+  # Chrome has offscreen canvas, so test webgl in a webworker.
+  yarn test-webworker --browsers=bs_safari_mac,bs_chrome_mac
 else
-yarn run-browserstack --browsers=bs_chrome_mac
+  yarn run-browserstack --browsers=bs_chrome_mac
 fi

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -20,6 +20,8 @@ yarn lint
 # Test in node (headless environment).
 yarn test-node-ci
 
+if [ "$NIGHTLY" = true ]
+then
 # Run the first karma separately so it can download the BrowserStack binary
 # without conflicting with others.
 yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
@@ -38,3 +40,6 @@ yarn rollup -c --ci
 # Safari doesn't have offscreen canvas so test cpu in a webworker.
 # Chrome has offscreen canvas, so test webgl in a webworker.
 yarn test-webworker --browsers=bs_safari_mac,bs_chrome_mac
+else
+yarn run-browserstack --browsers=bs_chrome_mac
+fi


### PR DESCRIPTION
This PR has below changes:
1. Change the run-build.sh logic, trigger build either there's change in the package or env is nightly. Basically, nightly build will build and test the whole repo.

2. Change Core's test-ci.sh logic, for regular build only test for chrome with default settings, for nightly build test all permutations. Basically, moving testing of different settings to nightly.

p.s. Some observation: Core test duration reduced from ~10 mins. to ~6mins., browserstack instances usage reduced from 12 instances to 1 instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2960)
<!-- Reviewable:end -->
