### PR TITLE
Use custom docker for tfjs-wasm.

### DIFF
--- a/dockers/wasm-docker/Dockerfile
+++ b/dockers/wasm-docker/Dockerfile
@@ -1,0 +1,5 @@
+ # Official emsdk docker: https://hub.docker.com/r/emscripten/emsdk
+ FROM emscripten/emsdk:1.39.15
+
+ # Install required tools that are useful for your project i.e. ninja-build
+ RUN npm install -g yarn

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Install build-deps.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -22,15 +22,15 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'bitnami/node:latest'
+- name: 'gcr.io/learnjs-174218/wasm'
   dir: 'tfjs-backend-wasm'
-  entrypoint: 'yarn'
+  entrypoint: 'bash'
   id: 'build'
-  args: ['build-ci']
+  args: ['./scripts/build-ci.sh']
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'lint'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run JS tests.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-wasm'
@@ -48,7 +48,7 @@ steps:
   secretEnv: ['BROWSERSTACK_KEY']
 
 # Run C++ tests.
-- name: 'bitnami/node:latest'
+- name: 'gcr.io/learnjs-174218/wasm'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-cc'
@@ -56,7 +56,7 @@ steps:
   waitFor: ['build']
 
 # Check bundle size.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   id: 'test-bundle-size'
   entrypoint: 'yarn'
@@ -64,7 +64,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'build']
 
 # Lint bazel files.
-- name: 'bitnami/node:latest'
+- name: 'node:10'
   dir: 'tfjs-backend-wasm'
   id: 'buildifier'
   entrypoint: 'yarn'

--- a/tfjs-backend-wasm/scripts/build-ci.sh
+++ b/tfjs-backend-wasm/scripts/build-ci.sh
@@ -16,24 +16,6 @@
 
 set -e
 
-git clone --depth=1 --single-branch https://github.com/emscripten-core/emsdk.git
-
-cd emsdk
-
-# Install emsdk with up to 1 retry.
-for i in $(seq 0 1)
-do
-  # Wait for 15 seconds then retry.
-  [ $i -gt 0 ] && echo "Retry in 15 seconds, count: $i" && sleep 15
-  # If install is successful, $? will hold 0 and execution will break from the
-  # loop.
-  ./emsdk install 1.39.15 && break
-done
-
-./emsdk activate 1.39.15
-source ./emsdk_env.sh
-cd ..
-
 yarn tsc
 
 ./scripts/build-wasm.sh

--- a/tfjs-backend-wasm/src/cc/kernels/PadV2.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/PadV2.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "src/cc/backend.h"
+#include "src/cc/kernels/PadV2.h"
 #include "src/cc/util.h"
 
 namespace {


### PR DESCRIPTION
This PR has below changes:
1. Created a custom docker for tfjs-wasm CI. 
2. Changed the wasm cloudbuild.yml
3. Fix the lint step issue. Before, the step uses bitnami/node image, which doesn't have python 2, so lint step simply skip to run. If we run lint in local, it actually failed. This PR fixes the lint issue, and also changes the image so that lint actually runs.
4. Removed installing emsdk.

Result:
1. The build step reduces from 359s -> 80s, which is 4x+ faster.
2. Making the build stable, by eliminating the flakiness problem during downloading and installing emsdk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3710)
<!-- Reviewable:end -->
