### PR TITLE
[core] Change inputs to matMul test to avoid precision issues in Safari as stopgap.

### DIFF
--- a/tfjs-core/src/ops/conv2d_test.ts
+++ b/tfjs-core/src/ops/conv2d_test.ts
@@ -328,18 +328,23 @@ describeWithFlags('conv2d', ALL_ENVS, () => {
     const pad = 'same';
     const stride: [number, number] = [2, 2];
 
-    const inputs = generateCaseInputs(
-        1 * xSize * xSize * inputDepth, fSize * fSize * inputDepth);
-    const x = tf.tensor4d(inputs.input, inputShape);
-    const w =
-        tf.tensor4d(inputs.filter, [fSize, fSize, inputDepth, outputDepth]);
+    const inputData = [];
+    for (let i = 0; i < xSize * xSize * inputDepth; i++) {
+      inputData.push(i % 5);
+    }
 
+    const wData = [];
+    for (let i = 0; i < fSize * fSize * inputDepth * outputDepth; i++) {
+      wData.push(i % 5);
+    }
+
+    const x = tf.tensor4d(inputData, inputShape);
+    const w = tf.tensor4d(wData, [fSize, fSize, inputDepth, outputDepth]);
     const result = tf.conv2d(x, w, stride, pad);
     expect(result.shape).toEqual([1, 4, 4, 1]);
     expectArraysClose(await result.data(), new Float32Array([
-                        2209560, 2543640, 2877720, 1890576, 4882200, 5216280,
-                        5550360, 3475728, 7554840, 7888920, 8223000, 5060880,
-                        4153744, 4302736, 4451728, 2551904
+                        854, 431, 568, 382, 580, 427, 854, 288, 431, 568, 580,
+                        289, 285, 570, 285, 258
                       ]));
   });
 

--- a/tfjs-core/src/ops/conv2d_test.ts
+++ b/tfjs-core/src/ops/conv2d_test.ts
@@ -328,6 +328,8 @@ describeWithFlags('conv2d', ALL_ENVS, () => {
     const pad = 'same';
     const stride: [number, number] = [2, 2];
 
+    // TODO(annxingyuan): Make this test work with large inputs using
+    // generateCaseInputs https://github.com/tensorflow/tfjs/issues/3143
     const inputData = [];
     for (let i = 0; i < xSize * xSize * inputDepth; i++) {
       inputData.push(i % 5);


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3142)
<!-- Reviewable:end -->
