### PR TITLE
[wasm] Modularize remaining kernels.

### DIFF
--- a/e2e/cloudbuild-release.yml
+++ b/e2e/cloudbuild-release.yml
@@ -1,29 +1,12 @@
 steps:
 
-# Install packages.
+# Release e2e flow.
 - name: 'node:10'
   dir: 'e2e'
-  entrypoint: 'yarn'
-  id: 'yarn'
-  args: ['install']
-
-# Build deps.
-- name: 'node:10'
-  dir: 'e2e'
-  entrypoint: 'yarn'
-  id: 'build-deps'
-  args: ['build-deps-ci']
-  waitFor: ['yarn']
-
-# Test.
-- name: 'node:10'
-  dir: 'e2e'
-  entrypoint: 'yarn'
-  id: 'test'
-  args: ['test-ci']
-  waitFor: ['build-deps']
-  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
-  secretEnv: ['BROWSERSTACK_KEY']
+  entrypoint: 'bash'
+  id: 'verdaccio'
+  args: ['./scripts/release-e2e.sh']
+  env: ['RELEASE=$_RELEASE']
 
 secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
@@ -32,7 +15,7 @@ secrets:
 timeout: 1800s
 logsBucket: 'gs://tfjs-build-logs'
 substitutions:
-  _NIGHTLY: ''
+  _RELEASE: ''
 options:
   logStreamingOption: 'STREAM_ON'
   substitution_option: 'ALLOW_LOOSE'

--- a/e2e/scripts/release-e2e.sh
+++ b/e2e/scripts/release-e2e.sh
@@ -55,32 +55,40 @@ set -x
 cd ..
 e2e_root_path=$PWD
 
-if [[ "$RELEASE" = true ]]; then
-  # ****************************************************************************
-  # First, install emsdk.
-  # ****************************************************************************
-  # tfjs-backend-wasm needs emsdk to build. emsdk install needs to be done
-  # before switch to local registry, otherwise some packages installation will
-  # fail.
-  # Todo(linazhao): Remove this once we have a custom docker with emsdk.
-  cd ..
-  git clone https://github.com/emscripten-core/emsdk.git
-  cd emsdk
-  ./emsdk install 1.39.15
-  ./emsdk activate 1.39.15
-  source ./emsdk_env.sh
-  cd $e2e_root_path
+# ****************************************************************************
+# First, install emsdk.
+# ****************************************************************************
+# tfjs-backend-wasm needs emsdk to build. emsdk install needs to be done
+# before switch to local registry, otherwise some packages installation will
+# fail.
+# Todo(linazhao): Remove this once we have a custom docker with emsdk.
+cd ..
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install 1.39.15
+./emsdk activate 1.39.15
+source ./emsdk_env.sh
+cd $e2e_root_path
 
-  # ****************************************************************************
-  # Second, publish the monorepo.
-  # ****************************************************************************
-  # Start the local NPM registry
-  startLocalRegistry "$e2e_root_path"/scripts/verdaccio.yaml
+# ****************************************************************************
+# Second, publish the monorepo.
+# ****************************************************************************
+# Start the local NPM registry
+startLocalRegistry "$e2e_root_path"/scripts/verdaccio.yaml
 
-  # Publish the monorepo and update package.json tfjs dependency to the
-  # published version.
-  "$e2e_root_path"/scripts/publish-tfjs-ci.sh
+# Publish the monorepo and update package.json tfjs dependency to the
+# published version.
+"$e2e_root_path"/scripts/publish-tfjs-ci.sh
 
-  # Cleanup
-  cleanup
-fi
+# ****************************************************************************
+# Third, install the packages from local registry.
+# ****************************************************************************
+yarn
+
+# ****************************************************************************
+# Fourth, run integration tests against locally published version.
+# ****************************************************************************
+yarn test-ci
+
+# Cleanup
+cleanup

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -20,7 +20,7 @@ set -e
 TAGS="#SMOKE"
 
 # Regression tests run in nightly builds.
-if [[ "$NIGHTLY" = true ]]; then
+if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
     TAGS="${TAGS},#REGRESSION"
 fi
 
@@ -45,7 +45,7 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
   cd ..
 fi
 
-if [ "$NIGHTLY" = true ]; then
+if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
   yarn run-browserstack --browsers=bs_safari_mac,bs_firefox_mac,win_10_chrome,bs_ios_11,bs_android_9 --tags $TAGS
 else

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -31,7 +31,7 @@ if [[ $RELEASE = true ]]; then
   # Release flow: Only run e2e release test, ignore unit tests in all other
   # directories.
   if [[ $DIR = "e2e" ]]; then
-    gcloud build submit . --config=$DIR/cloudbuild.yml \
+    gcloud build submit . --config=$DIR/cloudbuild-release.yml \
       --substitutions _RELEASE=$RELEASE
   fi
 else

--- a/tfjs-backend-wasm/src/kernels/Abs.ts
+++ b/tfjs-backend-wasm/src/kernels/Abs.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Abs, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const absConfig: KernelConfig = createUnaryKernelConfig('Abs');
+
+export const absConfig: KernelConfig = createUnaryKernelConfig(Abs);

--- a/tfjs-backend-wasm/src/kernels/Add.ts
+++ b/tfjs-backend-wasm/src/kernels/Add.ts
@@ -15,11 +15,11 @@
  * =============================================================================
  */
 
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Add, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 
 const supportsFullBroadcast = true;
 
 export const addConfig: KernelConfig =
