### PR TITLE
Add docs about backends to tfjs-core readme

### DIFF
--- a/tfjs-backend-cpu/README.md
+++ b/tfjs-backend-cpu/README.md
@@ -10,7 +10,7 @@ Note: this backend is included by default in `@tensorflow/tfjs`.
 
 ```js
 // Import @tensorflow/tfjs-core
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 // Adds the CPU backend to the global backend registry.
 import '@tensorflow/tfjs-backend-cpu';
 ```

--- a/tfjs-backend-webgl/README.md
+++ b/tfjs-backend-webgl/README.md
@@ -10,7 +10,7 @@ Note: this backend is included by default in `@tensorflow/tfjs`.
 
 ```js
 // Import @tensorflow/tfjs-core
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 // Adds the WebGL backend to the global backend registry.
 import '@tensorflow/tfjs-backend-webgl';
 ```

--- a/tfjs-core/README.md
+++ b/tfjs-core/README.md
@@ -31,6 +31,10 @@ import * as tfc from '@tensorflow/tfjs-core';
 // No Layers API.
 ```
 
+**Note**: If you are only importing the Core API, you also need to import a
+backend (e.g., [tfjs-backend-cpu](/tfjs-backend-cpu),
+[tfjs-backend-webgl](/tfjs-backend-webgl), [tfjs-backend-wasm](/tfjs-backend-wasm)).
+
 For info about development, check out [DEVELOPMENT.md](/DEVELOPMENT.md).
 
 ## For more information


### PR DESCRIPTION
I think it'd be useful to note that a backend needs to be imported if using tfjs-core directly. A backend is no longer included in core by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3382)
<!-- Reviewable:end -->
