### PR TITLE
webgpu: Fix the mapAsync error

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -252,8 +252,8 @@ describeWebGPU('backend webgpu', () => {
       tf.setBackend('webgpu');
       const d = tf.add(a, b);
       await d.data();
+      expect(() => d.dataSync()).not.toThrow();
     };
-
-    expect(f).not.toThrow();
+    await f();
   });
 });


### PR DESCRIPTION
BUG

This change fixes below error:
Uncaught (in promise) DOMException: Unknown error in mapAsync.

Since f is an async function, we should use 'await f()' to make sure the promise has finished.
Otherwise, the execution sequence of function in and out of the body will mess and generate weird result.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3940)
<!-- Reviewable:end -->
