### PR TITLE
allow tfjs to dep on tf-cpu latest version

### DIFF
--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,7 +1,6 @@
 h5py>=2.8.0
 numpy>=1.16.4
 six>=1.12.0
-tensorflow-cpu==2.1.0
+tensorflow-cpu>=2.1.0<3
 tensorflow-hub==0.7.0
-gast==0.2.2
 PyInquirer==1.0.3


### PR DESCRIPTION
This fixes TFX nightly error.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3237)
<!-- Reviewable:end -->
