### PR TITLE
use instantiateWasm override and platform fetch

### DIFF
--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -87,7 +87,8 @@ optional `usePlatformFetch` to true:
 
 ```ts
 import {setWasmPath} from '@tensorflow/tfjs-backend-wasm';
-setWasmPath(yourCustomPath, true); // or tf.wasm.setWasmPath when using <script> tags.
+const usePlatformFetch = true;
+setWasmPath(yourCustomPath, usePlatformFetch); // or tf.wasm.setWasmPath when using <script> tags.
 tf.setBackend('wasm').then(() => {...});
 ```
 ## Benchmarks

--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -82,6 +82,14 @@ setWasmPath(yourCustomPath); // or tf.wasm.setWasmPath when using <script> tags.
 tf.setBackend('wasm').then(() => {...});
 ```
 
+If you are using platform that does not support fetch directly, please set the
+optional `usePlatformFetch` to true:
+
+```ts
+import {setWasmPath} from '@tensorflow/tfjs-backend-wasm';
+setWasmPath(yourCustomPath, true); // or tf.wasm.setWasmPath when using <script> tags.
+tf.setBackend('wasm').then(() => {...});
+```
 ## Benchmarks
 
 The benchmarks below show inference times (ms) for two different edge-friendly

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -209,6 +209,9 @@ export async function init(): Promise<{wasm: BackendWasmModule}> {
         }
         return prefix + path;
       };
+      // use wasm instantiateWasm override when system fetch is not available.
+      // For detail references
+      // https://github.com/emscripten-core/emscripten/blob/2bca083cbbd5a4133db61fbd74d04f7feecfa907/tests/manual_wasm_instantiate.html#L170
       if (customFetch) {
         factoryConfig.instantiateWasm = createInstantiateWasmFunc(wasmPath);
       }
@@ -277,17 +280,17 @@ let customFetch = false;
  * for more details.
  * @param path wasm file path or url
  * @param usePlatformFetch optional boolean to use platform fetch to download
- *     the wasm file
+ *     the wasm file, default to false.
  */
 /** @doc {heading: 'Environment', namespace: 'wasm'} */
-export function setWasmPath(path: string, usePlatformFetch?: boolean): void {
+export function setWasmPath(path: string, usePlatformFetch = false): void {
   if (initAborted) {
     throw new Error(
         'The WASM backend was already initialized. Make sure you call ' +
         '`setWasmPath()` before you call `tf.setBackend()` or `tf.ready()`');
   }
   wasmPath = path;
-  customFetch = !!usePlatformFetch;
+  customFetch = usePlatformFetch;
 }
 
 /** Used in unit tests. */

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -176,6 +176,7 @@ registerBackend('wasm', async () => {
 }, WASM_PRIORITY);
 
 function createInstantiateWasmFunc(path: string) {
+  // tslint:disable-next-line:no-any
   return (imports: any, callback: any) => {
     util.fetch(path, {credentials: 'same-origin'}).then((response) => {
       if (!response['ok']) {

--- a/tfjs-backend-wasm/src/index.ts
+++ b/tfjs-backend-wasm/src/index.ts
@@ -16,5 +16,6 @@
  */
 
 import './kernels/all_kernels';
+
 export {BackendWasm, setWasmPath} from './backend_wasm';
 export {version as version_wasm} from './version';

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tf from '@tensorflow/tfjs-core';
-import {registerBackend, removeBackend, test_util} from '@tensorflow/tfjs-core';
+import {registerBackend, removeBackend, test_util, util} from '@tensorflow/tfjs-core';
 // tslint:disable-next-line:no-imports-from-dist
 import {ALL_ENVS, BROWSER_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
@@ -78,6 +78,19 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
     expect(await tf.setBackend('wasm-test')).toBe(false);
     expect(wasmPath).toBe('invalid/path');
   });
+
+  it('backend init fails when the path is invalid and use platform fetch',
+     async () => {
+       setWasmPath('invalid/path', true);
+       let wasmPath: string;
+       const realFetch = util.fetch;
+       spyOn(util, 'fetch').and.callFake((path: string) => {
+         wasmPath = path;
+         return realFetch(path);
+       });
+       expect(await tf.setBackend('wasm-test')).toBe(false);
+       expect(wasmPath).toBe('invalid/path');
+     });
 
   it('backend init succeeds with default path', async () => {
     expect(await tf.setBackend('wasm-test')).toBe(true);

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -79,9 +79,25 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
     expect(wasmPath).toBe('invalid/path');
   });
 
+  it('backend init works when the path is valid and use platform fetch',
+     async () => {
+       const usePlatformFetch = true;
+       const validPath = '/base/wasm-out/tfjs-backend-wasm.wasm';
+       setWasmPath(validPath, usePlatformFetch);
+       let wasmPath: string;
+       const realFetch = util.fetch;
+       spyOn(util, 'fetch').and.callFake((path: string) => {
+         wasmPath = path;
+         return realFetch(path);
+       });
+       expect(await tf.setBackend('wasm-test')).toBe(true);
+       expect(wasmPath).toBe(validPath);
+     });
+
   it('backend init fails when the path is invalid and use platform fetch',
      async () => {
-       setWasmPath('invalid/path', true);
+       const usePlatformFetch = true;
+       setWasmPath('invalid/path', usePlatformFetch);
        let wasmPath: string;
        const realFetch = util.fetch;
        spyOn(util, 'fetch').and.callFake((path: string) => {

--- a/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
+++ b/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
@@ -31,6 +31,7 @@ export interface BackendWasmModule extends EmscriptenModule {
 
 export interface WasmFactoryConfig {
   locateFile?(path: string, prefix: string): string;
+  instantiateWasm?: Function;
 }
 
 declare var moduleFactory: (settings: WasmFactoryConfig) => BackendWasmModule;


### PR DESCRIPTION
This allows platforms like WeChat miniprogram to load the wasm file using
the platform fetch method.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3100)
<!-- Reviewable:end -->
