### PR TITLE
refactor(tfjs-core): redundant default

### DIFF
--- a/tfjs-core/src/util.ts
+++ b/tfjs-core/src/util.ts
@@ -733,7 +733,6 @@ export function fetch(
  * @doc {heading: 'Util'}
  */
 export function encodeString(s: string, encoding = 'utf-8'): Uint8Array {
-  encoding = encoding || 'utf-8';
   return env().platform.encode(s, encoding);
 }
 
@@ -746,7 +745,6 @@ export function encodeString(s: string, encoding = 'utf-8'): Uint8Array {
  * @doc {heading: 'Util'}
  */
 export function decodeString(bytes: Uint8Array, encoding = 'utf-8'): string {
-  encoding = encoding || 'utf-8';
   return env().platform.decode(bytes, encoding);
 }
 


### PR DESCRIPTION
This PR removes the redundant defaults in `encodeString` and `decodeString`.
With [default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters), `encoding` defaults to `utf-8`.

history: https://github.com/tensorflow/tfjs/commit/b5854a26952e4ecf253f6ffd78c2cc657150bf57#diff-8cd4968b81985f0efc2053eabc37db6dR698-R721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3964)
<!-- Reviewable:end -->
