### PR TITLE
Fix release e2e setup.

### DIFF
--- a/e2e/cloudbuild-release.yml
+++ b/e2e/cloudbuild-release.yml
@@ -1,7 +1,7 @@
 steps:
 
 # Release e2e flow.
-- name: 'node:10'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   dir: 'e2e'
   entrypoint: 'bash'
   id: 'verdaccio'

--- a/e2e/scripts/publish-tfjs-ci.sh
+++ b/e2e/scripts/publish-tfjs-ci.sh
@@ -82,4 +82,4 @@ done
 # Update e2e's package.json's all tfjs related packages to locally published
 # version.
 cd e2e
-yarn update-dependency --version=$RELEASE_VERSION
+npx ts-node ./scripts/update-dependency.ts --version=$RELEASE_VERSION

--- a/e2e/scripts/release-e2e.sh
+++ b/e2e/scripts/release-e2e.sh
@@ -19,9 +19,6 @@
 # Start in scripts/ even if run from root directory
 cd "$(dirname "$0")"
 
-# Load functions for working with local NPM registry (Verdaccio)
-source local-registry.sh
-
 function cleanup {
   echo 'Cleaning up.'
   # Restore the original NPM and Yarn registry URLs and stop Verdaccio
@@ -56,8 +53,9 @@ cd ..
 e2e_root_path=$PWD
 
 # ****************************************************************************
-# First, install emsdk.
+# First, install env.
 # ****************************************************************************
+# emsdk
 # tfjs-backend-wasm needs emsdk to build. emsdk install needs to be done
 # before switch to local registry, otherwise some packages installation will
 # fail.
@@ -69,6 +67,22 @@ cd emsdk
 ./emsdk activate 1.39.15
 source ./emsdk_env.sh
 cd $e2e_root_path
+
+# NVM
+touch ~/.bashrc
+curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# node 10
+nvm install 10
+
+# yarn
+npm install -g yarn
+
+# Load functions for working with local NPM registry (Verdaccio)
+source "$e2e_root_path"/scripts/local-registry.sh
 
 # ****************************************************************************
 # Second, publish the monorepo.


### PR DESCRIPTION
This PR fixes release e2e setup, tested the complete flow by triggering gcloud build in local. Tested up until seeing the same error as nightly build. Waiting for nightly build fix and will apply the same fix to e2e. 

This PR has below changes:
1. Change the image to use google-cloud-sdk, because we need gsutil with proper authentication to upload tfjs-node add-on to storage.
2. Install the node environment in setup script. TODO, build a custom docker image and install all the necessary env in the docker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3682)
<!-- Reviewable:end -->
