### PR TITLE
Fix gradient for min and max

### DIFF
--- a/e2e/integration_tests/grad_layers_test.ts
+++ b/e2e/integration_tests/grad_layers_test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import '@tensorflow/tfjs-backend-cpu';
+import '@tensorflow/tfjs-backend-webgl';
+
+import * as tfc from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
+import {ALL_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
+import * as tfl from '@tensorflow/tfjs-layers';
+
+import {SMOKE} from './constants';
+
+/**
+ *  Tests that tf.grad works for layers models.
+ *  Regression test for https://github.com/tensorflow/tfjs/issues/4130
+ */
+describe(`${SMOKE} tf.grad for layers models`, () => {
+  describeWithFlags(`layers_model`, ALL_ENVS, () => {
+    let model: tfl.Sequential;
+
+    beforeAll(async () => {
+      model = tfl.sequential();
+      model.add(tfl.layers.dense({inputShape: [1], units: 1}));
+    });
+
+    it(`can compute grad of prediction`, async () => {
+      const forward = (x: tfc.Tensor) => model.predict(x) as tfc.Tensor;
+      const grad = tfc.grad(forward);
+
+      const input = tfc.tensor([1], [1, 1]);
+      const dy = tfc.onesLike(input);
+      expect(() => {
+        grad(input, dy);
+      }).not.toThrow();
+    });
+  });
+});

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -929,10 +929,10 @@
   resolved "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
-  integrity sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw==
+"@types/webgl2@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
+  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 abbrev@1:
   version "1.1.1"

--- a/tfjs-core/src/gradients/Max_grad.ts
+++ b/tfjs-core/src/gradients/Max_grad.ts
@@ -17,8 +17,6 @@
 
 import {Max, MaxAttrs} from '../kernel_names';
 import {GradConfig, NamedAttrMap} from '../kernel_registry';
-import * as axis_util from '../ops/axis_util';
-import {transpose} from '../ops/transpose';
 import {Tensor} from '../tensor';
 import * as util from '../util';
 
@@ -31,17 +29,13 @@ export const maxGradConfig: GradConfig = {
   gradFunc: (dy: Tensor, saved: Tensor[], attrs: NamedAttrMap) => {
     const maxAttrs: MaxAttrs = attrs as {} as MaxAttrs;
     const {reductionIndices} = maxAttrs;
-    const [x, y] = saved;
+    const x = saved[0];
+    const y = saved[1];
     const origAxes = util.parseAxisParam(reductionIndices, x.shape);
-    const permutedAxes = axis_util.getAxesPermutation(origAxes, x.rank);
-    const maxGrad = gradForMinAndMax(dy, y, x, origAxes, permutedAxes);
+    const maxGrad = gradForMinAndMax(dy, y, x, origAxes);
     return {
       x: () => {
-        let out = maxGrad['x']();
-        if (permutedAxes != null) {
-          out = transpose(out);
-        }
-        return out;
+        return maxGrad['x']();
       }
     };
   }

--- a/tfjs-core/src/gradients/Min_grad.ts
+++ b/tfjs-core/src/gradients/Min_grad.ts
@@ -17,8 +17,6 @@
 
 import {Min, MinAttrs} from '../kernel_names';
 import {GradConfig, NamedAttrMap} from '../kernel_registry';
-import * as axis_util from '../ops/axis_util';
-import {transpose} from '../ops/transpose';
 import {Tensor} from '../tensor';
 import * as util from '../util';
 
@@ -33,15 +31,10 @@ export const minGradConfig: GradConfig = {
     const {axis} = minAttrs;
     const [x, y] = saved;
     const origAxes = util.parseAxisParam(axis, x.shape);
-    const permutedAxes = axis_util.getAxesPermutation(origAxes, x.rank);
-    const minGrad = gradForMinAndMax(dy, y, x, origAxes, permutedAxes);
+    const minGrad = gradForMinAndMax(dy, y, x, origAxes);
     return {
       x: () => {
-        let out = minGrad['x']();
-        if (permutedAxes != null) {
-          out = transpose(out);
-        }
-        return out;
+        return minGrad['x']();
       }
     };
   }

--- a/tfjs-core/src/gradients/min_max_grad_util.ts
+++ b/tfjs-core/src/gradients/min_max_grad_util.ts
@@ -20,14 +20,13 @@ import {cast} from '../ops/cast';
 import {equal} from '../ops/equal';
 import {mul} from '../ops/mul';
 import {reshape} from '../ops/reshape';
-import {transpose} from '../ops/transpose';
 import {Tensor} from '../tensor';
 
 /**
  * Gradient helper function for the min and max operations.
  */
 export function gradForMinAndMax<T extends Tensor>(
-    dy: T, y: T, xOrig: Tensor, origAxes: number[], permutedAxes: number[]) {
+    dy: T, y: T, xOrig: Tensor, origAxes: number[]) {
   if (y.rank < xOrig.rank) {
     y = reshape(y, axis_util.expandShapeToKeepDim(y.shape, origAxes)) as T;
   }
@@ -37,7 +36,7 @@ export function gradForMinAndMax<T extends Tensor>(
   return {
     x: () => {
       const dx = mul(dy, cast(equal(xOrig, y), dy.dtype));
-      return permutedAxes == null ? dx : transpose(dx, permutedAxes);
+      return dx;
     }
   };
 }

--- a/tfjs-core/src/ops/max_test.ts
+++ b/tfjs-core/src/ops/max_test.ts
@@ -186,6 +186,13 @@ describeWithFlags('max', ALL_ENVS, () => {
     expect(gradients.shape).toEqual([2, 3]);
   });
 
+  it('max gradient: 3D, axis=1 keepDims=false', async () => {
+    const x = tf.ones([2, 1, 250]);
+    const axis = 1;
+    const gradients = tf.grad(v => tf.max(v, axis))(x);
+    expect(gradients.shape).toEqual(x.shape);
+  });
+
   it('max gradient: 3D, axes=[1, 2], keepDims=false', async () => {
     const x = tf.tensor3d([[[0, 20], [10, 15]], [[-10, -30], [-20, -15]]]);
     const dy = tf.tensor1d([-1, -1]);

--- a/tfjs-core/src/ops/min_test.ts
+++ b/tfjs-core/src/ops/min_test.ts
@@ -161,6 +161,13 @@ describeWithFlags('min', ALL_ENVS, () => {
     expect(gradients.shape).toEqual([2, 3]);
   });
 
+  it('max gradient: 3D, axis=1 keepDims=false', async () => {
+    const x = tf.ones([2, 1, 250]);
+    const axis = 1;
+    const gradients = tf.grad(v => tf.min(v, axis))(x);
+    expect(gradients.shape).toEqual(x.shape);
+  });
+
   it('min gradient: 3D, axes=[1, 2], keepDims=false', async () => {
     const x = tf.tensor3d([[[0, -20], [-10, -15]], [[10, 30], [20, 15]]]);
     const dy = tf.tensor1d([-1, -1]);


### PR DESCRIPTION
Closes #4135 
Adds a regression test to guard against #4130 (which seems to be fixed at HEAD at the time of that issue being reported).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4136)
<!-- Reviewable:end -->
