### PR TITLE
[WASM] Fix allocation issue for buffers with byteOffsets

### DIFF
--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -84,7 +84,8 @@ export class BackendWasm extends KernelBackend {
     if (values != null) {
       this.wasm.HEAPU8.set(
           new Uint8Array(
-              (values as backend_util.TypedArray).buffer, 0, numBytes),
+              (values as backend_util.TypedArray).buffer,
+              (values as backend_util.TypedArray).byteOffset, numBytes),
           memoryOffset);
     }
   }

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -48,6 +48,21 @@ describeWithFlags('wasm read/write', ALL_ENVS, () => {
     // This should fail in case of a memory leak.
     expect(memOffset1).toBe(memOffset2);
   });
+
+  it('allocates buffers with byteOffsets', async () => {
+    const data = [-0.5, 0.5, 3.14];
+    const buffer = new ArrayBuffer(32);
+    const view = new Float32Array(buffer, 8, data.length);
+
+    // Write values to buffer.
+    for (let i = 0; i < data.length; ++i) {
+      view[i] = data[i];
+    }
+
+    const t = tf.tensor(view);
+    // Tensor values should match.
+    test_util.expectArraysClose(await t.data(), view);
+  });
 });
 
 describeWithFlags('wasm init', BROWSER_ENVS, () => {


### PR DESCRIPTION
Use the TypedArray byteOffset instead of defaulting to 0.

Fixes: #2998

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3334)
<!-- Reviewable:end -->
