### PR TITLE
Update README.md for local custom models

### DIFF
--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -5,9 +5,7 @@ The `custom model` in the [local benchmark tool](https://tensorflow.github.io/tf
 If you want to benchmark more complex TensorFlow.js models with customized input preprocessing logic, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
 
 ## Models in local file system
-If you have a TensorFlow.js model in local file system, you can benchmark it by: locally host the [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) and the model on a http server.
-
-In addition, if the online [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) is blocked by `CORS` problems when fetching custom models, you can locally serve the models by the above steps to solve this problem.
+If you have a TensorFlow.js model in local file system, you can benchmark it by: locally host the [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) and the model on a http server. In addition, if the online [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) is blocked by `CORS` problems when fetching custom models, this solution also works.
 
 ### Example
 You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1) in local file system through the following steps:

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -1,17 +1,40 @@
 # Benchmark custom models
 
-The `custom model` in the [benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) currently only supports `tf.GraphModel` or `tf.LayersModel`.
+The `custom model` in the [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) currently only supports `tf.GraphModel` or `tf.LayersModel`.
 
-If you want to benchmark more complex models with customized input preprocessing logic, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
+If you want to benchmark more complex TensorFlow.js models with customized input preprocessing logic, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
 
 ## Models in local file system
-If you have a model in local file system, you can follow the steps below:
+If you have a TensorFlow.js model in local file system, you can benchmark it through the following steps:
 1. Download [tfjs repository](https://github.com/tensorflow/tfjs.git).
-2. Put your `model.json` file and the weight files under the `tfjs/e2e/benchmarks/local-benchmark/` folder.
-3. Under the `tfjs/e2e/benchmarks/local-benchmark/` folder, run `npx http-server`.
-4. Open the browser go to `http://127.0.0.1:8080/`, this will open the benchmark tool. Then populate the `model.json` url to `modelUrl` under the custom model, which is `http://127.0.0.1:8080/model.json`.
+2. Under `tfjs/e2e/benchmarks/`, host the model and the tool on a http server:
+   1. Make a folder, `model/`.
+   2. Put your `model.json` file and the weight files into the `model/` folder.
+   3. Run `npx http-server`.
+3. Open `http://127.0.0.1:8080/local-benchmark/` through a browser, and you will see the local benchmark tool.
+4. Populate the path to the `model.json` file into the `modelUrl` field for the custom model, which is `http://127.0.0.1:8080/model/model.json`.
 
-In addition, if the online tool is blocked by `CORS` problems when fetching the custom model, you can locally serve the model by the above steps to solve this problem.
+In addition, if the online [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) is blocked by `CORS` problems when fetching custom models, you can locally serve the models by the above steps to solve this problem.
+
+### Example
+You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1) in local file system, by:
+1. Download the tool.
+```shell
+git clone https://github.com/tensorflow/tfjs.git
+```
+2. Download the model and run a http server.
+```shell
+cd tfjs/e2e/benchmarks/
+wget -O model.tar.gz "https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1?tfjs-format=compressed"
+mkdir model
+tar -xf model.tar.gz -C model/
+
+npx http-server
+```
+3. Open http://127.0.0.1:8080/local-benchmark/ through the browser.
+4. Select `custom` in the `models` field.
+5. Fill `http://127.0.0.1:8080/model/model.json` into the `modelUrl` field.
+6. Run benchmark.
 
 ## Paths to custom models
 The benchmark tool suopports three kinds of paths to the custom models.

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -17,7 +17,7 @@ If you have a TensorFlow.js model in local file system, you can benchmark it thr
 In addition, if the online [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) is blocked by `CORS` problems when fetching custom models, you can locally serve the models by the above steps to solve this problem.
 
 ### Example
-You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1) in local file system, by:
+You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1) in local file system.
 1. Download the tool.
 ```shell
 git clone https://github.com/tensorflow/tfjs.git

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -14,7 +14,7 @@ You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imag
 git clone https://github.com/tensorflow/tfjs.git
 cd tfjs/e2e/benchmarks/
 ```
-2. Download the model and run a http server.
+2. Download the model.
 ```shell
 wget -O model.tar.gz "https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1?tfjs-format=compressed"
 mkdir model

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -5,36 +5,31 @@ The `custom model` in the [local benchmark tool](https://tensorflow.github.io/tf
 If you want to benchmark more complex TensorFlow.js models with customized input preprocessing logic, you need to implement `load` and `predictFunc` methods, following this [example PR](https://github.com/tensorflow/tfjs/pull/3168/files).
 
 ## Models in local file system
-If you have a TensorFlow.js model in local file system, you can benchmark it through the following steps:
-1. Download [tfjs repository](https://github.com/tensorflow/tfjs.git).
-2. Under `tfjs/e2e/benchmarks/`, host the model and the tool on a http server:
-   1. Make a folder, `model/`.
-   2. Put your `model.json` file and the weight files into the `model/` folder.
-   3. Run `npx http-server`.
-3. Open `http://127.0.0.1:8080/local-benchmark/` through a browser, and you will see the local benchmark tool.
-4. Populate the path to the `model.json` file into the `modelUrl` field for the custom model, which is `http://127.0.0.1:8080/model/model.json`.
+If you have a TensorFlow.js model in local file system, you can benchmark it by: locally host the [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) and the model on a http server.
 
 In addition, if the online [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) is blocked by `CORS` problems when fetching custom models, you can locally serve the models by the above steps to solve this problem.
 
 ### Example
-You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1) in local file system.
+You can benchmark the [MobileNet model](https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1) in local file system through the following steps:
 1. Download the tool.
 ```shell
 git clone https://github.com/tensorflow/tfjs.git
+cd tfjs/e2e/benchmarks/
 ```
 2. Download the model and run a http server.
 ```shell
-cd tfjs/e2e/benchmarks/
 wget -O model.tar.gz "https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_130_224/classification/3/default/1?tfjs-format=compressed"
 mkdir model
 tar -xf model.tar.gz -C model/
-
+```
+3. Run a http server to host the model and the local benchmark tool.
+```
 npx http-server
 ```
-3. Open http://127.0.0.1:8080/local-benchmark/ through the browser.
-4. Select `custom` in the `models` field.
-5. Fill `http://127.0.0.1:8080/model/model.json` into the `modelUrl` field.
-6. Run benchmark.
+4. Open http://127.0.0.1:8080/local-benchmark/ through the browser.
+5. Select `custom` in the `models` field.
+6. Fill `http://127.0.0.1:8080/model/model.json` into the `modelUrl` field.
+7. Run benchmark.
 
 ## Paths to custom models
 The benchmark tool suopports three kinds of paths to the custom models.


### PR DESCRIPTION
This PR does the following:
1. Update the work folder for running the http server. The original work folder becomes incorrect because we migrated the [local benchmark tool](https://tensorflow.github.io/tfjs/e2e/benchmarks/local-benchmark/index.html) from `tfjs/e2e/benchmarks/` to a `tfjs/e2e/benchmarks/local-benchmark`.
2. Use an example to describe how to benchmark the models in local file system. The [original README.md](https://github.com/tensorflow/tfjs/blob/master/e2e/benchmarks/local-benchmark/README.md) can be confusing about the work folder.

You can preview the new [README.md](https://github.com/Linchenn/tfjs/blob/local-custom-model/e2e/benchmarks/local-benchmark/README.md).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.