### PR TITLE
[BrowserStack-benchmark tool] Spawn processes for test runner instead of shells

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -19,7 +19,7 @@ const http = require('http');
 const socketio = require('socket.io');
 const fs = require('fs');
 const path = require('path');
-const {exec} = require('child_process');
+const {execFile} = require('child_process');
 
 const port = process.env.PORT || 8001;
 let io;
@@ -110,9 +110,11 @@ function benchmark(config) {
 
   console.log(`Start benchmarking.`);
   for (const tabId in config.browsers) {
-    const command = `yarn test --browserstack --browsers=${tabId}`;
+    const args = ['test', '--browserstack', `--browsers=${tabId}`];
+    const command = `yarn ${args.join(' ')}`;
     console.log(`Running: ${command}`);
-    exec(command, (error, stdout, stderr) => {
+
+    execFile('yarn', args, (error, stdout, stderr) => {
       console.log(`benchmark ${tabId} completed.`);
       if (error) {
         console.log(error);


### PR DESCRIPTION
Previously, we use `child_process.exec` to execute `yarn test`, but it would spawn a shell each time. If we use `child_process.execFile`, it will spawn a process each time, increasing efficiency.
(Reference: https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3798)
<!-- Reviewable:end -->
