### PR TITLE
Enable multiple devices to benchmark for the BrowserStack-benchmark tool

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/SpecRunner.html
+++ b/e2e/benchmarks/browserstack-benchmark/SpecRunner.html
@@ -25,9 +25,6 @@ limitations under the License.
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.5.0/jasmine-html.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.5.0/boot.js"></script>
 
-
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.7/dat.gui.min.js"></script>
   <script src='socket.io/socket.io.js'></script>
 
   <!-- include source files here... -->

--- a/e2e/benchmarks/browserstack-benchmark/SpecRunner.html
+++ b/e2e/benchmarks/browserstack-benchmark/SpecRunner.html
@@ -1,0 +1,44 @@
+<!-- Copyright 2020 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jasmine Test</title>
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.5.0/jasmine.css">
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.5.0/jasmine.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.5.0/jasmine-html.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.5.0/boot.js"></script>
+
+
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.7/dat.gui.min.js"></script>
+  <script src='socket.io/socket.io.js'></script>
+
+  <!-- include source files here... -->
+  <script src="./index.js"></script>
+
+  <!-- include spec files here... -->
+  <script src="./index_test.js"></script>
+  <script src="./app_test.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -62,7 +62,13 @@ function runServer() {
   });
 }
 
-function setupBenchmarkConfig(config) {
+/**
+ * Supplement the browser configurations and create `browsers.json` and
+ * `benchmark_parameters.json` configuration files for karma.
+ *
+ * @param {{browsers, benchmark}} config
+ */
+function setupBenchmarkEnv(config) {
   // Write the map (tabId - browser setting) to `./browsers.json`.
   for (const tabId in config.browsers) {
     const browser = config.browsers[tabId];
@@ -79,9 +85,28 @@ function setupBenchmarkConfig(config) {
       './benchmark_parameters.json', JSON.stringify(config.benchmark, null, 2));
 }
 
+/**
+ * Run model benchmark on BrowserStack.
+ *
+ * The benchmark configuration object contains two objects:
+ * - `browsers`: Each key-value pair represents a browser instance to be
+ * benchmarked. The key is a unique string id/tabId (assigned by the webpage)
+ * for the browser instance, while the value is the browser configuration.
+ *
+ * - `benchmark`: An object with the following properties:
+ *  - `model`: The name of model (registed at
+ * 'tfjs/e2e/benchmarks/model_config.js') or `custom`.
+ *  - modelUrl: The URL to the model description file. Only applicable when the
+ * `model` is `custom`.
+ *  - `numRuns`: The number of rounds for model inference.
+ *  - `backend`: The backend to be benchmarked on.
+ *
+ *
+ * @param {{browsers, benchmark}} config Benchmark configuration.
+ */
 function benchmark(config) {
   console.log('Preparing configuration files for the test runner.');
-  setupBenchmarkConfig(config);
+  setupBenchmarkEnv(config);
 
   console.log(`Start benchmarking.`);
   for (const tabId in config.browsers) {

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -111,7 +111,7 @@ function benchmark(config) {
   console.log(`Start benchmarking.`);
   for (const tabId in config.browsers) {
     const command = `yarn test --browserstack --browsers=${tabId}`;
-    console.log(`Running: ${command}`)
+    console.log(`Running: ${command}`);
     exec(command, (error, stdout, stderr) => {
       console.log(`benchmark ${tabId} completed.`);
       if (error) {

--- a/e2e/benchmarks/browserstack-benchmark/app_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_test.js
@@ -16,7 +16,7 @@
  */
 
 describe('benchmark multiple browsers', () => {
-  const testBrowserList = [
+  const browsersList = [
     {
       'os': 'OS X',
       'os_version': 'Catalina',
@@ -48,7 +48,7 @@ describe('benchmark multiple browsers', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
 
     // Populate `browsers`.
-    for (const browserConfig of testBrowserList) {
+    for (const browserConfig of browsersList) {
       const tabId = getTabId(browserConfig);
       browsers[tabId] = browserConfig;
     }
@@ -62,7 +62,7 @@ describe('benchmark multiple browsers', () => {
        socket.on('benchmarkComplete', benchmarkResult => {
          expect(benchmarkResult.error).toBeUndefined();
          benchmarkResults.push(benchmarkResult);
-         if (benchmarkResults.length === testBrowserList.length) {
+         if (benchmarkResults.length === browsersList.length) {
            done();
          }
        });

--- a/e2e/benchmarks/browserstack-benchmark/app_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_test.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+describe('benchmark multiple browsers', () => {
+  const testBrowserList = [
+    {
+      'os': 'OS X',
+      'os_version': 'Catalina',
+      'browser': 'chrome',
+      'device': null,
+      'browser_version': '84.0'
+    },
+    {
+      'os': 'android',
+      'os_version': '9.0',
+      'browser': 'android',
+      'device': 'Samsung Galaxy Note 10 Plus',
+      'browser_version': null,
+      'real_mobile': true
+    },
+    {
+      'os': 'Windows',
+      'os_version': '10',
+      'browser': 'chrome',
+      'device': null,
+      'browser_version': '84.0',
+      'real_mobile': null
+    }
+  ];
+  const benchmark = {model: 'mobilenet_v2', numRuns: 1, backend: 'cpu'};
+  const browsers = {};
+
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
+
+    // Populate `browsers`.
+    for (const browserConfig of testBrowserList) {
+      const tabId = getTabId(browserConfig);
+      browsers[tabId] = browserConfig;
+    }
+  });
+
+  it('the number of received results is equal to the number of browsers',
+     done => {
+       socket.emit('run', {benchmark, browsers});
+
+       benchmarkResults = [];
+       socket.on('benchmarkComplete', benchmarkResult => {
+         expect(benchmarkResult.error).toBeUndefined();
+         benchmarkResults.push(benchmarkResult);
+         if (benchmarkResults.length === testBrowserList.length) {
+           done();
+         }
+       });
+     });
+});

--- a/e2e/benchmarks/browserstack-benchmark/index.html
+++ b/e2e/benchmarks/browserstack-benchmark/index.html
@@ -43,7 +43,7 @@ limitations under the License.
           }
         </style>
     </head>
-    <body>
+    <body onload="onPageLoad()">
         <script src='/../model_config.js'></script>
         <script src='./index.js'></script>
     </body>

--- a/e2e/benchmarks/browserstack-benchmark/index.js
+++ b/e2e/benchmarks/browserstack-benchmark/index.js
@@ -54,6 +54,9 @@ const state = {
   }
 };
 
+let gui;
+let benchmarkButton;
+
 function initVisor() {
   if (state.isVisorInitiated) {
     return;
@@ -268,20 +271,6 @@ function drawBenchmarkParameterTable(tabId) {
   tfvis.render.table(surface, {headers, values});
 }
 
-socket.on('benchmarkComplete', benchmarkResult => {
-  // Enable the button.
-  benchmarkButton.__li.style.pointerEvents = '';
-  benchmarkButton.__li.style.opacity = 1;
-
-  reportBenchmarkResult(benchmarkResult);
-});
-
-const gui = new dat.gui.GUI();
-gui.domElement.id = 'gui';
-showModelSelection();
-showParameterSettings();
-const benchmarkButton = gui.add(state, 'run').name('Run benchmark');
-
 function showModelSelection() {
   const modelFolder = gui.addFolder('Model');
   let modelUrlController = null;
@@ -324,4 +313,20 @@ function printMemory(bytes) {
   } else {
     return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
   }
+}
+
+function onPageLoad() {
+  gui = new dat.gui.GUI();
+  gui.domElement.id = 'gui';
+  showModelSelection();
+  showParameterSettings();
+  benchmarkButton = gui.add(state, 'run').name('Run benchmark');
+
+  socket.on('benchmarkComplete', benchmarkResult => {
+    // Enable the button.
+    benchmarkButton.__li.style.pointerEvents = '';
+    benchmarkButton.__li.style.opacity = 1;
+
+    reportBenchmarkResult(benchmarkResult);
+  });
 }

--- a/e2e/benchmarks/browserstack-benchmark/index.js
+++ b/e2e/benchmarks/browserstack-benchmark/index.js
@@ -48,7 +48,9 @@ const state = {
       delete benchmark['modelUrl'];
     }
 
-    socket.emit('run', {tabId, benchmark, browser: state.browser});
+    const browsers = {};
+    browsers[tabId] = state.browser;
+    socket.emit('run', {benchmark, browsers});
   }
 };
 
@@ -110,13 +112,14 @@ function getTabId(browserConf) {
   if (browserConf.os === 'android' || browserConf.os === 'ios') {
     baseName = browserConf.device;
   } else {
-    baseName = `${browserConf.os}(${browserConf.os_version})`;
+    baseName = `${browserConf.os}_${browserConf.os_version}`;
   }
+  baseName = baseName.split(' ').join('_');
   if (visorTabNameCounter[baseName] == null) {
     visorTabNameCounter[baseName] = 0;
   }
   visorTabNameCounter[baseName] += 1;
-  return `${baseName} - ${visorTabNameCounter[baseName]}`;
+  return `${baseName}_${visorTabNameCounter[baseName]}`;
 }
 
 function createTab(browserConf) {
@@ -135,7 +138,7 @@ function reportBenchmarkResult(benchmarkResult) {
 
   if (benchmarkResult.error != null) {
     // TODO: show error message under the tab.
-    alert(benchmarkResult.error);
+    console.log(benchmarkResult.error);
     return;
   }
 

--- a/e2e/benchmarks/browserstack-benchmark/index.js
+++ b/e2e/benchmarks/browserstack-benchmark/index.js
@@ -48,6 +48,8 @@ const state = {
       delete benchmark['modelUrl'];
     }
 
+    // TODO: Let `browsers` variable record multiple browser settings, when
+    // building UI for the multiple-selection.
     const browsers = {};
     browsers[tabId] = state.browser;
     socket.emit('run', {benchmark, browsers});

--- a/e2e/benchmarks/browserstack-benchmark/index_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/index_test.js
@@ -46,12 +46,12 @@ describe('getTabId', () => {
 
   it('for mobile devices, uses device name as part of the tab name', () => {
     const mobileName = getTabId(iphoneX);
-    expect(mobileName).toContain(iphoneX.device);
+    expect(mobileName).toContain('iPhone_X');
   });
 
   it('for desktop devices, uses OS name as part of the tab name', () => {
     const desktopName = getTabId(mac);
-    expect(desktopName).toContain(mac.os);
-    expect(desktopName).toContain(mac.os_version);
+    expect(desktopName).toContain('OS_X');
+    expect(desktopName).toContain('High_Sierra');
   });
 });

--- a/e2e/benchmarks/browserstack-benchmark/karma.conf.js
+++ b/e2e/benchmarks/browserstack-benchmark/karma.conf.js
@@ -35,13 +35,10 @@ function getBrowserStackConfig() {
     browsers: []
   };
 
-  // The JSON file stores an array of browsers to benchmark, which is
-  // automatically generated based on browser selection from the webpage.
+  // The JSON file `./browsers.json` stores the `customLaunchers`. The key is
+  // tabId, while the value is specific browser setting.
   const browsers = require('./browsers.json');
-  browsers.forEach((browser, index) => {
-    browserstackConfig.customLaunchers[index.toString()] = browser;
-    browserstackConfig.browsers.push(index.toString());
-  });
+  browserstackConfig.customLaunchers = browsers;
   return browserstackConfig;
 }
 


### PR DESCRIPTION
This PR implements the multi-device benchmark feature by: for each browser instance, the node server creates a process.

Since the UI has not been built, you can run the test in `app_test.js` to check by the following commands:
``` shell
git clone https://github.com/Linchenn/tfjs.git
cd tfjs
git checkout multi-device
cd e2e/benchmarks/browserstack-benchmark
yarn install

export BROWSERSTACK_USERNAME=YOUR_USERNAME
export BROWSERSTACK_ACCESS_KEY=YOUR_ACCESS_KEY

node app.js
```
When you can open http://localhost:8001/SpecRunner.html, three browser instances will start benchmarking. When the benchmark complete, you can see 4 specs are passed.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3768)
<!-- Reviewable:end -->
