### PR TITLE
fix tensor array gather 

### DIFF
--- a/tfjs-converter/src/executor/tensor_array.ts
+++ b/tfjs-converter/src/executor/tensor_array.ts
@@ -67,9 +67,9 @@ export class TensorArray {
       throw new Error(`TensorArray ${this.name} has already been closed.`);
     }
 
-    if (index < 0 || index >= this.tensors.length) {
+    if (index < 0 || index >= this.size()) {
       throw new Error(`Tried to read from index ${index}, but array size is: ${
-          this.tensors.length}`);
+          this.size()}`);
     }
 
     const tensorWithState = this.tensors[index];
@@ -182,6 +182,8 @@ export class TensorArray {
       for (let i = 0; i < this.size(); i++) {
         indices.push(i);
       }
+    } else {
+      indices = indices.slice(0, this.size());
     }
 
     if (indices.length === 0) {

--- a/tfjs-converter/src/executor/tensor_array_test.ts
+++ b/tfjs-converter/src/executor/tensor_array_test.ts
@@ -145,6 +145,11 @@ describe('TensorArray', () => {
       expect(gathered.shape).toEqual([2, 1, 1]);
       test_util.expectArraysClose(await gathered.data(), [2, 1]);
     });
+    it('should return when indices longer than available tensors', async () => {
+      const gathered = tensorArray.gather([1, 0, 2, 3]);
+      expect(gathered.shape).toEqual([2, 1, 1]);
+      test_util.expectArraysClose(await gathered.data(), [2, 1]);
+    });
     it('should fail if dtype is not matched', () => {
       expect(() => tensorArray.gather([0, 1], 'float32')).toThrow();
     });


### PR DESCRIPTION
In TF tensor array gather op, the indices can be longer than the tensor available in the array.
This aligns our implementation with TF.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3157)
<!-- Reviewable:end -->
