### PR TITLE
increase test timeouts

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/app_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_test.js
@@ -50,7 +50,7 @@ describe('benchmark multiple browsers', () => {
   const browsers = {};
 
   beforeAll(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
 
     // Populate `browsers`.
     for (const browserConfig of browsersList) {

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -76,7 +76,7 @@ secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
   secretEnv:
     BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
-timeout: 1800s
+timeout: 3600s
 logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''

--- a/tfjs/integration_tests/models/benchmarks.ts
+++ b/tfjs/integration_tests/models/benchmarks.ts
@@ -45,7 +45,7 @@ const LOSS_MAP: {[pyName: string]: string} = {
 
 describe('TF.js Layers Benchmarks', () => {
   beforeAll(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
   });
 
   // Karma serves static files under the base/ path.

--- a/tfjs/integration_tests/models/validation.ts
+++ b/tfjs/integration_tests/models/validation.ts
@@ -28,7 +28,7 @@ import * as common from './common';
 
 describe('TF.js converter validation', () => {
   beforeAll(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
   });
 
   // Karma serves static files under the base/ path.
@@ -104,7 +104,7 @@ describe('TF.js converter validation', () => {
             if (!Array.isArray(predictOut)) {
               predictOut = [predictOut];
             }
-            
+
             outputs.map((key, index) => {
               expect(predictOut[index].dtype).toEqual(task.outputs[key].dtype);
               expect(predictOut[index].shape).toEqual(task.outputs[key].shape);


### PR DESCRIPTION
Increases timeouts to try and resolve some of the issues/timeouts we are seeing in nightly tests.

From my observation either e2e or wasm fails (sometimes webgl). But there aren't error messages from tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3892)
<!-- Reviewable:end -->
