### PR TITLE
Add retry to download emsdk due to flaky download.

### DIFF
--- a/tfjs-backend-wasm/scripts/build-ci.sh
+++ b/tfjs-backend-wasm/scripts/build-ci.sh
@@ -16,8 +16,16 @@
 
 set -e
 
-# Install emsdk
-git clone --depth=1 --single-branch https://github.com/emscripten-core/emsdk.git
+# Install emsdk with up to 1 retry.
+for i in $(seq 0 1)
+do
+  # Wait for 15 seconds then retry.
+  [ $i -gt 0 ] && echo "Retry in 15 seconds, count: $i" && sleep 15
+  # If git clone is successful, $? will hold 0 and execution will break from the
+  # loop.
+  git clone --depth=1 --single-branch https://github.com/emscripten-core/emsdk.git && break
+done
+
 cd emsdk
 # Need to tell emsdk where to write the .emscripten file.
 export HOME='/root'


### PR DESCRIPTION
Context: downloading emsdk is pretty flaky recently. One observation is manually clicking on retry usually just works. One guess is this is due to unstable network. If so, retry can reduce the occurrences of this error. This PR automates retry. 

Long term, consider using docker image with emsdk preinstalled, which can completely solve the problem, suggested by @tafsiri.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3076)
<!-- Reviewable:end -->
