### PR TITLE
remove chain api use from converter

### DIFF
--- a/tfjs-converter/metadata/kernel2op.json
+++ b/tfjs-converter/metadata/kernel2op.json
@@ -181,13 +181,15 @@
     "fused.depthwiseConv2d"
   ],
   "Gather": [
-    "gather"
+    "gather",
+    "cast"
   ],
   "GatherNd": [
     "gatherND"
   ],
   "GatherV2": [
-    "gather"
+    "gather",
+    "cast"
   ],
   "Greater": [
     "greater"
@@ -314,7 +316,9 @@
   ],
   "Pack": [
     "tidy",
+    "squeeze",
     "util.arraysEqual",
+    "reshape",
     "stack"
   ],
   "Pad": [
@@ -430,7 +434,8 @@
     "spaceToBatchND"
   ],
   "SparseToDense": [
-    "sparseToDense"
+    "sparseToDense",
+    "cast"
   ],
   "Split": [
     "split"
@@ -506,6 +511,7 @@
     "unstack"
   ],
   "Where": [
+    "cast",
     "whereAsync"
   ],
   "While": [],

--- a/tfjs-converter/src/executor/tensor_array.ts
+++ b/tfjs-converter/src/executor/tensor_array.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {concat, DataType, keep, scalar, slice, stack, Tensor, tensor, tidy, unstack} from '@tensorflow/tfjs-core';
+import {concat, DataType, keep, reshape, scalar, slice, stack, Tensor, tensor, tidy, unstack} from '@tensorflow/tfjs-core';
 
 import {assertShapesMatchAllowUndefinedSize} from './tensor_utils';
 
@@ -294,12 +294,12 @@ export class TensorArray {
     const elementPerRow = totalLength === 0 ? 0 : tensor.size / totalLength;
     const tensors: Tensor[] = [];
     tidy(() => {
-      tensor = tensor.reshape([1, totalLength, elementPerRow]);
+      tensor = reshape(tensor, [1, totalLength, elementPerRow]);
       for (let i = 0; i < length.length; ++i) {
         const previousLength = (i === 0) ? 0 : cumulativeLengths[i - 1];
         const indices = [0, previousLength, 0];
         const sizes = [1, length[i], elementPerRow];
-        tensors[i] = slice(tensor, indices, sizes).reshape(this.elementShape);
+        tensors[i] = reshape(slice(tensor, indices, sizes), this.elementShape);
       }
       return tensors;
     });

--- a/tfjs-converter/src/executor/tensor_list.ts
+++ b/tfjs-converter/src/executor/tensor_list.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {concat, DataType, keep, scalar, slice, stack, Tensor, tensor, tidy, unstack} from '@tensorflow/tfjs-core';
+import {concat, DataType, keep, reshape, scalar, slice, stack, Tensor, tensor, tidy, unstack} from '@tensorflow/tfjs-core';
 
 import {assertShapesMatchAllowUndefinedSize} from './tensor_utils';
 
@@ -114,7 +114,7 @@ export class TensorList {
         elementShape, this.elementShape, 'TensorList shape mismatch: ');
     return tidy(() => {
       const reshapedTensors =
-          this.tensors.map(tensor => tensor.reshape(elementShape));
+          this.tensors.map(tensor => reshape(tensor, elementShape));
       return stack(reshapedTensors, 0);
     });
   }
@@ -137,7 +137,7 @@ export class TensorList {
     const tensor = this.tensors.pop();
     assertShapesMatchAllowUndefinedSize(
         tensor.shape, elementShape, 'TensorList shape mismatch: ');
-    return tensor.reshape(elementShape);
+    return reshape(tensor, elementShape);
   }
 
   /**
@@ -254,7 +254,7 @@ export class TensorList {
     }
 
     return tidy(() => {
-      const tensors = indices.map(i => this.tensors[i].reshape(elementShape));
+      const tensors = indices.map(i => reshape(this.tensors[i], elementShape));
       return stack(tensors, 0);
     });
   }
@@ -278,7 +278,7 @@ export class TensorList {
     }
 
     return tidy(() => {
-      const tensors = this.tensors.map(t => t.reshape(elementShape));
+      const tensors = this.tensors.map(t => reshape(t, elementShape));
       return concat(tensors, 0);
     });
   }
@@ -304,7 +304,7 @@ export function fromTensor(
   assertShapesMatchAllowUndefinedSize(
       outputShape, elementShape, 'TensorList shape mismatch: ');
 
-  const tensorList: Tensor[] = tensor.unstack();
+  const tensorList: Tensor[] = unstack(tensor);
   return new TensorList(tensorList, elementShape, dtype);
 }
 
@@ -373,12 +373,12 @@ export function split(
   const elementPerRow = totalLength === 0 ? 0 : tensor.size / totalLength;
   const tensors: Tensor[] = tidy(() => {
     const tensors = [];
-    tensor = tensor.reshape([1, totalLength, elementPerRow]);
+    tensor = reshape(tensor, [1, totalLength, elementPerRow]);
     for (let i = 0; i < length.length; ++i) {
       const previousLength = (i === 0) ? 0 : cumulativeLengths[i - 1];
       const indices = [0, previousLength, 0];
       const sizes = [1, length[i], elementPerRow];
-      tensors[i] = slice(tensor, indices, sizes).reshape(elementShape);
+      tensors[i] = reshape(slice(tensor, indices, sizes), elementShape);
     }
     tensor.dispose();
     return tensors;

--- a/tfjs-converter/src/operations/executors/dynamic_executor.ts
+++ b/tfjs-converter/src/operations/executors/dynamic_executor.ts
@@ -91,9 +91,9 @@ export const executeOp: InternalOpAsyncExecutor = async(
           iouThreshold, scoreThreshold)];
     }
     case 'Where': {
-      const condition =
-          (getParamValue('condition', node, tensorMap, context) as tfc.Tensor)
-              .asType('bool');
+      const condition = tfc.cast(
+          (getParamValue('condition', node, tensorMap, context) as tfc.Tensor),
+          'bool');
       const result = [await tfc.whereAsync(condition)];
       condition.dispose();
       return result;


### PR DESCRIPTION
As part of modularization we want to remove internal use of the chained api.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.