### PR TITLE
add clipByValue int32 test and fix the node impl

### DIFF
--- a/tfjs-backend-cpu/src/backend_cpu.ts
+++ b/tfjs-backend-cpu/src/backend_cpu.ts
@@ -1152,7 +1152,7 @@ export class MathBackendCPU extends KernelBackend {
       const v = values[i];
       resultValues[i] = v > max ? max : (v < min ? min : v);
     }
-    return this.makeOutput(resultValues, x.shape, 'float32');
+    return this.makeOutput(resultValues, x.shape, x.dtype);
   }
 
   abs<T extends Tensor>(x: T): T {

--- a/tfjs-backend-wasm/src/kernels/ClipByValue.ts
+++ b/tfjs-backend-wasm/src/kernels/ClipByValue.ts
@@ -39,7 +39,7 @@ function clip(args: {
   const {x} = inputs;
   const {clipValueMin, clipValueMax} = attrs;
   const xId = backend.dataIdMap.get(x.dataId).id;
-  const out = backend.makeOutput(x.shape, 'float32');
+  const out = backend.makeOutput(x.shape, x.dtype);
   const outId = backend.dataIdMap.get(out.dataId).id;
   wasmClip(xId, clipValueMin, clipValueMax, outId);
   return out;

--- a/tfjs-core/src/ops/clip_by_value_test.ts
+++ b/tfjs-core/src/ops/clip_by_value_test.ts
@@ -135,4 +135,13 @@ describeWithFlags('clipByValue', ALL_ENVS, () => {
     expect(() => tf.clipByValue('q', 0, 1))
         .toThrowError(/Argument 'x' passed to 'clipByValue' must be numeric/);
   });
+
+  it('clip int32 tensor', async () => {
+    const min = -1;
+    const max = 50;
+    const tensor = tf.tensor([2, 3, 4], [3], 'int32');
+    const result = tf.clipByValue(tensor, min, max);
+    expectArraysClose(await result.data(), [2, 3, 4]);
+    expect(result.dtype).toEqual('int32');
+  });
 });

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -722,8 +722,8 @@ export class NodeJSKernelBackend extends KernelBackend {
   }
 
   clip<T extends Tensor>(x: T, min: number, max: number): T {
-    const xMin = this.minimum(x, scalar(max));
-    return this.maximum(xMin, scalar(min)) as T;
+    const xMin = this.minimum(x, scalar(max, x.dtype));
+    return this.maximum(xMin, scalar(min, x.dtype)) as T;
   }
 
   abs<T extends Tensor>(x: T): T {


### PR DESCRIPTION
Fixed https://github.com/tensorflow/tfjs/issues/3716

ClipByValue implementation in node is using Min and Max op against a float32 scalar, this will fail for input tensor with
int32 dtype.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3822)
<!-- Reviewable:end -->
