### PR TITLE
Use tf.profile to profile model inference

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -322,45 +322,12 @@ async function profileInferenceMemory(predict) {
         `a(n) ${typeof predict} is found.`);
   }
 
-  const memoryInfo = await profile(async () => {
+  const memoryInfo = await tf.profile(async () => {
     const res = await predict();
     await downloadValuesFromTensorContainer(res);
     tf.dispose(res);
   });
   return memoryInfo;
-}
-
-/**
- * This function is temporarily used and will be deleted after a new release of
- * tf-core. This function modifies
- * This function is temporarily used and will be deleted after a new release
- * of tf-core. This function modifies
- * [`tf.profile`](https://github.com/tensorflow/tfjs/blob/95b5f878218ee45c0f8464386ee01d1f96e78297/tfjs-core/src/engine.ts#L848)
- * in the following points:
- * - replaces all `this` by `tf.engine()`
- * - adds `await` in `this.state.activeProfile.result = query();`
- *
- * When deleting this method, please change the caller
- * `profileInferenceMemory`.
- */
-async function profile(query) {
-  const engine = tf.engine();
-  engine.state.profiling = true;
-
-  const startBytes = engine.state.numBytes;
-  const startNumTensors = engine.state.numTensors;
-
-  engine.state.activeProfile.kernels = [];
-  engine.state.activeProfile.result = await query();
-
-  engine.state.profiling = false;
-
-  engine.state.activeProfile.peakBytes = Math.max(
-      ...engine.state.activeProfile.kernels.map(d => d.totalBytesSnapshot));
-  engine.state.activeProfile.newBytes = engine.state.numBytes - startBytes;
-  engine.state.activeProfile.newTensors =
-      engine.state.numTensors - startNumTensors;
-  return engine.state.activeProfile;
 }
 
 /**

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -20,6 +20,10 @@
  * browser.
  */
 
+function sleep(timeMs) {
+  return new Promise(resolve => setTimeout(resolve, timeMs));
+}
+
 describe('benchmark_util', () => {
   beforeEach(() => tf.setBackend('cpu'));
 
@@ -74,6 +78,25 @@ describe('benchmark_util', () => {
 
         model.dispose();
         input.dispose();
+      });
+
+      it('profile all statements in async predict function', async () => {
+        const predict = async () => {
+          await sleep(1);
+          const x = tf.tensor1d([1, 2, 3]);
+          const x2 = x.square();
+          x2.dispose();
+          return x;
+        };
+
+        const oldTensorCount = tf.memory().numTensors;
+        let profileInfo = await profileInferenceMemory(predict);
+        expect(tf.memory().numTensors).toEqual(oldTensorCount);
+
+        // If `profileInferenceMemory` cannot profile async function, it would
+        // fail to profile all the statements after `await sleep(1);` and the
+        // peak memory would be `-Infinity`.
+        expect(profileInfo.peakBytes).toBeGreaterThan(0);
       });
     });
   });


### PR DESCRIPTION
Since `tf.profile()` can profile async functions, https://github.com/tensorflow/tfjs/pull/3564, we would utilize it to profile model inference.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3812)
<!-- Reviewable:end -->
