### PR TITLE
Downgrade karma-browserstack-launcher to 1.4.0.

### DIFF
--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -30,7 +30,7 @@
     "jasmine-core": "~3.1.0",
     "karma": "~4.2.0",
     "karma-browserify": "~6.0.0",
-    "karma-browserstack-launcher": "~1.5.0",
+    "karma-browserstack-launcher": "~1.4.0",
     "karma-chrome-launcher": "~2.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-typescript": "~4.1.1",


### PR DESCRIPTION
Downgrade karma-browserstack-launcher to 1.4.0. After upgrade to 1.5.0 and adjusting timeout, we are still seeing a lot of timeout, this is a known issue and seems is not resolved yet, https://github.com/karma-runner/karma-browserstack-launcher/issues/152