### PR TITLE
Speed up builds.

### DIFF
--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -19,7 +19,7 @@ set -e
 if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1
   yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac
-  yarn run-browserstack --browsers=bs_chrome_mac,win_10_chrome,bs_android_9 --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  yarn run-browserstack --browsers=win_10_chrome,bs_android_9 --testEnv webgl2
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
 else

--- a/tfjs-layers/package.json
+++ b/tfjs-layers/package.json
@@ -63,7 +63,7 @@
     "test": "yarn && yarn build-deps && karma start",
     "test-ci": "./scripts/test-ci.sh",
     "test-snippets": "ts-node --skip-ignore -s ./scripts/test_snippets.ts",
-    "run-browserstack": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
+    "run-browserstack": "karma start --browsers='bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'",
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {

--- a/tfjs-node-gpu/cloudbuild.yml
+++ b/tfjs-node-gpu/cloudbuild.yml
@@ -73,4 +73,5 @@ timeout: 1800s
 logsBucket: 'gs://tfjs-build-logs'
 options:
   logStreamingOption: 'STREAM_ON'
+  machineType: 'N1_HIGHCPU_8'
   substitution_option: 'ALLOW_LOOSE'

--- a/tfjs-node/cloudbuild.yml
+++ b/tfjs-node/cloudbuild.yml
@@ -65,4 +65,5 @@ timeout: 1800s
 logsBucket: 'gs://tfjs-build-logs'
 options:
   logStreamingOption: 'STREAM_ON'
+  machineType: 'N1_HIGHCPU_8'
   substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
Changes in this PR includes:

1. Remove redundant test conditions in webgl.
2. Layers tests with both firefox and chrome every PR, use chrome should be sufficient.
3. Node and NodeGpu takes too much time to build deps (~9mins), upgrade to a more powerful computation unit.

After test:
- Node and NodeGpu reduced 3 mins.
- Layers and Webgl is mainly saving some browserstack resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4072)
<!-- Reviewable:end -->