-    createBinaryKernelConfig('Add', supportsFullBroadcast);
+    createBinaryKernelConfig(Add, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/AddN.ts
+++ b/tfjs-backend-wasm/src/kernels/AddN.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {AddN, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -52,7 +52,7 @@ function addn(args: {inputs: TensorInfo[], backend: BackendWasm}) {
 }
 
 export const addNConfig: KernelConfig = {
-  kernelName: 'AddN',
+  kernelName: AddN,
   backendName: 'wasm',
   setupFunc,
   kernelFunc: addn as {} as KernelFunc,

--- a/tfjs-backend-wasm/src/kernels/AddN.ts
+++ b/tfjs-backend-wasm/src/kernels/AddN.ts
@@ -26,7 +26,7 @@ let wasmFunc:
         void;
 
 function setupFunc(backend: BackendWasm): void {
-  wasmFunc = backend.wasm.cwrap('AddN', null /* void */, [
+  wasmFunc = backend.wasm.cwrap(AddN, null /* void */, [
     'array',   // input_ids
     'number',  // input_ids.length
     'number',  // dtype

--- a/tfjs-backend-wasm/src/kernels/ArgMax.ts
+++ b/tfjs-backend-wasm/src/kernels/ArgMax.ts
@@ -27,7 +27,7 @@ let wasmFunc: (
     outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmFunc = backend.wasm.cwrap('ArgMax', null /* void */, [
+  wasmFunc = backend.wasm.cwrap(ArgMax, null /* void */, [
     'number',  // x_id
     'number',  // dtype
     'number',  // outer_size

--- a/tfjs-backend-wasm/src/kernels/AvgPool.ts
+++ b/tfjs-backend-wasm/src/kernels/AvgPool.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {AvgPoolAttrs, AvgPoolInputs, backend_util, KernelConfig, KernelFunc, Tensor4D} from '@tensorflow/tfjs-core';
+import {AvgPool, AvgPoolAttrs, AvgPoolInputs, backend_util, KernelConfig, KernelFunc, Tensor4D} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -26,7 +26,7 @@ let wasmAvgPool: (
     strideWidth: number, channels: number, outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmAvgPool = backend.wasm.cwrap('AvgPool', null /* void */, [
+  wasmAvgPool = backend.wasm.cwrap(AvgPool, null /* void */, [
     'number',  // xId
     'number',  // batchSize
     'number',  // inputHeight
@@ -88,7 +88,7 @@ function avgPool(
 }
 
 export const avgPoolConfig: KernelConfig = {
-  kernelName: 'AvgPool',
+  kernelName: AvgPool,
   backendName: 'wasm',
   setupFunc: setup,
   kernelFunc: avgPool as {} as KernelFunc

--- a/tfjs-backend-wasm/src/kernels/BatchMatMul.ts
+++ b/tfjs-backend-wasm/src/kernels/BatchMatMul.ts
@@ -15,19 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {BatchMatMul, BatchMatMulAttrs, BatchMatMulInputs, KernelConfig, KernelFunc} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface BatchMatMulInputs extends NamedTensorInfoMap {
-  a: TensorInfo;
-  b: TensorInfo;
-}
-
-interface BatchMatMulAttrs extends NamedAttrMap {
-  transposeA: boolean;
-  transposeB: boolean;
-}
 
 let wasmBatchMatMul: (
     aId: number, aShape: Uint8Array, aShapeSize: number, bId: number,
@@ -35,7 +25,7 @@ let wasmBatchMatMul: (
     transposeB: boolean, outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmBatchMatMul = backend.wasm.cwrap('BatchMatMul', null /* void */, [
+  wasmBatchMatMul = backend.wasm.cwrap(BatchMatMul, null /* void */, [
     'number',  // a_id
     'array',   // a_shape
     'number',  // a_shape.length
@@ -83,8 +73,8 @@ function batchMatMul(args: {
 }
 
 export const batchMatMulConfig: KernelConfig = {
-  kernelName: 'BatchMatMul',
+  kernelName: BatchMatMul,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: batchMatMul
+  kernelFunc: batchMatMul as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Cast.ts
+++ b/tfjs-backend-wasm/src/kernels/Cast.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {DataType, KernelConfig, NamedAttrMap, NamedTensorInfoMap} from '@tensorflow/tfjs-core';
+import {Cast, DataType, KernelConfig, NamedAttrMap, NamedTensorInfoMap} from '@tensorflow/tfjs-core';
 import {TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
@@ -40,7 +40,7 @@ export function cast(
 }
 
 export const castConfig: KernelConfig = {
-  kernelName: 'Cast',
+  kernelName: Cast,
   backendName: 'wasm',
   kernelFunc: cast,
 };

--- a/tfjs-backend-wasm/src/kernels/Cast.ts
+++ b/tfjs-backend-wasm/src/kernels/Cast.ts
@@ -15,18 +15,10 @@
  * =============================================================================
  */
 
-import {Cast, DataType, KernelConfig, NamedAttrMap, NamedTensorInfoMap} from '@tensorflow/tfjs-core';
+import {Cast, CastAttrs, CastInputs, KernelConfig, KernelFunc} from '@tensorflow/tfjs-core';
 import {TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface CastInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
-
-interface CastAttrs extends NamedAttrMap {
-  dtype: DataType;
-}
 
 export function cast(
     args: {inputs: CastInputs, attrs: CastAttrs, backend: BackendWasm}):
@@ -42,5 +34,5 @@ export function cast(
 export const castConfig: KernelConfig = {
   kernelName: Cast,
   backendName: 'wasm',
-  kernelFunc: cast,
+  kernelFunc: cast as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/Concat.ts
+++ b/tfjs-backend-wasm/src/kernels/Concat.ts
@@ -15,16 +15,12 @@
  * =============================================================================
  */
 
-import {backend_util, KernelConfig, KernelFunc, NamedAttrMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, Concat, ConcatAttrs, ConcatInputs, KernelConfig, KernelFunc, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
-interface ConcatAttrs extends NamedAttrMap {
-  axis: number;
-}
-
 function concat(
-    args: {inputs: TensorInfo[], backend: BackendWasm, attrs: ConcatAttrs}) {
+    args: {inputs: ConcatInputs, backend: BackendWasm, attrs: ConcatAttrs}) {
   const {inputs, backend} = args;
 
   const axis = util.parseAxisParam(args.attrs.axis, inputs[0].shape)[0];
@@ -55,7 +51,7 @@ function concat(
 }
 
 export const concatConfig: KernelConfig = {
-  kernelName: 'Concat',
+  kernelName: Concat,
   backendName: 'wasm',
   kernelFunc: concat as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/Conv2D.ts
+++ b/tfjs-backend-wasm/src/kernels/Conv2D.ts
@@ -15,14 +15,9 @@
  * =============================================================================
  */
 
-import {backend_util, Conv2DAttrs, KernelConfig, KernelFunc, NamedTensorInfoMap, Tensor4D, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, Conv2D, Conv2DAttrs, Conv2DInputs, KernelConfig, KernelFunc, Tensor4D} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface Conv2DInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-  filter: TensorInfo;
-}
 
 let wasmConv2d: (
     xId: number, batchSize: number, inputHeight: number, inputWidth: number,
@@ -33,7 +28,7 @@ let wasmConv2d: (
     outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmConv2d = backend.wasm.cwrap('Conv2D', null /* void */, [
+  wasmConv2d = backend.wasm.cwrap(Conv2D, null /* void */, [
     'number',  // xId
     'number',  // batchSize
     'number',  // inputHeight
@@ -101,7 +96,7 @@ function conv2d(
 }
 
 export const conv2DConfig: KernelConfig = {
-  kernelName: 'Conv2D',
+  kernelName: Conv2D,
   backendName: 'wasm',
   setupFunc: setup,
   kernelFunc: conv2d as {} as KernelFunc

--- a/tfjs-backend-wasm/src/kernels/Conv2DBackpropInput.ts
+++ b/tfjs-backend-wasm/src/kernels/Conv2DBackpropInput.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, Conv2DBackpropInput, Conv2DBackpropInputAttrs, Conv2DBackpropInputInputs, KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, Conv2DBackpropInput, Conv2DBackpropInputAttrs, Conv2DBackpropInputInputs, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -63,13 +63,12 @@ function setup(backend: BackendWasm): void {
 
 function conv2DBackpropInput(args: {
   backend: BackendWasm,
-  inputs: NamedTensorInfoMap,
-  attrs: NamedAttrMap
+  inputs: Conv2DBackpropInputInputs,
+  attrs: Conv2DBackpropInputAttrs
 }): TensorInfo {
   const {backend, inputs, attrs} = args;
-  const {dy, filter} = inputs as Conv2DBackpropInputInputs;
-  const {strides, pad, dataFormat, dimRoundingMode, inputShape} =
-      attrs as {} as Conv2DBackpropInputAttrs;
+  const {dy, filter} = inputs;
+  const {strides, pad, dataFormat, dimRoundingMode, inputShape} = attrs;
 
   const dilations = 1;
 
@@ -125,5 +124,5 @@ export const conv2DBackpropInputConfig: KernelConfig = {
   kernelName: Conv2DBackpropInput,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: conv2DBackpropInput
+  kernelFunc: conv2DBackpropInput as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Cos.ts
+++ b/tfjs-backend-wasm/src/kernels/Cos.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Cos, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
 
-export const cosConfig: KernelConfig = createUnaryKernelConfig('Cos');
+export const cosConfig: KernelConfig = createUnaryKernelConfig(Cos);

--- a/tfjs-backend-wasm/src/kernels/CropAndResize.ts
+++ b/tfjs-backend-wasm/src/kernels/CropAndResize.ts
@@ -33,7 +33,7 @@ let wasmCropAndResize: (
     method: number, extrapolationValue: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmCropAndResize = backend.wasm.cwrap('CropAndResize', null /*void*/, [
+  wasmCropAndResize = backend.wasm.cwrap(CropAndResize, null /*void*/, [
     'number',  // imagesId
     'number',  // boxesId
     'number',  // boxIndId

--- a/tfjs-backend-wasm/src/kernels/CropAndResize.ts
+++ b/tfjs-backend-wasm/src/kernels/CropAndResize.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {CropAndResize, CropAndResizeAttrs, CropAndResizeInputs, KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {CropAndResize, CropAndResizeAttrs, CropAndResizeInputs, KernelConfig, KernelFunc, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -49,13 +49,12 @@ function setup(backend: BackendWasm): void {
 
 function cropAndResize(args: {
   backend: BackendWasm,
-  inputs: NamedTensorInfoMap,
-  attrs: NamedAttrMap
+  inputs: CropAndResizeInputs,
+  attrs: CropAndResizeAttrs
 }): TensorInfo {
   const {backend, inputs, attrs} = args;
-  const {method, extrapolationValue, cropSize} =
-      attrs as {} as CropAndResizeAttrs;
-  const {image, boxes, boxInd} = inputs as CropAndResizeInputs;
+  const {method, extrapolationValue, cropSize} = attrs;
+  const {image, boxes, boxInd} = inputs;
 
   const numBoxes = boxes.shape[0];
 
@@ -95,5 +94,5 @@ export const cropAndResizeConfig: KernelConfig = {
   kernelName: CropAndResize,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: cropAndResize
+  kernelFunc: cropAndResize as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/DepthwiseConv2dNative.ts
+++ b/tfjs-backend-wasm/src/kernels/DepthwiseConv2dNative.ts
@@ -15,14 +15,9 @@
  * =============================================================================
  */
 
-import {backend_util, DepthwiseConv2dNativeAttrs, KernelConfig, KernelFunc, NamedTensorInfoMap, Tensor4D, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, DepthwiseConv2dNative, DepthwiseConv2dNativeAttrs, DepthwiseConv2dNativeInputs, KernelConfig, KernelFunc, Tensor4D} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface DepthwiseConv2DInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-  filter: TensorInfo;
-}
 
 let wasmDepthwiseConv2d: (
     xId: number, batchSize: number, inputHeight: number, inputWidth: number,
@@ -34,7 +29,7 @@ let wasmDepthwiseConv2d: (
 
 function setup(backend: BackendWasm) {
   wasmDepthwiseConv2d =
-      backend.wasm.cwrap('DepthwiseConv2dNative', null /* void */, [
+      backend.wasm.cwrap(DepthwiseConv2dNative, null /* void */, [
         'number',  // xId
         'number',  // batchSize
         'number',  // inputHeight
@@ -58,7 +53,7 @@ function setup(backend: BackendWasm) {
 }
 
 function depthwiseConv2d(args: {
-  inputs: DepthwiseConv2DInputs,
+  inputs: DepthwiseConv2dNativeInputs,
   backend: BackendWasm,
   attrs: DepthwiseConv2dNativeAttrs
 }) {
@@ -108,7 +103,7 @@ function depthwiseConv2d(args: {
 }
 
 export const depthwiseConv2DNativeConfig: KernelConfig = {
-  kernelName: 'DepthwiseConv2dNative',
+  kernelName: DepthwiseConv2dNative,
   backendName: 'wasm',
   setupFunc: setup,
   kernelFunc: depthwiseConv2d as {} as KernelFunc

--- a/tfjs-backend-wasm/src/kernels/Div.ts
+++ b/tfjs-backend-wasm/src/kernels/Div.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Div, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
+
 const supportsFullBroadcast = true;
 export const divConfig: KernelConfig =
-    createBinaryKernelConfig('Div', supportsFullBroadcast);
+    createBinaryKernelConfig(Div, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Equal.ts
+++ b/tfjs-backend-wasm/src/kernels/Equal.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Equal, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
+
 const supportsFullBroadcast = false;
 export const equalConfig: KernelConfig =
-    createBinaryKernelConfig('Equal', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(Equal, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/Exp.ts
+++ b/tfjs-backend-wasm/src/kernels/Exp.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Exp, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const expConfig: KernelConfig = createUnaryKernelConfig('Exp');
+
+export const expConfig: KernelConfig = createUnaryKernelConfig(Exp);

--- a/tfjs-backend-wasm/src/kernels/FloorDiv.ts
+++ b/tfjs-backend-wasm/src/kernels/FloorDiv.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {FloorDiv, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
+
 const supportsFullBroadcast = false;
 export const floorDivConfig: KernelConfig =
-    createBinaryKernelConfig('FloorDiv', supportsFullBroadcast);
+    createBinaryKernelConfig(FloorDiv, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/FusedBatchNorm.ts
+++ b/tfjs-backend-wasm/src/kernels/FusedBatchNorm.ts
@@ -15,21 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {FusedBatchNorm, FusedBatchNormAttrs, FusedBatchNormInputs, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface BatchNormInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-  mean: TensorInfo;
-  variance: TensorInfo;
-  offset: TensorInfo;
-  scale: TensorInfo;
-}
-
-interface BatchNormAttrs extends NamedAttrMap {
-  varianceEpsilon: number;
-}
 
 let wasmBatchNorm: (
     xId: number, meanId: number, varianceId: number, offsetId: number,
@@ -37,14 +25,15 @@ let wasmBatchNorm: (
 
 function setup(backend: BackendWasm): void {
   wasmBatchNorm = backend.wasm.cwrap(
-      'FusedBatchNorm', null /* void */,
+      FusedBatchNorm, null /* void */,
       ['number', 'number', 'number', 'number', 'number', 'number', 'number']);
 }
 
-function fusedBatchNorm(
-    args:
-        {backend: BackendWasm, inputs: BatchNormInputs, attrs: BatchNormAttrs}):
-    TensorInfo {
+function fusedBatchNorm(args: {
+  backend: BackendWasm,
+  inputs: FusedBatchNormInputs,
+  attrs: FusedBatchNormAttrs
+}): TensorInfo {
   const {backend, inputs, attrs} = args;
   const {varianceEpsilon} = attrs;
   const {x, mean, variance, offset, scale} = inputs;
@@ -68,8 +57,8 @@ function fusedBatchNorm(
 }
 
 export const fusedBatchNormConfig: KernelConfig = {
-  kernelName: 'FusedBatchNorm',
+  kernelName: FusedBatchNorm,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: fusedBatchNorm
+  kernelFunc: fusedBatchNorm as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-wasm/src/kernels/FusedConv2D.ts
@@ -31,7 +31,7 @@ let wasmFusedConv2d: (
     preluActivationWeightsId: number, outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmFusedConv2d = backend.wasm.cwrap('FusedConv2D', null /* void */, [
+  wasmFusedConv2d = backend.wasm.cwrap(FusedConv2D, null /* void */, [
     'number',  // xId
     'number',  // batchSize
     'number',  // inputHeight

--- a/tfjs-backend-wasm/src/kernels/GatherNd.ts
+++ b/tfjs-backend-wasm/src/kernels/GatherNd.ts
@@ -27,7 +27,7 @@ let wasmGatherNd: (
     void;
 
 function setup(backend: BackendWasm): void {
-  wasmGatherNd = backend.wasm.cwrap('GatherNd', null /*void*/, [
+  wasmGatherNd = backend.wasm.cwrap(GatherNd, null /*void*/, [
     'number',  // xId
     'number',  // dtype
     'number',  // indicesId

--- a/tfjs-backend-wasm/src/kernels/Greater.ts
+++ b/tfjs-backend-wasm/src/kernels/Greater.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {Greater, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
+
 const supportsFullBroadcast = false;
 export const greaterConfig: KernelConfig =
-    createBinaryKernelConfig('Greater', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(Greater, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/GreaterEqual.ts
+++ b/tfjs-backend-wasm/src/kernels/GreaterEqual.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {GreaterEqual, KernelConfig} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
+
 const supportsFullBroadcast = false;
 export const greaterEqualConfig: KernelConfig =
-    createBinaryKernelConfig('GreaterEqual', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(GreaterEqual, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/Less.ts
+++ b/tfjs-backend-wasm/src/kernels/Less.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Less} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const lessConfig: KernelConfig =
-    createBinaryKernelConfig('Less', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(Less, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/LessEqual.ts
+++ b/tfjs-backend-wasm/src/kernels/LessEqual.ts
@@ -15,9 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, LessEqual} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const lessEqualConfig: KernelConfig =
-    createBinaryKernelConfig('LessEqual', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(LessEqual, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/Log.ts
+++ b/tfjs-backend-wasm/src/kernels/Log.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Log} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const logConfig: KernelConfig = createUnaryKernelConfig('Log');
+export const logConfig: KernelConfig = createUnaryKernelConfig(Log);

--- a/tfjs-backend-wasm/src/kernels/LogicalAnd.ts
+++ b/tfjs-backend-wasm/src/kernels/LogicalAnd.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, LogicalAnd} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const logicalAndConfig: KernelConfig =
-    createBinaryKernelConfig('LogicalAnd', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(LogicalAnd, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/Max.ts
+++ b/tfjs-backend-wasm/src/kernels/Max.ts
@@ -25,8 +25,7 @@ import {permuteAxesAndTranspose} from './kernel_utils';
 let wasmMax: (xId: number, reduceSize: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmMax =
-      backend.wasm.cwrap('Max', null /*void*/, ['number, number, number']);
+  wasmMax = backend.wasm.cwrap(Max, null /*void*/, ['number, number, number']);
 }
 
 function max(args: {backend: BackendWasm, inputs: MaxInputs, attrs: MaxAttrs}):

--- a/tfjs-backend-wasm/src/kernels/MaxPool.ts
+++ b/tfjs-backend-wasm/src/kernels/MaxPool.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, KernelConfig, KernelFunc, MaxPoolAttrs, MaxPoolInputs, Tensor4D} from '@tensorflow/tfjs-core';
+import {backend_util, KernelConfig, KernelFunc, MaxPool, MaxPoolAttrs, MaxPoolInputs, Tensor4D} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -27,7 +27,7 @@ let wasmMaxPool: (
     inputChannels: number, outputChannels: number, outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmMaxPool = backend.wasm.cwrap('MaxPool', null /* void */, [
+  wasmMaxPool = backend.wasm.cwrap(MaxPool, null /* void */, [
     'number',  // xId
     'number',  // batchSize
     'number',  // inputHeight
@@ -89,7 +89,7 @@ function maxPool(
 }
 
 export const maxPoolConfig: KernelConfig = {
-  kernelName: 'MaxPool',
+  kernelName: MaxPool,
   backendName: 'wasm',
   setupFunc: setup,
   kernelFunc: maxPool as {} as KernelFunc

--- a/tfjs-backend-wasm/src/kernels/Maximum.ts
+++ b/tfjs-backend-wasm/src/kernels/Maximum.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Maximum} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const maximumConfig: KernelConfig =
-    createBinaryKernelConfig('Maximum', supportsFullBroadcast);
+    createBinaryKernelConfig(Maximum, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Min.ts
+++ b/tfjs-backend-wasm/src/kernels/Min.ts
@@ -24,8 +24,7 @@ import {permuteAxesAndTranspose} from './kernel_utils';
 let wasmMin: (xId: number, reduceSize: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmMin =
-      backend.wasm.cwrap('Min', null /*void*/, ['number, number, number']);
+  wasmMin = backend.wasm.cwrap(Min, null /*void*/, ['number, number, number']);
 }
 
 function min(args: {backend: BackendWasm, inputs: MinInputs, attrs: MinAttrs}):

--- a/tfjs-backend-wasm/src/kernels/Minimum.ts
+++ b/tfjs-backend-wasm/src/kernels/Minimum.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Minimum} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const minimumConfig: KernelConfig =
-    createBinaryKernelConfig('Minimum', supportsFullBroadcast);
+    createBinaryKernelConfig(Minimum, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Negate.ts
+++ b/tfjs-backend-wasm/src/kernels/Negate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Negate} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const negateConfig: KernelConfig = createUnaryKernelConfig('Negate');
+export const negateConfig: KernelConfig = createUnaryKernelConfig(Negate);

--- a/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV3.ts
+++ b/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV3.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, NamedAttrMap, NamedTensorInfoMap, NonMaxSuppressionV3, NonMaxSuppressionV3Attrs, NonMaxSuppressionV3Inputs, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, NonMaxSuppressionV3, NonMaxSuppressionV3Attrs, NonMaxSuppressionV3Inputs, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 

--- a/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV3.ts
+++ b/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV3.ts
@@ -15,22 +15,11 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, NamedAttrMap, NamedTensorInfoMap, NonMaxSuppressionV3, NonMaxSuppressionV3Attrs, NonMaxSuppressionV3Inputs, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 import {parseResultStruct} from './NonMaxSuppression_util';
-
-interface NonMaxSuppressionInputs extends NamedTensorInfoMap {
-  boxes: TensorInfo;
-  scores: TensorInfo;
-}
-
-interface NonMaxSuppressionAttrs extends NamedAttrMap {
-  maxOutputSize: number;
-  iouThreshold: number;
-  scoreThreshold: number;
-}
 
 let wasmFunc: (
     boxesId: number, scoresId: number, maxOutputSize: number,
@@ -38,7 +27,7 @@ let wasmFunc: (
 
 function setup(backend: BackendWasm): void {
   wasmFunc = backend.wasm.cwrap(
-      'NonMaxSuppressionV3',
+      NonMaxSuppressionV3,
       'number',  // Result*
       [
         'number',  // boxesId
@@ -51,8 +40,8 @@ function setup(backend: BackendWasm): void {
 
 function kernelFunc(args: {
   backend: BackendWasm,
-  inputs: NonMaxSuppressionInputs,
-  attrs: NonMaxSuppressionAttrs
+  inputs: NonMaxSuppressionV3Inputs,
+  attrs: NonMaxSuppressionV3Attrs
 }): TensorInfo {
   const {backend, inputs, attrs} = args;
   const {iouThreshold, maxOutputSize, scoreThreshold} = attrs;
@@ -78,8 +67,8 @@ function kernelFunc(args: {
 }
 
 export const nonMaxSuppressionV3Config: KernelConfig = {
-  kernelName: 'NonMaxSuppressionV3',
+  kernelName: NonMaxSuppressionV3,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc,
+  kernelFunc: kernelFunc as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV5.ts
+++ b/tfjs-backend-wasm/src/kernels/NonMaxSuppressionV5.ts
@@ -15,23 +15,11 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, NonMaxSuppressionV5, NonMaxSuppressionV5Attrs, NonMaxSuppressionV5Inputs, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 import {parseResultStruct} from './NonMaxSuppression_util';
-
-interface NonMaxSuppressionInputs extends NamedTensorInfoMap {
-  boxes: TensorInfo;
-  scores: TensorInfo;
-}
-
-interface NonMaxSuppressionAttrs extends NamedAttrMap {
-  maxOutputSize: number;
-  iouThreshold: number;
-  scoreThreshold: number;
-  softNmsSigma: number;
-}
 
 let wasmFunc:
     (boxesId: number, scoresId: number, maxOutputSize: number,
@@ -40,7 +28,7 @@ let wasmFunc:
 
 function setup(backend: BackendWasm): void {
   wasmFunc = backend.wasm.cwrap(
-      'NonMaxSuppressionV5',
+      NonMaxSuppressionV5,
       'number',  // Result*
       [
         'number',  // boxesId
@@ -54,8 +42,8 @@ function setup(backend: BackendWasm): void {
 
 function kernelFunc(args: {
   backend: BackendWasm,
-  inputs: NonMaxSuppressionInputs,
-  attrs: NonMaxSuppressionAttrs
+  inputs: NonMaxSuppressionV5Inputs,
+  attrs: NonMaxSuppressionV5Attrs
 }): TensorInfo[] {
   const {backend, inputs, attrs} = args;
   const {iouThreshold, maxOutputSize, scoreThreshold, softNmsSigma} = attrs;
@@ -84,8 +72,8 @@ function kernelFunc(args: {
 }
 
 export const nonMaxSuppressionV5Config: KernelConfig = {
-  kernelName: 'NonMaxSuppressionV5',
+  kernelName: NonMaxSuppressionV5,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc,
+  kernelFunc: kernelFunc as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/NotEqual.ts
+++ b/tfjs-backend-wasm/src/kernels/NotEqual.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, NotEqual} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const notEqualConfig: KernelConfig =
-    createBinaryKernelConfig('NotEqual', supportsFullBroadcast, 'bool');
+    createBinaryKernelConfig(NotEqual, supportsFullBroadcast, 'bool');

--- a/tfjs-backend-wasm/src/kernels/OneHot.ts
+++ b/tfjs-backend-wasm/src/kernels/OneHot.ts
@@ -24,7 +24,7 @@ let wasmOneHot: (
     outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmOneHot = backend.wasm.cwrap('OneHot', null /* void */, [
+  wasmOneHot = backend.wasm.cwrap(OneHot, null /* void */, [
     'number',  // indices_id
     'number',  // depth,
     'number',  // onValue

--- a/tfjs-backend-wasm/src/kernels/OnesLike.ts
+++ b/tfjs-backend-wasm/src/kernels/OnesLike.ts
@@ -15,13 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, OnesLike, OnesLikeInputs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface OnesLikeInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
 
 function onesLike(args: {inputs: OnesLikeInputs, backend: BackendWasm}) {
   const {inputs: {x}, backend} = args;
@@ -32,7 +28,7 @@ function onesLike(args: {inputs: OnesLikeInputs, backend: BackendWasm}) {
 }
 
 export const onesLikeConfig: KernelConfig = {
-  kernelName: 'OnesLike',
+  kernelName: OnesLike,
   backendName: 'wasm',
   kernelFunc: onesLike as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/Pow.ts
+++ b/tfjs-backend-wasm/src/kernels/Pow.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Pow} from '@tensorflow/tfjs-core';
 
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = false;
 export const powConfig: KernelConfig =
-    createBinaryKernelConfig('Pow', supportsFullBroadcast);
+    createBinaryKernelConfig(Pow, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Prelu.ts
+++ b/tfjs-backend-wasm/src/kernels/Prelu.ts
@@ -15,20 +15,14 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedTensorInfoMap} from '@tensorflow/tfjs-core';
-import {TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, Prelu, PreluInputs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface PreluInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-  alpha: TensorInfo;
-}
 
 let wasmPrelu: (xId: number, weightsId: number, outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmPrelu = backend.wasm.cwrap('Prelu', null /* void */, [
+  wasmPrelu = backend.wasm.cwrap(Prelu, null /* void */, [
     'number',  // x_id
     'number',  // weights_id
     'number'   // out_id
@@ -48,8 +42,8 @@ function prelu(args: {inputs: PreluInputs, backend: BackendWasm}) {
 }
 
 export const preluConfig: KernelConfig = {
-  kernelName: 'Prelu',
+  kernelName: Prelu,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: prelu
+  kernelFunc: prelu as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Relu.ts
+++ b/tfjs-backend-wasm/src/kernels/Relu.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Relu} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const reluConfig: KernelConfig = createUnaryKernelConfig('Relu');
+export const reluConfig: KernelConfig = createUnaryKernelConfig(Relu);

--- a/tfjs-backend-wasm/src/kernels/Relu6.ts
+++ b/tfjs-backend-wasm/src/kernels/Relu6.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Relu6} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const relu6Config: KernelConfig = createUnaryKernelConfig('Relu6');
+export const relu6Config: KernelConfig = createUnaryKernelConfig(Relu6);

--- a/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
+++ b/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, ResizeBilinear, ResizeBilinearAttrs, ResizeBilinearInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, ResizeBilinear, ResizeBilinearAttrs, ResizeBilinearInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -42,13 +42,13 @@ function setup(backend: BackendWasm): void {
 
 function resizeBilinear(args: {
   backend: BackendWasm,
-  inputs: NamedTensorInfoMap,
-  attrs: NamedAttrMap
+  inputs: ResizeBilinearInputs,
+  attrs: ResizeBilinearAttrs
 }): TensorInfo {
   const {backend, inputs, attrs} = args;
 
-  const {images} = inputs as ResizeBilinearInputs;
-  const {alignCorners, size} = attrs as {} as ResizeBilinearAttrs;
+  const {images} = inputs;
+  const {alignCorners, size} = attrs;
   const [newHeight, newWidth] = size;
 
   const [batch, oldHeight, oldWidth, numChannels] = images.shape;
@@ -84,5 +84,5 @@ export const resizeBilinearConfig: KernelConfig = {
   kernelName: ResizeBilinear,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: resizeBilinear
+  kernelFunc: resizeBilinear as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
+++ b/tfjs-backend-wasm/src/kernels/ResizeBilinear.ts
@@ -27,7 +27,7 @@ let wasmResizeBilinear: (
     alignCorners: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmResizeBilinear = backend.wasm.cwrap('ResizeBilinear', null /*void*/, [
+  wasmResizeBilinear = backend.wasm.cwrap(ResizeBilinear, null /*void*/, [
     'number',  // xId
     'number',  // batch
     'number',  // oldHeight

--- a/tfjs-backend-wasm/src/kernels/Rsqrt.ts
+++ b/tfjs-backend-wasm/src/kernels/Rsqrt.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Rsqrt} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const rsqrtConfig: KernelConfig = createUnaryKernelConfig('Rsqrt');
+export const rsqrtConfig: KernelConfig = createUnaryKernelConfig(Rsqrt);

--- a/tfjs-backend-wasm/src/kernels/ScatterNd.ts
+++ b/tfjs-backend-wasm/src/kernels/ScatterNd.ts
@@ -27,7 +27,7 @@ let wasmScatterNd: (
     outputSize: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmScatterNd = backend.wasm.cwrap('ScatterNd', null /*void*/, [
+  wasmScatterNd = backend.wasm.cwrap(ScatterNd, null /*void*/, [
     'number',  // indicesId
     'number',  // updatesId
     'number',  // dtype

--- a/tfjs-backend-wasm/src/kernels/SelectV2.ts
+++ b/tfjs-backend-wasm/src/kernels/SelectV2.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedTensorInfoMap, SelectV2, SelectV2Inputs, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, SelectV2, SelectV2Inputs, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -33,9 +33,9 @@ function setup(backend: BackendWasm) {
   ]);
 }
 
-function select(args: {inputs: NamedTensorInfoMap, backend: BackendWasm}) {
+function select(args: {inputs: SelectV2Inputs, backend: BackendWasm}) {
   const {inputs, backend} = args;
-  const {condition, t, e} = inputs as {} as SelectV2Inputs;
+  const {condition, t, e} = inputs;
 
   const conditionId = backend.dataIdMap.get(condition.dataId).id;
   const tId = backend.dataIdMap.get(t.dataId).id;
@@ -57,6 +57,6 @@ function select(args: {inputs: NamedTensorInfoMap, backend: BackendWasm}) {
 export const selectV2Config: KernelConfig = {
   kernelName: SelectV2,
   backendName: 'wasm',
-  kernelFunc: select,
+  kernelFunc: select as {} as KernelFunc,
   setupFunc: setup
 };

--- a/tfjs-backend-wasm/src/kernels/Sigmoid.ts
+++ b/tfjs-backend-wasm/src/kernels/Sigmoid.ts
@@ -15,13 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, NamedTensorInfoMap, Sigmoid, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, Sigmoid, SigmoidInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface SigmoidInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
 
 let wasmFunc: (xId: number, outId: number) => void;
 

--- a/tfjs-backend-wasm/src/kernels/Sigmoid.ts
+++ b/tfjs-backend-wasm/src/kernels/Sigmoid.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedTensorInfoMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, NamedTensorInfoMap, Sigmoid, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -26,8 +26,7 @@ interface SigmoidInputs extends NamedTensorInfoMap {
 let wasmFunc: (xId: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmFunc =
-      backend.wasm.cwrap('Sigmoid', null /* void */, ['number', 'number']);
+  wasmFunc = backend.wasm.cwrap(Sigmoid, null /* void */, ['number', 'number']);
 }
 
 function sigmoid(args: {backend: BackendWasm, inputs: SigmoidInputs}):
@@ -50,5 +49,5 @@ export const sigmoidConfig: KernelConfig = {
   kernelName: 'Sigmoid',
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: sigmoid
+  kernelFunc: sigmoid as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Sin.ts
+++ b/tfjs-backend-wasm/src/kernels/Sin.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Sin} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const sinConfig: KernelConfig = createUnaryKernelConfig('Sin');
+export const sinConfig: KernelConfig = createUnaryKernelConfig(Sin);

--- a/tfjs-backend-wasm/src/kernels/Slice.ts
+++ b/tfjs-backend-wasm/src/kernels/Slice.ts
@@ -15,19 +15,10 @@
  * =============================================================================
  */
 
-import {backend_util, buffer, KernelConfig, NamedAttrMap, NamedTensorInfoMap, slice_util, Tensor, util} from '@tensorflow/tfjs-core';
+import {backend_util, buffer, KernelConfig, KernelFunc, Slice, slice_util, SliceAttrs, SliceInputs, Tensor, util} from '@tensorflow/tfjs-core';
 import {TensorInfo} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface SliceInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
-
-interface SliceAttrs extends NamedAttrMap {
-  begin: number[];
-  size: number[];
-}
 
 export function slice(
     args: {inputs: SliceInputs, attrs: SliceAttrs, backend: BackendWasm}) {
@@ -136,7 +127,7 @@ function genericSliceSlow(
 }
 
 export const sliceConfig: KernelConfig = {
-  kernelName: 'Slice',
+  kernelName: Slice,
   backendName: 'wasm',
-  kernelFunc: slice,
+  kernelFunc: slice as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/Softmax.ts
+++ b/tfjs-backend-wasm/src/kernels/Softmax.ts
@@ -15,23 +15,15 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, Softmax, SoftmaxAttrs, SoftmaxInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface SoftmaxInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
-
-interface SoftmaxAttrs extends NamedAttrMap {
-  dim: number;
-}
 
 let wasmFunc: (xId: number, outId: number, channels: number, batch: number) =>
     void;
 
 function setup(backend: BackendWasm): void {
-  wasmFunc = backend.wasm.cwrap('Softmax', null /* void */, [
+  wasmFunc = backend.wasm.cwrap(Softmax, null /* void */, [
     'number',  // xId
     'number',  // outId
     'number',  // channels
@@ -60,8 +52,8 @@ function softmax(
 }
 
 export const softmaxConfig: KernelConfig = {
-  kernelName: 'Softmax',
+  kernelName: Softmax,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: softmax
+  kernelFunc: softmax as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Split.ts
+++ b/tfjs-backend-wasm/src/kernels/Split.ts
@@ -15,21 +15,18 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, SplitV, SplitVAttrs, SplitVInputs, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, SplitV, SplitVAttrs, SplitVInputs, util} from '@tensorflow/tfjs-core';
 import {backend_util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 import {slice} from './Slice';
 
-export function split(args: {
-  inputs: NamedTensorInfoMap,
-  attrs: NamedAttrMap,
-  backend: BackendWasm
-}) {
+export function split(
+    args: {inputs: SplitVInputs, attrs: SplitVAttrs, backend: BackendWasm}) {
   const {inputs, attrs, backend} = args;
-  const {x} = inputs as {} as SplitVInputs;
-  const {numOrSizeSplits, axis} = attrs as {} as SplitVAttrs;
+  const {x} = inputs;
+  const {numOrSizeSplits, axis} = attrs;
 
   const $axis = util.parseAxisParam(axis, x.shape)[0];
 
@@ -49,5 +46,5 @@ export function split(args: {
 export const splitVConfig: KernelConfig = {
   kernelName: SplitV,
   backendName: 'wasm',
-  kernelFunc: split
+  kernelFunc: split as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Sqrt.ts
+++ b/tfjs-backend-wasm/src/kernels/Sqrt.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Sqrt} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const sqrtConfig: KernelConfig = createUnaryKernelConfig('Sqrt');
+export const sqrtConfig: KernelConfig = createUnaryKernelConfig(Sqrt);

--- a/tfjs-backend-wasm/src/kernels/Square.ts
+++ b/tfjs-backend-wasm/src/kernels/Square.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Square} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const squareConfig: KernelConfig = createUnaryKernelConfig('Square');
+export const squareConfig: KernelConfig = createUnaryKernelConfig(Square);

--- a/tfjs-backend-wasm/src/kernels/Sub.ts
+++ b/tfjs-backend-wasm/src/kernels/Sub.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Sub} from '@tensorflow/tfjs-core';
 import {createBinaryKernelConfig} from './binary_kernel';
 const supportsFullBroadcast = true;
 export const subConfig: KernelConfig =
-    createBinaryKernelConfig('Sub', supportsFullBroadcast);
+    createBinaryKernelConfig(Sub, supportsFullBroadcast);

--- a/tfjs-backend-wasm/src/kernels/Sum.ts
+++ b/tfjs-backend-wasm/src/kernels/Sum.ts
@@ -24,8 +24,7 @@ import {permuteAxesAndTranspose} from './kernel_utils';
 let wasmSum: (xId: number, reduceSize: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
-  wasmSum =
-      backend.wasm.cwrap('Sum', null /*void*/, ['number, number, number']);
+  wasmSum = backend.wasm.cwrap(Sum, null /*void*/, ['number, number, number']);
 }
 
 function sum(args: {backend: BackendWasm, inputs: SumInputs, attrs: SumAttrs}):

--- a/tfjs-backend-wasm/src/kernels/Tanh.ts
+++ b/tfjs-backend-wasm/src/kernels/Tanh.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {KernelConfig} from '@tensorflow/tfjs-core';
+import {KernelConfig, Tanh} from '@tensorflow/tfjs-core';
 
 import {createUnaryKernelConfig} from './unary_kernel';
-export const tanhConfig: KernelConfig = createUnaryKernelConfig('Tanh');
+export const tanhConfig: KernelConfig = createUnaryKernelConfig(Tanh);

--- a/tfjs-backend-wasm/src/kernels/Tile.ts
+++ b/tfjs-backend-wasm/src/kernels/Tile.ts
@@ -15,27 +15,18 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap} from '@tensorflow/tfjs-core';
-import {TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, Tile, TileAttrs, TileInputs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 import {CppDType} from './types';
-
-interface TileInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
-
-interface TileAttrs extends NamedAttrMap {
-  reps: number[];
-}
 
 let wasmTile: (
     xId: number, xShape: Uint8Array, xShapeSize: number, newShape: Uint8Array,
     newShapeSize: number, dtype: number, outId: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmTile = backend.wasm.cwrap('Tile', null /* void */, [
+  wasmTile = backend.wasm.cwrap(Tile, null /* void */, [
     'number',  // x_id
     'array',   // x_shape
     'number',  // x_shape.length
@@ -68,8 +59,8 @@ function tile(
 }
 
 export const tileConfig: KernelConfig = {
-  kernelName: 'Tile',
+  kernelName: Tile,
   backendName: 'wasm',
   setupFunc: setup,
-  kernelFunc: tile
+  kernelFunc: tile as {} as KernelFunc
 };

--- a/tfjs-backend-wasm/src/kernels/Transpose.ts
+++ b/tfjs-backend-wasm/src/kernels/Transpose.ts
@@ -15,27 +15,19 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, TensorInfo, Transpose, TransposeAttrs, TransposeInputs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 import {identity} from './Identity';
 import {CppDType} from './types';
 
-interface TransposeInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
-
-interface TransposeAttrs extends NamedAttrMap {
-  perm: number[];
-}
-
 let wasmTranspose: (
     xId: number, xShape: Uint8Array, xShapeLength: number, dtype: CppDType,
     outId: number, perm: Uint8Array, permLength: number) => void;
 
 function setup(backend: BackendWasm) {
-  wasmTranspose = backend.wasm.cwrap('Transpose', null /* void */, [
+  wasmTranspose = backend.wasm.cwrap(Transpose, null /* void */, [
     'number',  // xId
     'array',   // x.shape
     'number',  // x.shape.length
@@ -120,8 +112,8 @@ function removeOneSizeDims(
 }
 
 export const transposeConfig: KernelConfig = {
-  kernelName: 'Transpose',
+  kernelName: Transpose,
   backendName: 'wasm',
-  kernelFunc: transpose,
+  kernelFunc: transpose as {} as KernelFunc,
   setupFunc: setup,
 };

--- a/tfjs-backend-wasm/src/kernels/Unpack.ts
+++ b/tfjs-backend-wasm/src/kernels/Unpack.ts
@@ -15,20 +15,18 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedAttrMap, NamedTensorInfoMap, TensorInfo, Unpack, UnpackAttrs, UnpackInputs} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, TensorInfo, Unpack, UnpackAttrs, UnpackInputs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 import {slice} from './Slice';
 
-function unpack(args: {
-  inputs: NamedTensorInfoMap,
-  backend: BackendWasm,
-  attrs: NamedAttrMap
-}): TensorInfo[] {
+function unpack(
+    args: {inputs: UnpackInputs, backend: BackendWasm, attrs: UnpackAttrs}):
+    TensorInfo[] {
   const {inputs, backend, attrs} = args;
-  const {value} = inputs as {} as UnpackInputs;
-  const {axis} = attrs as {} as UnpackAttrs;
+  const {value} = inputs;
+  const {axis} = attrs;
   const numOutputs = value.shape[axis];
   const rank = value.shape.length;
   const outShape: number[] = new Array(rank - 1);
@@ -52,5 +50,5 @@ function unpack(args: {
 export const unpackConfig: KernelConfig = {
   kernelName: Unpack,
   backendName: 'wasm',
-  kernelFunc: unpack,
+  kernelFunc: unpack as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/ZerosLike.ts
+++ b/tfjs-backend-wasm/src/kernels/ZerosLike.ts
@@ -15,13 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, NamedTensorInfoMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, ZerosLike, ZerosLikeInputs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface ZerosLikeInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
 
 function zerosLike(args: {inputs: ZerosLikeInputs, backend: BackendWasm}) {
   const {inputs: {x}, backend} = args;
@@ -32,7 +28,7 @@ function zerosLike(args: {inputs: ZerosLikeInputs, backend: BackendWasm}) {
 }
 
 export const zerosLikeConfig: KernelConfig = {
-  kernelName: 'ZerosLike',
+  kernelName: ZerosLike,
   backendName: 'wasm',
   kernelFunc: zerosLike as {} as KernelFunc,
 };

--- a/tfjs-backend-wasm/src/kernels/binary_kernel.ts
+++ b/tfjs-backend-wasm/src/kernels/binary_kernel.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, DataType, KernelConfig, NamedTensorInfoMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, BinaryInputs, DataType, KernelConfig, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
@@ -86,9 +86,4 @@ export function createBinaryKernelConfig(
   }
 
   return {kernelName, backendName: 'wasm', setupFunc, kernelFunc};
-}
-
-interface BinaryInputs extends NamedTensorInfoMap {
-  a: TensorInfo;
-  b: TensorInfo;
 }

--- a/tfjs-backend-wasm/src/kernels/unary_kernel.ts
+++ b/tfjs-backend-wasm/src/kernels/unary_kernel.ts
@@ -15,13 +15,9 @@
  * =============================================================================
  */
 
-import {KernelConfig, NamedTensorInfoMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, TensorInfo, UnaryInputs, util} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
-
-interface UnaryInputs extends NamedTensorInfoMap {
-  x: TensorInfo;
-}
 
 export function createUnaryKernelConfig(kernelName: string): KernelConfig {
   let wasmFunc: (xId: number, outId: number) => void;


### PR DESCRIPTION
This PR cleans up remaining cases in the WASM backend where we define kernel names / inputs / attrs within the kernel rather than importing from `tfjs-core/src/kernel_names.ts`. Also casts `kernelFunc` functions as `KernelFunc` to avoid having to cast inputs / attrs before using them.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3663)
<!-- Reviewable:end -->
