### PR TITLE
Log error caught when creating WebGL context

### DIFF
--- a/tfjs-backend-webgl/src/webgl_util.ts
+++ b/tfjs-backend-webgl/src/webgl_util.ts
@@ -534,6 +534,7 @@ export function isWebGLVersionEnabled(webGLVersion: 1|2) {
       return true;
     }
   } catch (e) {
+    console.log("Error when getting WebGL context: ", e);
     return false;
   }
   return false;

--- a/tfjs-backend-webgl/src/webgl_util.ts
+++ b/tfjs-backend-webgl/src/webgl_util.ts
@@ -534,7 +534,7 @@ export function isWebGLVersionEnabled(webGLVersion: 1|2) {
       return true;
     }
   } catch (e) {
-    console.log("Error when getting WebGL context: ", e);
+    console.log('Error when getting WebGL context: ', e);
     return false;
   }
   return false;


### PR DESCRIPTION
My day today: I spent a _long_ time debugging the error `Initialization of backend webgl failed` on a particular machine. Ultimately, the cause was really obscure: Chrome was returning `null` from `canvas.getContext` when passed [this `failIfMajorPerformanceCaveat` flag](https://github.com/tensorflow/tfjs/blob/c823c1f944fcf97c8070fd75036da8f4bf14c660/tfjs-backend-webgl/src/canvas_util.ts#L27). Another line in TensorFlow assumes that `getContext` cannot return null, and so throws an error `TypeError: Cannot read property 'isContextLost' of null`. This is another bug. But that error was then silently swallowed at the line here.

On restarting the machine, Chrome mysteriously stopped behaving this way. But that underlying issue is a story for another time.

The point is, silently swallowing all thrown errors is a pretty bad practice. To go further, unless we actually _expect_ errors thrown here, I think this `try`/`catch` should be removed - if it fails unexpectedly, just let it fail. If we do expect errors thrown here, that should at least be documented in a comment here.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/3969)
<!-- Reviewable:end -->
