### PR TITLE
Fix saving to IndexedDB inside web worker

### DIFF
--- a/tfjs-core/src/io/indexed_db.ts
+++ b/tfjs-core/src/io/indexed_db.ts
@@ -57,7 +57,7 @@ function getIndexedDBFactory(): IDBFactory {
         'is not a web browser.');
   }
   // tslint:disable-next-line:no-any
-  const theWindow: any = window || self;
+  const theWindow: any = typeof window === 'undefined' ? self : window;
   const factory = theWindow.indexedDB || theWindow.mozIndexedDB ||
       theWindow.webkitIndexedDB || theWindow.msIndexedDB ||
       theWindow.shimIndexedDB;


### PR DESCRIPTION
This PR fixes the `ReferenceError` that is being thrown when saving a `LayersModel` to the IndexedDB inside a web worker (fixes #3402).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3403)
<!-- Reviewable:end -->
