### PR TITLE
use NamedTensorMap input to execute model for e2e tests

### DIFF
--- a/e2e/integration_tests/convert_predict.py
+++ b/e2e/integration_tests/convert_predict.py
@@ -90,14 +90,23 @@ def _save_and_convert_model(model_fn, model_path, control_flow_v2=False):
   with open(xs_dtype_path, 'w') as f:
     f.write(json.dumps(xs_dtype))
   # Write outputs to file.
-  ys = model_info['outputs'].values()
+  ys_data = []
+  ys_shape = []
+  ys_dtype = []
+  ys_names = []
+  keys = model_info['outputs'].keys()
+  for key in keys:
+    ys_names.append(key)
+    ys_data.append(model_info['outputs'][key]['value'])
+    ys_shape.append(model_info['outputs'][key]['shape'])
+    ys_dtype.append(model_info['outputs'][key]['dtype'])
 
-  ys_data = [y['value'] for y in ys]
-  ys_shape = [y['shape'] for y in ys]
-  ys_dtype = [y['dtype'] for y in ys]
+  ys_name_path = os.path.join(_tmp_dir, model_path + '.ys-name.json')
   ys_data_path = os.path.join(_tmp_dir, model_path + '.ys-data.json')
   ys_shape_path = os.path.join(_tmp_dir, model_path + '.ys-shapes.json')
   ys_dtype_path = os.path.join(_tmp_dir, model_path + '.ys-dtype.json')
+  with open(ys_name_path, 'w') as f:
+    f.write(json.dumps(ys_names))
   with open(ys_data_path, 'w') as f:
     f.write(json.dumps(ys_data))
   with open(ys_shape_path, 'w') as f:

--- a/e2e/integration_tests/create_save_predict.ts
+++ b/e2e/integration_tests/create_save_predict.ts
@@ -63,7 +63,8 @@ describe(`${REGRESSION} create_save_predict`, () => {
           const $model = await tfl.loadLayersModel(
               `${KARMA_SERVER}/${DATA_URL}/${model}/model.json`);
 
-          const xs = createInputTensors(inputsData, inputsShapes);
+          const xs =
+              createInputTensors(inputsData, inputsShapes) as tfc.Tensor[];
 
           await tfc.setBackend(backend);
 

--- a/e2e/integration_tests/test_util.ts
+++ b/e2e/integration_tests/test_util.ts
@@ -26,7 +26,8 @@ import * as tfc from '@tensorflow/tfjs-core';
  */
 export function createInputTensors(
     inputsData: tfc.TypedArray[], inputsShapes: number[][],
-    inputDtypes?: tfc.DataType[], inputNames?: string[]) {
+    inputDtypes?: tfc.DataType[], inputNames?: string[]): tfc.Tensor[]|
+    tfc.NamedTensorMap {
   const xs: tfc.Tensor[] = [];
   for (let i = 0; i < inputsData.length; i++) {
     const input = tfc.tensor(

--- a/e2e/integration_tests/test_util.ts
+++ b/e2e/integration_tests/test_util.ts
@@ -26,14 +26,19 @@ import * as tfc from '@tensorflow/tfjs-core';
  */
 export function createInputTensors(
     inputsData: tfc.TypedArray[], inputsShapes: number[][],
-    inputDtypes?: tfc.DataType[]) {
-  const xs = [];
+    inputDtypes?: tfc.DataType[], inputNames?: string[]) {
+  const xs: tfc.Tensor[] = [];
   for (let i = 0; i < inputsData.length; i++) {
     const input = tfc.tensor(
         inputsData[i], inputsShapes[i],
         inputDtypes ? inputDtypes[i] : 'float32');
     xs.push(input);
   }
-
+  if (inputNames) {
+    return inputNames.reduce((map: tfc.NamedTensorMap, name, index) => {
+      map[name] = xs[index];
+      return map;
+    }, {});
+  }
   return xs;
 }


### PR DESCRIPTION
The flakiness of the e2e test is caused by the wrong assignment of input tensors.
When the input is an array, the order of assignment is determined by the order of the graph parsing.
Use the named tensor map will make sure there is no wrong assignment.



To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3412)
<!-- Reviewable:end -->
