### PR TITLE
webgpu: Fix 'outSize' is missing error in ReduceInfo

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -815,7 +815,8 @@ export class WebGPUBackend extends KernelBackend {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize = backend_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = {windowSize, inSize, batchSize};
+    const outSize = Math.ceil(inSize / windowSize);
+    const reduceInfo = {windowSize, inSize, batchSize, outSize};
     const program = new ReduceProgram(reduceInfo, reduceType);
     const output = this.makeOutputArray(program.outputShape, dtype);
     return this.compileAndRun(program, [x], output);


### PR DESCRIPTION
BUG

Due to the change of ReduceInfo, webgpu backend is complaining that
Property 'outSize' is missing in type '{ windowSize: number; inSize: number; batchSize: number; }' but required in type 'ReduceInfo'.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3927)
<!-- Reviewable:end -->
