### PR TITLE
Use union package start/end version for all.

### DIFF
--- a/scripts/release_notes/release_notes.ts
+++ b/scripts/release_notes/release_notes.ts
@@ -65,8 +65,15 @@ const NODE_REPO: Repo = {
   identifier: 'tfjs-node'
 };
 
-async function askUserForVersions(validVersions: string[], packageName: string):
-    Promise<{startVersion: string, endVersion: string}> {
+const WASM_REPO: Repo = {
+  name: 'Wasm',
+  identifier: 'tfjs-backend-wasm'
+}
+
+async function
+askUserForVersions(validVersions: string[], packageName: string): Promise<{
+  startVersion: string, endVersion: string
+}> {
   const YELLOW_TERMINAL_COLOR = '\x1b[33m%s\x1b[0m';
   const RED_TERMINAL_COLOR = '\x1b[31m%s\x1b[0m';
 
@@ -119,13 +126,16 @@ async function main() {
   const {startVersion, endVersion} = await askUserForVersions(versions, 'tfjs');
 
   // Clone the Node.js repo eagerly so we can query the tags.
-  const validNodeVersions = getTaggedVersions('tfjs-node');
-  const nodeVersions =
-      await askUserForVersions(validNodeVersions, NODE_REPO.identifier);
-  NODE_REPO.startVersion = nodeVersions.startVersion;
-  NODE_REPO.endVersion = nodeVersions.endVersion;
+  NODE_REPO.startVersion = startVersion;
+  NODE_REPO.endVersion = endVersion;
   NODE_REPO.startCommit = $(`git rev-list -n 1 ${
       getTagName(NODE_REPO.identifier, NODE_REPO.startVersion)}`);
+
+  // Clone the Wasm repo eagerly so we can query the tags.
+  WASM_REPO.startVersion = startVersion;
+  WASM_REPO.endVersion = endVersion;
+  WASM_REPO.startCommit = $(`git rev-list -n 1 ${
+      getTagName(WASM_REPO.identifier, WASM_REPO.startVersion)}`);
 
   // Get all the commits of the union package between the versions.
   const unionCommits =
@@ -149,8 +159,8 @@ async function main() {
     // Find the version of the dependency from the package.json from the
     // earliest union tag.
     const npm = '@tensorflow/' + repo.identifier;
-    const repoStartVersion = earliestUnionPackageJson.dependencies[npm];
-    const repoEndVersion = latestUnionPackageJson.dependencies[npm];
+    const repoStartVersion = startVersion;
+    const repoEndVersion = endVersion;
 
     const dir = `${repo.name}`;
 
@@ -168,7 +178,7 @@ async function main() {
   const repoCommits: RepoCommits[] = [];
 
   // Clone all of the dependencies into the tmp directory.
-  [...UNION_DEPENDENCIES, NODE_REPO].forEach(repo => {
+  [...UNION_DEPENDENCIES, NODE_REPO, WASM_REPO].forEach(repo => {
     console.log(
         `${repo.name}: ${repo.startVersion}` +
         ` =====> ${repo.endVersion}`);

--- a/scripts/release_notes/release_notes.ts
+++ b/scripts/release_notes/release_notes.ts
@@ -125,13 +125,13 @@ async function main() {
   const versions = getTaggedVersions('tfjs');
   const {startVersion, endVersion} = await askUserForVersions(versions, 'tfjs');
 
-  // Clone the Node.js repo eagerly so we can query the tags.
+  // Get Node start version and end version.
   NODE_REPO.startVersion = startVersion;
   NODE_REPO.endVersion = endVersion;
   NODE_REPO.startCommit = $(`git rev-list -n 1 ${
       getTagName(NODE_REPO.identifier, NODE_REPO.startVersion)}`);
 
-  // Clone the Wasm repo eagerly so we can query the tags.
+  // Get WASM start version and end version.
   WASM_REPO.startVersion = startVersion;
   WASM_REPO.endVersion = endVersion;
   WASM_REPO.startCommit = $(`git rev-list -n 1 ${
@@ -159,20 +159,15 @@ async function main() {
     // Find the version of the dependency from the package.json from the
     // earliest union tag.
     const npm = '@tensorflow/' + repo.identifier;
-    const repoStartVersion = startVersion;
-    const repoEndVersion = endVersion;
-
-    const dir = `${repo.name}`;
 
     repo.startCommit =
-        $(repoStartVersion != null ?
-              `git rev-list -n 1 ` +
-                  getTagName(repo.identifier, repoStartVersion) :
+        $(startVersion != null ?
+              `git rev-list -n 1 ` + getTagName(repo.identifier, startVersion) :
               // Get the first commit if there are no tags yet.
               `git rev-list --max-parents=0 HEAD`);
 
-    repo.startVersion = repoStartVersion != null ? repoStartVersion : null;
-    repo.endVersion = repoEndVersion;
+    repo.startVersion = startVersion != null ? startVersion : null;
+    repo.endVersion = endVersion;
   });
 
   const repoCommits: RepoCommits[] = [];


### PR DESCRIPTION
After monorepo change, only need to ask user start and end version once, and use that for all the packages. Cannot rely on versions in package.json anymore, because those will become link:../tfjs-

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3034)
<!-- Reviewable:end -->
