### PR TITLE
Add DEBUG_QUERY flag

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -615,7 +615,9 @@ export class Engine implements TensorTracker, DataMover {
     // Stop recording to a tape when running a kernel.
     this.scopedRun(
         () => this.state.kernelDepth++, () => this.state.kernelDepth--, () => {
-          if (!this.ENV.getBool('DEBUG')) {
+          const debugFlag =
+              this.ENV.getBool('DEBUG') || this.ENV.getBool('DEBUG_QUERY');
+          if (!debugFlag) {
             outputs = kernelFunc();
           } else {
             outputs = this.profiler.profileKernel(

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -33,6 +33,14 @@ ENV.registerFlag('DEBUG', () => false, debugValue => {
   }
 });
 
+/** Whether to enable debug query mode. */
+ENV.registerFlag('DEBUG_QUERY', () => false, debugValue => {
+  if (debugValue) {
+    console.warn('Debugging mode is ON. This significantly impacts ' +
+        'performance on WebGL but small impacts on WebGPU.');
+  }
+});
+
 /** Whether we are in a browser (as versus, say, node.js) environment. */
 ENV.registerFlag('IS_BROWSER', () => device_util.isBrowser());
 

--- a/tfjs-core/src/flags_test.ts
+++ b/tfjs-core/src/flags_test.ts
@@ -42,6 +42,30 @@ describe('DEBUG', () => {
   });
 });
 
+describe('DEBUG_QUERY', () => {
+  beforeEach(() => {
+    tf.env().reset();
+    spyOn(console, 'warn').and.callFake((msg: string) => {});
+  });
+  afterAll(() => tf.env().reset());
+
+  it('disabled by default', () => {
+    expect(tf.env().getBool('DEBUG_QUERY')).toBe(false);
+  });
+
+  it('warns when enabled', () => {
+    const consoleWarnSpy = console.warn as jasmine.Spy;
+    tf.env().set('DEBUG_QUERY', true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+    expect((consoleWarnSpy.calls.first().args[0] as string)
+               .startsWith('Debugging mode is ON. '))
+        .toBe(true);
+
+    expect(tf.env().getBool('DEBUG_QUERY')).toBe(true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+  });
+});
+
 // TODO (yassogba) figure out why this spy is not working / fix this test.
 describe('IS_BROWSER', () => {
   let isBrowser: boolean;


### PR DESCRIPTION
Fix: https://github.com/tensorflow/tfjs/issues/3551

This DEBUG_QUERY flag is used for getting performance data of each operators, so no read back and numerical error check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3552)
<!-- Reviewable:end -->
