### PR TITLE
padding empty tensor fails on node backend

### DIFF
--- a/tfjs-core/src/ops/pad_test.ts
+++ b/tfjs-core/src/ops/pad_test.ts
@@ -271,4 +271,11 @@ describeWithFlags('pad', ALL_ENVS, () => {
     // 0, 0, 0
     expectArraysClose(await res.data(), [0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 0, 0]);
   });
+
+  it("pads an empty tensor", async () => {
+    await expect(async () => {
+      const padded = tf.pad(tf.ones([0, 3]), [[5, 6]], 12);
+      expectArraysClose(await padded.data(), await tf.fill([11, 3], 12).data());
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
Fixes #3757 issuesI may come back and try and fix this, but this simple pad test throws an exception on the node backend and passes with tfjs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3756)
<!-- Reviewable:end -->
