### PR TITLE
Increase capture timeout.

### DIFF
--- a/tfjs-core/karma.conf.js
+++ b/tfjs-core/karma.conf.js
@@ -99,7 +99,7 @@ module.exports = function(config) {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY
     },
-    captureTimeout: 3e5,
+    captureTimeout: 6e5,
     reportSlowerThan: 500,
     browserNoActivityTimeout: 3e5,
     browserDisconnectTimeout: 3e5,

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -31,6 +31,7 @@ then
     "run-browserstack --browsers=bs_firefox_mac,bs_safari_mac,bs_ios_11,bs_android_9 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu"
 
   ### The next section tests TF.js in a webworker using the CPU backend.
+  echo "Start webworker test."
   # Make a dist/tf-core.min.js file to be imported by the web worker.
   yarn rollup -c --ci
   # copy the cpu backend bundle somewhere the test can access it

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -23,12 +23,12 @@ if [ "$NIGHTLY" = true ]
 then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac
+  yarn run-browserstack --browsers=bs_chrome_mac
 
   # Run the rest of the karma tests in parallel. These runs will reuse the
   # already downloaded binary.
   npm-run-all -p -c --aggregate-output \
-    "run-browserstack --browsers=bs_safari_mac,bs_ios_11,bs_android_9 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu"
+    "run-browserstack --browsers=bs_firefox_mac,bs_safari_mac,bs_ios_11,bs_android_9 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu"
 
   ### The next section tests TF.js in a webworker using the CPU backend.
   # Make a dist/tf-core.min.js file to be imported by the web worker.


### PR DESCRIPTION
Nightly test fail, I have several theories. This PR tries several things:
- When browserDisconnectTimeout is reached, browser is reconnected, but at the same time captureTimeout is reached, so karma restart. I suspect a recent nightly build broke is due to this condition. captureTimeout should be a bigger number, so that karma allows browser to reconnect before it restarts.

- Only initiate browserstack with Chrome and download the binary. Start all other browsers later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3198)
<!-- Reviewable:end -->
