### PR TITLE
make tensor instanceof more robust

### DIFF
--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -443,7 +443,7 @@ export class Tensor<R extends Rank = Rank> {
 }
 Object.defineProperty(Tensor, Symbol.hasInstance, {
   value: (instance: Tensor) => {
-    // Implementation note: we should use properties of the object will be
+    // Implementation note: we should use properties of the object that will be
     // defined before the constructor body has finished executing (methods).
     // This is because when this code is transpiled by babel, babel will call
     // classCallCheck before the constructor body is run.

--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -292,7 +292,8 @@ export class Tensor<R extends Rank = Rank> {
     return opHandler.buffer(this.shape, this.dtype as D, vals);
   }
 
-  /** Returns a `tf.TensorBuffer` that holds the underlying data.
+  /**
+   * Returns a `tf.TensorBuffer` that holds the underlying data.
    * @doc {heading: 'Tensors', subheading: 'Classes'}
    */
   bufferSync<D extends DataType = 'float32'>(): TensorBuffer<R, D> {
@@ -411,7 +412,8 @@ export class Tensor<R extends Rank = Rank> {
     return opHandler.print(this, verbose);
   }
 
-  /** Returns a copy of the tensor. See `tf.clone` for details.
+  /**
+   * Returns a copy of the tensor. See `tf.clone` for details.
    * @doc {heading: 'Tensors', subheading: 'Classes'}
    */
   clone<T extends Tensor>(this: T): T {
@@ -441,8 +443,13 @@ export class Tensor<R extends Rank = Rank> {
 }
 Object.defineProperty(Tensor, Symbol.hasInstance, {
   value: (instance: Tensor) => {
-    return !!instance && instance.dataId != null && instance.shape != null &&
-        instance.dtype != null;
+    // Implementation note: we should use properties of the object will be
+    // defined before the constructor body has finished executing (methods).
+    // This is because when this code is transpiled by babel, babel will call
+    // classCallCheck before the constructor body is run.
+    // See https://github.com/tensorflow/tfjs/issues/3384 for backstory.
+    return !!instance && instance.data != null && instance.dataSync != null &&
+        instance.throwIfDisposed != null;
   }
 });
 

--- a/tfjs-core/src/tensor_test.ts
+++ b/tfjs-core/src/tensor_test.ts
@@ -2208,11 +2208,6 @@ describeWithFlags('x instanceof Tensor', ALL_ENVS, () => {
     expect(t instanceof Tensor).toBe(true);
   });
 
-  it('x: Tensor-like', () => {
-    const t = {shape: [2], dtype: 'float32', dataId: {}};
-    expect(t instanceof Tensor).toBe(true);
-  });
-
   it('x: other object, fails', () => {
     const t = {something: 'else'};
     expect(t instanceof Tensor).toBe(false);

--- a/tfjs-core/src/variable_test.ts
+++ b/tfjs-core/src/variable_test.ts
@@ -220,11 +220,6 @@ describeWithFlags('x instanceof Variable', ALL_ENVS, () => {
     expect(t instanceof Variable).toBe(true);
   });
 
-  it('x: Variable-like', () => {
-    const t = {assign: () => {}, shape: [2], dtype: 'float32', dataId: {}};
-    expect(t instanceof Variable).toBe(true);
-  });
-
   it('x: other object, fails', () => {
     const t = {something: 'else'};
     expect(t instanceof Variable).toBe(false);


### PR DESCRIPTION
This adds a workaround for how babel compiles our classes, and should fix #3384.

The main issue is that babel will try and run instanceof on a tensor before our constructor body has executed. This works around this by checking for the presence of methods on Tensor.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3906)
<!-- Reviewable:end -->
