### PR TITLE
[wasm] Add more logging during init.

### DIFF
--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -44,8 +44,13 @@ export class BackendWasm extends KernelBackend {
 
   constructor(public wasm: BackendWasmModule) {
     super();
-    this.wasm.tfjs.init();
-    this.dataIdMap = new DataStorage(this, engine());
+
+    try {
+      this.wasm.tfjs.init();
+      this.dataIdMap = new DataStorage(this, engine());
+    } catch (e) {
+      throw new Error(`Unable to initialize an instance of BackendWasm: ${e}`);
+    }
   }
 
   write(values: backend_util.BackendValues, shape: number[], dtype: DataType):
@@ -176,7 +181,14 @@ export class BackendWasm extends KernelBackend {
 }
 
 registerBackend('wasm', async () => {
-  const {wasm} = await init();
+  let wasm;
+
+  try {
+    wasm = (await init()).wasm;
+  } catch (e) {
+    throw new Error(`Unable to initialize the wasm module: ${e}`);
+  }
+
   return new BackendWasm(wasm);
 }, WASM_PRIORITY);
 

--- a/tfjs-core/src/jasmine_util.ts
+++ b/tfjs-core/src/jasmine_util.ts
@@ -259,8 +259,7 @@ function executeTests(
       }
       env().set('IS_TEST', true);
       // Await setting the new backend since it can have async init.
-      ENGINE.setBackend(testEnv.backendName);
-      await ENGINE.ready();
+      await ENGINE.setBackend(testEnv.backendName);
     });
 
     beforeEach(() => {

--- a/tfjs-core/src/jasmine_util.ts
+++ b/tfjs-core/src/jasmine_util.ts
@@ -259,7 +259,8 @@ function executeTests(
       }
       env().set('IS_TEST', true);
       // Await setting the new backend since it can have async init.
-      await ENGINE.setBackend(testEnv.backendName);
+      ENGINE.setBackend(testEnv.backendName);
+      await ENGINE.ready();
     });
 
     beforeEach(() => {


### PR DESCRIPTION
Nightly build is flaky, sometimes we saw: Backend 'wasm' has not yet been initialized error. This error is not reproducible everytime, so add more logging to help capture the point that cause failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3850)
<!-- Reviewable:end -->
