### PR TITLE
Update tfjs-react-native to depend on tfjs 2.x

### DIFF
--- a/tfjs-react-native/cloudbuild.yml
+++ b/tfjs-react-native/cloudbuild.yml
@@ -14,30 +14,28 @@ steps:
   waitFor: ['yarn-common']
 
 # Build tfjs-react-native.
-# Restore once next 2.x RC is out.
-# - name: 'node:10'
-#   dir: 'tfjs-react-native'
-#   id: 'build'
-#   entrypoint: 'yarn'
-#   args: ['build-ci']
-#   waitFor: ['yarn']
+- name: 'node:10'
+  dir: 'tfjs-react-native'
+  id: 'build'
+  entrypoint: 'yarn'
+  args: ['build-ci']
+  waitFor: ['yarn']
 
 # Run unit tests in react native. Tests against version published on NPM.
-# Restore once next 2.x RC is out.
-# - name: 'node:10'
-#   dir: 'tfjs-react-native/integration_rn59'
-#   id: 'test-ci'
-#   entrypoint: 'yarn'
-#   args: ['test-ci']
-#   waitFor: ['build']
-#   env: ['BROWSERSTACK_USERNAME=deeplearnjs1']
-#   secretEnv: ['BROWSERSTACK_KEY']
+- name: 'node:10'
+  dir: 'tfjs-react-native/integration_rn59'
+  id: 'test-ci'
+  entrypoint: 'yarn'
+  args: ['test-ci']
+  waitFor: ['build']
+  env: ['BROWSERSTACK_USERNAME=deeplearnjs1']
+  secretEnv: ['BROWSERSTACK_KEY']
 
 # General configuration
-# secrets:
-# - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
-#   secretEnv:
-#     BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
+secrets:
+- kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
+  secretEnv:
+    BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
 timeout: 1800s
 logsBucket: 'gs://tfjs-build-logs'
 substitutions:

--- a/tfjs-react-native/integration_rn59/package.json
+++ b/tfjs-react-native/integration_rn59/package.json
@@ -21,7 +21,7 @@
     "@tensorflow-models/blazeface": "^0.0.2",
     "@tensorflow-models/mobilenet": "^2.0.4",
     "@tensorflow-models/posenet": "^2.2.1",
-    "@tensorflow/tfjs": "2.0.0-rc.2.1",
+    "@tensorflow/tfjs": "2.0.0-rc.3",
     "@tensorflow/tfjs-react-native": "0.2.3",
     "expo-camera": "^7.0.0",
     "expo-gl": "^7.0.0",

--- a/tfjs-react-native/integration_rn59/yarn.lock
+++ b/tfjs-react-native/integration_rn59/yarn.lock
@@ -863,35 +863,35 @@
   resolved "https://registry.yarnpkg.com/@tensorflow-models/posenet/-/posenet-2.2.1.tgz#2f0a68d909842f59eec195f23c6f3d4cebc53fa8"
   integrity sha512-n9/g6DfjAyrBTf/zt1haRCyWsgALxUCzg9/Ks3Y2mbYavRZVSCSTRPy/qlE5Hr4tLfyckGfDN14zmGTthNcg/g==
 
-"@tensorflow/tfjs-backend-cpu@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.0.0-rc.1.tgz#13b68c820148ea3198ff52099f34d259158bf2ee"
-  integrity sha512-1ur6W11Dj/PiHa7WxfzF4CXYzgxP9uLzBMJJF6P3/qiZiRpjse8l+rYQun9i/kKzfO/vJzaSlNSBRCtrYuloJg==
+"@tensorflow/tfjs-backend-cpu@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.0.0-rc.3.tgz#cadcc99a366c13e9c346f78b23ceff8375cfc46b"
+  integrity sha512-qwg0GmfVRPaF4bMrzpWV2fcTnvU5f6UxsOySgso+3id3KbQmh89XZGtSLUJL4iw8P6HIxNiR++KJkygmQFWhDA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-backend-webgl@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.0.0-rc.1.tgz#4b0962d63493178c5c7d79e36c26be476fcb7bd6"
-  integrity sha512-3DbDljKQ8Akev1GkGJ05dvlrig55S/2x1klFXdSns0eLssgTpoA7aU5x8LLZPZJ3f13VhheXL3Cey2uhbQMprg==
+"@tensorflow/tfjs-backend-webgl@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.0.0-rc.3.tgz#6bf36de6be2a7fecec17d1bce57daa233722685c"
+  integrity sha512-iWsuQ5M21lHulLwkAF1KilzCvXT1WCumCYcdYrBzKNT9Ghi0YoNbcoT8s1RRli2jhgy/YqBLLaRFXy9s0kJb0A==
   dependencies:
