### PR TITLE
Turn off nightly run for union package.

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -54,7 +54,6 @@ steps:
   id: 'tfjs'
   args: ['./scripts/run-build.sh', 'tfjs']
   waitFor: ['find-affected-packages']
-  env: ['NIGHTLY=$_NIGHTLY']
 
 # Vis.
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
The tests in tfjs has two parts, benchmark and converter validate, both seems require some work to get them working. Given that this is causing nightly build failure, we want to turn this off for now so that other packages can still have nightly coverage. Will fix in another PR. Also note that, our original nightly build doesn't run any tests in this package either, so we are not losing any coverage comparing to before. But yes, we are losing some coverage comparing to the ideal. For the time being, turn off the nightly build for tfjs so that other packages can still build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/2985)
<!-- Reviewable:end -->
