### PR TITLE
[tfjs-react-native] Fixed model loading after applying CodePush update

### DIFF
--- a/tfjs-react-native/src/platform_react_native.ts
+++ b/tfjs-react-native/src/platform_react_native.ts
@@ -155,7 +155,7 @@ export class PlatformReactNative implements Platform {
     if (encoding === 'utf-16') {
       encoding = 'utf16le';
     }
-    return Buffer.from(bytes).toString(encoding);
+    return Buffer.from(bytes).toString(encoding as BufferEncoding);
   }
 
   now(): number {


### PR DESCRIPTION
[react-native-code-push](https://github.com/microsoft/react-native-code-push) allows update js bundle and assets without publishing new version of app package.

After applying CodePush update, Asset returns uri in file:// URL form instead of file path. which is okay in most use but since tfjs-react-native uses react-native-fs for loading bundled weights, converting URL to path must be done.

This pull request implements file URL detection and converting for solving this problem.

and here's quick workaround for before this request accepted:

```javascript
import * as tf from '@tensorflow/tfjs';
import {Image} from 'react-native';

const myModelJson = require('../assets/palmistry/my_model.json');
const myModelWeights = require('../assets/palmistry/my_model_weights.bin');

class LocalFileHandler {
  constructor(modelJson, modelWeightsId) {
    this.modelJson = modelJson;
    this.modelWeightsId = modelWeightsId;
  }

  async load() {
    const localFilePath = unescape(
      Image.resolveAssetSource(this.modelWeightsId).uri.substr(
        'file://'.length,
      ),
    );
    const base64Weights = await RNFS.readFile(localFilePath, 'base64');
    const weightData = tf.util.encodeString(base64Weights, 'base64').buffer;

    const modelArtifacts = Object.assign({}, this.modelJson);
    modelArtifacts.weightSpecs = this.modelJson.weightsManifest[0].weights;
    delete modelArtifacts.weightManifest;
    modelArtifacts.weightData = weightData;
    return modelArtifacts;
  }
}

      let resourceIO = bundleResourceIO(
        myModelJson,
        myModelWeights,
      );

      if (
        Image.resolveAssetSource(myModelWeights).uri.match('^file://')
      ) {
        resourceIO = new LocalFileHandler(
          myModelJson,
          myModelWeights,
        );
      }

```