### PR TITLE
Extract input generation from the benchmark webpage

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -17,9 +17,9 @@
 
 function generateInput(model) {
   if (model == null) {
-    throw new Error('The model does not exist');
+    throw new Error('The model does not exist.');
   } else if (model.inputs == null) {
-    throw new Error('The model.inputs cannot be found');
+    throw new Error('The model.inputs cannot be found.');
   }
 
   const tensorArray = [];
@@ -32,7 +32,7 @@ function generateInput(model) {
         } else if (shapeValue == 0) {
           throw new Error(
               `In the model.inputs[${inputNodeIndex}], ` +
-              `'${inputNode.name}', shape[${dimension}] is zero`);
+              `'${inputNode.name}', the shape[${dimension}] is zero.`);
         } else {
           return shapeValue;
         }
@@ -44,8 +44,8 @@ function generateInput(model) {
         inputTensor = tf.randomNormal(inputShape, 0, 1000, inputNode.dtype);
       } else {
         throw new Error(
-            `The ${inputNode.dtype} dtype  of '${inputNode.name}' input ` +
-            `at model.inputs[${inputNodeIndex}] is not supported`);
+            `The ${inputNode.dtype} dtype of '${inputNode.name}' input ` +
+            `at model.inputs[${inputNodeIndex}] is not supported.`);
       }
       tensorArray.push(inputTensor);
     });
