### PR TITLE
webgpu: Optimize pool2d

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/maxpool_filtersizeone_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/maxpool_filtersizeone_webgpu.ts
@@ -18,7 +18,7 @@
 import {backend_util} from '@tensorflow/tfjs-core';
 
 import {getShapeCoords} from '../shader_preprocessor';
-import {computeDispatch} from '../webgpu_util';
+import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
 
@@ -26,15 +26,15 @@ export class MaxPoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
   outputShape: number[];
   shaderKey: string;
   userCode: string;
-  dispatchLayout: {x: number[], y: number[], z: number[]};
+  dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'ivec2 pad, stride, dilation, convDims, filterDims;';
-  workGroupSize: [number, number, number] = [4, 4, 4];
+  workGroupSize: [number, number, number] = [256, 1, 1];
 
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;
-    this.dispatchLayout = {x: [0, 1], y: [2], z: [3]};
+    this.dispatchLayout = flatDispatchLayout(this.outputShape);
 
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);

--- a/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
@@ -26,23 +26,23 @@ export class Pool2DProgram implements WebGPUProgram {
   outputShape: number[];
   shaderKey: string;
   userCode: string;
-  dispatchLayout: {x: number[], y: number[], z: number[]};
+  dispatchLayout: {x: number[], y: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'ivec2 pad, stride, dilation, convDims, filterDims;';
   // TODO(jiajia.qin@intel.com): Dynamically choose different workGroupSize and
   // workPerThead for different output shapes.
-  workGroupSize: [number, number, number] = [4, 4, 1];
-  workPerThread = 16;
+  workGroupSize: [number, number, number] = [16, 16, 1];
+  workPerThread = 4;
 
   constructor(convInfo: backend_util.Conv2DInfo, poolType: 'max'|'avg') {
     this.outputShape = convInfo.outShape;
 
-    this.dispatchLayout = {x: [0, 1], y: [2], z: [3]};
+    this.dispatchLayout = {x: [0, 1, 2], y: [3]};
 
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
-        [1, 1, this.workPerThread]);
+        [1, this.workPerThread, 1]);
 
     let updateSnippet = `resultValue[i] = max(value, resultValue[i]);`;
     if (poolType === 'avg') {


### PR DESCRIPTION
Use flat dispatch layout when possible.

Before:
maxPool(1, 57, 57, 256) 0.868/rep
maxPool(1, 131, 131, 64) 3.377/rep

After:
maxPool(1, 57, 57, 256) 0.677/rep
maxPool(1, 131, 131, 64) 1.890/rep

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3844)
<!-- Reviewable:end -->
