### PR TITLE
Add README.md for the browserstack-benchmark tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ on NPM.
 
 ## Benchmarks
 
-* [Local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html). Use this webpage tool to collect the performance related metrics (speed, memory, etc) of TensorFlow.js models, kernels and ops **on your local device** with CPU, WebGL or WASM backends. You can benchmark custom models by following this [guide](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md).
+* [Local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html). Use this webpage tool to collect the performance related metrics (speed, memory, etc) of TensorFlow.js models and kernels **on your local device** with CPU, WebGL or WASM backends. You can benchmark custom models by following this [guide](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md).
 * [Multi-device benchmark tool](https://github.com/tensorflow/tfjs/tree/master/e2e/benchmarks/browserstack-benchmark/README.md). Use this tool to collect the same performance related metrics **on a collection of remote devices**.
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ on NPM.
 
 ## Benchmarks
 
-* [Local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html). Use this webpage tool to test the performance related metrics (speed, memory, etc) of TensorFlow.js models, kernels and ops **on your local device** with CPU, WebGL or WASM backend. You can benchmark custom models following this [guide](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md).
-* [Multi-device benchmark tool](https://github.com/tensorflow/tfjs/tree/master/e2e/benchmarks/browserstack-benchmark/README.md). Use this tool to test the same performance related metrics **on a collection of remote devices**.
+* [Local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html). Use this webpage tool to collect the performance related metrics (speed, memory, etc) of TensorFlow.js models, kernels and ops **on your local device** with CPU, WebGL or WASM backends. You can benchmark custom models by following this [guide](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md).
+* [Multi-device benchmark tool](https://github.com/tensorflow/tfjs/tree/master/e2e/benchmarks/browserstack-benchmark/README.md). Use this tool to collect the same performance related metrics **on a collection of remote devices**.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ on NPM.
 
 ## Benchmarks
 
-[Benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html). Use this webpage tool to test the performance related metrics (speed, memory, power, etc) of TensorFlow.js models on your local device with CPU, WebGL or WASM backend. You can benchmark custom models following this [guide](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md).
+* [Local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html). Use this webpage tool to test the performance related metrics (speed, memory, etc) of TensorFlow.js models, kernels and ops **on your local device** with CPU, WebGL or WASM backend. You can benchmark custom models following this [guide](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md).
+* [Multi-device benchmark tool](https://github.com/tensorflow/tfjs/tree/master/e2e/benchmarks/browserstack-benchmark/README.md). Use this tool to test the same performance related metrics **on a collection of remote devices**.
 
 ## Getting started
 

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -33,6 +33,10 @@ The BrowserStack-benchmark tool can benchmark the performance (time, memory) of 
   Then you can see `> Running socket on port: 8001` on your Command-line interface.
 
 3. Open http://localhost:8001/ and start to benchmark.
+4. When the benchmark is complete, you can see the benchmark results in the webpage, like:
+<center>
+  <img src="https://user-images.githubusercontent.com/40653845/90341914-a432f180-dfb8-11ea-841e-0d9078c6d50d.png" alt="drawing" height="300px"/>
+</center>
 
 ## Custom model
 The custom model is supported, but is constrained by:

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -1,0 +1,52 @@
+# Benchmark on multiple devices
+
+> :warning: To use this tool, you need to have an access key of BrowserStack's Automate service.
+
+The BrowserStack-benchmark tool can benchmark the performance (time, memory) of model inference on a collection of remote devices. Using this tool you will be able to:
+  * Select a collection of BrowserStack devices, based on the following fields:
+    - OS
+    - OS version
+    - browser
+    - browser version
+    - device
+  * Select a backend:
+    - WASM
+    - WebGL
+    - CPU
+  * Set the number of rounds for model inference.
+  * Select a model to benchmark.
+
+## Usage
+1. Export your access key of BrowserStack's Automate service:
+  ``` shell
+  export BROWSERSTACK_USERNAME=YOUR_USERNAME
+  export BROWSERSTACK_ACCESS_KEY=YOUR_ACCESS_KEY
+  ```
+2. Download and install the tool:
+  ``` shell
+  git clone https://github.com/Linchenn/tfjs.git
+  cd tfjs/e2e/benchmarks/browserstack-benchmark
+  yarn install
+  ```
+  Then you can see `> Running socket on port: 8001` on your Command-line interface.
+
+3. Open http://localhost:8001/ and start to benchmark.
+
+## Custom model
+The custom model is supported, but is constrained by:
+  * A URL path to the model is required, while the model in local file system is not supported. The following URLs are examples.
+    - TF Hub: https://tfhub.dev/google/tfjs-model/imagenet/resnet_v2_50/feature_vector/1/default/1
+    - Storage: https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/model.json
+  * Currently only `tf.GraphModel` and `tf.LayersModel` are supported.
+
+If you want to benchmark models in other types or customize the inputs for model inference, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
+
+## About this tool
+The tool mainly contains:
+  * A test runner - Karma:
+    - [benchmark_models.js](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/browserstack-benchmark/benchmark_models.js) warps the all benchmark logics into a Jasmine spec.
+    - [browser_list.json](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/browserstack-benchmark/browser_list.json) lists the supported BrowserStack combinations. If you want to add more combinations or refactor this list, you can follow this [conversation](https://github.com/tensorflow/tfjs/pull/3737#issue-463759838).
+  * A node server. [app.js](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/browserstack-benchmark/app.js) runs the test runner and send the benchmark results back to the webpage.
+  * A webpage.
+
+Thanks, <a href="https://www.browserstack.com/">BrowserStack</a>, for providing supports.

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -24,7 +24,7 @@ The BrowserStack-benchmark tool can benchmark the performance (time, memory) of 
   ```
 2. Download and run the tool:
   ``` shell
-  git clone https://github.com/Linchenn/tfjs.git
+  git clone https://github.com/tensorflow/tfjs.git
   cd tfjs/e2e/benchmarks/browserstack-benchmark
   yarn install
 

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -1,8 +1,8 @@
 # Benchmark on multiple devices
 
-> :warning: To use this tool, you need to have an access key of BrowserStack's [Automate](https://automate.browserstack.com/dashboard) service.
+> :warning: To use this tool, you need to sign up for BrowserStack's [Automate](https://automate.browserstack.com/dashboard) service.
 
-The BrowserStack-benchmark tool can benchmark the performance (time, memory) of model inference on a collection of remote devices. Using this tool you will be able to:
+The Multi-device benchmark tool can benchmark the performance (time, memory) of model inference on a collection of remote devices. Using this tool you will be able to:
   * Select a collection of BrowserStack devices, based on the following fields:
     - OS
     - OS version
@@ -34,9 +34,9 @@ The BrowserStack-benchmark tool can benchmark the performance (time, memory) of 
 
 3. Open http://localhost:8001/ and start to benchmark.
 4. When the benchmark is complete, you can see the benchmark results in the webpage, like:
-<center>
+<div style="text-align:center">
   <img src="https://user-images.githubusercontent.com/40653845/90341914-a432f180-dfb8-11ea-841e-0d9078c6d50d.png" alt="drawing" height="300px"/>
-</center>
+</div>
 
 ## Custom model
 The custom model is supported, but is constrained by:
@@ -45,10 +45,10 @@ The custom model is supported, but is constrained by:
     - Storage: https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/model.json
   * Currently only `tf.GraphModel` and `tf.LayersModel` are supported.
 
-If you want to benchmark models in other types or customize the inputs for model inference, you need to add your model with `load` and `predictFunc` methods into [`tfjs/e2e/benchmarks/model_config.js`](https://github.com/Linchenn/tfjs/blob/bs-benchmark-readme/e2e/benchmarks/model_config.js), following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
+If you want to benchmark more complex models with customized input preprocessing logic, you need to add your model with `load` and `predictFunc` methods into [`tfjs/e2e/benchmarks/model_config.js`](https://github.com/Linchenn/tfjs/blob/bs-benchmark-readme/e2e/benchmarks/model_config.js), following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
 
 ## About this tool
-The tool mainly contains:
+The tool contains:
   * A test runner - Karma:
     - [benchmark_models.js](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/browserstack-benchmark/benchmark_models.js) warps the all benchmark logics into a Jasmine spec.
     - [browser_list.json](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/browserstack-benchmark/browser_list.json) lists the supported BrowserStack combinations. If you want to add more combinations or refactor this list, you can follow this [conversation](https://github.com/tensorflow/tfjs/pull/3737#issue-463759838).

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -1,14 +1,14 @@
 # Benchmark on multiple devices
 
-> :warning: To use this tool, you need to have an access key of BrowserStack's Automate service.
+> :warning: To use this tool, you need to have an access key of BrowserStack's [Automate](https://automate.browserstack.com/dashboard) service.
 
 The BrowserStack-benchmark tool can benchmark the performance (time, memory) of model inference on a collection of remote devices. Using this tool you will be able to:
   * Select a collection of BrowserStack devices, based on the following fields:
     - OS
     - OS version
-    - browser
-    - browser version
-    - device
+    - Browser
+    - Browser version
+    - Device
   * Select a backend:
     - WASM
     - WebGL
@@ -22,11 +22,13 @@ The BrowserStack-benchmark tool can benchmark the performance (time, memory) of 
   export BROWSERSTACK_USERNAME=YOUR_USERNAME
   export BROWSERSTACK_ACCESS_KEY=YOUR_ACCESS_KEY
   ```
-2. Download and install the tool:
+2. Download and run the tool:
   ``` shell
   git clone https://github.com/Linchenn/tfjs.git
   cd tfjs/e2e/benchmarks/browserstack-benchmark
   yarn install
+
+  node app.js
   ```
   Then you can see `> Running socket on port: 8001` on your Command-line interface.
 
@@ -34,12 +36,12 @@ The BrowserStack-benchmark tool can benchmark the performance (time, memory) of 
 
 ## Custom model
 The custom model is supported, but is constrained by:
-  * A URL path to the model is required, while the model in local file system is not supported. The following URLs are examples.
+  * A URL path to the model is required, while the model in local file system is not supported. The following URLs are examples:
     - TF Hub: https://tfhub.dev/google/tfjs-model/imagenet/resnet_v2_50/feature_vector/1/default/1
     - Storage: https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/model.json
   * Currently only `tf.GraphModel` and `tf.LayersModel` are supported.
 
-If you want to benchmark models in other types or customize the inputs for model inference, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
+If you want to benchmark models in other types or customize the inputs for model inference, you need to add your model with `load` and `predictFunc` methods into [`tfjs/e2e/benchmarks/model_config.js`](https://github.com/Linchenn/tfjs/blob/bs-benchmark-readme/e2e/benchmarks/model_config.js), following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
 
 ## About this tool
 The tool mainly contains:

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -2,7 +2,7 @@
 
 The `custom model` in the [benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) currently only supports `tf.GraphModel` or `tf.LayersModel`.
 
-If you want to benchmark models in other types or customize the inputs for model inference, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
+If you want to benchmark more complex models with customized input preprocessing logic, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
 
 ## Models in local file system
 If you have a model in local file system, you can follow the steps below:


### PR DESCRIPTION
This PR does the following:
1. Add a README.md for the browserstack-benchmark tool. 
2. Add a link to this tool under the README.md of tfjs repo.

You can preview it at [README.md](https://github.com/Linchenn/tfjs/blob/bs-benchmark-readme/e2e/benchmarks/browserstack-benchmark/README.md).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3809)
<!-- Reviewable:end -->
