### PR TITLE
revised method signatures: InferenceModel.predict

### DIFF
--- a/tfjs-converter/src/executor/graph_model.ts
+++ b/tfjs-converter/src/executor/graph_model.ts
@@ -248,6 +248,9 @@ export class GraphModel implements InferenceModel {
    * will be returned for model with multiple outputs.
    */
   /** @doc {heading: 'Models', subheading: 'Classes'} */
+  predict(inputs: Tensor, config?: ModelPredictConfig): Tensor;
+  predict(inputs: Tensor[], config?: ModelPredictConfig): Tensor[];
+  predict(inputs: NamedTensorMap, config?: ModelPredictConfig): NamedTensorMap;
   predict(inputs: Tensor|Tensor[]|NamedTensorMap, config?: ModelPredictConfig):
       Tensor|Tensor[]|NamedTensorMap {
     return this.execute(inputs, this.outputNodes);

--- a/tfjs-converter/src/executor/graph_model_test.ts
+++ b/tfjs-converter/src/executor/graph_model_test.ts
@@ -255,7 +255,7 @@ describe('Model', () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.predict(input);
-        expect((output as tfc.Tensor).dataSync()[0]).toEqual(3);
+        expect(output.dataSync()[0]).toEqual(3);
       });
     });
 
@@ -313,7 +313,7 @@ describe('Model', () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.predict(input);
-        expect((output as tfc.Tensor).dataSync()[0]).toEqual(3);
+        expect(output.dataSync()[0]).toEqual(3);
       });
 
       it('should support signature keys', async () => {

--- a/tfjs-core/src/model_types.ts
+++ b/tfjs-core/src/model_types.ts
@@ -76,8 +76,9 @@ export interface InferenceModel {
    * model has single output node, otherwise Tensor[] or NamedTensorMap[] will
    * be returned for model with multiple outputs.
    */
-  predict(inputs: Tensor|Tensor[]|NamedTensorMap, config: ModelPredictConfig):
-      Tensor|Tensor[]|NamedTensorMap;
+  predict(inputs: Tensor, config: ModelPredictConfig): Tensor;
+  predict(inputs: Tensor[], config: ModelPredictConfig): Tensor[];
+  predict(inputs: NamedTensorMap, config: ModelPredictConfig): NamedTensorMap;
 
   /**
    * Single Execute the inference for the input tensors and return activation

--- a/tfjs-layers/src/engine/training.ts
+++ b/tfjs-layers/src/engine/training.ts
@@ -1097,6 +1097,8 @@ export class LayersModel extends Container implements tfc.InferenceModel {
   /**
    * @doc {heading: 'Models', subheading: 'Classes'}
    */
+  predict(x: Tensor, args: ModelPredictArgs): Tensor;
+  predict(x: Tensor[], args: ModelPredictArgs): Tensor[];
   predict(x: Tensor|Tensor[], args: ModelPredictArgs = {}): Tensor|Tensor[] {
     const xsRank2OrHigher = ensureTensorsRank2OrHigher(x);
     checkInputData(


### PR DESCRIPTION
The following showed up while completing the tutorial [TensorFlow.js — Making Predictions from 2D Data](https://codelabs.developers.google.com/codelabs/tfjs-training-regression/#0) with TypeScript.

![grafik](https://user-images.githubusercontent.com/8401267/85944919-8642fc00-b93a-11ea-93ad-14769b789b92.png)

It seems that the signature for `InferenceModel.predict` can be revised to support the usecase from the tutorial.

Sources from the screenshot can be found [in my test-repository](https://github.com/claasahl/experimental/blob/b93ef9cb734fbe2f91903144541026f1242d0c12/tensorflow/index.ts#L121) as well as the [official tutorial](https://codelabs.developers.google.com/codelabs/tfjs-training-regression/#6)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3522)
<!-- Reviewable:end -->
