### PR TITLE
Distinguish ops from kernels in tf.profile

### DIFF
--- a/tfjs-core/src/ops/operation.ts
+++ b/tfjs-core/src/ops/operation.ts
@@ -16,6 +16,8 @@
  */
 import {ENGINE} from '../engine';
 
+export const OP_SCOPE_SUFFIX = '__op';
+
 /**
  * Used for wrapping functions that perform math operations on
  * Tensors. The function will be wrapped in a named scope that cleans all
@@ -38,9 +40,8 @@ export function op<T extends Function>(f: {[name: string]: T}): T {
     opName = opName.substring(0, opName.length - 1);
   }
 
-  // an an __op suffix to distinguish ops from kernels in tf.profile
-
-  opName = opName + '__op';
+  // add an __op suffix to distinguish ops from kernels in tf.profile
+  opName = opName + OP_SCOPE_SUFFIX;
 
   // tslint:disable-next-line:no-any
   const f2 = (...args: any[]) => {

--- a/tfjs-core/src/ops/operation.ts
+++ b/tfjs-core/src/ops/operation.ts
@@ -38,6 +38,10 @@ export function op<T extends Function>(f: {[name: string]: T}): T {
     opName = opName.substring(0, opName.length - 1);
   }
 
+  // an an __op suffix to distinguish ops from kernels in tf.profile
+
+  opName = opName + '__op';
+
   // tslint:disable-next-line:no-any
   const f2 = (...args: any[]) => {
     ENGINE.startScope(opName);

--- a/tfjs-core/src/ops/operation_test.ts
+++ b/tfjs-core/src/ops/operation_test.ts
@@ -22,7 +22,7 @@ describeWithFlags('operation', ALL_ENVS, () => {
     const f = () => 2;
     const opfn = op({'opName': f});
 
-    expect(opfn.name).toBe('opName');
+    expect(opfn.name).toBe('opName__op');
     expect(opfn()).toBe(2);
   });
 
@@ -30,7 +30,7 @@ describeWithFlags('operation', ALL_ENVS, () => {
     const f = () => 2;
     const opfn = op({'opName_': f});
 
-    expect(opfn.name).toBe('opName');
+    expect(opfn.name).toBe('opName__op');
     expect(opfn()).toBe(2);
   });
 

--- a/tfjs-core/src/ops/ops.ts
+++ b/tfjs-core/src/ops/ops.ts
@@ -206,7 +206,7 @@ export * from './dropout';
 export * from './signal_ops_util';
 export * from './in_top_k';
 
-export {op} from './operation';
+export {op, OP_SCOPE_SUFFIX} from './operation';
 
 import {rfft} from './spectral/rfft';
 import {fft} from './spectral/fft';

--- a/tfjs/tools/custom_bundle/cli.ts
+++ b/tfjs/tools/custom_bundle/cli.ts
@@ -99,7 +99,15 @@ function getKernelNamesForConfig(config: CustomTFJSBundleConfig) {
   // (and kernels used by the converter itself) Currently we only support
   // directly listing kernels. remember that this also needs to handle
   // kernels used by gradients if forwardModeOnly is false.
-  return config.kernels;
+
+  // Ops in core that are implemented as custom ops may appear in tf.profile
+  // they will have __op as a suffix. These do not have corresponding backend
+  // kernels so we need to filter them out.
+  function isNotCustomOp(kernelName: string) {
+    return !kernelName.endsWith('__op');
+  }
+
+  return config.kernels.filter(isNotCustomOp);
 }
 
 function getOpsForConfig(config: CustomTFJSBundleConfig) {

--- a/tfjs/tools/custom_bundle/cli.ts
+++ b/tfjs/tools/custom_bundle/cli.ts
@@ -27,6 +27,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as mkdirp from 'mkdirp';
 
+import {OP_SCOPE_SUFFIX} from '@tensorflow/tfjs-core';
+
 import {getCustomModuleString, getCustomConverterOpsModule} from './custom_module';
 import {CustomTFJSBundleConfig, SupportedBackends} from './types';
 import {esmModuleProvider} from './esm_module_provider';
@@ -104,7 +106,9 @@ function getKernelNamesForConfig(config: CustomTFJSBundleConfig) {
   // they will have __op as a suffix. These do not have corresponding backend
   // kernels so we need to filter them out.
   function isNotCustomOp(kernelName: string) {
-    return !kernelName.endsWith('__op');
+    // opSuffix value is defined in tfjs-core/src/operation.ts
+    // duplicating it here to avoid an export.
+    return !kernelName.endsWith(OP_SCOPE_SUFFIX);
   }
 
   return config.kernels.filter(isNotCustomOp);


### PR DESCRIPTION

![8fPPbEdzvwb9jpL](https://user-images.githubusercontent.com/26408/92636780-e8f33500-f2a5-11ea-8528-91f9124db627.png)

This makes it easier to process the list of kernels for a custom build since ops implemented with customGrad don't have true backend kernels.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3897)
<!-- Reviewable:end -->
