### PR TITLE
Browserstack disconnection issue.

### DIFF
--- a/tfjs-core/karma.conf.js
+++ b/tfjs-core/karma.conf.js
@@ -108,9 +108,11 @@ module.exports = function(config) {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY
     },
-    captureTimeout: 120000,
+    captureTimeout: 3e5,
     reportSlowerThan: 500,
-    browserNoActivityTimeout: 240000,
+    browserNoActivityTimeout: 3e5,
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 3,
     customLaunchers: {
       // For browserstack configs see:
       // https://www.browserstack.com/automate/node

--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -30,7 +30,7 @@
     "jasmine-core": "~3.1.0",
     "karma": "~4.2.0",
     "karma-browserify": "~6.0.0",
-    "karma-browserstack-launcher": "~1.4.0",
+    "karma-browserstack-launcher": "~1.5.0",
     "karma-chrome-launcher": "~2.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-typescript": "~4.1.1",

--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -30,7 +30,7 @@
     "jasmine-core": "~3.1.0",
     "karma": "~4.2.0",
     "karma-browserify": "~6.0.0",
-    "karma-browserstack-launcher": "~1.5.0",
+    "karma-browserstack-launcher": "~1.4.0",
     "karma-chrome-launcher": "~2.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-typescript": "~4.1.1",


### PR DESCRIPTION
BrowserStack support recommended the following configs. After upgrade to 1.5.0, we are seeing a lot of timeouts, see issue https://github.com/karma-runner/karma-browserstack-launcher/issues/152. If changing config doesn't help, we will have to downgrade to 1.4.0.
```
captureTimeout: 3e5,
browserNoActivityTimeout: 3e5,
browserDisconnectTimeout: 3e5,
browserDisconnectTolerance: 3
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3038)
<!-- Reviewable:end -->
