### PR TITLE
Update release note script.

### DIFF
--- a/scripts/release_notes/release_notes_test.ts
+++ b/scripts/release_notes/release_notes_test.ts
@@ -54,7 +54,7 @@ const fakeOctokit: OctokitGetCommit = {
 describe('getReleaseNotesDraft', () => {
   it('Basic draft written', done => {
     const repoCommits: RepoCommits[] = [{
-      repo: {name: 'Core', identifier: 'tfjs-core'},
+      repo: {name: 'Core', identifier: 'tfjs', path: 'tfjs-core'},
       startVersion: '0.9.0',
       endVersion: '0.10.0',
       startCommit: 'fakecommit',
@@ -81,7 +81,7 @@ describe('getReleaseNotesDraft', () => {
 
   it('Basic draft external contributor thanks them', done => {
     const repoCommits: RepoCommits[] = [{
-      repo: {name: 'Core', identifier: 'tfjs'},
+      repo: {name: 'Core', identifier: 'tfjs', path: 'tfjs-core'},
       startVersion: '0.9.0',
       endVersion: '0.10.0',
       startCommit: 'fakecommit',
@@ -110,7 +110,7 @@ describe('getReleaseNotesDraft', () => {
   it('Complex draft', done => {
     const repoCommits: RepoCommits[] = [
       {
-        repo: {name: 'Core', identifier: 'tfjs'},
+        repo: {name: 'Core', identifier: 'tfjs', path: 'tfjs-core'},
         startVersion: '0.9.0',
         endVersion: '0.10.0',
         startCommit: 'fakecommit',
@@ -136,7 +136,7 @@ describe('getReleaseNotesDraft', () => {
         ]
       },
       {
-        repo: {name: 'Layers', identifier: 'tfjs-layers'},
+        repo: {name: 'Layers', identifier: 'tfjs', path: 'tfjs-layers'},
         startVersion: '0.4.0',
         endVersion: '0.5.1',
         startCommit: 'fakecommit2',
@@ -193,7 +193,7 @@ describe('getReleaseNotesDraft', () => {
 
   it('Subject has no pull request number', done => {
     const repoCommits: RepoCommits[] = [{
-      repo: {name: 'Core', identifier: 'tfjs-core'},
+      repo: {name: 'Core', identifier: 'tfjs', path: 'tfjs-core'},
       startVersion: '0.9.0',
       endVersion: '0.10.0',
       startCommit: 'fakecommit',

--- a/scripts/release_notes/util.ts
+++ b/scripts/release_notes/util.ts
@@ -50,6 +50,7 @@ export async function question(questionStr: string): Promise<string> {
 export interface Repo {
   name: string;
   identifier: string;
+  path: string;
   startVersion?: string;
   startCommit?: string;
   endVersion?: string;

--- a/scripts/update-tfjs-lockfiles.ts
+++ b/scripts/update-tfjs-lockfiles.ts
@@ -77,6 +77,21 @@ async function main() {
   $(`git commit -a -m "${message}"`);
   $(`git push`);
 
+  // ========== Tag version. ========================================
+  console.log('~~~ Tag version ~~~');
+  shell.cd('..');
+
+  // The releaseBranch format is tfjs_x.x.x, we only need the version part.
+  const version = releaseBranch.split('_')[1];
+  const tag = `tfjs-v${version}`;
+  var exec = require('child_process').exec;
+  exec(`git tag ${tag} && git push --tags`, (err) => {
+    if (err) {
+      throw new Error(`Could not git tag with ${tag}: ${err.message}.`);
+    }
+    console.log(`Successfully tagged with ${tag}.`);
+  });
+
   console.log('Done.');
 
   process.exit(0);


### PR DESCRIPTION
1. Tag the whole release right after update yarn.lock.
2. Update release note script for tfjs packages. After moving from multi-step release to single step, we no longer need to tag each package, as they will all be tagged at the same commit, so we just use one tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3805)
<!-- Reviewable:end -->