-    "@tensorflow/tfjs-backend-cpu" "2.0.0-rc.1"
+    "@tensorflow/tfjs-backend-cpu" "2.0.0-rc.3"
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-converter@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-2.0.0-rc.1.tgz#aa089c22a670524f913c6b1f4ef37a570d5b4ae8"
-  integrity sha512-IVjCiEHc3gNlishPE0s7Gbp+GE4VN0bY/PFScHEQmmASAxM5FdCJJ4wneFxFnFqb7YTM8plyAvnxN0v8ObN6mw==
+"@tensorflow/tfjs-converter@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-2.0.0-rc.3.tgz#14a3ccb2588da8b26a530ea4569d083a19052097"
+  integrity sha512-6tBGQzeJizZCs1NXiO/ZviDeeGxc4VylFDE8COc1qUbfyp+dVbaANpuniN7DH6dgCsJm6qf5y/CiKycObsWWUA==
 
-"@tensorflow/tfjs-core@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-2.0.0-rc.1.tgz#578b4b6d6375fe62b92cb4240d0b6fb54ea7ffd0"
-  integrity sha512-h/QS5LfW53Y8XGCRqUYos/fD/eKXM3GkShDuYJoTgG/rJProofW5LAYQCk+a8F1hGmEHZPIM6ti/5p9ii5Nr2Q==
+"@tensorflow/tfjs-core@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-2.0.0-rc.3.tgz#a665a1a4106c6bc802762c4a4f022d4971908cd2"
+  integrity sha512-EvsGWWwoDX3lD7YujlMlv9DRCKAEZevzWjO5cE8vJnZkVToQ3B5l5fsUH2eGoe/+6FHUPr2HfkwU/492/sfOiQ==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
@@ -900,18 +900,18 @@
     node-fetch "~2.1.2"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-data@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-2.0.0-rc.1.tgz#566084964f7ed4857bb22ba82ffd39101718b21c"
-  integrity sha512-hAUVe64UWaVdL+YXRhGQK3/hzZ/iuV/DT/FEw46u4xW+YUSL3oHxwMNwZYjGSATbcTmO/z5RhGbWXw0jXwq13g==
+"@tensorflow/tfjs-data@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-2.0.0-rc.3.tgz#c385b472990ccbbdca1d96f6de5445e220a9079e"
+  integrity sha512-YfGc2JB3IMzWj3T8KBp0iV4Ht7NPztthZSB+VAHOy3c/CDYBPTV9DnQa5Jqo3BEt2Pa6eP6s4y61oc8f4ID8qg==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
 
-"@tensorflow/tfjs-layers@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-2.0.0-rc.1.tgz#800d6f37195cc40f1a3d5a50cc7837939ca5e044"
-  integrity sha512-be8Itwy8r5iGnn1z95fSBHZNNV8D4t8yjZ3MAdmcfkGzOIGplS7OXNY8gCrb+t73Yt7aZo1Na1IBMxuWsqk4fA==
+"@tensorflow/tfjs-layers@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-2.0.0-rc.3.tgz#ea2d920c78defe8886110fd1c531b656b443c340"
+  integrity sha512-rQqnTBjPdkaEH3jcsO8Fj77eCR+VzcJl3luH7FsWCHdPaEn75+Cv4n2k/6SkrB7rLBaE2z6Nc3s1eeT/bARaEA==
 
 "@tensorflow/tfjs-react-native@0.2.3":
   version "0.2.3"
@@ -922,17 +922,17 @@
     buffer "^5.2.1"
     jpeg-js "^0.3.6"
 
-"@tensorflow/tfjs@2.0.0-rc.2.1":
-  version "2.0.0-rc.2.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-2.0.0-rc.2.1.tgz#9948e1d2df87607d2c51b7a960a046f21468685e"
-  integrity sha512-IAnftIndE7JTiMYudYwhZ+OyFEg1yqhugfMeY6jB5T4T+7lQvmpB+w4htJCtYXP/6Jxgp9Azeb2Xl559w5OPDw==
+"@tensorflow/tfjs@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-2.0.0-rc.3.tgz#85bef5f0a1819933dd4a8b482ac427fd88ae63bd"
+  integrity sha512-Um18bDePKfxaYkKEUCPZAxh3JkAQaJ2chai05DMFwdBOcIcttaofl+v6f2fMaXOseitG7anOy6via2nJ6x4U8A==
   dependencies:
