### PR TITLE
fix file:// URLs on Windows

### DIFF
--- a/tfjs-node/src/io/file_system.ts
+++ b/tfjs-node/src/io/file_system.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 import * as fs from 'fs';
 import {dirname, join, resolve} from 'path';
+import {fileURLToPath} from 'url';
 import {promisify} from 'util';
 
 import {getModelArtifactsInfoForJSON, toArrayBuffer} from './io_utils';
@@ -245,13 +246,13 @@ export const nodeFileSystemRouter = (url: string|string[]) => {
     if (url.every(
             urlElement => urlElement.startsWith(NodeFileSystem.URL_SCHEME))) {
       return new NodeFileSystem(url.map(
-          urlElement => urlElement.slice(NodeFileSystem.URL_SCHEME.length)));
+          urlElement => fileURLToPath(urlElement)));
     } else {
       return null;
     }
   } else {
     if (url.startsWith(NodeFileSystem.URL_SCHEME)) {
-      return new NodeFileSystem(url.slice(NodeFileSystem.URL_SCHEME.length));
+      return new NodeFileSystem(fileURLToPath(url));
     } else {
       return null;
     }


### PR DESCRIPTION
BUG In Node.js on Windows, file: URLs have three slashes before the
drive letter. For example:

    file:///c:/Users/strager/[snip]/nsfwjs/model.json

When converting a file: URL to a file path, NodeFileSystem's router
incorrectly preserves one leading slash. This results in a
drive-relative path, which refers to a different file than intended.
This leads to errors down the road:

    Error: Path C:\C:\Users\strager\[snip]\nsfwjs\model.json does not exist: loading failed
        at C:\Users\strager\[snip]\node_modules\@tensorflow\tfjs-node\dist\io\file_system.js:67:23

Use Node.js' built-in functions for dealing with file: URLs instead of
hackily parsing them ourselves.

On POSIX systems, this commit should not change behavior.