### PR TITLE
Use versioned CDN URL in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Add the following code to an HTML file:
 <html>
   <head>
     <!-- Load TensorFlow.js -->
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs/dist/tf.min.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.6.0/dist/tf.min.js"> </script>
 
 
     <!-- Place your code in the script tag below. You can also use an external .js file -->


### PR DESCRIPTION
Is there a backward compatibility guarantee with the `@tensorflow/tfjs/dist/tf.min.js` file? If so, please close this pull request.

If there is no backwards compatibility guarantee, then it seems like a bad idea to have a non-versioned URL in the examples, since users often copy-and-paste without realising that they need to add a version to ensure their code doesn't break when breaking changes are introduced to the library. [This page](https://publicwww.com/websites/%22tfjs%2Fdist%2Ftf.min.js%22+depth%3Aall/) shows 79 web pages without a version, and this search is very likely non-exhaustive (sites must reach some threshold to popularity to be indexed by that search engine). If v3 has breaking changes, there could be hundreds of sites that break.

The only disadvantage here is that the readme will need to be updated with each new release. This could be avoided by adding a comment above the script tag saying "change 2.6.0 to the latest version", or something like that, and then only updating the version number in the readme every now and then.

Assuming there is no backwards compatibility guarantee, I hope you'll consider merging this - mainly to help newbies who don't realise the trouble with non-versioned CDN urls :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4123)
<!-- Reviewable:end -->
