### PR TITLE
Fix browserstack iPhone browser issue.

### DIFF
--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -19,5 +19,5 @@ set -e
 DIR=$1
 if [[ -f "$DIR/run-ci" || "$NIGHTLY" = true ]]; then
   gcloud builds submit . --config=$DIR/cloudbuild.yml \
-    --substitutions _NIGHTLY=$NIGHTLY
+    --substitutions _NIGHTLY=true
 fi

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -19,5 +19,5 @@ set -e
 DIR=$1
 if [[ -f "$DIR/run-ci" || "$NIGHTLY" = true ]]; then
   gcloud builds submit . --config=$DIR/cloudbuild.yml \
-    --substitutions _NIGHTLY=true
+    --substitutions _NIGHTLY=$NIGHTLY
 fi

--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -40,6 +40,24 @@ const karmaTypescriptConfig = {
   }
 };
 
+const devConfig = {
+  frameworks: ['jasmine', 'karma-typescript'],
+  files: [
+    {pattern: './node_modules/@babel/polyfill/dist/polyfill.js'},
+    'src/setup_test.ts',
+    {pattern: 'src/**/*.ts'},
+  ],
+  preprocessors: {'**/*.ts': ['karma-typescript']},
+  karmaTypescriptConfig,
+  reporters: ['dots', 'karma-typescript']
+};
+
+const browserstackConfig = {
+  ...devConfig,
+  hostname: 'bs-local.com',
+  singleRun: true
+};
+
 module.exports = function(config) {
   const args = [];
   if (config.testEnv) {
@@ -51,34 +69,34 @@ module.exports = function(config) {
   if (config.flags) {
     args.push('--flags', config.flags);
   }
+
+  let extraConfig = null;
+
+  if (config.browserstack) {
+    extraConfig = browserstackConfig;
+  } else {
+    extraConfig = devConfig;
+  }
+
   let exclude = [];
   if (config.excludeTest != null) {
     exclude.push(config.excludeTest);
   }
 
   config.set({
-    frameworks: ['jasmine', 'karma-typescript'],
-    files: [
-      {pattern: './node_modules/@babel/polyfill/dist/polyfill.js'},
-      'src/setup_test.ts',
-      {pattern: 'src/**/*.ts'},
-    ],
-    preprocessors: {'**/*.ts': ['karma-typescript']},
-    karmaTypescriptConfig,
-    reporters: ['dots', 'karma-typescript'],
+    ...extraConfig,
     exclude,
-    colors: true,
-    autoWatch: false,
     browsers: ['Chrome'],
-    singleRun: true,
-    client: {jasmine: {random: false}, args: args},
     browserStack: {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY
     },
-    captureTimeout: 120000,
+    captureTimeout: 3e5,
     reportSlowerThan: 500,
-    browserNoActivityTimeout: 240000,
+    browserNoActivityTimeout: 3e5,
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 0,
+    browserSocketTimeout: 1.2e5,
     customLaunchers: {
       // For browserstack configs see:
       // https://www.browserstack.com/automate/node
@@ -127,5 +145,6 @@ module.exports = function(config) {
         os_version: '10'
       },
     },
+    client: {jasmine: {random: false}, args: args}
   })
 }

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -20,8 +20,7 @@ if [ "$NIGHTLY" = true ]
 then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-  # TODO(lina128): Add back bs_ios_11 once browserstack issue is resolved.
-  yarn run-browserstack --browsers=bs_safari_mac --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
   # Run the rest of the karma tests in parallel. These runs will reuse the
   # already downloaded binary.

--- a/tfjs-core/karma.conf.js
+++ b/tfjs-core/karma.conf.js
@@ -43,12 +43,12 @@ const devConfig = {
   ],
   preprocessors: {'**/*.ts': ['karma-typescript']},
   karmaTypescriptConfig,
-  reporters: ['dots', 'karma-typescript'],
+  reporters: ['dots', 'karma-typescript']
 };
 
 const browserstackConfig = {
   ...devConfig,
-  reporters: ['dots', 'karma-typescript'],
+  hostname: 'bs-local.com',
   singleRun: true
 };
 

--- a/tfjs-core/karma.conf.js
+++ b/tfjs-core/karma.conf.js
@@ -99,11 +99,12 @@ module.exports = function(config) {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY
     },
-    captureTimeout: 6e5,
+    captureTimeout: 3e5,
     reportSlowerThan: 500,
     browserNoActivityTimeout: 3e5,
     browserDisconnectTimeout: 3e5,
-    browserDisconnectTolerance: 3,
+    browserDisconnectTolerance: 0,
+    browserSocketTimeout: 1.2e5,
     customLaunchers: {
       // For browserstack configs see:
       // https://www.browserstack.com/automate/node
@@ -131,7 +132,7 @@ module.exports = function(config) {
       bs_ios_11: {
         base: 'BrowserStack',
         device: 'iPhone X',
-        os: 'iOS',
+        os: 'ios',
         os_version: '11.0',
         real_mobile: true
       },

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -24,6 +24,8 @@ then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
   yarn run-browserstack --browsers=bs_chrome_mac
+  echo "Test iPhone X."
+  yarn run-browserstack --browsers=bs_ios_11 --flags '{"HAS_WEBGL": false}' --testEnv cpu
 
   # TODO(lina128): Add back bs_ios_11 once browserstack issue is resolved.
   yarn run-browserstack --browsers=bs_firefox_mac,bs_safari_mac,bs_android_9 --flags '{"HAS_WEBGL": false}' --testEnv cpu

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -24,11 +24,8 @@ then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
   yarn run-browserstack --browsers=bs_chrome_mac
-  echo "Test iPhone X."
-  yarn run-browserstack --browsers=bs_ios_11 --flags '{"HAS_WEBGL": false}' --testEnv cpu
 
-  # TODO(lina128): Add back bs_ios_11 once browserstack issue is resolved.
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_safari_mac,bs_android_9 --flags '{"HAS_WEBGL": false}' --testEnv cpu
+  yarn run-browserstack --browsers=bs_firefox_mac,bs_safari_mac,bs_ios_11,bs_android_9 --flags '{"HAS_WEBGL": false}' --testEnv cpu
 
   ### The next section tests TF.js in a webworker using the CPU backend.
   echo "Start webworker test."


### PR DESCRIPTION
This PR fixes browserstack iOS not responding issue. We have to use bs-local.com for localhost, see explanation on browserstack website: https://www.browserstack.com/question/759

The bs-local.com was accidentally removed, add it back.

This PR also include a couple of other small refactors:
1. use singleRun only for CI, local run shouldn't use singleRun so that browser stays on for debugging.
2. Use recommended config numbers for browserstack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3204)
<!-- Reviewable:end -->
