### PR TITLE
Speed up builds for union package.

### DIFF
--- a/tfjs/cloudbuild.yml
+++ b/tfjs/cloudbuild.yml
@@ -59,4 +59,5 @@ substitutions:
   _NIGHTLY: ''
 options:
   logStreamingOption: 'STREAM_ON'
+  machineType: 'N1_HIGHCPU_8'
   substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
Using HIGHCPU in Node and NodeGPU resulted in a 3 mins. (30%) reduction in total build time. This should apply to all packages that does a lot of build. Following @tafsiri suggestion, adding the configuration to union package too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4074)
<!-- Reviewable:end -->
