### PR TITLE
Release and bundle tests

### DIFF
--- a/e2e/cloudbuild.yml
+++ b/e2e/cloudbuild.yml
@@ -20,7 +20,10 @@ steps:
   entrypoint: 'yarn'
   id: 'test'
   args: ['test-ci']
-  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
+  # TEMPORARY force nightly CI
+  # env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
+  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=TRUE']
+
   secretEnv: ['BROWSERSTACK_KEY']
 
 secrets:

--- a/e2e/script_tag_tests/karma.conf.js
+++ b/e2e/script_tag_tests/karma.conf.js
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+module.exports = function(config) {
+  const args = [];
+
+  const tfjsBundle = config.testBundle ? config.testBundle : 'tf.min.js';
+  const tfjsBundlePath = `../node_modules/@tensorflow/tfjs/dist/${tfjsBundle}`;
+
+  const devConfig = {
+    frameworks: ['jasmine'],
+    files: [
+      {
+        pattern: tfjsBundlePath,
+        nocache: true,
+      },
+      {pattern: './**/*_test.js'},
+    ],
+    reporters: ['progress']
+  };
+
+  const browserstackConfig = {
+    ...devConfig,
+    hostname: 'bs-local.com',
+    singleRun: true
+  };
+
+  if (config.grep) {
+    args.push('--grep', config.grep);
+  }
+  if (config.tags) {
+    args.push('--tags', config.tags);
+  }
+
+  let extraConfig = null;
+
+  if (config.browserstack) {
+    extraConfig = browserstackConfig;
+  } else {
+    extraConfig = devConfig;
+  }
+
+  config.set({
+    ...extraConfig,
+    browsers: ['Chrome'],
+    browserStack: {
+      username: process.env.BROWSERSTACK_USERNAME,
+      accessKey: process.env.BROWSERSTACK_KEY
+    },
+    captureTimeout: 3e5,
+    reportSlowerThan: 500,
+    browserNoActivityTimeout: 3e5,
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 0,
+    browserSocketTimeout: 1.2e5,
+    customLaunchers: {
+      bs_chrome_mac: {
+        base: 'BrowserStack',
+        browser: 'chrome',
+        browser_version: 'latest',
+        os: 'OS X',
+        os_version: 'High Sierra'
+      },
+      bs_firefox_mac: {
+        base: 'BrowserStack',
+        browser: 'firefox',
+        browser_version: 'latest',
+        os: 'OS X',
+        os_version: 'High Sierra'
+      },
+      bs_safari_mac: {
+        base: 'BrowserStack',
+        browser: 'safari',
+        browser_version: 'latest',
+        os: 'OS X',
+        os_version: 'High Sierra'
+      },
+      bs_ios_11: {
+        base: 'BrowserStack',
+        device: 'iPhone X',
+        os: 'iOS',
+        os_version: '11.0',
+        real_mobile: true
+      },
+      bs_android_9: {
+        base: 'BrowserStack',
+        device: 'Google Pixel 3 XL',
+        os: 'android',
+        os_version: '9.0',
+        real_mobile: true
+      },
+      win_10_chrome: {
+        base: 'BrowserStack',
+        browser: 'chrome',
+        // Latest Chrome on Windows has WebGL problems:
+        // https://github.com/tensorflow/tfjs/issues/2272
+        browser_version: '77.0',
+        os: 'Windows',
+        os_version: '10'
+      }
+    },
+    client: {jasmine: {random: false}, args: args}
+  });
+};

--- a/e2e/script_tag_tests/symbols_and_basic_api_test.js
+++ b/e2e/script_tag_tests/symbols_and_basic_api_test.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+describe('tfjs union sub-packages', () => {
+  it('should have core', () => {
+    expect(tf.version['tfjs-core']).toBeTruthy();
+  });
+
+  it('should have cpu backend', () => {
+    expect(tf.version['tfjs-backend-cpu']).toBeTruthy();
+  });
+
+  it('should have webgl backend', () => {
+    expect(tf.version['tfjs-backend-webgl']).toBeTruthy();
+  });
+
+  it('should have converter', () => {
+    expect(tf.version['tfjs-converter']).toBeTruthy();
+  });
+
+  it('should have layers', () => {
+    expect(tf.version['tfjs-layers']).toBeTruthy();
+  });
+
+  it('should have data', () => {
+    expect(tf.version['tfjs-data']).toBeTruthy();
+  });
+
+  it('should have union version', () => {
+    expect(tf.version['tfjs']).toBeTruthy();
+  });
+});
+
+describe('ops', () => {
+  it('should support basic math', () => {
+    tf.tidy(() => {
+      const a = tf.scalar(3);
+      const b = tf.scalar(4);
+      expect(tf.add(a, b).dataSync()[0]).toBe(7);
+    });
+  });
+
+  it('should clone', () => {
+    tf.tidy(() => {
+      const a = tf.tensor([1, 2, 3, 4]);
+      const b = tf.tensor([1, 2, 3, 4]).clone();
+      expect(a.dataSync()).toEqual(b.dataSync());
+    });
+  });
+
+  it('should reshape', () => {
+    tf.tidy(() => {
+      const a = tf.tensor([1, 2, 3, 4], [1, 4]);
+      const b = a.reshape([2, 2]);
+      expect(a.dataSync()).toEqual(b.dataSync());
+    });
+  });
+
+  it('should cast', () => {
+    tf.tidy(() => {
+      const a = tf.tensor([1, 2, 3, 4], [1, 4], 'float32');
+      const b = a.cast('int32');
+      expect(Array.from(a.dataSync())).toEqual(Array.from(b.dataSync()));
+    });
+  });
+});
+
+describe('backends are registered', () => {
+  it('should find cpu backend', () => {
+    expect(tf.findBackend('cpu')).toBeTruthy();
+  });
+
+  it('should find webgl backend', () => {
+    expect(tf.findBackend('webgl')).toBeTruthy();
+  });
+
+  it('should not find fake backend', () => {
+    expect(tf.findBackend('fake')).toBeFalsy();
+  });
+});

--- a/e2e/scripts/release-e2e.sh
+++ b/e2e/scripts/release-e2e.sh
@@ -68,6 +68,10 @@ startLocalRegistry "$e2e_root_path"/scripts/verdaccio.yaml
 # ****************************************************************************
 # Second, install the packages from local registry.
 # ****************************************************************************
+# First make sure npm install succeeds.
+npm install
+rm -rf node_modules
+# Then install dependencies via yarn.
 yarn
 
 # ****************************************************************************

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -48,6 +48,10 @@ fi
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
   yarn run-browserstack --browsers=bs_safari_mac,bs_firefox_mac,win_10_chrome,bs_ios_11,bs_android_9 --tags $TAGS
+
+  # Test script tag bundles
+  karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js
+  karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.es2017.min.js
 else
   yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
 fi

--- a/tfjs/rollup.config.js
+++ b/tfjs/rollup.config.js
@@ -61,6 +61,8 @@ function config({
 
   return {
     input: entry,
+    // Do not tree shake union package library
+    treeshake: false,
     plugins: [
       typescript(tsoptions),
       resolve({dedupe: ['seedrandom']}),


### PR DESCRIPTION
- Add "npm install" to release e2e tests. This is in addition to yarn as we have observed different behaviour.
- Add e2e tests that test the script tag version of the libray for the union package.
- Disable tree shaking when building the union package bundles.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.