### PR TITLE
webgpu: Fix the binding buffer size error

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -365,8 +365,7 @@ export class WebGPUBackend extends KernelBackend {
     return {
       resource: {
         offset: 0,
-        size: util.sizeFromShape(tensor.shape) *
-            util.bytesPerElement(tensor.dtype),
+        size: tensorData.bufferInfo.byteSize,
         buffer: tensorData.bufferInfo.buffer
       }
     };


### PR DESCRIPTION
BUG

In latest chrome canary, many below errors are printed when running
'yarn test'
'Binding sizes too small for bind group 0.'

The original code used util.bytesPerElement(tensor.dtype) which will
treat bool as 1 byte. However, for GPU, bool should be treated as 4 bytes.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3525)
<!-- Reviewable:end -->
