### PR TITLE
Remove usage of deprecated WebGPU mapping APIs

### DIFF
--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@webgpu/glslang": "0.0.12",
-    "@webgpu/types": "0.0.28"
+    "@webgpu/types": "0.0.30"
   },
   "peerDependencies": {
     "@tensorflow/tfjs-core": "link:../tfjs-core"

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -238,14 +238,14 @@ export class WebGPUBackend extends KernelBackend {
     const staging = this.acquireBuffer(
         info.bufferInfo.byteSize,
         GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
-    const encoder = this.device.createCommandEncoder({});
+    const encoder = this.device.createCommandEncoder();
     encoder.copyBufferToBuffer(
         info.bufferInfo.buffer, 0, staging, 0, info.bufferInfo.byteSize);
     this.commandQueue.push(encoder);
     this.submitQueue();
 
-    const mapped: ArrayBuffer = await staging.mapReadAsync();
-    const values = mapped.slice(0);
+    await staging.mapAsync(GPUMapMode.READ);
+    const values = staging.getMappedRange().slice(0);
 
     staging.unmap();
     if (staging != null) {
@@ -450,7 +450,7 @@ export class WebGPUBackend extends KernelBackend {
         this.device, bindGroupLayout, inputs.map(t => this.tensorToBinding(t)),
         this.tensorToBinding(output), uniforms);
 
-    const encoder = this.device.createCommandEncoder({});
+    const encoder = this.device.createCommandEncoder();
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bg);

--- a/tfjs-backend-webgpu/yarn.lock
+++ b/tfjs-backend-webgpu/yarn.lock
@@ -865,10 +865,10 @@
   resolved "https://registry.yarnpkg.com/@webgpu/glslang/-/glslang-0.0.12.tgz#ee40e8d38c31436508147feaf0f646fde9bb4da6"
   integrity sha512-GfEVo1GUxNfXjO4Z7I06XXYJA45N6sHoKqI5Ptf3vafnPowq2C1woCqVe7frsClMfBB2yLn1vJss2oWl5EdTig==
 
-"@webgpu/types@0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.0.28.tgz#8492939ded7c9217ad894bae4977c8db8cbb5bd9"
-  integrity sha512-7jBZKttA3Zqb2Wh/YkgPjnCUM70TThZZJ1HU5DA9odKrPnGCSNJKWUSaOTLsar13aFVzotG8ezwg6Pv4bRcI/Q==
+"@webgpu/types@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.0.30.tgz#c2912de0d15c916f12d35579bf9efb44392c7784"
+  integrity sha512-MWVOk6ACnm8wFMaRa7SGa3FK2FetDkdmAVi8homWEGIS28X8Kgdf1i6sdeLsaeV47sqxJG3NQ++e3M23l5xUbA==
 
 accepts@~1.3.4:
   version "1.3.5"


### PR DESCRIPTION
The shape of WebGPU's mapping primitives has changed, and the
old path will be removed soon.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3773)
<!-- Reviewable:end -->
