### PR TITLE
update the tf deps and moved PyInquirer to extra_requires

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -48,8 +48,9 @@ virtualenv --no-site-packages venv
 
 __1. Install the TensorFlow.js pip package:__
 
+Install the library with interactive CLI:
 ```bash
- pip install tensorflowjs
+ pip install tensorflowjs[wizard]
 ```
 
 __2. Run the converter script provided by the pip package:__

--- a/tfjs-converter/python/README.md
+++ b/tfjs-converter/python/README.md
@@ -2,3 +2,8 @@
 
 The **tensorflowjs** pip package contains libraries and tools for
 [TensorFlow.js](https://js.tensorflow.org).
+
+Use following command to install the library with support of interactive CLI:
+```bash
+pip install tensorflowjs[wizard]
+```

--- a/tfjs-converter/python/build-pip-package.sh
+++ b/tfjs-converter/python/build-pip-package.sh
@@ -158,6 +158,11 @@ echo
 echo "Copying requirements.txt"
 cp "${SCRIPTS_DIR}/requirements.txt" "${TMP_DIR}/"
 
+# Copy requirements.txt
+echo
+echo "Copying extra-requirements.txt"
+cp "${SCRIPTS_DIR}/extra-requirements.txt" "${TMP_DIR}/"
+
 # Copy README.md.
 echo
 echo "Copying README.md"

--- a/tfjs-converter/python/build-pip-package.sh
+++ b/tfjs-converter/python/build-pip-package.sh
@@ -244,7 +244,7 @@ for VENV_PYTHON_BIN in ${VENV_PYTHON_BINS}; do
 
     pushd "${TEST_ON_INSTALL_DIR}" > /dev/null
 
-    pip install "${WHEEL_PATH}"
+    pip install "${WHEEL_PATH}[wizard]"
     echo "Successfully installed ${WHEEL_PATH} for $(python --version 2>&1)."
     echo
 

--- a/tfjs-converter/python/extra-requirements.txt
+++ b/tfjs-converter/python/extra-requirements.txt
@@ -1,0 +1,1 @@
+PyInquirer==1.0.3: wizard

--- a/tfjs-converter/python/requirements-dev.txt
+++ b/tfjs-converter/python/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
+PyInquirer==1.0.3
 pylint==1.9.4; python_version < '3.0'
 pylint==2.5.0; python_version > '3.0'

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,6 +1,5 @@
 h5py>=2.8.0
 numpy>=1.16.4,<1.19.0
 six>=1.12.0
-tensorflow-cpu>=2.1.0,<3
 tensorflow-hub==0.7.0
-PyInquirer==1.0.3
+tensorflow>=2.1.0,<3

--- a/tfjs-converter/python/setup.py
+++ b/tfjs-converter/python/setup.py
@@ -25,6 +25,28 @@ def _get_requirements(file):
   with open(os.path.join(DIR_NAME, file), 'r') as requirements:
     return requirements.readlines()
 
+def get_extra_requires(path, add_all=True):
+    import re
+    from collections import defaultdict
+
+    with open(path) as fp:
+        extra_deps = defaultdict(set)
+        for k in fp:
+            if k.strip() and not k.startswith('#'):
+                tags = set()
+                if ':' in k:
+                    k, v = k.split(':')
+                    tags.update(vv.strip() for vv in v.split(','))
+                tags.add(re.split('[<=>]', k)[0])
+                for t in tags:
+                    extra_deps[t].add(k)
+
+        # add tag `all` at the end
+        if add_all:
+            extra_deps['all'] = set(vv for v in extra_deps.values() for vv in v)
+
+    return extra_deps
+
 CONSOLE_SCRIPTS = [
     'tensorflowjs_converter = tensorflowjs.converters.converter:pip_main',
     'tensorflowjs_wizard = tensorflowjs.converters.wizard:pip_main',
@@ -78,6 +100,7 @@ setuptools.setup(
         'tensorflowjs/op_list': ['*.json']
     },
     install_requires=_get_requirements('requirements.txt'),
+    extras_require=get_extra_requires('extra-requirements.txt'),
     entry_points={
         'console_scripts': CONSOLE_SCRIPTS,
     },

--- a/tfjs-converter/python/tensorflowjs/converters/wizard.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard.py
@@ -26,8 +26,8 @@ import traceback
 try:
   import PyInquirer
 except ImportError:
-    sys.exit("""Please install PyInquirer using following command:
-                `pip install PyInquirer==1.0.3`""")
+  sys.exit("""Please install PyInquirer using following command:
+              pip install PyInquirer==1.0.3""")
 
 import h5py
 import tensorflow.compat.v2 as tf

--- a/tfjs-converter/python/tensorflowjs/converters/wizard.py
+++ b/tfjs-converter/python/tensorflowjs/converters/wizard.py
@@ -23,7 +23,12 @@ import sys
 import tempfile
 import traceback
 
-import PyInquirer
+try:
+  import PyInquirer
+except ImportError:
+    sys.exit("""Please install PyInquirer using following command:
+                `pip install PyInquirer==1.0.3`""")
+
 import h5py
 import tensorflow.compat.v2 as tf
 from tensorflow.core.framework import types_pb2


### PR DESCRIPTION
When integrating with TFX OSS, some pip dependencies problem was found, namely:
1. we are depending on tensorflow-cpu, which conflict with TFX dependencies of Tensorflow
2. we are using PyInquirer which uses an old prompt-toolkit that conflict with one of TFX dependencies

Since TFX does not need the wizard and tfjs converter should work with TensorFlow pip as well, we decide to make following changes:

1. Update the tensorflow-cpu dependencies to tensorflow, since this is mainly a size consideration. 
2. use the extra_require as following:
```
    extras_require = {
      "wizard": ["PyInquirer==1.0.3"]
    }
```
when users need to install tensorflowjs pip, they need to do 
```bash
pip install tensorflowjs[wizard]
```

Update the READMEs, and will print error message if the PyInquirer is not installed when users run tensorflow_wizard command.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3965)
<!-- Reviewable:end -->
