### PR TITLE
make flags dependency in io namespace explicit

### DIFF
--- a/tfjs-core/src/io/browser_files.ts
+++ b/tfjs-core/src/io/browser_files.ts
@@ -20,6 +20,7 @@
  * user-selected files in browser.
  */
 
+import '../flags';
 import {env} from '../environment';
 
 import {basename, concatenateArrayBuffers, getModelArtifactsInfoForJSON} from './io_utils';

--- a/tfjs-core/src/io/indexed_db.ts
+++ b/tfjs-core/src/io/indexed_db.ts
@@ -15,10 +15,11 @@
  * =============================================================================
  */
 
+import '../flags';
+
 import {env} from '../environment';
 
 import {getModelArtifactsInfoForJSON} from './io_utils';
-import {ModelStoreManagerRegistry} from './model_management';
 import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, ModelArtifactsInfo, ModelStoreManager, SaveResult} from './types';
 
@@ -349,15 +350,5 @@ export class BrowserIndexedDBManager implements ModelStoreManager {
       };
       openRequest.onerror = error => reject(openRequest.error);
     });
-  }
-}
-
-if (env().getBool('IS_BROWSER')) {
-  // Wrap the construction and registration, to guard against browsers that
-  // don't support Local Storage.
-  try {
-    ModelStoreManagerRegistry.registerManager(
-        BrowserIndexedDB.URL_SCHEME, new BrowserIndexedDBManager());
-  } catch (err) {
   }
 }

--- a/tfjs-core/src/io/local_storage.ts
+++ b/tfjs-core/src/io/local_storage.ts
@@ -15,11 +15,11 @@
  * =============================================================================
  */
 
+import '../flags';
 import {env} from '../environment';
 
 import {assert} from '../util';
 import {arrayBufferToBase64String, base64StringToArrayBuffer, getModelArtifactsInfoForJSON} from './io_utils';
-import {ModelStoreManagerRegistry} from './model_management';
 import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, ModelArtifactsInfo, ModelStoreManager, SaveResult} from './types';
 
@@ -37,8 +37,7 @@ const MODEL_METADATA_SUFFIX = 'model_metadata';
  * @returns Paths of the models purged.
  */
 export function purgeLocalStorageArtifacts(): string[] {
-  if (!env().getBool('IS_BROWSER') ||
-      typeof window === 'undefined' ||
+  if (!env().getBool('IS_BROWSER') || typeof window === 'undefined' ||
       typeof window.localStorage === 'undefined') {
     throw new Error(
         'purgeLocalStorageModels() cannot proceed because local storage is ' +
@@ -119,9 +118,8 @@ export class BrowserLocalStorage implements IOHandler {
   static readonly URL_SCHEME = 'localstorage://';
 
   constructor(modelPath: string) {
-    if (!env().getBool('IS_BROWSER') ||
-          typeof window === 'undefined' ||
-          typeof window.localStorage === 'undefined') {
+    if (!env().getBool('IS_BROWSER') || typeof window === 'undefined' ||
+        typeof window.localStorage === 'undefined') {
       // TODO(cais): Add more info about what IOHandler subtypes are
       // available.
       //   Maybe point to a doc page on the web and/or automatically determine
@@ -310,7 +308,7 @@ export class BrowserLocalStorageManager implements ModelStoreManager {
         () => 'Current environment is not a web browser');
     assert(
         typeof window === 'undefined' ||
-        typeof window.localStorage !== 'undefined',
+            typeof window.localStorage !== 'undefined',
         () => 'Current browser does not appear to support localStorage');
     this.LS = window.localStorage;
   }
@@ -342,15 +340,5 @@ export class BrowserLocalStorageManager implements ModelStoreManager {
     this.LS.removeItem(keys.weightSpecs);
     this.LS.removeItem(keys.weightData);
     return info;
-  }
-}
-
-if (env().getBool('IS_BROWSER')) {
-  // Wrap the construction and registration, to guard against browsers that
-  // don't support Local Storage.
-  try {
-    ModelStoreManagerRegistry.registerManager(
-        BrowserLocalStorage.URL_SCHEME, new BrowserLocalStorageManager());
-  } catch (err) {
   }
 }

--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -15,7 +15,12 @@
  * =============================================================================
  */
 
+import '../flags';
+
 import {env} from '../environment';
+import {BrowserIndexedDB, BrowserIndexedDBManager} from '../io/indexed_db';
+import {BrowserLocalStorage, BrowserLocalStorageManager} from '../io/local_storage';
+import {ModelStoreManagerRegistry} from '../io/model_management';
 
 import {Platform} from './platform';
 
@@ -49,4 +54,18 @@ export class PlatformBrowser implements Platform {
 
 if (env().get('IS_BROWSER')) {
   env().setPlatform('browser', new PlatformBrowser());
+
+  // Register LocalStorage IOHandler
+  try {
+    ModelStoreManagerRegistry.registerManager(
+        BrowserLocalStorage.URL_SCHEME, new BrowserLocalStorageManager());
+  } catch (err) {
+  }
+
+  // Register IndexedDB IOHandler
+  try {
+    ModelStoreManagerRegistry.registerManager(
+        BrowserIndexedDB.URL_SCHEME, new BrowserIndexedDBManager());
+  } catch (err) {
+  }
 }


### PR DESCRIPTION
- Make dependencies on IS_BROWSER flag being registered explicit. 
- Also move registration of `BrowserLocalStorage.URL_SCHEME` and `BrowserIndexedDB.URL_SCHEME` from the top-level of thier corresponding IO handlers to the platform_browser file. This co-locates side effects that happen in a browser environment and removes global side effects from the IO handler files themselves.

This fixes a bug we say in syncing to g3 where sometimes flags.ts would get loaded after io/indexed_db.ts (for examples). Since the dependency between the two is implicit rather than explicit. This makes that link explicit which imo is a good pattern and makes it easier to move around other imports as we separate side-effectful code from non side-effectful code.

cc @dsmilkov (this externalizes (and makes more complete) the fix in my last sync cl).

A bigger question is whether we want to replicate this pattern in all modules that depend on some flag being evaluatable. In many cases we have been able to rely on load order as defined in our imports. And once all the side effects and registries have been disentangled from code that we want to tree shake,  relying on load order might be sufficient. But I suspect making the dependency explicit is beneficial for documentation/debugging) purposes, and arguably more correct.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3848)
<!-- Reviewable:end -->
