### PR TITLE
update site release script to call yarn prep

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -107,7 +107,7 @@ export const REACT_NATIVE_PHASE: Phase = {
 export const WEBSITE_PHASE: Phase = {
   packages: ['tfjs-website'],
   deps: ['tfjs', 'tfjs-node', 'tfjs-vis', 'tfjs-react-native'],
-  scripts: {'tfjs-website': {'after-yarn': ['yarn build-prod']}},
+  scripts: {'tfjs-website': {'after-yarn': ['yarn prep && yarn build-prod']}},
   leaveVersion: true,
   title: 'Update website to latest dependencies.'
 };


### PR DESCRIPTION
This is a companion PR to https://github.com/tensorflow/tfjs-website/pull/375, that one should be reviewed first.

The additional call to yarn prep here is done on the assumption that the release script always uses a fresh clone. If that is not true let me know and I can update this.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3895)
<!-- Reviewable:end -->
