### PR TITLE
webgpu: Use setOutput instead of directly assignment

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
@@ -60,7 +60,7 @@ export class BinaryOpProgram implements WebGPUProgram {
 
             float a = A[index];
             float b = B[index];
-            result[index] = binaryOperation(a, b);
+            setOutput(index, binaryOperation(a, b));
           }
         `;
       this.shaderKey = `binary2${op}`;

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -71,7 +71,7 @@ export class UnaryOpProgram implements WebGPUProgram {
       void main() {
         int index = int(gl_GlobalInvocationID.x);
         float a = A[index];
-        result[index] = unaryOperation(a);
+        setOutput(index, unaryOperation(a));;
       }
       `;
       this.shaderKey = `unary2${op}`;


### PR DESCRIPTION
BUG

The inputs data and output data types may be different. So we should use
setOutput instead of direclty assignement to process the different type casting.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3532)
<!-- Reviewable:end -->
