### PR TITLE
Use tf.keras exclusively in e2e testing for generating keras models.

### DIFF
--- a/e2e/integration_tests/create_save_predict.py
+++ b/e2e/integration_tests/create_save_predict.py
@@ -25,12 +25,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflowjs as tfjs
 
-if os.environ['TFJS2KERAS_TEST_USING_TF_KERAS'] == '1':
-  print('Using tensorflow.keras.')
-  from tensorflow import keras
-else:
-  print('Using keras-team/keras.')
-  import keras
+from tensorflow import keras
 
 curr_dir = os.path.dirname(os.path.realpath(__file__))
 _tmp_dir = os.path.join(curr_dir, 'create_save_predict_data')

--- a/e2e/integration_tests/requirements-dev.txt
+++ b/e2e/integration_tests/requirements-dev.txt
@@ -1,2 +1,1 @@
-keras==2.3.1
 -r ../../tfjs-converter/python/requirements.txt

--- a/e2e/integration_tests/requirements-stable.txt
+++ b/e2e/integration_tests/requirements-stable.txt
@@ -1,2 +1,1 @@
-keras==2.3.1
 -r ../../tfjs-converter/python/requirements.txt

--- a/e2e/scripts/setup-py-env.sh
+++ b/e2e/scripts/setup-py-env.sh
@@ -7,16 +7,13 @@
 # https://opensource.org/licenses/MIT.
 # =============================================================================
 
-# Decide which keras to use.
+# Decide which environment to use.
 DEV_VERSION=""
-TFJS2KERAS_TEST_USING_TF_KERAS=0
 while [[ ! -z "$1" ]]; do
   if [[ "$1" == "--stable" ]]; then
     DEV_VERSION="stable"
   elif [[ "$1" == "--dev" ]]; then
     DEV_VERSION="dev"
-  elif [[ "$1" == "--tfkeras" ]]; then
-    TFJS2KERAS_TEST_USING_TF_KERAS=1
   else
     echo "ERROR: Unrecognized command-line flag $1"
     exit 1
@@ -25,21 +22,11 @@ while [[ ! -z "$1" ]]; do
 done
 
 echo "DEV_VERSION: ${DEV_VERSION}"
-echo "TFJS2KERAS_TEST_USING_TF_KERAS: ${TFJS2KERAS_TEST_USING_TF_KERAS}"
 
 if [[ -z "${DEV_VERSION}" ]]; then
   echo "Must specify one of --stable and --dev."
   exit 1
 fi
-
-if [[ "${DEV_VERSION}" == "dev" &&
-      "${TFJS2KERAS_TEST_USING_TF_KERAS}" == "0" ]]; then
-  echo "--dev && keras-team/keras is not a valid combination."
-  echo "Use --dev and --tfkeras together."
-  exit 1
-fi
-
-export TFJS2KERAS_TEST_USING_TF_KERAS="${TFJS2KERAS_TEST_USING_TF_KERAS}"
 
 # Install python env.
 if [[ -z "$(which pip3)" ]]; then

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -31,9 +31,7 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
 
   cd integration_tests
 
-  # Setup python env.
-  # TODO(linazhao): Investigate why --dev --tfkeras fail.
-  source ../scripts/setup-py-env.sh --stable
+  source ../scripts/setup-py-env.sh --dev
 
   echo "Load equivalent keras models and generate outputs."
   python create_save_predict.py

--- a/e2e/scripts/test.sh
+++ b/e2e/scripts/test.sh
@@ -37,8 +37,7 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
   cd integration_tests
 
   # Setup python env.
-  # TODO(linazhao): Investigate why --dev --tfkeras fail.
-  source ../scripts/setup-py-env.sh --stable
+  source ../scripts/setup-py-env.sh --dev
 
   echo "Load equivalent keras models and generate outputs."
   python create_save_predict.py


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3445)
<!-- Reviewable:end -->
