### PR TITLE
fix numpy version mismatch

### DIFF
--- a/tfjs-converter/python/requirements-exp.txt
+++ b/tfjs-converter/python/requirements-exp.txt
@@ -1,8 +1,0 @@
-h5py>=2.8.0
-numpy>=1.16.4,<1.19.0
-six>=1.12.0
-tf-nightly-cpu>=2.4.0.dev20200806,<3
-tensorflow-hub==0.7.0
-PyInquirer==1.0.3
-pylint==1.9.4; python_version < '3.0'
-pylint==2.5.0; python_version > '3.0'

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,5 +1,4 @@
-h5py>=2.8.0
-numpy>=1.16.4,<1.19.0
-six>=1.12.0
-tensorflow-hub>=0.7.0,<0.10
 tensorflow>=2.1.0,<3
+h5py>=2.8.0,<3
+six>=1.12.0,<2
+tensorflow-hub>=0.7.0,<0.10

--- a/tfjs-inference/python/requirements.txt
+++ b/tfjs-inference/python/requirements.txt
@@ -1,2 +1,1 @@
-numpy>=1.16.4, <1.19.0
-tensorflow-cpu>=2.1.0, <3
+tensorflow>=2.1.0, <3


### PR DESCRIPTION
remove the manually requirement of numpy, since tensorflow has a
specific numpy version deps that is >1.1.6.0<1.19.0
Moved the tensorflow deps to the top to ensure we align with that first.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4021)
<!-- Reviewable:end -->
