### PR TITLE
Add UI for tuning benchmark parameters for the BrowserStack-benchmark tool

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -25,7 +25,10 @@ const port = process.env.PORT || 8001;
 
 const app = http.createServer((request, response) => {
   const url = request.url === '/' ? '/index.html' : request.url;
-  const filePath = path.join(__dirname, url);
+  let filePath = path.join(__dirname, url);
+  if (!fs.existsSync(filePath)) {
+    filePath = path.join(__dirname, '../', url);
+  }
   fs.readFile(filePath, (err, data) => {
     if (err) {
       response.writeHead(404);

--- a/e2e/benchmarks/browserstack-benchmark/index.html
+++ b/e2e/benchmarks/browserstack-benchmark/index.html
@@ -37,6 +37,7 @@ limitations under the License.
         <div class="box">
           <pre id="results"></pre>
         </div>
+        <script src='/../modelConfig.js'></script>
         <script src='./index.js'></script>
     </body>
 </html>

--- a/e2e/benchmarks/browserstack-benchmark/index.js
+++ b/e2e/benchmarks/browserstack-benchmark/index.js
@@ -22,8 +22,13 @@ const state = {
     benchmarkButton.__li.style.pointerEvents = 'none';
     benchmarkButton.__li.style.opacity = .5;
 
-    socket.emit('run', true);
-  }
+    const benchmark = {...state.benchmark};
+    if (state.benchmark.model !== 'custom') {
+      delete benchmark['modelUrl'];
+    }
+    socket.emit('run', {benchmark});
+  },
+  benchmark: {model: 'mobilenet_v2', modelUrl: '', numRuns: 1, backend: 'wasm'}
 };
 
 socket.on('benchmarkComplete', benchmarkResult => {
@@ -37,4 +42,36 @@ socket.on('benchmarkComplete', benchmarkResult => {
 });
 
 const gui = new dat.gui.GUI();
+showModelSelection();
+showParameterSettings();
 const benchmarkButton = gui.add(state, 'run').name('Run benchmark');
+
+function showModelSelection() {
+  const modelFolder = gui.addFolder('Model');
+  let modelUrlController = null;
+
+  modelFolder.add(state.benchmark, 'model', Object.keys(benchmarks))
+      .name('model name')
+      .onChange(async model => {
+        if (model === 'custom') {
+          if (modelUrlController === null) {
+            modelUrlController = modelFolder.add(state.benchmark, 'modelUrl');
+            modelUrlController.domElement.querySelector('input').placeholder =
+                'https://your-domain.com/model-path/model.json';
+          }
+        } else if (modelUrlController != null) {
+          modelFolder.remove(modelUrlController);
+          modelUrlController = null;
+        }
+      });
+  modelFolder.open();
+  return modelFolder;
+}
+
+function showParameterSettings() {
+  const parameterFolder = gui.addFolder('Parameters');
+  parameterFolder.add(state.benchmark, 'numRuns');
+  parameterFolder.add(state.benchmark, 'backend', ['wasm', 'webgl', 'cpu']);
+  parameterFolder.open();
+  return parameterFolder;
+}


### PR DESCRIPTION
The previous [PR](https://github.com/tensorflow/tfjs/pull/3701) enables the webpage to define the benchmark parameters. This PR adds UI for tuning these benchmark parameters.

You can see the UI by:
``` shell
git clone https://github.com/Linchenn/tfjs.git
cd tfjs/e2e/benchmarks/browserstack-benchmark
git checkout benchmark-param-ui
yarn install
node app.js
```

Then you can open the webpage at [http://localhost:8001/](http://localhost:8001/) and see this:
**Notice**: When you can click `Run benchmark` on the webpage, then the server **will not** use the parameters you configured to benchmark. It will work after the previous PR is merged.

![Screen Shot 2020-07-31 at 10 18 09 AM](https://user-images.githubusercontent.com/40653845/89060060-29f74180-d317-11ea-81c2-bf6dd9b5facb.png)



To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3704)
<!-- Reviewable:end -->
