### PR TITLE
Add HashTableV2, LookupTableV2Find

### DIFF
--- a/tfjs-converter/docs/supported_ops.md
+++ b/tfjs-converter/docs/supported_ops.md
@@ -100,6 +100,10 @@
 |TensorArrayFromTensor|TensorArrayFromTensor|
 |TensorArrayPushBack|TensorArrayPushBack|
 |TensorArrayPopBack|TensorArrayPopBack|
+|HashTable|hashTable|
+|HashTableV2|hashTableV2|
+|LookupTableFind|lookupTableFind|
+|LookupTableFindV2|lookupTableFindV2|
 
 ## Operations - Convolution
 

--- a/tfjs-converter/python/tensorflowjs/op_list/control.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/control.json
@@ -787,5 +787,129 @@
         "type": "dtype"
       }
     ]
+  },
+  {
+    "tfOpName": "HashTable",
+    "category": "control",
+    "inputs": [],
+    "attrs": [
+      {
+        "tfName": "shared_name",
+        "name": "sharedName",
+        "type": "string"
+      },
+      {
+        "tfName": "use_node_name_sharing",
+        "name": "useNodeNameSharing",
+        "type": "bool"
+      },
+      {
+        "tfName": "key_dtype",
+        "name": "keyDType",
+        "type": "dtype"
+      },
+      {
+        "tfName": "value_dtype",
+        "name": "valueDType",
+        "type": "dtype"
+      }
+    ]
+  },
+  {
+    "tfOpName": "HashTableV2",
+    "category": "control",
+    "inputs": [],
+    "attrs": [
+      {
+        "tfName": "shared_name",
+        "name": "sharedName",
+        "type": "string"
+      },
+      {
+        "tfName": "use_node_name_sharing",
+        "name": "useNodeNameSharing",
+        "type": "bool"
+      },
+      {
+        "tfName": "key_dtype",
+        "name": "keyDType",
+        "type": "dtype"
+      },
+      {
+        "tfName": "value_dtype",
+        "name": "valueDType",
+        "type": "dtype"
+      }
+    ]
+  },
+  {
+    "tfOpName": "LookupTableFind",
+    "category": "control",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "tableHandle",
+        "type": "tensor"
+      },
+      {
+        "start": 1,
+        "name": "keys",
+        "type": "tensor"
+      },
+      {
+        "start": 2,
+        "name": "defaultValue",
+        "type": "tensor"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "Tin",
+        "name": "tIn",
+        "type": "dtype",
+        "notSupported": true
+      },
+      {
+        "tfName": "Tout",
+        "name": "tOut",
+        "type": "dtype",
+        "notSupported": true
+      }
+    ]
+  },
+  {
+    "tfOpName": "LookupTableFindV2",
+    "category": "control",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "tableHandle",
+        "type": "tensor"
+      },
+      {
+        "start": 1,
+        "name": "keys",
+        "type": "tensor"
+      },
+      {
+        "start": 2,
+        "name": "defaultValue",
+        "type": "tensor"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "Tin",
+        "name": "tIn",
+        "type": "dtype",
+        "notSupported": true
+      },
+      {
+        "tfName": "Tout",
+        "name": "tOut",
+        "type": "dtype",
+        "notSupported": true
+      }
+    ]
   }
 ]

--- a/tfjs-converter/src/data/types.ts
+++ b/tfjs-converter/src/data/types.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 import {DataType, Tensor} from '@tensorflow/tfjs-core';
+
+import {HashTable} from '../executor/hash_table';
 import {TensorArray} from '../executor/tensor_array';
 import {TensorList} from '../executor/tensor_list';
 