-    "@tensorflow/tfjs-backend-cpu" "2.0.0-rc.1"
-    "@tensorflow/tfjs-backend-webgl" "2.0.0-rc.1"
-    "@tensorflow/tfjs-converter" "2.0.0-rc.1"
-    "@tensorflow/tfjs-core" "2.0.0-rc.1"
-    "@tensorflow/tfjs-data" "2.0.0-rc.1"
-    "@tensorflow/tfjs-layers" "2.0.0-rc.1"
+    "@tensorflow/tfjs-backend-cpu" "2.0.0-rc.3"
+    "@tensorflow/tfjs-backend-webgl" "2.0.0-rc.3"
+    "@tensorflow/tfjs-converter" "2.0.0-rc.3"
+    "@tensorflow/tfjs-core" "2.0.0-rc.3"
+    "@tensorflow/tfjs-data" "2.0.0-rc.3"
+    "@tensorflow/tfjs-layers" "2.0.0-rc.3"
     core-js "3"
     regenerator-runtime "^0.13.5"
 

--- a/tfjs-react-native/package.json
+++ b/tfjs-react-native/package.json
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@react-native-community/async-storage": "^1.4.2",
-    "@tensorflow/tfjs-backend-cpu": "2.0.0-rc.1",
-    "@tensorflow/tfjs-backend-webgl": "2.0.0-rc.1",
-    "@tensorflow/tfjs-core": "2.0.0-rc.1",
+    "@tensorflow/tfjs-backend-cpu": "2.0.0-rc.3",
+    "@tensorflow/tfjs-backend-webgl": "2.0.0-rc.3",
+    "@tensorflow/tfjs-core": "2.0.0-rc.3",
     "@types/base64-js": "^1.2.5",
     "@types/jasmine": "~3.3.0",
     "@types/react-native": "0.60.2",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@react-native-community/async-storage": "^1.4.2",
-    "@tensorflow/tfjs-backend-webgl": "2.0.0-rc.2.1",
+    "@tensorflow/tfjs-backend-webgl": "2.0.0-rc.3",
     "expo-asset": "^7.0.0",
     "expo-camera": "^7.0.0",
     "expo-gl": "^7.0.0",

--- a/tfjs-react-native/yarn.lock
+++ b/tfjs-react-native/yarn.lock
@@ -35,30 +35,30 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tensorflow/tfjs-backend-cpu@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.0.0-rc.1.tgz#13b68c820148ea3198ff52099f34d259158bf2ee"
-  integrity sha512-1ur6W11Dj/PiHa7WxfzF4CXYzgxP9uLzBMJJF6P3/qiZiRpjse8l+rYQun9i/kKzfO/vJzaSlNSBRCtrYuloJg==
+"@tensorflow/tfjs-backend-cpu@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.0.0-rc.3.tgz#cadcc99a366c13e9c346f78b23ceff8375cfc46b"
+  integrity sha512-qwg0GmfVRPaF4bMrzpWV2fcTnvU5f6UxsOySgso+3id3KbQmh89XZGtSLUJL4iw8P6HIxNiR++KJkygmQFWhDA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-backend-webgl@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.0.0-rc.1.tgz#4b0962d63493178c5c7d79e36c26be476fcb7bd6"
-  integrity sha512-3DbDljKQ8Akev1GkGJ05dvlrig55S/2x1klFXdSns0eLssgTpoA7aU5x8LLZPZJ3f13VhheXL3Cey2uhbQMprg==
+"@tensorflow/tfjs-backend-webgl@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.0.0-rc.3.tgz#6bf36de6be2a7fecec17d1bce57daa233722685c"
+  integrity sha512-iWsuQ5M21lHulLwkAF1KilzCvXT1WCumCYcdYrBzKNT9Ghi0YoNbcoT8s1RRli2jhgy/YqBLLaRFXy9s0kJb0A==
   dependencies:
-    "@tensorflow/tfjs-backend-cpu" "2.0.0-rc.1"
+    "@tensorflow/tfjs-backend-cpu" "2.0.0-rc.3"
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-core@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-2.0.0-rc.1.tgz#578b4b6d6375fe62b92cb4240d0b6fb54ea7ffd0"
-  integrity sha512-h/QS5LfW53Y8XGCRqUYos/fD/eKXM3GkShDuYJoTgG/rJProofW5LAYQCk+a8F1hGmEHZPIM6ti/5p9ii5Nr2Q==
+"@tensorflow/tfjs-core@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-2.0.0-rc.3.tgz#a665a1a4106c6bc802762c4a4f022d4971908cd2"
+  integrity sha512-EvsGWWwoDX3lD7YujlMlv9DRCKAEZevzWjO5cE8vJnZkVToQ3B5l5fsUH2eGoe/+6FHUPr2HfkwU/492/sfOiQ==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"


### PR DESCRIPTION
Update tfjs-react native to depend on 2.0.0.rc-3. Add it back to CI.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3222)
<!-- Reviewable:end -->
