### PR TITLE
Fix missing query timer message in local-benchmark tool

### DIFF
--- a/e2e/benchmarks/index.html
+++ b/e2e/benchmarks/index.html
@@ -500,7 +500,7 @@ limitations under the License.
         await profileKernelTime();
       } else {
         await showMsg('Skipping kernel times since query timer extension is not ' +
-          'available. <br/> Use Chrome 70+.');
+          'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
       };
     }
 


### PR DESCRIPTION
Whether WebGL's query timer is enabled depends on whether the browser supports `EXT_disjoint_timer_query` or `EXT_disjoint_timer_query_webgl2` extensions, not just the browser version.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3725)
<!-- Reviewable:end -->