@@ -33,6 +35,8 @@ export type TensorArrayMap = {
 export type TensorListMap = {
   [key: number]: TensorList
 };
+
+export type HashTableMap = Map<Tensor, HashTable>;
 
 export interface TensorInfo {
   name: string;

--- a/tfjs-converter/src/executor/execution_context.ts
+++ b/tfjs-converter/src/executor/execution_context.ts
@@ -16,8 +16,9 @@
  */
 import {Tensor} from '@tensorflow/tfjs-core';
 
-import {NamedTensorsMap, TensorArrayMap, TensorListMap} from '../data/types';
+import {HashTableMap, NamedTensorsMap, TensorArrayMap, TensorListMap} from '../data/types';
 
+import {HashTable} from './hash_table';
 import {TensorArray} from './tensor_array';
 import {TensorList} from './tensor_list';
 import {FunctionExecutor} from './types';
@@ -48,6 +49,7 @@ export class ExecutionContext {
       readonly weightMap: NamedTensorsMap = {},
       readonly tensorArrayMap: TensorArrayMap = {},
       readonly tensorListMap: TensorListMap = {},
+      readonly hashTableMap: HashTableMap = new Map<Tensor, HashTable>(),
       readonly functionMap: {[key: string]: FunctionExecutor} = {}) {
     this.generateCurrentContextIds();
   }
@@ -175,6 +177,14 @@ export class ExecutionContext {
     return this.tensorListMap[id];
   }
 
+  addHashTable(hashTable: HashTable) {
+    this.hashTableMap.set(hashTable.handle, hashTable);
+  }
+
+  getHashTable(handle: Tensor): HashTable {
+    return this.hashTableMap.get(handle);
+  }
+
   dispose() {
     for (const key in this.tensorArrayMap) {
       this.tensorArrayMap[key].clearAndClose();
@@ -183,5 +193,11 @@ export class ExecutionContext {
     for (const key in this.tensorListMap) {
       this.tensorListMap[key].clearAndClose();
     }
+
+    this.hashTableMap.forEach((hashTable, handle) => {
+      hashTable.clearAndClose();
+      handle.dispose();
+    });
+    this.hashTableMap.clear();
   }
 }

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -359,14 +359,16 @@ export class GraphExecutor implements FunctionExecutor {
 
   async executeFunctionAsync(
       inputs: Tensor[], tensorArrayMap: TensorArrayMap,
-      tensorListMap: TensorListMap): Promise<Tensor[]> {
+      tensorListMap: TensorListMap,
+      hashTableMap: HashTableMap): Promise<Tensor[]> {
     const mappedInputs = inputs.reduce((map, tensor, index) => {
       map[this.inputs[index].name] = tensor;
       return map;
     }, {} as NamedTensorMap);
 
     return this._executeAsync(
-        mappedInputs, this.outputNodes, true, tensorArrayMap, tensorListMap);
+        mappedInputs, this.outputNodes, true, tensorArrayMap, tensorListMap,
+        hashTableMap);
   }
   /**
    * When there are control flow nodes in the graph, the graph execution use

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -18,12 +18,13 @@
 import {DataType, NamedTensorMap, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 import {ISignatureDef} from '../data/compiled_api';
-import {NamedTensorsMap, TensorArrayMap, TensorInfo, TensorListMap} from '../data/types';
+import {HashTableMap, NamedTensorsMap, TensorArrayMap, TensorInfo, TensorListMap} from '../data/types';
 import {getNodeNameAndIndex, getParamValue, getTensor, getTensorsForCurrentContenxt, parseNodeName} from '../operations/executors/utils';
 import {executeOp} from '../operations/operation_executor';
 import {Graph, Node} from '../operations/types';
 
 import {ExecutionContext, ExecutionContextInfo} from './execution_context';
+import {HashTable} from './hash_table';
 import {getExecutionSubgraph, getNodesInTopologicalOrder, isControlFlow} from './model_analysis';
 import {FunctionExecutor} from './types';
 
@@ -194,9 +195,10 @@ export class GraphExecutor implements FunctionExecutor {
     }
     const tensorArrayMap: TensorArrayMap = {};
     const tensorListMap: TensorListMap = {};
+    const hashTableMap: HashTableMap = new Map<Tensor, HashTable>();
     return tidy(() => {
       const context = new ExecutionContext(
-          this.weightMap, tensorArrayMap, tensorListMap,
+          this.weightMap, tensorArrayMap, tensorListMap, hashTableMap,
           this.functionExecutorMap);
       const tensorsMap: NamedTensorsMap = {...this.weightMap};
       Object.keys(inputs).forEach(name => {
@@ -311,8 +313,9 @@ export class GraphExecutor implements FunctionExecutor {
    */
   private async _executeAsync(
       inputs: NamedTensorMap, outputs: string[], isFunctionExecution = false,
-      tensorArrayMap: TensorArrayMap = {},
-      tensorListMap: TensorListMap = {}): Promise<Tensor[]> {
+      tensorArrayMap: TensorArrayMap = {}, tensorListMap: TensorListMap = {},
+      hashTableMap: HashTableMap = new Map<Tensor, HashTable>()):
+      Promise<Tensor[]> {
     if (!isFunctionExecution) {
       inputs = this.mapInputs(inputs);
       this.checkInputs(inputs);
@@ -322,7 +325,7 @@ export class GraphExecutor implements FunctionExecutor {
     }
 
     const context = new ExecutionContext(
-        this.weightMap, tensorArrayMap, tensorListMap,
+        this.weightMap, tensorArrayMap, tensorListMap, hashTableMap,
         this.functionExecutorMap);
 
     // Graph with control flow op requires runtime evaluation of the execution

--- a/tfjs-converter/src/executor/hash_table.ts
+++ b/tfjs-converter/src/executor/hash_table.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {DataType, equal, keep, scalar, stack, Tensor, unstack, util} from '@tensorflow/tfjs-core';
+
+/**
+ * Hashtable contains a set of tensors, which can be accessed by key.
+ */
+export class HashTable {
+  readonly handle: Tensor;
+
+  private tensorMap: Map<Tensor, Tensor>;
+  private initialized_ = false;
+
+  /**
+   * Constructor of HashTable. Creates a non-initialized hash table.
+   *
+   * @param keyDType `dtype` of the table keys.
+   * @param valueDType `dtype` of the table values.
+   * @param sharedName Optional. Defaults to ''. The name used to share the
+   *     table.
+   * @param useNodeNameSharing Optional. Defaults to false. If true and
+   *     sharedName is empty, the table is shared using the node name.
+   * @param name Optional. Name of the node.
+   */
+  constructor(
+      readonly keyDType: DataType, readonly valueDType: DataType,
+      readonly sharedName: string = '',
+      readonly useNodeNameSharing: boolean = false,
+      readonly name: string = '') {
+    if (useNodeNameSharing && sharedName === '') {
+      this.handle = scalar(util.encodeString(name), 'string');
+    }
+
+    this.handle = scalar(util.encodeString(sharedName), 'string');
+
+    keep(this.handle);
+  }
+
+  get initialized(): boolean {
+    return this.initialized_;
+  }
+
+  /**
+   * Dispose the tensors and idTensor and clear the hashtable.
+   */
+  clearAndClose() {
+    this.tensorMap.clear();
+    this.handle.dispose();
+  }
+
+  /**
+   * The number of items in the hash table.
+   */
+  size(): number {
+    return this.tensorMap.size;
+  }
+
+  /**
+   * Looks up keys in a hash table, outputs the corresponding values.
+   *
+   * Performs batch lookups, for every element in the key tensor, `find`
+   * stacks the corresponding value into the return tensor. Each lookup takes
+   * O(n) time, n is the size of the table.
+   *
+   * If an element is not present in the table, the given `defaultValue` is
+   * used.
+   *
+   * @param keys Keys to look up. Must have the same type as the keys of the
+   *     table.
+   * @param defaultValue The scalar `defaultValue` is the value output for keys
+   *     not present in the table. It must also be of the same type as the
+   *     table values.
+   */
+  async find(keys: Tensor, defaultValue: Tensor): Promise<Tensor> {
+    const $keys = unstack(keys);
+
+    const result: Tensor[] = [];
+    for (let i = 0; i < $keys.length; i++) {
+      const key = $keys[i];
+      this.checkKeyAndValueTensor(key, defaultValue);
+
+      const value = await this.findWithDefault(key, defaultValue);
+
+      result.push(value);
+    }
+
+    return stack(result);
+  }
+
+  /**
+   * Initializes the table with associated keys and values.
+   * @param keys Keys to store in the hashtable.
+   * @param values Values to store in the hashtable.
+   */
+  initialize(keys: Tensor, values: Tensor) {
+    if (this.initialized_) {
+      throw new Error(`Hashtable ${this.sharedName} already initialized.`);
+    }
+
+    this.tensorMap = new Map<Tensor, Tensor>();
+    this.insert(keys, values);
+    this.initialized_ = true;
+  }
+
+  private insert(keys: Tensor, values: Tensor) {
+    const $keys = unstack(keys);
+    const $values = unstack(values);
+
+    for (let i = 0; i < $keys.length; i++) {
+      const key = $keys[i];
+      const value = $values[i];
+
+      this.checkKeyAndValueTensor(key, value);
+
+      if (this.tensorMap.has(key) && this.tensorMap.get(key) !== value) {
+        throw new Error(`HashTable ${this.sharedName} already has key ${key}`);
+      }
+
+      this.tensorMap.set(key, value);
+    }
+  }
+
+  private async findWithDefault(keyToFind: Tensor, defaultValue: Tensor):
+      Promise<Tensor> {
+    for (const [key, value] of this.tensorMap) {
+      const $isEqual = (await equal(key, keyToFind).data())[0];
+      if ($isEqual) {
+        return value;
+      }
+    }
+
+    return defaultValue;
+  }
+
+  private checkKeyAndValueTensor(key: Tensor, value: Tensor) {
+    if (key.dtype !== this.keyDType) {
+      throw new Error(
+          `Expect key dtype ${this.keyDType}, but got ` +
+          `${key.dtype}`);
+    }
+
+    if (value.dtype !== this.valueDType) {
+      throw new Error(
+          `Expect value dtype ${this.valueDType}, but got ` +
+          `${value.dtype}`);
+    }
+  }
+}

--- a/tfjs-converter/src/executor/types.ts
+++ b/tfjs-converter/src/executor/types.ts
@@ -17,7 +17,7 @@
 
 import {Tensor} from '@tensorflow/tfjs-core';
 
-import {NamedTensorsMap, TensorArrayMap, TensorListMap} from '../data/types';
+import {HashTableMap, NamedTensorsMap, TensorArrayMap, TensorListMap} from '../data/types';
 
 /**
  *
@@ -25,6 +25,7 @@ import {NamedTensorsMap, TensorArrayMap, TensorListMap} from '../data/types';
 export interface FunctionExecutor {
   executeFunctionAsync(
       inputs: Tensor[], tensorArrayMap: TensorArrayMap,
-      tensorListMap: TensorListMap): Promise<Tensor[]>;
+      tensorListMap: TensorListMap,
+      hashTableMap: HashTableMap): Promise<Tensor[]>;
   weightMap: NamedTensorsMap;
 }

--- a/tfjs-converter/src/operations/executors/control_executor.ts
+++ b/tfjs-converter/src/operations/executors/control_executor.ts
@@ -20,6 +20,7 @@ import {scalar} from '@tensorflow/tfjs-core';
 
 import {NamedTensorsMap} from '../../data/types';
 import {ExecutionContext} from '../../executor/execution_context';
+import {HashTable} from '../../executor/hash_table';
 import {TensorArray} from '../../executor/tensor_array';
 import {fromTensor, reserve, scatter, split} from '../../executor/tensor_list';
 import {InternalOpAsyncExecutor, Node} from '../types';
@@ -371,6 +372,35 @@ export const executeOp: InternalOpAsyncExecutor = async(
       const tensorList = split(splitTensor, lengths, elementShape);
       context.addTensorList(tensorList);
       return [tensorList.idTensor];
+    }
+    case 'HashTable':
+    case 'HashTableV2': {
+      const keyDType =
+          getParamValue('keyDType', node, tensorMap, context) as tfc.DataType;
+      const valueDType =
+          getParamValue('valueDType', node, tensorMap, context) as tfc.DataType;
+      const sharedName =
+          getParamValue('sharedName', node, tensorMap, context) as string;
+      const useNodeNameSharing =
+          getParamValue('useNodeNameSharing', node, tensorMap, context) as
+          boolean;
+
+      const hashTable = new HashTable(
+          keyDType, valueDType, sharedName, useNodeNameSharing, node.name);
+      context.addHashTable(hashTable);
+      return [hashTable.handle];
+    }
+    case 'LookupTableFind':
+    case 'LookupTableFindV2': {
+      const handle =
+          getParamValue('tableHandle', node, tensorMap, context) as tfc.Tensor;
+      const keys =
+          getParamValue('keys', node, tensorMap, context) as tfc.Tensor;
+      const defaultValue =
+          getParamValue('defaultValue', node, tensorMap, context) as tfc.Tensor;
+
+      const hashTable = context.getHashTable(handle);
+      return [await hashTable.find(keys, defaultValue)];
     }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);

--- a/tfjs-converter/src/operations/executors/control_executor.ts
+++ b/tfjs-converter/src/operations/executors/control_executor.ts
@@ -44,10 +44,12 @@ export const executeOp: InternalOpAsyncExecutor = async(
       const condValue = await cond.data();
       if (condValue[0]) {
         return context.functionMap[thenFunc].executeFunctionAsync(
-            args, context.tensorArrayMap, context.tensorListMap);
+            args, context.tensorArrayMap, context.tensorListMap,
+            context.hashTableMap);
       } else {
         return context.functionMap[elseFunc].executeFunctionAsync(
-            args, context.tensorArrayMap, context.tensorListMap);
+            args, context.tensorArrayMap, context.tensorListMap,
+            context.hashTableMap);
       }
     }
     case 'While':
@@ -62,7 +64,8 @@ export const executeOp: InternalOpAsyncExecutor = async(
       // Calculate the condition of the loop
       const condResult =
           (await context.functionMap[condFunc].executeFunctionAsync(
-              args, context.tensorArrayMap, context.tensorListMap));
+              args, context.tensorArrayMap, context.tensorListMap,
+              context.hashTableMap));
       const argIds = args.map(tensor => tensor.id);
       let condValue = await condResult[0].data();
       // Dispose the intermediate tensors for condition function
@@ -79,7 +82,8 @@ export const executeOp: InternalOpAsyncExecutor = async(
         const origResult = result;
         // Execution the body of the loop
         result = await context.functionMap[bodyFunc].executeFunctionAsync(
-            result, context.tensorArrayMap, context.tensorListMap);
+            result, context.tensorArrayMap, context.tensorListMap,
+            context.hashTableMap);
         const resultIds = result.map(tensor => tensor.id);
 
         // Dispose the intermediate tensor for body function that is not global
@@ -94,7 +98,8 @@ export const executeOp: InternalOpAsyncExecutor = async(
         // Recalcuate the condition of the loop using the latest results.
         const condResult =
             (await context.functionMap[condFunc].executeFunctionAsync(
-                result, context.tensorArrayMap, context.tensorListMap));
+                result, context.tensorArrayMap, context.tensorListMap,
+                context.hashTableMap));
         condValue = await condResult[0].data();
         // Dispose the intermediate tensors for condition function
         condResult.forEach(tensor => {

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -972,7 +972,7 @@ describe('control', () => {
   });
 
   describe('HashTable', () => {
-    it('should create new tensor on the context', async () => {
+    it('should create new tensor on the context.', async () => {
       node.op = 'HashTable';
       node.attrParams['name'] = createStrAttr('');
       node.attrParams['sharedName'] = createDtypeAttr('');
@@ -980,12 +980,17 @@ describe('control', () => {
       node.attrParams['keyDType'] = createDtypeAttr('string');
       node.attrParams['valueDType'] = createDtypeAttr('float32');
 
+      const before = tfc.memory().numTensors;
       const handle = (await executeOp(node, {}, context))[0];
+      const after = tfc.memory().numTensors;
+      // 1 handle tensor is created.
+      expect(after).toBe(before + 1);
+
       const hashTable = context.getHashTable(handle);
       expect(hashTable).toBeDefined();
       expect(hashTable.initialized).toEqual(false);
     });
-    it('should match json def', () => {
+    it('should match json def.', () => {
       node.op = 'HashTable';
       node.attrParams['sharedName'] = createStrAttr('');
       node.attrParams['useNodeNameSharing'] = createBoolAttr(false);
@@ -997,7 +1002,7 @@ describe('control', () => {
   });
 
   describe('HashTableV2', () => {
-    it('should create new tensor on the context', async () => {
+    it('should create new tensor on the context.', async () => {
       node.op = 'HashTableV2';
       node.attrParams['name'] = createStrAttr('');
       node.attrParams['sharedName'] = createDtypeAttr('');
@@ -1005,12 +1010,17 @@ describe('control', () => {
       node.attrParams['keyDType'] = createDtypeAttr('string');
       node.attrParams['valueDType'] = createDtypeAttr('float32');
 
+      const before = tfc.memory().numTensors;
       const handle = (await executeOp(node, {}, context))[0];
+      const after = tfc.memory().numTensors;
+      // 1 handle tensor is created.
+      expect(after).toBe(before + 1);
+
       const hashTable = context.getHashTable(handle);
       expect(hashTable).toBeDefined();
       expect(hashTable.initialized).toEqual(false);
     });
-    it('should match json def', () => {
+    it('should match json def.', () => {
       node.op = 'HashTableV2';
       node.attrParams['sharedName'] = createStrAttr('');
       node.attrParams['useNodeNameSharing'] = createBoolAttr(false);
@@ -1022,7 +1032,7 @@ describe('control', () => {
   });
 
   describe('LookupTableFind', () => {
-    it('should create new tensor on the context', async () => {
+    it('should create new tensor on the context.', async () => {
       const hashTable = new HashTable('int32', 'float32');
       const keys = tfc.tensor1d([1], 'int32');
       const values = tfc.tensor1d([5.5]);
@@ -1039,11 +1049,42 @@ describe('control', () => {
       const input3 = [tfc.tensor1d([1, 2], 'int32')];
       const input5 = [scalar(0)];
 
+      const before = tfc.memory().numTensors;
       const result = (await executeOp(node, {input2, input3, input5}, context));
+      const after = tfc.memory().numTensors;
       test_util.expectArraysClose(await result[0].data(), [5.5, 0]);
+      expect(after).toBe(before + 1);
     });
-    it('should match json def', () => {
-      node.op = 'LookupTableFindV2';
+    it('should throw if dtype doesnot match.', async (done) => {
+      const hashTable = new HashTable('int32', 'float32');
+      const keys = tfc.tensor1d([1], 'int32');
+      const values = tfc.tensor1d([5.5]);
+      hashTable.initialize(keys, values);
+      context.addHashTable(hashTable);
+      const handle = hashTable.handle;
+
+      node.op = 'LookupTableFind';
+      node.inputParams['tableHandle'] = createTensorAttr(0);
+      node.inputParams['keys'] = createTensorAttr(1);
+      node.inputParams['defaultValue'] = createTensorAttr(2);
+      node.inputNames = ['input2', 'input3', 'input5'];
+      const input2 = [handle];
+      const input3 = [tfc.tensor1d([1, 2], 'float32')];
+      const input5 = [scalar(0)];
+
+      const before = tfc.memory().numTensors;
+      try {
+        await executeOp(node, {input2, input3, input5}, context);
+        done.fail('Shoudl fail, succeed unexpectedly.');
+      } catch (err) {
+        expect(err).toMatch(/Expect key dtype/);
+      }
+      const after = tfc.memory().numTensors;
+      expect(after).toBe(before + 1);
+      done();
+    });
+    it('should match json def.', () => {
+      node.op = 'LookupTableFind';
       node.inputParams['tableHandle'] = createTensorAttr(0);
       node.inputParams['keys'] = createTensorAttr(1);
       node.inputParams['defaultValue'] = createTensorAttr(2);
@@ -1053,7 +1094,7 @@ describe('control', () => {
   });
 
   describe('LookupTableFindV2', () => {
-    it('should create new tensor on the context', async () => {
+    it('should create new tensor on the context.', async () => {
       const hashTable = new HashTable('int32', 'float32');
       const keys = tfc.tensor1d([1], 'int32');
       const values = tfc.tensor1d([5.5]);
@@ -1070,10 +1111,41 @@ describe('control', () => {
       const input3 = [tfc.tensor1d([1, 2], 'int32')];
       const input5 = [scalar(0)];
 
+      const before = tfc.memory().numTensors;
       const result = (await executeOp(node, {input2, input3, input5}, context));
+      const after = tfc.memory().numTensors;
       test_util.expectArraysClose(await result[0].data(), [5.5, 0]);
+      expect(after).toBe(before + 1);
     });
-    it('should match json def', () => {
+    it('should throw if dtype doesnot match.', async (done) => {
+      const hashTable = new HashTable('int32', 'float32');
+      const keys = tfc.tensor1d([1], 'int32');
+      const values = tfc.tensor1d([5.5]);
+      hashTable.initialize(keys, values);
+      context.addHashTable(hashTable);
+      const handle = hashTable.handle;
+
+      node.op = 'LookupTableFind';
+      node.inputParams['tableHandle'] = createTensorAttr(0);
+      node.inputParams['keys'] = createTensorAttr(1);
+      node.inputParams['defaultValue'] = createTensorAttr(2);
+      node.inputNames = ['input2', 'input3', 'input5'];
+      const input2 = [handle];
+      const input3 = [tfc.tensor1d([1, 2], 'float32')];
+      const input5 = [scalar(0)];
+
+      const before = tfc.memory().numTensors;
+      try {
+        await executeOp(node, {input2, input3, input5}, context);
+        done.fail('Shoudl fail, succeed unexpectedly.');
+      } catch (err) {
+        expect(err).toMatch(/Expect key dtype/);
+      }
+      const after = tfc.memory().numTensors;
+      expect(after).toBe(before + 1);
+      done();
+    });
+    it('should match json def.', () => {
       node.op = 'LookupTableFindV2';
       node.inputParams['tableHandle'] = createTensorAttr(0);
       node.inputParams['keys'] = createTensorAttr(1);

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -982,7 +982,9 @@ describe('control', () => {
       node.attrParams['valueDType'] = createDtypeAttr('float32');
 
       const handle = (await executeOp(node, {}, context))[0];
-      expect(context.getHashTable(handle)).toBeDefined();
+      const hashTable = context.getHashTable(handle);
+      expect(hashTable).toBeDefined();
+      expect(hashTable.initialized).toEqual(false);
     });
     it('should match json def', () => {
       node.op = 'HashTable';
@@ -1005,7 +1007,9 @@ describe('control', () => {
       node.attrParams['valueDType'] = createDtypeAttr('float32');
 
       const handle = (await executeOp(node, {}, context))[0];
-      expect(context.getHashTable(handle)).toBeDefined();
+      const hashTable = context.getHashTable(handle);
+      expect(hashTable).toBeDefined();
+      expect(hashTable.initialized).toEqual(false);
     });
     it('should match json def', () => {
       node.op = 'HashTableV2';
@@ -1020,9 +1024,9 @@ describe('control', () => {
 
   describe('LookupTableFindV2', () => {
     it('should create new tensor on the context', async () => {
-      const hashTable = new HashTable('string', 'float32');
-      const keys = tfc.tensor1d(['a']);
-      const values = tfc.tensor1d([1.0]);
+      const hashTable = new HashTable('int32', 'float32');
+      const keys = tfc.tensor1d([1], 'int32');
+      const values = tfc.tensor1d([5.5]);
       hashTable.initialize(keys, values);
       context.addHashTable(hashTable);
       const handle = hashTable.handle;
@@ -1033,11 +1037,11 @@ describe('control', () => {
       node.inputParams['defaultValue'] = createTensorAttr(2);
       node.inputNames = ['input2', 'input3', 'input5'];
       const input2 = [handle];
-      const input3 = [tfc.tensor1d(['a', 'b'], 'string')];
+      const input3 = [tfc.tensor1d([1, 2], 'int32')];
       const input5 = [scalar(0)];
 
       const result = (await executeOp(node, {input2, input3, input5}, context));
-      expectArraysClose(await result[0].data(), [1, 0]);
+      expectArraysClose(await result[0].data(), [5.5, 0]);
     });
     it('should match json def', () => {
       node.op = 'LookupTableFindV2';

--- a/tfjs-converter/src/operations/op_list/control.ts
+++ b/tfjs-converter/src/operations/op_list/control.ts
@@ -355,4 +355,68 @@ export const json: OpMapper[] = [
     'attrs':
         [{'tfName': 'element_dtype', 'name': 'elementDType', 'type': 'dtype'}]
   },
+  {
+    'tfOpName': 'HashTable',
+    'category': 'control',
+    'inputs': [],
+    'attrs': [
+      {'tfName': 'shared_name', 'name': 'sharedName', 'type': 'string'},
+      {
+        'tfName': 'use_node_name_sharing',
+        'name': 'useNodeNameSharing',
+        'type': 'bool'
+      },
+      {'tfName': 'key_dtype', 'name': 'keyDType', 'type': 'dtype'},
+      {'tfName': 'value_dtype', 'name': 'valueDType', 'type': 'dtype'},
+    ]
+  },
+  {
+    'tfOpName': 'HashTableV2',
+    'category': 'control',
+    'inputs': [],
+    'attrs': [
+      {'tfName': 'shared_name', 'name': 'sharedName', 'type': 'string'},
+      {
+        'tfName': 'use_node_name_sharing',
+        'name': 'useNodeNameSharing',
+        'type': 'bool'
+      },
+      {'tfName': 'key_dtype', 'name': 'keyDType', 'type': 'dtype'},
+      {'tfName': 'value_dtype', 'name': 'valueDType', 'type': 'dtype'},
+    ]
+  },
+  {
+    'tfOpName': 'LookupTableFind',
+    'category': 'control',
+    'inputs': [
+      {'start': 0, 'name': 'tableHandle', 'type': 'tensor'},
+      {'start': 1, 'name': 'keys', 'type': 'tensor'},
+      {'start': 2, 'name': 'defaultValue', 'type': 'tensor'}
+    ],
+    'attrs': [
+      {'tfName': 'Tin', 'name': 'tIn', 'type': 'dtype', 'notSupported': true}, {
+        'tfName': 'Tout',
+        'name': 'tOut',
+        'type': 'dtype',
+        'notSupported': true
+      }
+    ]
+  },
+  {
+    'tfOpName': 'LookupTableFindV2',
+    'category': 'control',
+    'inputs': [
+      {'start': 0, 'name': 'tableHandle', 'type': 'tensor'},
+      {'start': 1, 'name': 'keys', 'type': 'tensor'},
+      {'start': 2, 'name': 'defaultValue', 'type': 'tensor'}
+    ],
+    'attrs': [
+      {'tfName': 'Tin', 'name': 'tIn', 'type': 'dtype', 'notSupported': true}, {
+        'tfName': 'Tout',
+        'name': 'tOut',
+        'type': 'dtype',
+        'notSupported': true
+      }
+    ]
+  }
 ];

--- a/tfjs-converter/tsconfig.json
+++ b/tfjs-converter/tsconfig.json
@@ -7,6 +7,7 @@
     "node_modules/"
   ],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "downlevelIteration": true,
   }
 }

--- a/tfjs-converter/tsconfig.json
+++ b/tfjs-converter/tsconfig.json
@@ -8,6 +8,6 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "downlevelIteration": true,
+    "downlevelIteration": true
   }
 }

--- a/tfjs-converter/tsconfig.test.json
+++ b/tfjs-converter/tsconfig.test.json
@@ -7,6 +7,7 @@
     "node_modules/"
   ],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "downlevelIteration": true,
   }
 }

--- a/tfjs-converter/tsconfig.test.json
+++ b/tfjs-converter/tsconfig.test.json
@@ -8,6 +8,6 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "downlevelIteration": true,
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
Followed api:
HashTableV2: https://www.tensorflow.org/api_docs/python/tf/raw_ops/HashTableV2
LookupTableV2Find: https://www.tensorflow.org/api_docs/python/tf/raw_ops/LookupTableFindV2

Notes:
1. I'm debating the implementation of the table handle. The c++ version has a logic of using shared_name | node.name as the table handle, this is also part of the parameter list of HashTable api. I only partially implement this logic to use a string tensor as the handle. The real benefit of using string tensor though, is to allow the `HashTableMap` to be able to find the `HashTable` by if the key is "equal" to the handle. In tf, "equal" is same value, not shallow equal in Javascript. The use case of this is to allow models to take shared_name as model input, but this use case is only hypothetical. So to fully support using tf.equal to lookup resource, I need to revise the current implementation. Instead of using the Map.get() method, which does a shallow equal, I need to use the tf.equal and download the result of equal to check value. A better solution, however, is to use the tf.while_loop, but this is a much bigger change of how we implement context. I'm leaning toward not supporting the string handle because of all the architecture difference. If the hypothetical use case mentioned above does have a real requirement, we can implement the intermediate solution of just use tf.equal. For future, we can keep in mind to refactor context to something similar to resource manager.

2. There will be a separate PR or PRs to support string tensors in multiple ops, slice, unstack, and equal. Until then, the HashTable and LookupTableV2 ops can only support numeric tensors. Given that the LookupTable may be used quite often in language models, we will need to support string tensors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3576)
<!-- Reviewable:end -->
