### PR TITLE
Fix release.ts

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -139,12 +139,16 @@ async function main() {
       `${dir}/package.json`;
     let pkg = `${fs.readFileSync(packageJsonPath)}`;
     const parsedPkg = JSON.parse(`${pkg}`);
+    // We can't use parsedPkg.version because it is set to 0.0.0. npm is
+    // the only source of truth of the latest version.
+    const parsedPkgVersion =
+      $(`npm view @tensorflow/${packageName} dist-tags.latest`);
 
     console.log(chalk.magenta.bold(
-      `~~~ Processing ${packageName} (${parsedPkg.version}) ~~~`));
+      `~~~ Processing ${packageName} (${parsedPkgVersion}) ~~~`));
 
-    const patchUpdateVersion = getPatchUpdateVersion(parsedPkg.version);
-    let newVersion = parsedPkg.version;
+    const patchUpdateVersion = getPatchUpdateVersion(parsedPkgVersion);
+    let newVersion = parsedPkgVersion;
     if (!phase.leaveVersion) {
       newVersion = await question(
         `New version (leave empty for ${patchUpdateVersion}): `);
@@ -162,7 +166,7 @@ async function main() {
     }
 
     pkg = `${pkg}`.replace(
-      `"version": "${parsedPkg.version}"`, `"version": "${newVersion}"`);
+      `"version": "0.0.0"`, `"version": "${newVersion}"`);
 
     if (deps != null) {
       for (let j = 0; j < deps.length; j++) {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -108,9 +108,9 @@ async function main() {
     // Publishing packages in tfjs.
     if (phaseInt !== 0) {
       // Phase0 should be published and release branch should have been created.
-      const latestVersion =
+      const firstPackageLatestVersion =
         $(`npm view @tensorflow/${phases[0].packages[0]} dist-tags.latest`);
-      releaseBranch = `${name}_${latestVersion}`;
+      releaseBranch = `${name}_${firstPackageLatestVersion}`;
 
       $(`git clone -b ${releaseBranch} ${urlBase}tensorflow/tfjs ${
         dir} --depth=1`);
@@ -139,16 +139,14 @@ async function main() {
       `${dir}/package.json`;
     let pkg = `${fs.readFileSync(packageJsonPath)}`;
     const parsedPkg = JSON.parse(`${pkg}`);
-    // We can't use parsedPkg.version because it is set to 0.0.0. npm is
-    // the only source of truth of the latest version.
-    const parsedPkgVersion =
+    const latestVersion =
       $(`npm view @tensorflow/${packageName} dist-tags.latest`);
 
     console.log(chalk.magenta.bold(
-      `~~~ Processing ${packageName} (${parsedPkgVersion}) ~~~`));
+      `~~~ Processing ${packageName} (${latestVersion}) ~~~`));
 
-    const patchUpdateVersion = getPatchUpdateVersion(parsedPkgVersion);
-    let newVersion = parsedPkgVersion;
+    const patchUpdateVersion = getPatchUpdateVersion(latestVersion);
+    let newVersion = latestVersion;
     if (!phase.leaveVersion) {
       newVersion = await question(
         `New version (leave empty for ${patchUpdateVersion}): `);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -166,7 +166,7 @@ async function main() {
     }
 
     pkg = `${pkg}`.replace(
-      `"version": "0.0.0"`, `"version": "${newVersion}"`);
+      `"version": "${parsedPkg.version}"`, `"version": "${newVersion}"`);
 
     if (deps != null) {
       for (let j = 0; j < deps.length; j++) {


### PR DESCRIPTION
PR: https://github.com/tensorflow/tfjs/pull/2958 set all release unit 0's package's version to 0.0.0 for dev branch. To guess the next version, the version field is no longer a reliable source, npm will be the only source of truth. This PR changes the logic to use npm as oppose to version field to find the latest version and use that to guess the next version. Tested locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2967)
<!-- Reviewable:end -->
