### PR TITLE
Define a list of browsers for the BrowserStack-benchmark tool

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/browser_list.json
+++ b/e2e/benchmarks/browserstack-benchmark/browser_list.json
@@ -1,0 +1,490 @@
+[
+  {
+    "os": "Windows",
+    "os_version": "10",
+    "browser": "chrome",
+    "device": null,
+    "browser_version": "84.0",
+    "real_mobile": null
+  },
+  {
+    "os": "Windows",
+    "os_version": "10",
+    "browser": "ie",
+    "device": null,
+    "browser_version": "11.0",
+    "real_mobile": null
+  },
+  {
+    "os": "Windows",
+    "os_version": "10",
+    "browser": "edge",
+    "device": null,
+    "browser_version": "84.0",
+    "real_mobile": null
+  },
+  {
+    "os": "Windows",
+    "os_version": "10",
+    "browser": "firefox",
+    "device": null,
+    "browser_version": "79.0",
+    "real_mobile": null
+  },
+  {
+    "os": "OS X",
+    "os_version": "Catalina",
+    "browser": "chrome",
+    "device": null,
+    "browser_version": "84.0",
+    "real_mobile": null
+  },
+  {
+    "os": "OS X",
+    "os_version": "Catalina",
+    "browser": "safari",
+    "device": null,
+    "browser_version": "13.1",
+    "real_mobile": null
+  },
+  {
+    "os": "OS X",
+    "os_version": "Catalina",
+    "browser": "firefox",
+    "device": null,
+    "browser_version": "79.0",
+    "real_mobile": null
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "iphone",
+    "device": "iPhone XS",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "iphone",
+    "device": "iPhone 11 Pro Max",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "iphone",
+    "device": "iPhone 11 Pro",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "iphone",
+    "device": "iPhone 11",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "iphone",
+    "device": "iPhone 8",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "iphone",
+    "device": "iPhone SE 2020",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "ipad",
+    "device": "iPad Pro 12.9 2020",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "ipad",
+    "device": "iPad Pro 11 2020",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "ipad",
+    "device": "iPad Mini 2019",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "ipad",
+    "device": "iPad Air 2019",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "13",
+    "browser": "ipad",
+    "device": "iPad 7th",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone XS",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone XS Max",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone XR",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone 8",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone 8 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone 7",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "iphone",
+    "device": "iPhone 6S",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "ipad",
+    "device": "iPad Pro 11 2018",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "ipad",
+    "device": "iPad Mini 2019",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "12",
+    "browser": "ipad",
+    "device": "iPad Air 2019",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S20",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S20 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S20 Ultra",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Samsung Galaxy A51",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Samsung Galaxy A11",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Google Pixel 4 XL",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Google Pixel 4",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "Google Pixel 3",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "OnePlus 8",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "10.0",
+    "browser": "android",
+    "device": "OnePlus 7T",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S9 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S8 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S10e",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S10 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S10",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy Note 10 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy Note 10",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy A10",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Google Pixel 3a XL",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Google Pixel 3a",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Google Pixel 3 XL",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Google Pixel 3",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Google Pixel 2",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Motorola Moto G7 Play",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "OnePlus 7",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "OnePlus 6T",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Xiaomi Redmi Note 8",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Xiaomi Redmi Note 7",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy Tab S6",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "9.0",
+    "browser": "android",
+    "device": "Samsung Galaxy Tab S5e",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "8.1",
+    "browser": "android",
+    "device": "Samsung Galaxy Note 9",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "8.1",
+    "browser": "android",
+    "device": "Samsung Galaxy J7 Prime",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "8.1",
+    "browser": "android",
+    "device": "Samsung Galaxy Tab S4",
+    "browser_version": null,
+    "real_mobile": true
+  }
+]


### PR DESCRIPTION
We selected 61 combinations between os, os_version, browser, browser_version, device. (Windows 4, OS X 3, android 33, ios 21).

If you want to use new rules to filter out the list of combinations, or, you want to get the full configuration for a certain combination, you can use the following tool:
``` bash
git clone https://github.com/tensorflow/tfjs.git
cd tfjs/e2e/benchmarks/browserstack-benchmark
git checkout select-BrowserStack-browsers
yarn install

export BROWSERSTACK_USERNAME=YOUR_USERNAME
export BROWSERSTACK_ACCESS_KEY=YOUR_ACCESS_KEY
```
- If you want to use new rules, you can override the [selectBrowsers](https://github.com/tensorflow/tfjs/blob/select-BrowserStack-browsers/e2e/benchmarks/browserstack-benchmark/app.js#L83) function with your rules. (the `availableBrowsers` is an array of all combinations.) Then run `node app.js`, then `browser_list.json` is the updated combination list.
- If you want to get the full configuration for a certain combination, you can run `node app.js` and open http://localhost:8001/ (the webpage includes all available combinations), you can see things like:
![Screen Shot 2020-08-05 at 8 37 17 PM](https://user-images.githubusercontent.com/40653845/89487888-7a2d3400-d75b-11ea-8d3d-412e5cd66409.png)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3737)
<!-- Reviewable:end -->
