### PR TITLE
[wasm] Enable compatibility with emscripten 1.39.11, which in turn enables pthread support.

### DIFF
--- a/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
+++ b/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
@@ -206,9 +206,11 @@ void slow_batch_matmul(const size_t a_id, const size_t* a_shape_ptr,
   float* out_buf = out_info.f32_write();
 
   const float* bias_buf = nullptr;
-  auto& bias_info = tfjs::backend::get_tensor_info_out(bias_id);
+  size_t bias_buf_size = 0;
   if (bias_id != 0) {
+    auto& bias_info = tfjs::backend::get_tensor_info_out(bias_id);
     bias_buf = bias_info.f32();
+    bias_buf_size = bias_info.size;
   }
 
   const size_t size = left_dim * right_dim;
@@ -239,7 +241,7 @@ void slow_batch_matmul(const size_t a_id, const size_t* a_shape_ptr,
               float current = out_buf[out_buf_index];
 
               // Handles 1D broadcasting.
-              size_t bias_index = std::min(innermost_dim, bias_info.size - 1);
+              size_t bias_index = std::min(innermost_dim, bias_buf_size - 1);
 
               out_buf[out_buf_index] = std::max(
                   std::min(current + sum + bias_buf[bias_index], output_max),

--- a/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
+++ b/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
@@ -240,12 +240,16 @@ void slow_batch_matmul(const size_t a_id, const size_t* a_shape_ptr,
               size_t out_buf_index = b * size + innermost_dim;
               float current = out_buf[out_buf_index];
 
-              // Handles 1D broadcasting.
-              size_t bias_index = std::min(innermost_dim, bias_buf_size - 1);
+              float bias_val = 0;
+              if (bias_id != 0) {
+                // Handles 1D broadcasting.
+                size_t bias_index = std::min(innermost_dim, bias_buf_size - 1);
+
+                bias_val = bias_buf[bias_index];
+              }
 
               out_buf[out_buf_index] = std::max(
-                  std::min(current + sum + bias_buf[bias_index], output_max),
-                  output_min);
+                  std::min(current + sum + bias_val, output_max), output_min);
             }
           }
         }


### PR DESCRIPTION
Without this change, our tests fail with emsdk 1.39.11 because `unordered_map.at` errors out if the key is not found. 

This change just enables compatibility with emsdk 1.39.11, but doesn't yet change our CI to use 1.39.11. I will make that change once we turn on pthread support. 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3108)
<!-- Reviewable:end -->