@@ -54,9 +54,9 @@ function generateInput(model) {
     if (model instanceof tf.GraphModel) {
       if (tensorArray.length !== model.inputNodes.length) {
         throw new Error(
-            'The generated input array and model.inputNodes are mismatched,' +
-            `the graph model has ${model.inputNodes.length} input nodes, ` +
-            `while the generated input array has ${tensorArray.length} nodes`);
+            'The generated input array and model.inputNodes are mismatched. ' +
+            `The graph model has ${model.inputNodes.length} input nodes, ` +
+            `while the generated input array has ${tensorArray.length} nodes.`);
       }
       const tensorMap = model.inputNodes.reduce((map, inputName, i) => {
         map[inputName] = tensorArray[i];

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -24,29 +24,28 @@ function generateInput(model) {
 
   const tensorArray = [];
   try {
-    model.inputs.forEach(input => {
+    model.inputs.forEach((inputNode, inputNodeIndex) => {
       // replace -1 or null in input tensor shape
-      const inputShape = [];
-      input.shape.forEach(shapeValue => {
+      const inputShape = inputNode.shape.map((shapeValue, dimension) => {
         if (shapeValue == null || shapeValue < 0) {
-          inputShape.push(1);
+          return 1;
         } else if (shapeValue == 0) {
           throw new Error(
-              `Warning: In the model.inputs[${inferenceInputIndex}], ` +
-              `'${input.name}', shape[${dimension}] is zero`);
+              `In the model.inputs[${inputNodeIndex}], ` +
+              `'${inputNode.name}', shape[${dimension}] is zero`);
         } else {
-          inputShape.push(shapeValue);
+          return shapeValue;
         }
       });
 
       // construct the input tensor
       let inputTensor;
-      if (input.dtype == 'float32' || input.dtype == 'int32') {
-        inputTensor = tf.randomNormal(inputShape, 0, 1, input.dtype);
+      if (inputNode.dtype == 'float32' || inputNode.dtype == 'int32') {
+        inputTensor = tf.randomNormal(inputShape, 0, 1000, inputNode.dtype);
       } else {
         throw new Error(
-            `The ${input.dtype} dtype  of '${input.name}' input ` +
-            `at model.inputs[${inferenceInputIndex}] is not supported`);
+            `The ${inputNode.dtype} dtype  of '${inputNode.name}' input ` +
+            `at model.inputs[${inputNodeIndex}] is not supported`);
       }
       tensorArray.push(inputTensor);
     });
@@ -55,9 +54,9 @@ function generateInput(model) {
     if (model instanceof tf.GraphModel) {
       if (tensorArray.length !== model.inputNodes.length) {
         throw new Error(
-            'model.inputs and model.inputNodes are mismatched,' +
-            `the graph model has ${model.inputNodes.length} input node, ` +
-            `while there are ${tensorArray.length} inputs in model.inputs.`);
+            'The generated input and model.inputNodes are mismatched,' +
+            `the graph model has ${model.inputNodes.length} input nodes, ` +
+            `while the generated input has ${tensorArray.length} input nodes`);
       }
       const tensorMap = model.inputNodes.reduce((map, inputName, i) => {
         map[inputName] = tensorArray[i];

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -26,13 +26,9 @@ function generateInput(model) {
   try {
     model.inputs.forEach((inputNode, inputNodeIndex) => {
       // replace -1 or null in input tensor shape
-      const inputShape = inputNode.shape.map((shapeValue, dimension) => {
+      const inputShape = inputNode.shape.map(shapeValue => {
         if (shapeValue == null || shapeValue < 0) {
           return 1;
-        } else if (shapeValue == 0) {
-          throw new Error(
-              `In the model.inputs[${inputNodeIndex}], ` +
-              `'${inputNode.name}', the shape[${dimension}] is zero.`);
         } else {
           return shapeValue;
         }
@@ -40,7 +36,7 @@ function generateInput(model) {
 
       // construct the input tensor
       let inputTensor;
-      if (inputNode.dtype == 'float32' || inputNode.dtype == 'int32') {
+      if (inputNode.dtype === 'float32' || inputNode.dtype === 'int32') {
         inputTensor = tf.randomNormal(inputShape, 0, 1000, inputNode.dtype);
       } else {
         throw new Error(

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -48,12 +48,6 @@ function generateInput(model) {
 
     // return tensor map for GraphModel
     if (model instanceof tf.GraphModel) {
-      if (tensorArray.length !== model.inputNodes.length) {
-        throw new Error(
-            'The generated input array and model.inputNodes are mismatched. ' +
-            `The graph model has ${model.inputNodes.length} input nodes, ` +
-            `while the generated input array has ${tensorArray.length} nodes.`);
-      }
       const tensorMap = model.inputNodes.reduce((map, inputName, i) => {
         map[inputName] = tensorArray[i];
         return map;

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -7,8 +7,8 @@ function generateInput(model) {
     throw new Error('The model.inputs cannot be found');
   }
 
-  const inferenceInputs = [];
   try {
+    const inferenceInputs = [];
     model.inputs.forEach(input => {
       // replace -1 or null in input tensor shape
       const inputShape = [];
@@ -35,6 +35,7 @@ function generateInput(model) {
       }
       inferenceInputs.push(inputTensor);
     });
+    return inferenceInputs;
   } catch (e) {
     // dispose input tensors
     for (let tensorIndex = 0; tensorIndex < inferenceInputs.length; tensorIndex++) {

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -54,9 +54,9 @@ function generateInput(model) {
     if (model instanceof tf.GraphModel) {
       if (tensorArray.length !== model.inputNodes.length) {
         throw new Error(
-            'The generated input and model.inputNodes are mismatched,' +
+            'The generated input array and model.inputNodes are mismatched,' +
             `the graph model has ${model.inputNodes.length} input nodes, ` +
-            `while the generated input has ${tensorArray.length} input nodes`);
+            `while the generated input array has ${tensorArray.length} nodes`);
       }
       const tensorMap = model.inputNodes.reduce((map, inputName, i) => {
         map[inputName] = tensorArray[i];

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -1,0 +1,52 @@
+
+
+function generateInput(model) {
+  const inferenceInputs = [];
+  try {
+    for (let inferenceInputIndex = 0; inferenceInputIndex < model.inputs.length; inferenceInputIndex++) {
+      // construct the input tensor shape
+      const inferenceInput = model.inputs[inferenceInputIndex];
+      const inputShape = [];
+      for (let dimension = 0; dimension < inferenceInput.shape.length; dimension++) {
+        const shapeValue = inferenceInput.shape[dimension];
+        if (shapeValue == null || shapeValue < 0) {
+          inputShape.push(1);
+        } else if (shapeValue == 0) {
+          await showMsg('Warning: one dimension of an input tensor is zero');
+          inputShape.push(shapeValue);
+        } else {
+          inputShape.push(shapeValue);
+        }
+      }
+
+      // construct the input tensor
+      let inputTensor;
+      if (inferenceInput.dtype == 'float32' || inferenceInput.dtype == 'int32') {
+        inputTensor = tf.randomNormal(inputShape, 0, 1, inferenceInput.dtype);
+      } else {
+        throw new Error(
+            `The ${inferenceInput.dtype} dtype  of '${inferenceInput.name}' input ` +
+            `at model.inputs[${inferenceInputIndex}] is not supported`);
+      }
+      inferenceInputs.push(inputTensor);
+    }
+
+    // run prediction
+    let resultTensor;
+    if (model instanceof tf.GraphModel && model.executeAsync != null) {
+      resultTensor = await model.executeAsync(inferenceInputs);
+    } else if (model.predict != null) {
+      resultTensor = model.predict(inferenceInputs);
+    } else {
+      throw new Error("Predict function was not found");
+    }
+    return resultTensor;
+  } finally {
+    // dispose input tensors
+    for (let tensorIndex = 0; tensorIndex < inferenceInputs.length; tensorIndex++) {
+      if (inferenceInputs[tensorIndex] instanceof tf.Tensor) {
+        inferenceInputs[tensorIndex].dispose();
+      }
+    }
+  }
+}

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -1,4 +1,19 @@
-
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
 
 function generateInput(model) {
   if (model == null) {

--- a/e2e/benchmarks/index.html
+++ b/e2e/benchmarks/index.html
@@ -98,6 +98,7 @@ limitations under the License.
 
   <script src="./modelConfig.js"></script>
   <script src="./util.js"></script>
+  <script src="./benchmark_util.js"></script>
   <script>
     'use strict';
 

--- a/e2e/benchmarks/index.html
+++ b/e2e/benchmarks/index.html
@@ -114,7 +114,7 @@ limitations under the License.
       testCorrectness: async () => {
         if (state.benchmark === 'custom') {
           // TODO: seperate input generation from the predict function
-          await showMsg('Testing correctness for custom models is not supported');
+          await showMsg('Testing correctness for custom models is not supported.');
           throw new Error();
         }
 
@@ -296,7 +296,7 @@ limitations under the License.
       state.isModelChanged = false; // used to clean the performance history
 
       if (benchmark['load'] == null) {
-        throw new Error(`Please provide a load method for '${state.benchmark}' model`);
+        throw new Error(`Please provide a load method for '${state.benchmark}' model.`);
       }
 
       await showMsg('Loading the model');

--- a/e2e/benchmarks/modelConfig.js
+++ b/e2e/benchmarks/modelConfig.js
@@ -227,33 +227,33 @@ const benchmarks = {
     },
     predictFunc: () => {
       return async model => {
-        let inferenceInputs;
+        let inferenceInput;
         try {
-          inferenceInputs = generateInput(model);
+          inferenceInput = generateInput(model);
           let resultTensor;
           if (model instanceof tf.GraphModel && model.executeAsync != null) {
-            resultTensor = await model.executeAsync(inferenceInputs);
+            resultTensor = await model.executeAsync(inferenceInput);
           } else if (model.predict != null) {
-            resultTensor = model.predict(inferenceInputs);
+            resultTensor = model.predict(inferenceInput);
           } else {
             throw new Error("Predict function was not found");
           }
           return resultTensor;
         } finally {
           // dispose input tensors
-          if (inferenceInputs instanceof tf.Tensor) {
-            inferenceInputs.dispose();
-          } else if (Array.isArray(inferenceInputs)) {
-            inferenceInputs.forEach(tensor => {
-              if (tensor instanceof tf.Tensor) {
-                tensor.dispose();
+          if (inferenceInput instanceof tf.Tensor) {
+            inferenceInput.dispose();
+          } else if (Array.isArray(inferenceInput)) {
+            inferenceInput.forEach(inputNode => {
+              if (inputNode instanceof tf.Tensor) {
+                inputNode.dispose();
               }
             });
-          } else if (inferenceInputs != null && typeof inferenceInputs === 'object') {
+          } else if (inferenceInput != null && typeof inferenceInput === 'object') {
             // inferenceInputs is a tensor map
-            for (const property in inferenceInputs) {
-              if (inferenceInputs[property] instanceof tf.Tensor) {
-                inferenceInputs[property].dispose();
+            for (const property in inferenceInput) {
+              if (inferenceInput[property] instanceof tf.Tensor) {
+                inferenceInput[property].dispose();
               }
             }
           }

--- a/e2e/benchmarks/modelConfig.js
+++ b/e2e/benchmarks/modelConfig.js
@@ -250,7 +250,9 @@ const benchmarks = {
             if (inferenceInput.dtype == 'float32' || inferenceInput.dtype == 'int32') {
               inputTensor = tf.randomNormal(inputShape, 0, 1, inferenceInput.dtype);
             } else {
-              throw new Error(`${inferenceInput.dtype} dtype is not supported`);
+              throw new Error(
+                  `The ${inferenceInput.dtype} dtype  of '${inferenceInput.name}' input ` +
+                  `at model.inputs[${inferenceInputIndex}] is not supported`);
             }
             inferenceInputs.push(inputTensor);
           }

--- a/e2e/benchmarks/modelConfig.js
+++ b/e2e/benchmarks/modelConfig.js
@@ -227,54 +227,16 @@ const benchmarks = {
     },
     predictFunc: () => {
       return async model => {
-        const inferenceInputs = [];
-        try {
-          for (let inferenceInputIndex = 0; inferenceInputIndex < model.inputs.length; inferenceInputIndex++) {
-            // construct the input tensor shape
-            const inferenceInput = model.inputs[inferenceInputIndex];
-            const inputShape = [];
-            for (let dimension = 0; dimension < inferenceInput.shape.length; dimension++) {
-              const shapeValue = inferenceInput.shape[dimension];
-              if (shapeValue == null || shapeValue < 0) {
-                inputShape.push(1);
-              } else if (shapeValue == 0) {
-                await showMsg('Warning: one dimension of an input tensor is zero');
-                inputShape.push(shapeValue);
-              } else {
-                inputShape.push(shapeValue);
-              }
-            }
-
-            // construct the input tensor
-            let inputTensor;
-            if (inferenceInput.dtype == 'float32' || inferenceInput.dtype == 'int32') {
-              inputTensor = tf.randomNormal(inputShape, 0, 1, inferenceInput.dtype);
-            } else {
-              throw new Error(
-                  `The ${inferenceInput.dtype} dtype  of '${inferenceInput.name}' input ` +
-                  `at model.inputs[${inferenceInputIndex}] is not supported`);
-            }
-            inferenceInputs.push(inputTensor);
-          }
-
-          // run prediction
-          let resultTensor;
-          if (model instanceof tf.GraphModel && model.executeAsync != null) {
-            resultTensor = await model.executeAsync(inferenceInputs);
-          } else if (model.predict != null) {
-            resultTensor = model.predict(inferenceInputs);
-          } else {
-            throw new Error("Predict function was not found");
-          }
-          return resultTensor;
-        } finally {
-          // dispose input tensors
-          for (let tensorIndex = 0; tensorIndex < inferenceInputs.length; tensorIndex++) {
-            if (inferenceInputs[tensorIndex] instanceof tf.Tensor) {
-              inferenceInputs[tensorIndex].dispose();
-            }
-          }
+        const inferenceInputs = generateInput(model);
+        let resultTensor;
+        if (model instanceof tf.GraphModel && model.executeAsync != null) {
+          resultTensor = await model.executeAsync(inferenceInputs);
+        } else if (model.predict != null) {
+          resultTensor = model.predict(inferenceInputs);
+        } else {
+          throw new Error("Predict function was not found");
         }
+        return resultTensor;
       }
     }
   },

--- a/e2e/benchmarks/modelConfig.js
+++ b/e2e/benchmarks/modelConfig.js
@@ -236,7 +236,7 @@ const benchmarks = {
           } else if (model.predict != null) {
             resultTensor = model.predict(inferenceInput);
           } else {
-            throw new Error("Predict function was not found");
+            throw new Error("Predict function was not found.");
           }
           return resultTensor;
         } finally {
@@ -291,7 +291,7 @@ function findIOHandler(path, loadOptions = {}) {
     } else if (handlers.length > 1) {
       throw new Error(
           `Found more than one (${handlers.length}) load handlers for ` +
-          `URL '${[path]}'`);
+          `URL '${[path]}'.`);
     }
     handler = handlers[0];
   }
@@ -320,7 +320,7 @@ async function loadModelByUrl(modelUrl, loadOptions = {}) {
 
   const supportedSchemes =  /^(https?|localstorage|indexeddb):\/\/.+$/;
   if (!supportedSchemes.test(modelUrl)) {
-    throw new Error(`Please use a valid URL, such as 'https://'`);
+    throw new Error(`Please use a valid URL, such as 'https://'.`);
   }
 
   const tfHubUrl =  /^https:\/\/tfhub.dev\/.+$/;
@@ -336,7 +336,7 @@ async function loadModelByUrl(modelUrl, loadOptions = {}) {
     ioHandler = findIOHandler(modelUrl, loadOptions);
     modelType = await ioHandler.load().then(artifacts => artifacts.format);
   } catch (e) {
-    throw new Error(`Failed to fetch or parse 'model.json' file`);
+    throw new Error(`Failed to fetch or parse 'model.json' file.`);
   }
 
   // load models
@@ -351,7 +351,7 @@ async function loadModelByUrl(modelUrl, loadOptions = {}) {
       model = await tryAllLoadingMethods(ioHandler, loadOptions);
     }
   } catch (e) {
-    throw new Error('Failed to load the model');
+    throw new Error('Failed to load the model.');
   }
 
   return model;

--- a/e2e/benchmarks/util.js
+++ b/e2e/benchmarks/util.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-async function disposeTensor(tensor) {
+async function convertTensorToData(tensor) {
   const data = await tensor.data();
   tensor.dispose();
   return data;
@@ -27,17 +27,17 @@ async function getPredictionData(output) {
   }
 
   if (output instanceof tf.Tensor) {
-    output = await disposeTensor(output);
+    output = await convertTensorToData(output);
   } else if (Array.isArray(output)) {
     for (let i = 0; i < output.length; i++) {
       if (output[i] instanceof tf.Tensor) {
-        output[i] = await disposeTensor(output[i]);
+        output[i] = await convertTensorToData(output[i]);
       }
     }
-  } else if (output.constructor === Object) {
-    for (const tensorName in output) {
-      if (typeof tensorName === 'string' && output[tensorName] instanceof tf.Tensor) {
-        output[tensorName] = await disposeTensor(output[tensorName]);
+  } else if (output != null && typeof output === 'object') {
+    for (const property in output) {
+      if (output[property] instanceof tf.Tensor) {
+        output[property] = await convertTensorToData(output[property]);
       }
     }
   }


### PR DESCRIPTION
This PR does the following:
1. Extract the codes of input generation from the benchmark webpage
2. Convert the generated tensor array to a tensor map for GraphModel
3. Add disposing logics for tensor map in the predict function

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3527)
<!-- Reviewable:end -->
