### PR TITLE
[tfjs-node] fix import in README.md

### DIFF
--- a/tfjs-node/README.md
+++ b/tfjs-node/README.md
@@ -72,10 +72,10 @@ Before executing any TensorFlow.js code, import the node package:
 
 ```js
 // Load the binding
-import * as tf from '@tensorflow/tfjs-node';
+const tf = require('@tensorflow/tfjs-node');
 
 // Or if running with GPU:
-import * as tf from '@tensorflow/tfjs-node-gpu';
+const tf = require('@tensorflow/tfjs-node-gpu');
 ```
 
 Note: you do not need to add the `@tensorflow/tfjs` package to your dependencies or import it directly.


### PR DESCRIPTION
Node.js doesn't support  import * .

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3201)
<!-- Reviewable:end -->
