### PR TITLE
Bump seedrandom version

### DIFF
--- a/tfjs-data/package.json
+++ b/tfjs-data/package.json
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "@tensorflow/tfjs-core": "link:../tfjs-core",
-    "seedrandom": "~2.4.3"
+    "seedrandom": "~3.0.5"
   },
   "dependencies": {
     "@types/node-fetch": "^2.1.2",


### PR DESCRIPTION
The current version of seedrandom doesn't load as a js module on unpkg because it's expecting a commonjs runtime. Bumping the version should help this.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4087)
<!-- Reviewable:end -->
