### PR TITLE
[wasm] Add StridedSlice kernel.

### DIFF
--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -261,6 +261,7 @@ tfjs_cc_library(
         ":Softmax",
         ":Square",
         ":SquaredDifference",
+        ":StridedSlice",
         ":Sub",
         ":Tile",
         ":Transpose",
@@ -913,6 +914,15 @@ tfjs_cc_library(
         ":backend",
         ":binary",
         ":unary",
+        ":util",
+    ],
+)
+
+tfjs_cc_library(
+    name = "StridedSlice",
+    srcs = ["kernels/StridedSlice.cc"],
+    deps = [
+        ":backend",
         ":util",
     ],
 )

--- a/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
@@ -27,12 +27,8 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 
 void StridedSlice(const size_t x_id, const int32_t* x_strides_ptr,
-                  const size_t x_strides_size, const int32_t* begin_ptr,
-                  const size_t begin_size, const int32_t* end_ptr,
-                  const size_t end_size, const int32_t* strides_ptr,
-                  const size_t strides_size, const size_t begin_mask,
-                  const size_t end_mask, const size_t ellipsis_mask,
-                  const size_t new_axis_mask, const size_t shrink_axis_mask,
+                  const size_t x_rank, const int32_t* begin_ptr,
+                  const int32_t* end_ptr, const int32_t* strides_ptr,
                   const int32_t* out_shape_ptr, const int32_t* out_strides_ptr,
                   const size_t out_shape_size, const size_t out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
@@ -43,12 +39,11 @@ void StridedSlice(const size_t x_id, const int32_t* x_strides_ptr,
   float* out_buf_ptr = out_info.f32_write();
 
   const auto x_strides =
-      std::vector<size_t>(x_strides_ptr, x_strides_ptr + x_strides_size);
+      std::vector<size_t>(x_strides_ptr, x_strides_ptr + x_rank - 1);
 
-  const auto begin = std::vector<size_t>(begin_ptr, begin_ptr + begin_size);
-  const auto end = std::vector<size_t>(end_ptr, end_ptr + end_size);
-  const auto strides =
-      std::vector<size_t>(strides_ptr, strides_ptr + strides_size);
+  const auto begin = std::vector<size_t>(begin_ptr, begin_ptr + x_rank);
+  const auto end = std::vector<size_t>(end_ptr, end_ptr + x_rank);
+  const auto strides = std::vector<size_t>(strides_ptr, strides_ptr + x_rank);
 
   const auto out_shape =
       std::vector<size_t>(out_shape_ptr, out_shape_ptr + out_shape_size);

--- a/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
@@ -40,11 +40,9 @@ void StridedSlice(const size_t x_id, const int32_t* x_strides_ptr,
 
   const auto x_strides =
       std::vector<size_t>(x_strides_ptr, x_strides_ptr + x_rank - 1);
-
   const auto begin = std::vector<size_t>(begin_ptr, begin_ptr + x_rank);
   const auto end = std::vector<size_t>(end_ptr, end_ptr + x_rank);
   const auto strides = std::vector<size_t>(strides_ptr, strides_ptr + x_rank);
-
   const auto out_shape =
       std::vector<size_t>(out_shape_ptr, out_shape_ptr + out_shape_size);
   const auto out_strides = std::vector<size_t>(

--- a/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
@@ -26,13 +26,15 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 
-void StridedSlice(const size_t x_id, const int32_t* begin_ptr,
+void StridedSlice(const size_t x_id, const int32_t* x_strides_ptr,
+                  const size_t x_strides_size, const int32_t* begin_ptr,
                   const size_t begin_size, const int32_t* end_ptr,
                   const size_t end_size, const int32_t* strides_ptr,
                   const size_t strides_size, const size_t begin_mask,
                   const size_t end_mask, const size_t ellipsis_mask,
                   const size_t new_axis_mask, const size_t shrink_axis_mask,
-                  const size_t out_id) {
+                  const int32_t* out_shape_ptr, const int32_t* out_strides_ptr,
+                  const size_t out_shape_size, const size_t out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& out_info = backend::get_tensor_info_out(out_id);
   const size_t out_size = out_info.size;
@@ -40,35 +42,29 @@ void StridedSlice(const size_t x_id, const int32_t* begin_ptr,
   const float* x_ptr = x_info.f32();
   float* out_buf_ptr = out_info.f32_write();
 
+  const auto x_strides =
+      std::vector<size_t>(x_strides_ptr, x_strides_ptr + x_strides_size);
+
   const auto begin = std::vector<size_t>(begin_ptr, begin_ptr + begin_size);
   const auto end = std::vector<size_t>(end_ptr, end_ptr + end_size);
   const auto strides =
       std::vector<size_t>(strides_ptr, strides_ptr + strides_size);
 
+  const auto out_shape =
+      std::vector<size_t>(out_shape_ptr, out_shape_ptr + out_shape_size);
+  const auto out_strides = std::vector<size_t>(
+      out_strides_ptr, out_strides_ptr + out_shape_size - 1);
+
   for (size_t i = 0; i < out_size; ++i) {
-    // auto coords = tfjs::util::offset_to_loc(i, out_strides);
-    // const size_t b = coords[0];
-    // const size_t h = channels_last ? coords[1] : coords[2];
-    // const size_t w = channels_last ? coords[2] : coords[3];
-    // const size_t d = channels_last ? coords[3] : coords[1];
-    // const size_t out_depth_size = channels_last ? out_shape[3] :
-    // out_shape[1];
+    auto coords = tfjs::util::offset_to_loc(i, out_strides);
 
-    // const size_t in_h = h / block_size;
-    // const size_t offset_h = h % block_size;
-    // const size_t in_w = w / block_size;
-    // const size_t offset_w = w % block_size;
-    // const size_t offset_d = (offset_h * block_size + offset_w) *
-    // out_depth_size;
+    std::vector<size_t> new_loc = {};
+    for (size_t j = 0; j < out_shape_size; ++j) {
+      new_loc.push_back(coords[j] * strides[j] + begin[j]);
+    }
 
-    // const size_t in_d = d + offset_d;
-
-    // size_t x_index =
-    //     channels_last
-    //         ? tfjs::util::loc_to_offset({b, in_h, in_w, in_d}, x_strides)
-    //         : tfjs::util::loc_to_offset({b, in_d, in_h, in_w}, x_strides);
-
-    // *out_buf_ptr = x_ptr[x_index];
+    const size_t x_index = tfjs::util::loc_to_offset(new_loc, x_strides);
+    *out_buf_ptr = x_ptr[x_index];
 
     out_buf_ptr++;
   }

--- a/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
@@ -1,0 +1,75 @@
+/* Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+#include "src/cc/backend.h"
+#include "src/cc/util.h"
+
+namespace tfjs {
+namespace wasm {
+extern "C" {
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+
+void StridedSlice(const size_t x_id, const size_t block_size,
+                  const bool channels_last, const int32_t* x_strides_ptr,
+                  const size_t x_strides_size, const int32_t* out_shape_ptr,
+                  const int32_t* out_strides_ptr, const size_t out_shape_size,
+                  const size_t out_id) {
+  auto& x_info = backend::get_tensor_info(x_id);
+  auto& out_info = backend::get_tensor_info_out(out_id);
+  const size_t out_size = out_info.size;
+
+  const float* x_ptr = x_info.f32();
+  float* out_buf_ptr = out_info.f32_write();
+
+  const auto x_strides =
+      std::vector<size_t>(x_strides_ptr, x_strides_ptr + x_strides_size);
+  const auto out_shape =
+      std::vector<size_t>(out_shape_ptr, out_shape_ptr + out_shape_size);
+  const auto out_strides = std::vector<size_t>(
+      out_strides_ptr, out_strides_ptr + out_shape_size - 1);
+
+  for (size_t i = 0; i < out_size; ++i) {
+    auto coords = tfjs::util::offset_to_loc(i, out_strides);
+    const size_t b = coords[0];
+    const size_t h = channels_last ? coords[1] : coords[2];
+    const size_t w = channels_last ? coords[2] : coords[3];
+    const size_t d = channels_last ? coords[3] : coords[1];
+    const size_t out_depth_size = channels_last ? out_shape[3] : out_shape[1];
+
+    const size_t in_h = h / block_size;
+    const size_t offset_h = h % block_size;
+    const size_t in_w = w / block_size;
+    const size_t offset_w = w % block_size;
+    const size_t offset_d = (offset_h * block_size + offset_w) * out_depth_size;
+
+    const size_t in_d = d + offset_d;
+
+    size_t x_index =
+        channels_last
+            ? tfjs::util::loc_to_offset({b, in_h, in_w, in_d}, x_strides)
+            : tfjs::util::loc_to_offset({b, in_d, in_h, in_w}, x_strides);
+    *out_buf_ptr = x_ptr[x_index];
+
+    out_buf_ptr++;
+  }
+}
+}  // extern "C"
+}  // namespace wasm
+}  // namespace tfjs

--- a/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
@@ -26,10 +26,12 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE
 #endif
 
-void StridedSlice(const size_t x_id, const size_t block_size,
-                  const bool channels_last, const int32_t* x_strides_ptr,
-                  const size_t x_strides_size, const int32_t* out_shape_ptr,
-                  const int32_t* out_strides_ptr, const size_t out_shape_size,
+void StridedSlice(const size_t x_id, const int32_t* begin_ptr,
+                  const size_t begin_size, const int32_t* end_ptr,
+                  const size_t end_size, const int32_t* strides_ptr,
+                  const size_t strides_size, const size_t begin_mask,
+                  const size_t end_mask, const size_t ellipsis_mask,
+                  const size_t new_axis_mask, const size_t shrink_axis_mask,
                   const size_t out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& out_info = backend::get_tensor_info_out(out_id);

--- a/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/StridedSlice.cc
@@ -40,34 +40,35 @@ void StridedSlice(const size_t x_id, const int32_t* begin_ptr,
   const float* x_ptr = x_info.f32();
   float* out_buf_ptr = out_info.f32_write();
 
-  const auto x_strides =
-      std::vector<size_t>(x_strides_ptr, x_strides_ptr + x_strides_size);
-  const auto out_shape =
-      std::vector<size_t>(out_shape_ptr, out_shape_ptr + out_shape_size);
-  const auto out_strides = std::vector<size_t>(
-      out_strides_ptr, out_strides_ptr + out_shape_size - 1);
+  const auto begin = std::vector<size_t>(begin_ptr, begin_ptr + begin_size);
+  const auto end = std::vector<size_t>(end_ptr, end_ptr + end_size);
+  const auto strides =
+      std::vector<size_t>(strides_ptr, strides_ptr + strides_size);
 
   for (size_t i = 0; i < out_size; ++i) {
-    auto coords = tfjs::util::offset_to_loc(i, out_strides);
-    const size_t b = coords[0];
-    const size_t h = channels_last ? coords[1] : coords[2];
-    const size_t w = channels_last ? coords[2] : coords[3];
-    const size_t d = channels_last ? coords[3] : coords[1];
-    const size_t out_depth_size = channels_last ? out_shape[3] : out_shape[1];
+    // auto coords = tfjs::util::offset_to_loc(i, out_strides);
+    // const size_t b = coords[0];
+    // const size_t h = channels_last ? coords[1] : coords[2];
+    // const size_t w = channels_last ? coords[2] : coords[3];
+    // const size_t d = channels_last ? coords[3] : coords[1];
+    // const size_t out_depth_size = channels_last ? out_shape[3] :
+    // out_shape[1];
 
-    const size_t in_h = h / block_size;
-    const size_t offset_h = h % block_size;
-    const size_t in_w = w / block_size;
-    const size_t offset_w = w % block_size;
-    const size_t offset_d = (offset_h * block_size + offset_w) * out_depth_size;
+    // const size_t in_h = h / block_size;
+    // const size_t offset_h = h % block_size;
+    // const size_t in_w = w / block_size;
+    // const size_t offset_w = w % block_size;
+    // const size_t offset_d = (offset_h * block_size + offset_w) *
+    // out_depth_size;
 
-    const size_t in_d = d + offset_d;
+    // const size_t in_d = d + offset_d;
 
-    size_t x_index =
-        channels_last
-            ? tfjs::util::loc_to_offset({b, in_h, in_w, in_d}, x_strides)
-            : tfjs::util::loc_to_offset({b, in_d, in_h, in_w}, x_strides);
-    *out_buf_ptr = x_ptr[x_index];
+    // size_t x_index =
+    //     channels_last
+    //         ? tfjs::util::loc_to_offset({b, in_h, in_w, in_d}, x_strides)
+    //         : tfjs::util::loc_to_offset({b, in_d, in_h, in_w}, x_strides);
+
+    // *out_buf_ptr = x_ptr[x_index];
 
     out_buf_ptr++;
   }

--- a/tfjs-backend-wasm/src/kernels/StridedSlice.ts
+++ b/tfjs-backend-wasm/src/kernels/StridedSlice.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC. All Rights Reserved.
+ * Copyright 2020 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -51,6 +51,10 @@ export function stridedSlice(args: {
   const {x} = inputs;
 
   let {begin, end, strides} = attrs;
+  if (strides == null) {
+    strides = new Array(begin.length);
+  }
+
   const {beginMask, endMask, ellipsisMask, newAxisMask, shrinkAxisMask} = attrs;
 
   const ellipsisAxes = backend_util.slice_util.maskToAxes(ellipsisMask);

--- a/tfjs-backend-wasm/src/kernels/StridedSlice.ts
+++ b/tfjs-backend-wasm/src/kernels/StridedSlice.ts
@@ -123,23 +123,19 @@ export function stridedSlice(args: {
     return reshape({inputs: {x: xSliced}, attrs: {shape: outShape}, backend});
   }
 
-  const xId = backend.dataIdMap.get(xReshaped.dataId).id;
-
   const out = backend.makeOutput(outShape, 'float32');
-
   if (!outShape.some(axis => axis === 0)) {
-    const outId = backend.dataIdMap.get(out.dataId).id;
-
+    const xId = backend.dataIdMap.get(xReshaped.dataId).id;
+    const xStridesBytes = new Uint8Array(
+        new Int32Array(util.computeStrides(xReshaped.shape)).buffer);
     const beginBytes = new Uint8Array(new Int32Array(begin).buffer);
     const endBytes = new Uint8Array(new Int32Array(end).buffer);
     const stridesBytes = new Uint8Array(new Int32Array(strides).buffer);
 
-    const xStridesBytes =
-        new Uint8Array(new Int32Array(util.computeStrides(x.shape)).buffer);
-
     const outputShapeBytes = new Uint8Array(new Int32Array(outShape).buffer);
     const outStridesBytes =
         new Uint8Array(new Int32Array(util.computeStrides(outShape)).buffer);
+    const outId = backend.dataIdMap.get(out.dataId).id;
 
     wasmStridedSlice(
         xId, xStridesBytes, xReshaped.shape.length, beginBytes, endBytes,

--- a/tfjs-backend-wasm/src/kernels/StridedSlice.ts
+++ b/tfjs-backend-wasm/src/kernels/StridedSlice.ts
@@ -127,7 +127,7 @@ export function stridedSlice(args: {
     return reshape({inputs: {x: xSliced}, attrs: {shape: outShape}, backend});
   }
 
-  const xId = backend.dataIdMap.get(xReshaped.dataId);
+  const xId = backend.dataIdMap.get(xReshaped.dataId).id;
 
   const out = backend.makeOutput(outShape, 'float32');
   const outId = backend.dataIdMap.get(out.dataId).id;
@@ -142,39 +142,6 @@ export function stridedSlice(args: {
       shrinkAxisMask, outId);
 
   return reshape({inputs: {x: out}, attrs: {shape: outShape}, backend});
-
-  // const batchSize = x.shape[0];
-  // const inputHeight = (dataFormat === 'NHWC') ? x.shape[1] : x.shape[2];
-  // const inputWidth = (dataFormat === 'NHWC') ? x.shape[2] : x.shape[3];
-  // const inputDepth = (dataFormat === 'NHWC') ? x.shape[3] : x.shape[1];
-
-  // const outputHeight = inputHeight * blockSize;
-  // const outputWidth = inputWidth * blockSize;
-  // const outputDepth = inputDepth / (blockSize * blockSize);
-
-  // const outputShape = (dataFormat === 'NHWC') ?
-  //     [batchSize, outputHeight, outputWidth, outputDepth] :
-  //     [batchSize, outputDepth, outputHeight, outputWidth];
-
-  // const out = backend.makeOutput(outputShape, 'float32');
-
-  // const xData = backend.dataIdMap.get(x.dataId);
-  // const xId = xData.id;
-  // const xStridesBytes =
-  //     new Uint8Array(new Int32Array(util.computeStrides(x.shape)).buffer);
-
-  // const outputShapeBytes = new Uint8Array(new
-  // Int32Array(outputShape).buffer); const outStridesBytes =
-  //     new Uint8Array(new
-  //     Int32Array(util.computeStrides(outputShape)).buffer);
-
-  // const outId = backend.dataIdMap.get(out.dataId).id;
-  // const channelsLast = dataFormat === 'NHWC' ? 1 : 0;
-  // wasmStridedSlice(
-  //     xId, blockSize, channelsLast, xStridesBytes, x.shape.length - 1,
-  //     outputShapeBytes, outStridesBytes, outputShape.length, outId);
-
-  // return out;
 }
 
 export const stridedSliceConfig: KernelConfig = {

--- a/tfjs-backend-wasm/src/kernels/StridedSlice.ts
+++ b/tfjs-backend-wasm/src/kernels/StridedSlice.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, KernelFunc, StridedSlice, StridedSliceAttrs, StridedSliceInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
+
+import {BackendWasm} from '../backend_wasm';
+
+let wasmStridedSlice: (
+    xId: number, blockSize: number, channelsLast: number, xStrides: Uint8Array,
+    xStridesLength: number, outputShape: Uint8Array, outputStrides: Uint8Array,
+    outSize: number, outId: number) => void;
+
+function setup(backend: BackendWasm): void {
+  wasmStridedSlice = backend.wasm.cwrap(StridedSlice, null /*void*/, [
+    'number',  // xId
+    'number',  // blockSize
+    'number',  // channelsLast
+    'array',   // xStrides
+    'number',  // xStridesLength
+    'array',   // outputShape
+    'array',   // outputStrides
+    'number',  // outSize
+    'number',  // outId
+  ]);
+}
+
+export function stridedSlice(args: {
+  backend: BackendWasm,
+  inputs: StridedSliceInputs,
+  attrs: StridedSliceAttrs
+}): TensorInfo {
+  const {backend, inputs, attrs} = args;
+  const {x} = inputs;
+  const {
+    begin,
+    end,
+    strides,
+    beginMask,
+    endMask,
+    ellipsisMask,
+    newAxisMask,
+    shrinkAxisMask
+  } = attrs;
+
+  util.assert(
+      blockSize > 1,
+      () => `blockSize should be > 1 for stridedSlice, but was: ${blockSize}`);
+
+  const batchSize = x.shape[0];
+  const inputHeight = (dataFormat === 'NHWC') ? x.shape[1] : x.shape[2];
+  const inputWidth = (dataFormat === 'NHWC') ? x.shape[2] : x.shape[3];
+  const inputDepth = (dataFormat === 'NHWC') ? x.shape[3] : x.shape[1];
+
+  const outputHeight = inputHeight * blockSize;
+  const outputWidth = inputWidth * blockSize;
+  const outputDepth = inputDepth / (blockSize * blockSize);
+
+  const outputShape = (dataFormat === 'NHWC') ?
+      [batchSize, outputHeight, outputWidth, outputDepth] :
+      [batchSize, outputDepth, outputHeight, outputWidth];
+
+  const out = backend.makeOutput(outputShape, 'float32');
+
+  const xData = backend.dataIdMap.get(x.dataId);
+  const xId = xData.id;
+  const xStridesBytes =
+      new Uint8Array(new Int32Array(util.computeStrides(x.shape)).buffer);
+
+  const outputShapeBytes = new Uint8Array(new Int32Array(outputShape).buffer);
+  const outStridesBytes =
+      new Uint8Array(new Int32Array(util.computeStrides(outputShape)).buffer);
+
+  const outId = backend.dataIdMap.get(out.dataId).id;
+  const channelsLast = dataFormat === 'NHWC' ? 1 : 0;
+  wasmStridedSlice(
+      xId, blockSize, channelsLast, xStridesBytes, x.shape.length - 1,
+      outputShapeBytes, outStridesBytes, outputShape.length, outId);
+
+  return out;
+}
+
+export const stridedSliceConfig: KernelConfig = {
+  kernelName: StridedSlice,
+  backendName: 'wasm',
+  setupFunc: setup,
+  kernelFunc: stridedSlice as {} as KernelFunc
+};

--- a/tfjs-backend-wasm/src/kernels/StridedSlice.ts
+++ b/tfjs-backend-wasm/src/kernels/StridedSlice.ts
@@ -22,29 +22,19 @@ import {reshape} from './Reshape';
 import {slice} from './Slice';
 
 let wasmStridedSlice: (
-    xId: number, xStridesBytes: Uint8Array, xStridesLength: number,
-    beginBytes: Uint8Array, beginLength: number, endBytes: Uint8Array,
-    endLength: number, stridesBytes: Uint8Array, stridesLength: number,
-    beginMask: number, endMask: number, ellipsisMask: number,
-    newAxisMask: number, shrinkAxisMask: number, outShapeBytes: Uint8Array,
-    outStridesBytes: Uint8Array, outShapeLength: number, outId: number) => void;
+    xId: number, xStridesBytes: Uint8Array, xRank: number,
+    beginBytes: Uint8Array, endBytes: Uint8Array, stridesBytes: Uint8Array,
+    outShapeBytes: Uint8Array, outStridesBytes: Uint8Array,
+    outShapeLength: number, outId: number) => void;
 
 function setup(backend: BackendWasm): void {
   wasmStridedSlice = backend.wasm.cwrap(StridedSlice, null /*void*/, [
     'number',  // xId
     'array',   // xStrides
-    'number',  // xStridesLength
+    'number',  // xRank
     'array',   // beginBytes
-    'number',  // beginLength
     'array',   // endBytes
-    'number',  // endLength
     'array',   // stridesBytes
-    'number',  // stridesLength
-    'number',  // beginMask
-    'number',  // endMask
-    'number',  // ellipsisMask
-    'number',  // newAxisMask
-    'number',  // shrinkAxisMask
     'array',   // outShapeBytes
     'array',   // outStridesBytes
     'number',  // outShapeLength
@@ -152,10 +142,9 @@ export function stridedSlice(args: {
         new Uint8Array(new Int32Array(util.computeStrides(outShape)).buffer);
 
     wasmStridedSlice(
-        xId, xStridesBytes, x.shape.length - 1, beginBytes, begin.length,
-        endBytes, end.length, stridesBytes, strides.length, beginMask, endMask,
-        ellipsisMask, newAxisMask, shrinkAxisMask, outputShapeBytes,
-        outStridesBytes, outShape.length, outId);
+        xId, xStridesBytes, xReshaped.shape.length, beginBytes, endBytes,
+        stridesBytes, outputShapeBytes, outStridesBytes, outShape.length,
+        outId);
   }
 
   return reshape({inputs: {x: out}, attrs: {shape: outShape}, backend});

--- a/tfjs-backend-wasm/src/register_all_kernels.ts
+++ b/tfjs-backend-wasm/src/register_all_kernels.ts
@@ -87,6 +87,7 @@ import {splitVConfig} from './kernels/Split';
 import {sqrtConfig} from './kernels/Sqrt';
 import {squareConfig} from './kernels/Square';
 import {squaredDifferenceConfig} from './kernels/SquaredDifference';
+import {stridedSliceConfig} from './kernels/StridedSlice';
 import {subConfig} from './kernels/Sub';
 import {sumConfig} from './kernels/Sum';
 import {tanhConfig} from './kernels/Tanh';
@@ -165,6 +166,7 @@ const kernelConfigs: KernelConfig[] = [
   sqrtConfig,
   squareConfig,
   squaredDifferenceConfig,
+  stridedSliceConfig,
   subConfig,
   sumConfig,
   tanhConfig,

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -192,6 +192,7 @@ const TEST_FILTERS: TestFilter[] = [
     ]
   },
   {include: 'slice '},
+  {include: 'stridedSlice '},
   {include: 'rotate '},
   {include: 'flipLeftRight '},
   {include: 'square '},

--- a/tfjs-core/src/backends/backend_util.ts
+++ b/tfjs-core/src/backends/backend_util.ts
@@ -36,6 +36,9 @@ export * from '../ops/fused_util';
 export * from '../ops/fused_types';
 export * from '../ops/reduce_util';
 
+import * as slice_util from '../ops/slice_util';
+export {slice_util};
+
 export {BackendValues, TypedArray, upcastType, PixelData} from '../types';
 export {MemoryInfo, TimingInfo} from '../engine';
 export * from '../ops/rotate_util';

--- a/tfjs-core/src/ops/slice_util.ts
+++ b/tfjs-core/src/ops/slice_util.ts
@@ -106,7 +106,8 @@ function getElidedAxes(numElidedAxes: number, ellipsisInsertionIndex: number) {
 export function getNormalizedAxes(
     inputShape: number[], ellipsisAxes: number[], numInterpolatedAxes: number,
     begin: number[], end: number[], strides: number[], beginMask: number,
-    endMask: number, ellipsisMask: number) {
+    endMask: number,
+    ellipsisMask: number): {begin: number[], end: number[], strides: number[]} {
   const inputRank = inputShape.length;
   let normalizedBegin = new Array(inputRank),
       normalizedEnd = new Array(inputRank),

--- a/tfjs-core/src/ops/slice_util.ts
+++ b/tfjs-core/src/ops/slice_util.ts
@@ -102,6 +102,44 @@ function getElidedAxes(numElidedAxes: number, ellipsisInsertionIndex: number) {
   return elidedAxes;
 }
 
+// Normalize the start, end and strides.
+export function getNormalizedAxes(
+    inputShape: number[], ellipsisAxes: number[], numInterpolatedAxes: number,
+    begin: number[], end: number[], strides: number[], beginMask: number,
+    endMask: number, ellipsisMask: number) {
+  const inputRank = inputShape.length;
+  let normalizedBegin = new Array(inputRank),
+      normalizedEnd = new Array(inputRank),
+      normalizedStrides = new Array(inputRank);
+  if (ellipsisAxes.length && numInterpolatedAxes > 0) {
+    const fullIndex = ellipsisAxes[0];
+
+    // The ellipsis applies to the masked index as well as any dimensions
+    // that are interpolated.
+    const numElidedAxes = numInterpolatedAxes + 1;
+    normalizedBegin = startIndicesWithElidedDims(
+        beginMask, fullIndex, numElidedAxes, begin, inputShape);
+    normalizedEnd = stopIndicesWithElidedDims(
+        endMask, fullIndex, numElidedAxes, end, inputShape);
+    normalizedStrides =
+        stridesWithElidedDims(strides, fullIndex, numElidedAxes, inputShape);
+  } else {
+    for (let axis = 0; axis < inputRank; axis++) {
+      normalizedBegin[axis] = startForAxis(
+          beginMask, begin, strides, inputShape, axis, ellipsisMask);
+      normalizedEnd[axis] =
+          stopForAxis(endMask, end, strides, inputShape, axis, ellipsisMask);
+      normalizedStrides[axis] = stridesForAxis(strides, axis, ellipsisMask);
+    }
+  }
+
+  return {
+    begin: normalizedBegin,
+    end: normalizedEnd,
+    strides: normalizedStrides
+  };
+}
+
 // Creates full selection at the elided dimensions. If the dimension matches
 // the ellipsis mask, override the current start value. Otherwise, insert.
 export function startIndicesWithElidedDims(

--- a/tfjs-core/src/ops/strided_slice.ts
+++ b/tfjs-core/src/ops/strided_slice.ts
@@ -65,13 +65,13 @@ function stridedSlice_(
     x: Tensor|TensorLike, begin: number[], end: number[], strides?: number[],
     beginMask = 0, endMask = 0, ellipsisMask = 0, newAxisMask = 0,
     shrinkAxisMask = 0): Tensor {
-  if (strides == null) {
-    strides = new Array(begin.length);
-  }
-
   let $x = convertToTensor(x, 'x', 'stridedSlice');
 
   const forward: ForwardFunc<Tensor> = (backend) => {
+    if (strides == null) {
+      strides = new Array(begin.length);
+    }
+
     const ellipsisAxes = maskToAxes(ellipsisMask);
     if (ellipsisAxes.length > 1) {
       throw new Error('Multiple ellipses in slice is not allowed.');

--- a/tfjs-core/src/ops/strided_slice.ts
+++ b/tfjs-core/src/ops/strided_slice.ts
@@ -26,7 +26,8 @@ import {TensorLike} from '../types';
 import {op} from './operation';
 import {reshape} from './reshape';
 import {slice} from './slice';
-import {computeOutShape, maskToAxes, startForAxis, startIndicesWithElidedDims, stopForAxis, stopIndicesWithElidedDims, stridesForAxis, stridesWithElidedDims} from './slice_util';
+import {computeOutShape, getNormalizedAxes, maskToAxes} from './slice_util';
+
 
 /**
  * Extracts a strided slice of a tensor.
@@ -98,28 +99,17 @@ function stridedSlice_(
     });
     $x = reshape($x, newShape);
 
-    // Normalize the start, end and strides.
-    if (ellipsisAxes.length && numInterpolatedAxes > 0) {
-      const fullIndex = ellipsisAxes[0];
-
-      // The ellipsis applies to the masked index as well as any dimensions
-      // that are interpolated.
-      const numElidedAxes = numInterpolatedAxes + 1;
-      begin = startIndicesWithElidedDims(
-          beginMask, fullIndex, numElidedAxes, begin, $x.shape);
-      end = stopIndicesWithElidedDims(
-          endMask, fullIndex, numElidedAxes, end, $x.shape);
-      strides =
-          stridesWithElidedDims(strides, fullIndex, numElidedAxes, $x.shape);
-    } else {
-      for (let axis = 0; axis < $x.rank; axis++) {
-        begin[axis] = startForAxis(
-            beginMask, begin, strides, $x.shape, axis, ellipsisMask);
-        end[axis] =
-            stopForAxis(endMask, end, strides, $x.shape, axis, ellipsisMask);
-        strides[axis] = stridesForAxis(strides, axis, ellipsisMask);
-      }
-    }
+    const {
+      begin: normalizedBegin,
+      end: normalizedEnd,
+      strides: normalizedStrides
+    } =
+        getNormalizedAxes(
+            $x.shape, ellipsisAxes, numInterpolatedAxes, begin, end, strides,
+            beginMask, endMask, ellipsisMask);
+    begin = normalizedBegin;
+    end = normalizedEnd;
+    strides = normalizedStrides;
 
     const shrinkAxes = maskToAxes(shrinkAxisMask);
     // Adjust the ends based on the shrink mask.

--- a/tfjs-core/src/ops/strided_slice.ts
+++ b/tfjs-core/src/ops/strided_slice.ts
@@ -28,7 +28,6 @@ import {reshape} from './reshape';
 import {slice} from './slice';
 import {computeOutShape, getNormalizedAxes, maskToAxes} from './slice_util';
 
-
 /**
  * Extracts a strided slice of a tensor.
  *


### PR DESCRIPTION
Adds modularized StridedSlice kernel to WASM backend. This makes it possible to create a modularized WASM build for the blazeface model.

There is still a lot of logic duplicated between the new kernel and the forwardFunc in the op. I moved a little of it out into slice_util, but I thought it might be best to hold off on the rest until we modularize StridedSlice for a second backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3904)
<!-- Reviewable:end -->
