### PR TITLE
Callback args mixed array

### DIFF
--- a/tfjs-layers/src/base_callbacks.ts
+++ b/tfjs-layers/src/base_callbacks.ts
@@ -460,11 +460,23 @@ export class CustomCallback extends BaseCallback {
 }
 
 /**
+ * Standardize a callback or configuration of one to a callback.
+ */
+function standardizeCallback(
+    callback: BaseCallback|CustomCallbackArgs,
+    yieldEvery: YieldEveryOptions): BaseCallback {
+  if (callback instanceof BaseCallback) {
+    return callback;
+  }
+  return new CustomCallback(callback, yieldEvery);
+}
+
+/**
  * Standardize callbacks or configurations of them to an Array of callbacks.
  */
 export function standardizeCallbacks(
-    callbacks: BaseCallback|BaseCallback[]|CustomCallbackArgs|
-    CustomCallbackArgs[],
+    callbacks: BaseCallback|CustomCallbackArgs|
+    Array<BaseCallback|CustomCallbackArgs>,
     yieldEvery: YieldEveryOptions): BaseCallback[] {
   if (callbacks == null) {
     callbacks = {} as BaseCallback;
@@ -472,14 +484,11 @@ export function standardizeCallbacks(
   if (callbacks instanceof BaseCallback) {
     return [callbacks];
   }
-  if (Array.isArray(callbacks) && callbacks[0] instanceof BaseCallback) {
-    return callbacks as BaseCallback[];
-  }
   // Convert custom callback configs to custom callback objects.
-  const callbackConfigs =
-      generic_utils.toList(callbacks) as CustomCallbackArgs[];
-  return callbackConfigs.map(
-      callbackConfig => new CustomCallback(callbackConfig, yieldEvery));
+  const callbacksAndConfigs =
+      generic_utils.toList(callbacks) as Array<BaseCallback|CustomCallbackArgs>;
+  return callbacksAndConfigs.map(
+      callbackOrConfig => standardizeCallback(callbackOrConfig, yieldEvery));
 }
 
 export declare type BaseCallbackConstructor = {

--- a/tfjs-layers/src/base_callbacks_test.ts
+++ b/tfjs-layers/src/base_callbacks_test.ts
@@ -420,4 +420,32 @@ describe('standardizeCallbacks', () => {
     standardized.forEach(cb => expect(cb instanceof BaseCallback).toBe(true));
     spies.forEach(spy => expect(spy).toHaveBeenCalled());
   });
+
+  it('standardize a mixed array starting with BaseCallback', async () => {
+    const callback = new CustomCallback({}), args = { onEpochEnd: () => {} };
+    const spy = spyOn(args, 'onEpochEnd');
+    const mixedArray = [callback, args];
+
+    const standardized = standardizeCallbacks(mixedArray, 'never');
+    await Promise.all(standardized.map(cb => cb.onEpochEnd(1)));
+
+    expect(standardized.length).toEqual(mixedArray.length);
+    standardized.forEach(cb => expect(cb instanceof BaseCallback).toBe(true));
+    expect(mixedArray[0]).toBe(callback);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('standardize a mixed array starting with CustomCallbackArgs', async () => {
+    const args = { onEpochEnd: () => {} }, callback = new CustomCallback({});
+    const spy = spyOn(args, 'onEpochEnd');
+    const mixedArray = [args, callback];
+
+    const standardized = standardizeCallbacks(mixedArray, 'never');
+    await Promise.all(standardized.map(cb => cb.onEpochEnd(1)));
+
+    expect(standardized.length).toEqual(mixedArray.length);
+    standardized.forEach(cb => expect(cb instanceof BaseCallback).toBe(true));
+    expect(spy).toHaveBeenCalled();
+    expect(mixedArray[1]).toBe(callback);
+  });
 });

--- a/tfjs-layers/src/engine/training_dataset.ts
+++ b/tfjs-layers/src/engine/training_dataset.ts
@@ -69,7 +69,8 @@ export interface ModelFitDatasetArgs<T> {
    *      as in `onBatchEnd()`. Note that `onYield` can skip batches or
    *      epochs. See also docs for `yieldEvery` below.
    */
-  callbacks?: BaseCallback[]|CustomCallbackArgs|CustomCallbackArgs[];
+  callbacks?: BaseCallback|CustomCallbackArgs|
+      Array<BaseCallback|CustomCallbackArgs>;
 
   /**
    * Data on which to evaluate the loss and any model

--- a/tfjs-layers/src/engine/training_tensors.ts
+++ b/tfjs-layers/src/engine/training_tensors.ts
@@ -64,7 +64,8 @@ export interface ModelFitArgs {
    *      as in `onBatchEnd()`. Note that `onYield` can skip batches or
    *      epochs. See also docs for `yieldEvery` below.
    */
-  callbacks?: BaseCallback[]|CustomCallbackArgs|CustomCallbackArgs[];
+  callbacks?: BaseCallback|CustomCallbackArgs|
+      Array<BaseCallback|CustomCallbackArgs>;
 
   /**
    * Float between 0 and 1: fraction of the training data


### PR DESCRIPTION
The `callbacks` argument to `model.fit()` and `model.fitDataSet()` accepts either a `BaseCallback` object or a `CustomCallbackArgs` object, or an array of either.  However, it does not accept an array containing a mixture of these two types.

It is possible to pass a mixed array when using loosely-typed Javascript. In this case, they are mishandled. See https://github.com/tensorflow/tfjs/issues/1792.

This change extends the flexibility of the `callbacks` argument to allow mixed types.