### PR TITLE
Rename profileInferenceTime to timeInference

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -140,7 +140,7 @@ function getPredictFnForModel(model, input) {
  * const model = await tf.loadGraphModel(modelUrl, {fromTFHub: true});
  * const zeros = tf.zeros([1, 224, 224, 3]);
  * const timeInfo =
- *    await profileInferenceTimeForModel(model, zeros, 2);
+ *    await timeModelInference(model, zeros, 2);
  *
  * console.log(`Elapsed time array: ${timeInfo.times}`);
  * console.log(`Average time: ${timeInfo.averageTime}`);
@@ -153,9 +153,9 @@ function getPredictFnForModel(model, input) {
  * @param input The input tensor container for model inference.
  * @param numRuns The number of rounds for timing the inference process.
  */
-async function profileInferenceTimeForModel(model, input, numRuns = 1) {
+async function timeModelInference(model, input, numRuns = 1) {
   const predict = getPredictFnForModel(model, input);
-  return profileInferenceTime(predict, numRuns);
+  return timeInference(predict, numRuns);
 }
 
 /**
@@ -176,7 +176,7 @@ async function profileInferenceTimeForModel(model, input, numRuns = 1) {
  * const model = await tf.loadGraphModel(modelUrl, {fromTFHub: true});
  * const zeros = tf.zeros([1, 224, 224, 3]);
  * const timeInfo =
- *    await profileInferenceTime(() => model.predict(zeros), 2);
+ *    await timeInference(() => model.predict(zeros), 2);
  *
  * console.log(`Elapsed time array: ${timeInfo.times}`);
  * console.log(`Average time: ${timeInfo.averageTime}`);
@@ -187,7 +187,7 @@ async function profileInferenceTimeForModel(model, input, numRuns = 1) {
  * @param predict The predict function to execute and time.
  * @param numRuns The number of rounds for `predict` to execute and time.
  */
-async function profileInferenceTime(predict, numRuns = 1) {
+async function timeInference(predict, numRuns = 1) {
   if (typeof predict !== 'function') {
     throw new Error(
         'The first parameter should be a function, while ' +

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -39,10 +39,10 @@ describe('benchmark_util', () => {
   });
 
   describe('profile inference time', () => {
-    describe('profileInferenceTime', () => {
+    describe('timeInference', () => {
       it('throws when passing in invalid predict', async () => {
         const predict = {};
-        await expectAsync(profileInferenceTime(predict)).toBeRejected();
+        await expectAsync(timeInference(predict)).toBeRejected();
       });
 
       it('does not add new tensors', async () => {
@@ -51,7 +51,7 @@ describe('benchmark_util', () => {
         const input = tf.zeros([1, 3]);
 
         const tensorsBefore = tf.memory().numTensors;
-        await profileInferenceTime(() => model.predict(input));
+        await timeInference(() => model.predict(input));
         expect(tf.memory().numTensors).toEqual(tensorsBefore);
 
         model.dispose();

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
@@ -88,11 +88,11 @@ describe('benchmark models', () => {
       let memoryInfo;
       if (benchmark.predictFunc != null) {
         const predict = benchmark.predictFunc();
-        timeInfo = await profileInferenceTime(() => predict(model), numRuns);
+        timeInfo = await timeInference(() => predict(model), numRuns);
         memoryInfo = await profileInference(() => predict(model));
       } else {
         const input = generateInput(model);
-        timeInfo = await profileInferenceTimeForModel(model, input, numRuns);
+        timeInfo = await timeModelInference(model, input, numRuns);
         memoryInfo = await profileModelInference(model, input);
       }
 

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -262,12 +262,12 @@ limitations under the License.
       if (state.benchmark === 'custom') {
         const input = generateInput(model);
         try {
-          timeInfo = await profileInferenceTimeForModel(model, input, 1);
+          timeInfo = await timeModelInference(model, input, 1);
         } finally {
           tf.dispose(input);
         }
       } else {
-        timeInfo = await profileInferenceTime(() => predict(model), 1);
+        timeInfo = await timeInference(() => predict(model), 1);
       }
 
       await showMsg(null);
@@ -348,12 +348,12 @@ limitations under the License.
       if (state.benchmark === 'custom') {
         const input = generateInput(model);
         try {
-          timeInfo = await profileInferenceTimeForModel(model, input, numRuns);
+          timeInfo = await timeModelInference(model, input, numRuns);
         } finally {
           tf.dispose(input);
         }
       } else {
-        timeInfo = await profileInferenceTime(() => predict(model), numRuns);
+        timeInfo = await timeInference(() => predict(model), numRuns);
       }
 
       const forceInferenceTrendYMinToZero = true;


### PR DESCRIPTION
Since the original ProfileInference Memory is changed to ProfileInference, timeInference is a more proper name for timing the inference, as discussed at https://github.com/tensorflow/tfjs/pull/3814#pullrequestreview-468676071.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3839)
<!-- Reviewable:end -->
