### PR TITLE
Python converter bugfix

### DIFF
--- a/tfjs-converter/python/tensorflowjs/read_weights.py
+++ b/tfjs-converter/python/tensorflowjs/read_weights.py
@@ -25,7 +25,7 @@ import numpy as np
 from tensorflowjs import quantization
 
 _INPUT_DTYPES = [np.float16, np.float32, np.int32, np.complex64,
-                 np.uint8, np.uint16, np.object]
+                 np.uint8, np.uint16, np.object, np.bool]
 
 # Number of bytes used to encode the length of a string in a string tensor.
 STRING_LENGTH_NUM_BYTES = 4
@@ -99,7 +99,7 @@ def _deserialize_string_array(data_buffer, offset, shape):
     strings, and the offset contains the new offset (the byte position in the
     buffer at the end of the string data).
   """
-  size = np.prod(shape)
+  size = int(np.prod(shape))
   if size == 0:
     return (np.array([], 'object').reshape(shape),
             offset + STRING_LENGTH_NUM_BYTES)

--- a/tfjs-converter/python/tensorflowjs/read_weights_test.py
+++ b/tfjs-converter/python/tensorflowjs/read_weights_test.py
@@ -368,10 +368,10 @@ class ReadWeightsTest(tf.test.TestCase):
 
   def testReadBoolWeights(self):
     groups = [
-      [{
-          'name': 'weight1',
-          'data': np.array([True, False, True], 'bool')
-      }]
+        [{
+            'name': 'weight1',
+            'data': np.array([True, False, True], 'bool')
+        }]
     ]
 
     manifest = write_weights.write_weights(groups, self._tmp_dir)
@@ -390,7 +390,7 @@ class ReadWeightsTest(tf.test.TestCase):
             'name': 'weight1',
             'data': np.array(u'abc'.encode('utf-8'), 'object')
         }]
-    ] 
+    ]
 
     manifest = write_weights.write_weights(groups, self._tmp_dir)
 

--- a/tfjs-converter/python/tensorflowjs/read_weights_test.py
+++ b/tfjs-converter/python/tensorflowjs/read_weights_test.py
@@ -366,6 +366,41 @@ class ReadWeightsTest(tf.test.TestCase):
     self.assertTrue(
         np.allclose(groups[0][0]['data'], read_output[0][0]['data']))
 
+  def testReadBoolWeights(self):
+    groups = [
+      [{
+          'name': 'weight1',
+          'data': np.array([True, False, True], 'bool')
+      }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    self.assertEqual(1, len(read_output[0]))
+    self.assertEqual('weight1', read_output[0][0]['name'])
+    np.testing.assert_array_equal(read_output[0][0]['data'],
+                                  np.array([True, False, True], 'bool'))
+
+  def testReadStringScalar(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array(u'abc'.encode('utf-8'), 'object')
+        }]
+    ] 
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    self.assertEqual(1, len(read_output[0]))
+    self.assertEqual('weight1', read_output[0][0]['name'])
+    np.testing.assert_array_equal(read_output[0][0]['data'],
+                                  np.array(u'abc'.encode('utf-8'), 'object'))
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
## Motivation

The Python converter code supports writing boolean weights, but not reading them. This causes problems when reading TFJS models from Python.

Furthermore, the Python converter fails to read scalar string weights. Numeric scalar weights are read just fine, but string scalars cause an error.

## Implementation

`np.bool` has been added to the list of supported input dtypes.

The deserialization code for string arrays has been fixed so the size calculation always returns a valid `int`.

## Details

Scalars are stored in the weight manifest with an empty shape ([]), which is technically correct to reflect the nature of a scalar.
The string deserialization uses `np.prod()` to calculate the total number of items. Unfortunately, `np.prod()` returns `1.0` when given an empty iterable (see  [numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.prod.html) under _Notes_).

This value cannot be used with `range()` later, which leads to an error in situations where a weight manifest contains string scalars (e.g. model [SSD OpenImages v4](https://tfhub.dev/google/openimages_v4/ssd/mobilenet_v2/1)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4037)
<!-- Reviewable:end -->
