### PR TITLE
Small fix in docs - camelCase

### DIFF
--- a/tfjs-core/src/ops/image/crop_and_resize.ts
+++ b/tfjs-core/src/ops/image/crop_and_resize.ts
@@ -29,7 +29,7 @@ import {op} from '../operation';
 /**
  * Extracts crops from the input image tensor and resizes them using bilinear
  * sampling or nearest neighbor sampling (possibly with aspect ratio change)
- * to a common output size specified by crop_size.
+ * to a common output size specified by cropSize.
  *
  * @param image 4d tensor of shape `[batch,imageHeight,imageWidth, depth]`,
  *     where imageHeight and imageWidth must be positive, specifying the


### PR DESCRIPTION
Variable was snake_case in docs in one place, and camel in actual parameters.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4089)
<!-- Reviewable:end -->
