### PR TITLE
webgpu: Optimize depthwise_conv2d

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -917,6 +917,10 @@ export class WebGPUBackend extends KernelBackend {
     return this.binaryOp(a, b, binary_op.MUL);
   }
 
+  realDivide(a: Tensor, b: Tensor): Tensor {
+    return this.binaryOp(a, b, binary_op.DIV);
+  }
+
   floorDiv(a: Tensor, b: Tensor): Tensor {
     return this.binaryOp(a, b, binary_op.INT_DIV);
   }

--- a/tfjs-backend-webgpu/src/benchmark_models_test.ts
+++ b/tfjs-backend-webgpu/src/benchmark_models_test.ts
@@ -64,4 +64,26 @@ describeWebGPU('Models benchmarks', () => {
     console.log(`Mean time: ${fmt(mean)} ms -> ${fmt(mean / 1)} / rep`);
     console.log(`Min time: ${fmt(min)} ms -> ${fmt(min / 1)} / rep`);
   });
+
+  it('mobilenet', async () => {
+    const input = tf.randomNormal([1, 500, 500, 3]);
+    const url =
+        'https://storage.googleapis.com/tfjs-models/savedmodel/posenet/mobilenet/float/075/model-stride16.json';
+    const model = await tfc.loadGraphModel(url);
+    const bench = () => model.predict(input);
+    await benchmark(bench);
+    const times = [];
+    const trials = 50;
+    for (let t = 0; t < trials; ++t) {
+      const time = await benchmark(bench);
+      times.push(time);
+    }
+    input.dispose();
+    console.log(times);
+    const mean = times.reduce((a, b) => a + b, 0) / trials;
+    const min = Math.min(...times);
+    const fmt = (n: number) => n.toFixed(3);
+    console.log(`Mean time: ${fmt(mean)} ms -> ${fmt(mean / 1)} / rep`);
+    console.log(`Min time: ${fmt(min)} ms -> ${fmt(min / 1)} / rep`);
+  });
 });


### PR DESCRIPTION
PERF

This patch also adds the mobilenet as the benchmark. See 15%~30%
improve with different platforms.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3740)
<!-- Reviewable:end -->
