### PR TITLE
Add operation time info for profileInference method

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -328,7 +328,8 @@ async function profileInferenceMemory(predict) {
     tf.dispose(res);
   });
 
-  // Aggregate kernel times into operation times.
+  kernelInfo.kernels =
+      kernelInfo.kernels.sort((a, b) => b.kernelTimeMs - a.kernelTimeMs);
   kernelInfo.operations = aggregateKernelTime(kernelInfo.kernels);
   return kernelInfo;
 }
@@ -345,7 +346,7 @@ function aggregateKernelTime(kernels) {
   });
 
   return Object.entries(operationTime)
-      .map((name, operationTimeMs) => ({name, operationTimeMs}))
+      .map(([name, operationTimeMs]) => ({name, operationTimeMs}))
       .sort((a, b) => b.operationTimeMs - a.operationTimeMs);
 }
 

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -269,9 +269,9 @@ async function downloadValuesFromTensorContainer(tensorContainer) {
  * output shapes, number of bytes used, number of new tensors created and kernel
  * time (ms). The array is sorted by `kernelTimeMs` field in non-ascending
  * order.
- * - `operations`: an array of operation information objects about their name
- * and time. The array is sorted by `operationTimeMs` field in non-ascending
- * order.
+ * - `aggregatedKernels`: an array of aggregated kernel information objects with
+ * `name` and `timeMs` fields. The array is sorted by `timeMs` field in
+ * non-ascending order.
  *
  * ```js
  * const modelUrl =
@@ -304,9 +304,9 @@ async function profileModelInference(model, input) {
  * output shapes, number of bytes used, number of new tensors created and kernel
  * time (ms). The array is sorted by `kernelTimeMs` field in non-ascending
  * order.
- * - `operations`: an array of operation information objects about their name
- * and time. The array is sorted by `operationTimeMs` field in non-ascending
- * order.
+ * - `aggregatedKernels`: an array of aggregated kernel information objects with
+ * `name` and `timeMs` fields. The array is sorted by `timeMs` field in
+ * non-ascending order.
  *
  * ```js
  * const modelUrl =
@@ -338,32 +338,32 @@ async function profileInference(predict) {
 
   kernelInfo.kernels =
       kernelInfo.kernels.sort((a, b) => b.kernelTimeMs - a.kernelTimeMs);
-  kernelInfo.operations = aggregateKernelTime(kernelInfo.kernels);
+  kernelInfo.aggregatedKernels = aggregateKernelTime(kernelInfo.kernels);
   return kernelInfo;
 }
 
 /**
- * Aggregate kernel times into operation times and sort the array in
- * non-ascending order of time. Return an array of objects with `name` and
- * `operationTimeMs` fields.
+ * Aggregate kernels by name and sort the array in non-ascending order of time.
+ * Return an array of objects with `name` and `timeMs` fields.
  *
  * @param {Array<Object>} kernels An array of kernel information objects. Each
  *     object must include `name` (string) and `kernelTimeMs` (number) fields.
  */
 function aggregateKernelTime(kernels) {
-  const operationTime = {};
+  const aggregatedKernelTime = {};
   kernels.forEach(kernel => {
-    const oldOperationTime = operationTime[kernel.name];
-    if (oldOperationTime == null) {
-      operationTime[kernel.name] = kernel.kernelTimeMs;
+    const oldAggregatedKernelTime = aggregatedKernelTime[kernel.name];
+    if (oldAggregatedKernelTime == null) {
+      aggregatedKernelTime[kernel.name] = kernel.kernelTimeMs;
     } else {
-      operationTime[kernel.name] = oldOperationTime + kernel.kernelTimeMs;
+      aggregatedKernelTime[kernel.name] =
+          oldAggregatedKernelTime + kernel.kernelTimeMs;
     }
   });
 
-  return Object.entries(operationTime)
-      .map(([name, operationTimeMs]) => ({name, operationTimeMs}))
-      .sort((a, b) => b.operationTimeMs - a.operationTimeMs);
+  return Object.entries(aggregatedKernelTime)
+      .map(([name, timeMs]) => ({name, timeMs}))
+      .sort((a, b) => b.timeMs - a.timeMs);
 }
 
 /**

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -267,9 +267,11 @@ async function downloadValuesFromTensorContainer(tensorContainer) {
  * - `peakBytes`: the peak number of bytes allocated.
  * - `kernels`: an array of kernel information objects about their input and
  * output shapes, number of bytes used, number of new tensors created and kernel
- * time (ms). The array is sorted by `kernelTimeMs` field.
+ * time (ms). The array is sorted by `kernelTimeMs` field in non-ascending
+ * order.
  * - `operations`: an array of operation information objects about their name
- * and time. The array is sorted by `operationTimeMs` field.
+ * and time. The array is sorted by `operationTimeMs` field in non-ascending
+ * order.
  *
  * ```js
  * const modelUrl =
@@ -300,9 +302,11 @@ async function profileModelInference(model, input) {
  * - `peakBytes`: the peak number of bytes allocated.
  * - `kernels`: an array of kernel information objects about their input and
  * output shapes, number of bytes used, number of new tensors created and kernel
- * time (ms). The array is sorted by `kernelTimeMs` field.
+ * time (ms). The array is sorted by `kernelTimeMs` field in non-ascending
+ * order.
  * - `operations`: an array of operation information objects about their name
- * and time. The array is sorted by `operationTimeMs` field.
+ * and time. The array is sorted by `operationTimeMs` field in non-ascending
+ * order.
  *
  * ```js
  * const modelUrl =

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -322,7 +322,7 @@ async function profileInferenceMemory(predict) {
         `a(n) ${typeof predict} is found.`);
   }
 
-  const memoryInfo = await profile(async () => {
+  const memoryInfo = await tf.profile(async () => {
     const res = await predict();
     await downloadValuesFromTensorContainer(res);
     tf.dispose(res);

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -262,40 +262,9 @@ async function downloadValuesFromTensorContainer(tensorContainer) {
  * Executes the predict function for `model` (`model.predict` for
  * tf.LayersModel and `model.executeAsync` for tf.GraphModel) and returns a
  * promise that resolves with information about the memory usage:
- * - `newBytes`: the number of new bytes allocated
- * - `newTensors`: the number of new tensors created
- * - `peakBytes`: the peak number of bytes allocated
- * - `kernels`: an array of objects for each kernel involved that reports
- * their input and output shapes, number of bytes used, and number of new
- * tensors created.
- *
- * ```js
- * const modelUrl =
- *    'https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/2';
- * const model = await tf.loadGraphModel(modelUrl, {fromTFHub: true});
- * const zeros = tf.zeros([1, 224, 224, 3]);
- * const memoryInfo = await profileInferenceMemoryForModel(model, zeros);
- *
- * console.log(`newBytes: ${memoryInfo.newBytes}`);
- * console.log(`newTensors: ${memoryInfo.newTensors}`);
- * console.log(`peakBytes: ${memoryInfo.peakBytes}`);
- * ```
- *
- * @param model An instance of tf.GraphModel or tf.LayersModel for profiling
- *     memory usage in the inference process.
- * @param input The input tensor container for model inference.
- */
-async function profileInferenceMemoryForModel(model, input) {
-  const predict = getPredictFnForModel(model, input);
-  return profileInferenceMemory(predict);
-}
-
-/**
- * Executes `predict()` and returns a promise that resolves with information
- * about the memory usage:
- * - `newBytes`: the number of new bytes allocated
- * - `newTensors`: the number of new tensors created
- * - `peakBytes`: the peak number of bytes allocated
+ * - `newBytes`: the number of new bytes allocated.
+ * - `newTensors`: the number of new tensors created.
+ * - `peakBytes`: the peak number of bytes allocated.
  * - `kernels`: an array of kernel information objects about their input and
  * output shapes, number of bytes used, number of new tensors created and kernel
  * time (ms). The array is sorted by `kernelTimeMs` field.
@@ -307,7 +276,40 @@ async function profileInferenceMemoryForModel(model, input) {
  *    'https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/2';
  * const model = await tf.loadGraphModel(modelUrl, {fromTFHub: true});
  * const zeros = tf.zeros([1, 224, 224, 3]);
- * const profileInfo = await profileInferenceMemory(() =>
+ * const profileInfo = await profileModelInference(model, zeros);
+ *
+ * console.log(`newBytes: ${profileInfo.newBytes}`);
+ * console.log(`newTensors: ${profileInfo.newTensors}`);
+ * console.log(`peakBytes: ${profileInfo.peakBytes}`);
+ * ```
+ *
+ * @param model An instance of tf.GraphModel or tf.LayersModel for profiling
+ *     memory usage in the inference process.
+ * @param input The input tensor container for model inference.
+ */
+async function profileModelInference(model, input) {
+  const predict = getPredictFnForModel(model, input);
+  return profileInference(predict);
+}
+
+/**
+ * Executes `predict()` and returns a promise that resolves with information
+ * about the memory usage:
+ * - `newBytes`: the number of new bytes allocated.
+ * - `newTensors`: the number of new tensors created.
+ * - `peakBytes`: the peak number of bytes allocated.
+ * - `kernels`: an array of kernel information objects about their input and
+ * output shapes, number of bytes used, number of new tensors created and kernel
+ * time (ms). The array is sorted by `kernelTimeMs` field.
+ * - `operations`: an array of operation information objects about their name
+ * and time. The array is sorted by `operationTimeMs` field.
+ *
+ * ```js
+ * const modelUrl =
+ *    'https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/2';
+ * const model = await tf.loadGraphModel(modelUrl, {fromTFHub: true});
+ * const zeros = tf.zeros([1, 224, 224, 3]);
+ * const profileInfo = await profileInference(() =>
  * model.predict(zeros));
  *
  * console.log(`newBytes: ${profileInfo.newBytes}`);
@@ -317,7 +319,7 @@ async function profileInferenceMemoryForModel(model, input) {
  *
  * @param predict The predict function to execute for profiling memory usage.
  */
-async function profileInferenceMemory(predict) {
+async function profileInference(predict) {
   if (typeof predict !== 'function') {
     throw new Error(
         'The first parameter should be a function, while ' +

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -296,21 +296,23 @@ async function profileInferenceMemoryForModel(model, input) {
  * - `newBytes`: the number of new bytes allocated
  * - `newTensors`: the number of new tensors created
  * - `peakBytes`: the peak number of bytes allocated
- * - `kernels`: an array of objects for each kernel involved that reports
- * their input and output shapes, number of bytes used, and number of new
- * tensors created.
+ * - `kernels`: an array of kernel information objects about their input and
+ * output shapes, number of bytes used, number of new tensors created and kernel
+ * time (ms). The array is sorted by `kernelTimeMs` field.
+ * - `operations`: an array of operation information objects about their name
+ * and time. The array is sorted by `operationTimeMs` field.
  *
  * ```js
  * const modelUrl =
  *    'https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/2';
  * const model = await tf.loadGraphModel(modelUrl, {fromTFHub: true});
  * const zeros = tf.zeros([1, 224, 224, 3]);
- * const memoryInfo = await profileInferenceMemory(() =>
+ * const profileInfo = await profileInferenceMemory(() =>
  * model.predict(zeros));
  *
- * console.log(`newBytes: ${memoryInfo.newBytes}`);
- * console.log(`newTensors: ${memoryInfo.newTensors}`);
- * console.log(`peakBytes: ${memoryInfo.peakBytes}`);
+ * console.log(`newBytes: ${profileInfo.newBytes}`);
+ * console.log(`newTensors: ${profileInfo.newTensors}`);
+ * console.log(`peakBytes: ${profileInfo.peakBytes}`);
  * ```
  *
  * @param predict The predict function to execute for profiling memory usage.
@@ -334,6 +336,14 @@ async function profileInferenceMemory(predict) {
   return kernelInfo;
 }
 
+/**
+ * Aggregate kernel times into operation times and sort the array in
+ * non-ascending order of time. Return an array of objects with `name` and
+ * `operationTimeMs` fields.
+ *
+ * @param {Array<Object>} kernels An array of kernel information objects. Each
+ *     object must include `name` (string) and `kernelTimeMs` (number) fields.
+ */
 function aggregateKernelTime(kernels) {
   const operationTime = {};
   kernels.forEach(kernel => {

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -56,11 +56,11 @@ describe('benchmark_util', () => {
     });
   });
 
-  describe('Profile Memory', () => {
-    describe('profileInferenceMemory', () => {
+  describe('Profile Inference', () => {
+    describe('profileInference', () => {
       it('pass in invalid predict', async () => {
         const predict = {};
-        await expectAsync(profileInferenceMemory(predict)).toBeRejected();
+        await expectAsync(profileInference(predict)).toBeRejected();
       });
 
       it('check tensor leak', async () => {
@@ -69,7 +69,7 @@ describe('benchmark_util', () => {
         const input = tf.zeros([1, 3]);
 
         const tensorsBefore = tf.memory().numTensors;
-        await profileInferenceMemory(() => model.predict(input));
+        await profileInference(() => model.predict(input));
         expect(tf.memory().numTensors).toEqual(tensorsBefore);
 
         model.dispose();

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -90,10 +90,10 @@ describe('benchmark_util', () => {
         };
 
         const oldTensorCount = tf.memory().numTensors;
-        let profileInfo = await profileInferenceMemory(predict);
+        let profileInfo = await profileInference(predict);
         expect(tf.memory().numTensors).toEqual(oldTensorCount);
 
-        // If `profileInferenceMemory` cannot profile async function, it would
+        // If `profileInference` cannot profile async function, it would
         // fail to profile all the statements after `await sleep(1);` and the
         // peak memory would be `-Infinity`.
         expect(profileInfo.peakBytes).toBeGreaterThan(0);

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -111,12 +111,12 @@ describe('benchmark_util', () => {
         {name: 'testKernel2', kernelTimeMs: 1},
       ];
 
-      const operations = aggregateKernelTime(kernels);
-      expect(operations.length).toBe(2);
-      expect(operations[0].name).toBe('testKernel1');
-      expect(operations[0].operationTimeMs).toBe(3);
-      expect(operations[1].name).toBe('testKernel2');
-      expect(operations[1].operationTimeMs).toBe(2);
+      const aggregatedKernels = aggregateKernelTime(kernels);
+      expect(aggregatedKernels.length).toBe(2);
+      expect(aggregatedKernels[0].name).toBe('testKernel1');
+      expect(aggregatedKernels[0].timeMs).toBe(3);
+      expect(aggregatedKernels[1].name).toBe('testKernel2');
+      expect(aggregatedKernels[1].timeMs).toBe(2);
     });
   });
 

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -78,6 +78,25 @@ describe('benchmark_util', () => {
     });
   });
 
+  describe('aggregateKernelTime', () => {
+    it('aggregates the kernels according to names', () => {
+      const kernels = [
+        {name: 'testKernel1', kernelTimeMs: 1},
+        {name: 'testKernel1', kernelTimeMs: 1},
+        {name: 'testKernel1', kernelTimeMs: 1},
+        {name: 'testKernel2', kernelTimeMs: 1},
+        {name: 'testKernel2', kernelTimeMs: 1},
+      ];
+
+      const operations = aggregateKernelTime(kernels);
+      expect(operations.length).toBe(2);
+      expect(operations[0].name).toBe('testKernel1');
+      expect(operations[0].operationTimeMs).toBe(3);
+      expect(operations[1].name).toBe('testKernel2');
+      expect(operations[1].operationTimeMs).toBe(2);
+    });
+  });
+
   describe('getPredictFnForModel', () => {
     it('graph model with async ops uses executeAsync to run', () => {
       const model = new tf.GraphModel();

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
@@ -89,11 +89,11 @@ describe('benchmark models', () => {
       if (benchmark.predictFunc != null) {
         const predict = benchmark.predictFunc();
         timeInfo = await profileInferenceTime(() => predict(model), numRuns);
-        memoryInfo = await profileInferenceMemory(() => predict(model));
+        memoryInfo = await profileInference(() => predict(model));
       } else {
         const input = generateInput(model);
         timeInfo = await profileInferenceTimeForModel(model, input, numRuns);
-        memoryInfo = await profileInferenceMemoryForModel(model, input);
+        memoryInfo = await profileModelInference(model, input);
       }
 
       // Report results.

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -401,8 +401,7 @@ limitations under the License.
     function showKernelTime(profileInfo) {
       const tbody = document.querySelector('#kernels tbody');
       if (state.kernelTiming === 'individual') {
-        const kernels = profileInfo.kernels.sort((a, b) => b.time - a.time);
-        kernels.forEach(kernel => {
+        profileInfo.kernels.forEach(kernel => {
           const nameSpan = document.createElement('span');
           nameSpan.textContent = kernel.name;
           let inputSummary;

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -366,8 +366,8 @@ limitations under the License.
       appendRow(timeTable, '', '');
     }
 
-    async function profileMemory() {
-      await showMsg('Profile memory');
+    async function profileMemoryAndKernelTime() {
+      await showMsg('Profile memory and kernels');
       const start = performance.now();
 
       let profileInfo;
@@ -403,23 +403,24 @@ limitations under the License.
       if (state.kernelTiming === 'individual') {
         profileInfo.kernels.forEach(kernel => {
           const nameSpan = document.createElement('span');
+          nameSpan.setAttribute('title', kernel.name);
           nameSpan.textContent = kernel.name;
-          let inputSummary;
+          let inputInfo;
           kernel.inputShapes.forEach((inputShape, index) => {
-            if (inputSummary == null) {
-              inputSummary = '';
+            if (inputInfo == null) {
+              inputInfo = '';
             } else {
-              inputSummary += '<br>';
+              inputInfo += '<br>';
             }
             // TODO: Add the name for each input node in the returned value of
             // `tf.profile` at https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/engine.ts#L657.
             if (inputShape == null) {
-              inputSummary += `input${index}: null`;
+              inputInfo += `input${index}: null`;
             } else {
-              inputSummary += `input${index}: ${inputShape.length}D[${inputShape}]`;
+              inputInfo += `input${index}: ${inputShape.length}D[${inputShape}]`;
             }
           });
-          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), inputSummary, kernel.outputShapes, kernel.extraInfo);
+          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), inputInfo, kernel.outputShapes, kernel.extraInfo);
         });
       } else {
         profileInfo.operations.forEach(r => {
@@ -459,7 +460,7 @@ limitations under the License.
       await warmUpAndRecordTime();
       await showMsg('Waiting for GC');
       await sleep(1000);
-      await profileMemory();
+      await profileMemoryAndKernelTime();
       await sleep(200);
       await measureAveragePredictTime();
     }

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -374,12 +374,12 @@ limitations under the License.
       if (state.benchmark === 'custom') {
         const input = generateInput(model);
         try {
-          profileInfo = await profileInferenceMemoryForModel(model, input);
+          profileInfo = await profileModelInference(model, input);
         } finally {
           tf.dispose(input);
         }
       } else {
-        profileInfo = await profileInferenceMemory(() => predict(model));
+        profileInfo = await profileInference(() => predict(model));
       }
 
       const elapsed = performance.now() - start;

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -423,11 +423,11 @@ limitations under the License.
           appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), inputInfo, kernel.outputShapes, kernel.extraInfo);
         });
       } else {
-        profileInfo.operations.forEach(r => {
+        profileInfo.aggregatedKernels.forEach(r => {
           const nameSpan = document.createElement('span');
           nameSpan.setAttribute('title', r.name);
           nameSpan.textContent = r.name;
-          appendRow(tbody, nameSpan, r.operationTimeMs.toFixed(2));
+          appendRow(tbody, nameSpan, r.timeMs.toFixed(2));
         });
       }
     }

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -392,7 +392,7 @@ limitations under the License.
         await showMsg('Profiling kernels');
         const kernels = profileInfo.kernels.sort((a, b) => b.time - a.time);
         appendRow(timeTable, 'Number of kernels', kernels.length);
-        // showKernelTime(kernels);
+        showKernelTime(kernels);
       } else {
         await showMsg('Skipping kernel times since query timer extension is not ' +
           'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
@@ -402,20 +402,35 @@ limitations under the License.
     function showKernelTime(kernels) {
       const tbody = document.querySelector('#kernels tbody');
       if (state.kernelTiming === 'individual') {
-        kernels.forEach(k => {
+        kernels.forEach(kernel => {
           const nameSpan = document.createElement('span');
-          nameSpan.setAttribute('title', k.scopes.slice(0, -1).join(' --> '));
-          nameSpan.textContent = k.scopes[k.scopes.length - 1];
-          appendRow(tbody, nameSpan, k.time.toFixed(2), k.inputs, k.output, k.gpuProgramsInfo);
+          nameSpan.textContent = kernel.name;
+          let inputSummary;
+          kernel.inputShapes.forEach((inputShape, index) => {
+            if (inputSummary == null) {
+              inputSummary = '';
+            } else {
+              inputSummary += '<br>';
+            }
+            // TODO: Add the name for each input node in the returned value of
+            // `tf.profile` at https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/engine.ts#L657.
+            if (inputShape == null) {
+              inputSummary += `input${index}: null`;
+            } else {
+              inputSummary += `input${index}: ${inputShape.length}D[${inputShape}]`;
+            }
+          });
+          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), inputSummary, kernel.outputShapes, kernel.extraInfo);
         });
       } else {
         const kernelTotalTime = {};
-        kernels.forEach(k => {
-          const kernelName = k.scopes[0];
-          if (kernelTotalTime[kernelName] == null) {
-            kernelTotalTime[kernelName] = 0;
+        kernels.forEach(kernel => {
+          const oldKernelTotalTime = kernelTotalTime[kernel.name];
+          if (oldKernelTotalTime == null) {
+            kernelTotalTime[kernel.name] = kernel.kernelTimeMs;
+          } else {
+            kernelTotalTime[kernel.name] = oldKernelTotalTime + kernel.kernelTimeMs;
           }
-          kernelTotalTime[kernelName] += k.time;
         });
 
         const result = Object.keys(kernelTotalTime)

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -362,29 +362,41 @@ limitations under the License.
       await showMsg(null);
       appendRow(timeTable, `Subsequent average(${state.numRuns} runs)`, printTime(timeInfo.averageTime));
       appendRow(timeTable, 'Best time', printTime(timeInfo.minTime));
+      // Add an empty row at the end of a round of benchmark.
+      appendRow(timeTable, '', '');
     }
 
     async function profileMemory() {
       await showMsg('Profile memory');
       const start = performance.now();
 
-      let memoryInfo;
+      let profileInfo;
       if (state.benchmark === 'custom') {
         const input = generateInput(model);
         try {
-          memoryInfo = await profileInferenceMemoryForModel(model, input);
+          profileInfo = await profileInferenceMemoryForModel(model, input);
         } finally {
           tf.dispose(input);
         }
       } else {
-        memoryInfo = await profileInferenceMemory(() => predict(model));
+        profileInfo = await profileInferenceMemory(() => predict(model));
       }
 
       const elapsed = performance.now() - start;
       await showMsg(null);
-      appendRow(timeTable, 'Peak memory', printMemory(memoryInfo.peakBytes));
-      appendRow(timeTable, 'Leaked tensors', memoryInfo.newTensors);
+      appendRow(timeTable, 'Peak memory', printMemory(profileInfo.peakBytes));
+      appendRow(timeTable, 'Leaked tensors', profileInfo.newTensors);
       appendRow(timeTable, '2nd inference', printTime(elapsed));
+
+      if (state.backend != 'webgl' || queryTimerIsEnabled()) {
+        await showMsg('Profiling kernels');
+        const kernels = profileInfo.kernels.sort((a, b) => b.time - a.time);
+        appendRow(timeTable, 'Number of kernels', kernels.length);
+        // showKernelTime(kernels);
+      } else {
+        await showMsg('Skipping kernel times since query timer extension is not ' +
+          'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
+      };
     }
 
     function showKernelTime(kernels) {
@@ -418,51 +430,6 @@ limitations under the License.
       }
     }
 
-    async function profileKernelTime() {
-      await showMsg('Profiling kernels');
-      _tfengine.ENV.set('DEBUG', true);
-      const oldLog = console.log;
-      let kernels = [];
-      console.log = msg => {
-        let parts = [];
-        if (typeof msg === 'string') {
-          parts = msg.split('\t').map(x => x.slice(2));
-        }
-
-        if (parts.length > 2) {
-          // heuristic for determining whether we've caught a profiler
-          // log statement as opposed to a regular console.log
-          // TODO(https://github.com/tensorflow/tfjs/issues/563): return timing information as part of tf.profile
-          const scopes = parts[0].trim()
-            .split('||')
-            .filter(s => s !== 'unnamed scope');
-          kernels.push({
-            scopes: scopes,
-            time: Number.parseFloat(parts[1]),
-            output: parts[2].trim(),
-            inputs: parts[4],
-            gpuProgramsInfo: parts[5]
-          });
-        } else {
-          oldLog.call(oldLog, msg);
-        }
-      }
-      let res = predict(model);
-      res = await getPredictionData(res);
-
-      await showMsg(null);
-      await sleep(10);
-      kernels = kernels.sort((a, b) => b.time - a.time);
-      appendRow(timeTable, 'Number of kernels', kernels.length);
-
-      // Add an empty row at the end of a benchmark run
-      appendRow(timeTable, '', '');
-      showKernelTime(kernels);
-      _tfengine.ENV.set('DEBUG', false);
-      // Switch back to the old log;
-      console.log = oldLog;
-    }
-
     async function cleanUpTable() {
       parameterTable.innerHTML = '';
       if (state.isModelChanged) {
@@ -494,14 +461,6 @@ limitations under the License.
       await profileMemory();
       await sleep(200);
       await measureAveragePredictTime();
-      await sleep(200);
-
-      if (state.backend != 'webgl' || queryTimerIsEnabled()) {
-        await profileKernelTime();
-      } else {
-        await showMsg('Skipping kernel times since query timer extension is not ' +
-          'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
-      };
     }
 
 

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -390,18 +390,18 @@ limitations under the License.
 
       if (state.backend != 'webgl' || queryTimerIsEnabled()) {
         await showMsg('Profiling kernels');
-        const kernels = profileInfo.kernels.sort((a, b) => b.time - a.time);
-        appendRow(timeTable, 'Number of kernels', kernels.length);
-        showKernelTime(kernels);
+        appendRow(timeTable, 'Number of kernels', profileInfo.kernels.length);
+        showKernelTime(profileInfo);
       } else {
         await showMsg('Skipping kernel times since query timer extension is not ' +
           'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
       };
     }
 
-    function showKernelTime(kernels) {
+    function showKernelTime(profileInfo) {
       const tbody = document.querySelector('#kernels tbody');
       if (state.kernelTiming === 'individual') {
+        const kernels = profileInfo.kernels.sort((a, b) => b.time - a.time);
         kernels.forEach(kernel => {
           const nameSpan = document.createElement('span');
           nameSpan.textContent = kernel.name;
@@ -423,24 +423,11 @@ limitations under the License.
           appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), inputSummary, kernel.outputShapes, kernel.extraInfo);
         });
       } else {
-        const kernelTotalTime = {};
-        kernels.forEach(kernel => {
-          const oldKernelTotalTime = kernelTotalTime[kernel.name];
-          if (oldKernelTotalTime == null) {
-            kernelTotalTime[kernel.name] = kernel.kernelTimeMs;
-          } else {
-            kernelTotalTime[kernel.name] = oldKernelTotalTime + kernel.kernelTimeMs;
-          }
-        });
-
-        const result = Object.keys(kernelTotalTime)
-            .map(k => [k, kernelTotalTime[k]])
-            .sort((a, b) => b[1] - a[1]);
-        result.forEach(r => {
+        profileInfo.operations.forEach(r => {
           const nameSpan = document.createElement('span');
-          nameSpan.setAttribute('title', r[0]);
-          nameSpan.textContent = r[0];
-          appendRow(tbody, nameSpan, r[1].toFixed(2));
+          nameSpan.setAttribute('title', r.name);
+          nameSpan.textContent = r.name;
+          appendRow(tbody, nameSpan, r.operationTimeMs.toFixed(2));
         });
       }
     }


### PR DESCRIPTION
This PR does the following:
1. Rename profile methods in `benchmark_util.js`:
     - `profileInferenceMemory` -> `profileInference`
     - `profileInferenceMemoryForModel` -> `profileModelInference`
2. Add a method to aggregate the kernel times into operation times in `benchmark_util.js`.
3. Reduce the redundant logics in the local-benchmark tool.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3814)
<!-- Reviewable:end -->
