### PR TITLE
[tfjs-converter] fix output tensor get disposed if output name contains index

### DIFF
--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -183,8 +183,8 @@ export class GraphExecutor implements FunctionExecutor {
     this.checkOutputs(outputs);
     const inputNodes =
         names.map(name => this.graph.nodes[parseNodeName(name)[0]]);
-    const outputNodes =
-        outputs.map(name => this.graph.nodes[parseNodeName(name)[0]]);
+    const outputNodeNames = outputs.map(name => parseNodeName(name)[0]);
+    const outputNodes = outputNodeNames.map(name => this.graph.nodes[name]);
     const compilationKey = this.getCompilationKey(inputNodes, outputNodes);
     // Do nothing if the compiled graph cache contains the input.
     let orderedNodes = this.compiledMap.get(compilationKey);
@@ -218,8 +218,8 @@ export class GraphExecutor implements FunctionExecutor {
           }
           tensorsMap[node.name] = tensors;
           this.checkTensorForDisposal(
-              node.name, node, tensorsMap, context, tensorsToKeep, outputs,
-              intermediateTensorConsumerCount);
+              node.name, node, tensorsMap, context, tensorsToKeep,
+              outputNodeNames, intermediateTensorConsumerCount);
         }
       }
       // dispose the context for the root executor
@@ -377,8 +377,8 @@ export class GraphExecutor implements FunctionExecutor {
     const names = Object.keys(inputs);
     const inputNodes =
         names.map(name => this.graph.nodes[parseNodeName(name)[0]]);
-    const outputNodes =
-        outputNames.map(name => this.graph.nodes[parseNodeName(name)[0]]);
+    const outputNodeNames = outputNames.map(name => parseNodeName(name)[0]);
+    const outputNodes = outputNodeNames.map(name => this.graph.nodes[name]);
     const {usedNodes, missingInputs, dynamicNode, syncInputs} =
         getExecutionSubgraph(inputs, outputNodes, this.weightMap);
 
@@ -399,7 +399,7 @@ export class GraphExecutor implements FunctionExecutor {
     while (stack.length > 0) {
       const promises = this.processStack(
           inputNodes, stack, context, tensorsMap, added, tensorsToKeep,
-          outputNames, intermediateTensorConsumerCount, usedNodes);
+          outputNodeNames, intermediateTensorConsumerCount, usedNodes);
       await Promise.all(promises);
     }
     if (dynamicNode == null && !isFunctionExecution) {

--- a/tfjs-converter/src/executor/graph_executor_test.ts
+++ b/tfjs-converter/src/executor/graph_executor_test.ts
@@ -251,6 +251,15 @@ describe('GraphExecutor', () => {
           const res = executor.execute({input: inputTensor}, ['output']);
           expect(res).not.toBeNull();
         });
+
+        it('should not have mem leak when add index', async () => {
+          const inputTensor = tfc.tensor4d([1, 1], [2, 1, 1, 1], 'float32');
+          const numTensors: number = tfc.memory().numTensors;
+
+          const res = executor.execute({input: inputTensor}, ['output:0']);
+          expect(res).not.toBeNull();
+          expect(tfc.memory().numTensors).toEqual(numTensors + 1);
+        });
       });
 
       describe('executeAsync', () => {
@@ -614,6 +623,15 @@ describe('GraphExecutor', () => {
 
           await executor.executeAsync(
               {x: trueTensor, y: falseTensor}, ['output']);
+          expect(tfc.memory().numTensors).toEqual(numTensors + 1);
+        });
+        it('should not have mem leak when add index', async () => {
+          const trueTensor = tfc.scalar(-1, 'int32');
+          const falseTensor = tfc.scalar(1, 'int32');
+          const numTensors: number = tfc.memory().numTensors;
+
+          await executor.executeAsync(
+              {x: trueTensor, y: falseTensor}, ['output:0']);
           expect(tfc.memory().numTensors).toEqual(numTensors + 1);
         });
       });


### PR DESCRIPTION
The output nodes should be disposed during intermediate tensor check.
But when the output nodes contains the index, the output names failed to match with the node name (contains no index).
This fix the problem by clean up the output node names.
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3920)
<!-- Reviewable:end -->
