### PR TITLE
allow TF DT_UINT8 to map to tfjs int32

### DIFF
--- a/tfjs-converter/src/operations/operation_mapper.ts
+++ b/tfjs-converter/src/operations/operation_mapper.ts
@@ -352,6 +352,8 @@ export function parseDtypeParam(value: string|tensorflow.DataType): DataType {
       return 'float32';
     case tensorflow.DataType.DT_INT32:
     case tensorflow.DataType.DT_INT64:
+    case tensorflow.DataType.DT_INT8:
+    case tensorflow.DataType.DT_UINT8:
       return 'int32';
     case tensorflow.DataType.DT_BOOL:
       return 'bool';


### PR DESCRIPTION
Fixed internal team request on failure with model execution, where cast op try to take float tensor into a uint8 tensor.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2981)
<!-- Reviewable:end -->
