### PR TITLE
fix tensorarray disposing weight tensors

### DIFF
--- a/tfjs-converter/src/executor/execution_context.ts
+++ b/tfjs-converter/src/executor/execution_context.ts
@@ -175,13 +175,13 @@ export class ExecutionContext {
     return this.tensorListMap[id];
   }
 
-  dispose() {
+  dispose(keepIds: Set<number>) {
     for (const key in this.tensorArrayMap) {
-      this.tensorArrayMap[key].clearAndClose();
+      this.tensorArrayMap[key].clearAndClose(keepIds);
     }
 
     for (const key in this.tensorListMap) {
-      this.tensorListMap[key].clearAndClose();
+      this.tensorListMap[key].clearAndClose(keepIds);
     }
   }
 }

--- a/tfjs-converter/src/executor/graph_executor_test.ts
+++ b/tfjs-converter/src/executor/graph_executor_test.ts
@@ -469,6 +469,7 @@ describe('GraphExecutor', () => {
           };
 
           executor = new GraphExecutor(graphWithControlFlow);
+          executor.weightMap = {};
         });
 
         it('should execute control flow v2 graph', async () => {
@@ -595,6 +596,7 @@ describe('GraphExecutor', () => {
           };
 
           executor = new GraphExecutor(graphWithControlFlow);
+          executor.weightMap = {};
         });
 
         it('should execute control flow v2 graph', async () => {

--- a/tfjs-converter/src/executor/tensor_array.ts
+++ b/tfjs-converter/src/executor/tensor_array.ts
@@ -52,8 +52,12 @@ export class TensorArray {
   /**
    * Dispose the tensors and idTensor and mark the TensoryArray as closed.
    */
-  clearAndClose() {
-    this.tensors.forEach(tensor => tensor.tensor.dispose());
+  clearAndClose(keepIds?: Set<number>) {
+    this.tensors.forEach(tensor => {
+      if (keepIds == null || !keepIds.has(tensor.tensor.id)) {
+        tensor.tensor.dispose();
+      }
+    });
     this.tensors = [];
     this.closed_ = true;
     this.idTensor.dispose();

--- a/tfjs-converter/src/executor/tensor_array_test.ts
+++ b/tfjs-converter/src/executor/tensor_array_test.ts
@@ -54,8 +54,24 @@ describe('TensorArray', () => {
     tensorArray.clearAndClose();
     expect(tensorArray.size()).toBe(0);
     expect(tensorArray.closed).toBeTruthy();
+
     // disposed the tensor in the array and idTensor of the array
     expect(memory().numTensors).toEqual(numOfTensors - size - 1);
+  });
+
+  it('should not dispose keep tensors when close', () => {
+    const numOfTensors = memory().numTensors;
+    tensorArray.write(0, tensor);
+    tensorArray.write(1, tensor2);
+    const size = tensorArray.size();
+    const keepIds = new Set([tensor.id]);
+    tensorArray.clearAndClose(keepIds);
+    expect(tensorArray.size()).toBe(0);
+    expect(tensorArray.closed).toBeTruthy();
+    expect(tensor.isDisposed).toBeFalsy();
+    expect(tensor2.isDisposed).toBeTruthy();
+    // disposed the tensor in the array and idTensor of the array
+    expect(memory().numTensors).toEqual(numOfTensors - size);
   });
 
   describe('write', () => {

--- a/tfjs-converter/src/executor/tensor_list.ts
+++ b/tfjs-converter/src/executor/tensor_list.ts
@@ -80,8 +80,12 @@ export class TensorList {
   /**
    * Dispose the tensors and idTensor and clear the tensor list.
    */
-  clearAndClose() {
-    this.tensors.forEach(tensor => tensor.dispose());
+  clearAndClose(keepIds?: Set<number>) {
+    this.tensors.forEach(tensor => {
+      if (keepIds == null || !keepIds.has(tensor.id)) {
+        tensor.dispose();
+      }
+    });
     this.tensors.length = 0;
     this.idTensor.dispose();
   }

--- a/tfjs-converter/src/executor/tensor_list_test.ts
+++ b/tfjs-converter/src/executor/tensor_list_test.ts
@@ -40,6 +40,20 @@ describe('TensorList', () => {
     expect(tensorList.elementShape).toEqual(SHAPE);
   });
 
+  it('should not dispose keep tensors when close', () => {
+    const numOfTensors = memory().numTensors;
+    tensorList.pushBack(tensor);
+    tensorList.pushBack(tensor2);
+    const size = tensorList.size();
+    const keepIds = new Set([tensor.id]);
+    tensorList.clearAndClose(keepIds);
+    expect(tensorList.size()).toBe(0);
+    expect(tensor.isDisposed).toBeFalsy();
+    expect(tensor2.isDisposed).toBeTruthy();
+    // disposed the tensor in the array and idTensor of the array
+    expect(memory().numTensors).toEqual(numOfTensors - size);
+  });
+
   describe('pushBack', () => {
     it('should add new tensor', () => {
       tensorList.pushBack(tensor);


### PR DESCRIPTION
Fixed https://github.com/tensorflow/tfjs/issues/3823

The error is triggered by pushing weight tensor into TensorArray, we disposed the weight at the end of the execution.
This fix make sure, when we clean up execution context, the tensorArrays and tensorLists will not dispose weights/inputs/outputs.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3847)
<!-- Reviewable:end -->
