### PR TITLE
Fix the tests of tf.profile

### DIFF
--- a/tfjs-core/src/engine_test.ts
+++ b/tfjs-core/src/engine_test.ts
@@ -391,10 +391,10 @@ describeWithFlags('profile', ALL_ENVS, () => {
 
     // Test the types for `kernelTimeMs` and `extraInfo` to confirm the promises
     // are resolved.
-    expect(typeof profile.kernels[0].kernelTimeMs).toBe('number');
-    expect(typeof profile.kernels[0].extraInfo).toBe('string');
-    expect(typeof profile.kernels[1].kernelTimeMs).toBe('number');
-    expect(typeof profile.kernels[1].extraInfo).toBe('string');
+    expect(profile.kernels[0].kernelTimeMs instanceof Promise).toBe(false);
+    expect(profile.kernels[0].extraInfo instanceof Promise).toBe(false);
+    expect(profile.kernels[1].kernelTimeMs instanceof Promise).toBe(false);
+    expect(profile.kernels[1].extraInfo instanceof Promise).toBe(false);
 
     // The specific values of `kernelTimeMs` and `extraInfo` are tested in the
     // tests of Profiler.profileKernel, so their values are not tested here.
@@ -437,8 +437,8 @@ describeWithFlags('profile', ALL_ENVS, () => {
     expect(profile.newTensors).toBe(2);
     expectArraysClose(await result.data(), [1, 4, 9]);
     expect(profile.kernels.length).toBe(1);
-    expect(typeof profile.kernels[0].kernelTimeMs).toBe('number');
-    expect(typeof profile.kernels[0].extraInfo).toBe('string');
+    expect(profile.kernels[0].kernelTimeMs instanceof Promise).toBe(false);
+    expect(profile.kernels[0].extraInfo instanceof Promise).toBe(false);
     expect(profile.kernels[0]).toEqual({
       'name': 'Square',
       'bytesAdded': 12,
@@ -468,8 +468,8 @@ describeWithFlags('profile', ALL_ENVS, () => {
     expect(profile.newTensors).toBe(1);
     expectArraysClose(await result.data(), [1, 2, 3]);
     expect(profile.kernels.length).toBe(1);
-    expect(typeof profile.kernels[0].kernelTimeMs).toBe('number');
-    expect(typeof profile.kernels[0].extraInfo).toBe('string');
+    expect(profile.kernels[0].kernelTimeMs instanceof Promise).toBe(false);
+    expect(profile.kernels[0].extraInfo instanceof Promise).toBe(false);
     expect(profile.kernels[0]).toEqual({
       'name': 'Square',
       'bytesAdded': 12,


### PR DESCRIPTION
The `tf.profile()`'s tests expect the `kernelTimeMs` and `extraInfo` have been resolved from `Promise`, but the `kernelTimeMs` in `tf.profile()`'s return value can not only be `number` type, but also `{error: string}`, as:
```javascript
type KernelInfo = {
  ...
  kernelTimeMs: number | {error: string} | Promise<number|{error: string}>;
  extraInfo: string | Promise<string>;
};
```
(at https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/engine.ts#L55)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3761)
<!-- Reviewable:end -->
