### PR TITLE
allow TFHUB saved_models with no tags converted properly

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -152,7 +152,7 @@ saved a tf.keras model in the SavedModel format.
 |---|---|
 |`--input_format`     | The format of input model, use `tf_saved_model` for SavedModel, `tf_hub` for TensorFlow Hub module, `tfjs_layers_model` for TensorFlow.js JSON format, and `keras` for Keras HDF5. |
 |`--output_format`| The desired output format.  Must be `tfjs_layers_model`, `tfjs_graph_model` or `keras`. Not all pairs of input-output formats are supported.  Please file a [github issue](https://github.com/tensorflow/tfjs/issues) if your desired input-output pair is not supported.|
-|<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion. Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
+|<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion. Tags of the MetaGraphDef to load, in comma separated format. If there are no tags defined in the saved model, set it to empty string `saved_model_tags=''`. Defaults to `serve`.|
 |`--signature_name`   | Only applicable to TensorFlow SavedModel and Hub module conversion, signature to load. Defaults to `serving_default` for SavedModel and `default` for Hub module. See https://www.tensorflow.org/hub/common_signatures/.|
 |`--strip_debug_ops`   | Strips out TensorFlow debug operations `Print`, `Assert`, `CheckNumerics`. Defaults to `True`.|
 |`--quantization_bytes`  | (Deprecated) How many bytes to optionally quantize/compress the weights to. Valid values are 1 and 2. which will quantize int32 and float32 to 1 or 2 bytes respectively. The default (unquantized) size is 4 bytes.|

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -492,6 +492,16 @@ def convert_tf_frozen_model(frozen_model_path,
                  weight_shard_size_bytes=weight_shard_size_bytes,
                  experiments=experiments)
 
+def _load_model(saved_model_dir, saved_model_tags):
+  model = None
+  # Ensure any graphs created in eager mode are able to run.
+  with context.eager_mode():
+    if saved_model_tags:
+      model = load(saved_model_dir, saved_model_tags)
+    else:
+      model = load(saved_model_dir)
+  return model
+
 def convert_tf_saved_model(saved_model_dir,
                            output_dir, signature_def='serving_default',
                            saved_model_tags='serve',
@@ -536,13 +546,8 @@ def convert_tf_saved_model(saved_model_dir,
 
   if saved_model_tags:
     saved_model_tags = saved_model_tags.split(',')
-  model = None
-  # Ensure any graphs created in eager mode are able to run.
-  with context.eager_mode():
-    if saved_model_tags:
-      model = load(saved_model_dir, saved_model_tags)
-    else:
-      model = load(saved_model_dir)
+
+  model = _load_model(saved_model_dir, saved_model_tags)
 
   _check_signature_in_model(model, signature_def)
 

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -373,6 +373,10 @@ def _freeze_saved_model_v1(saved_model_dir, saved_model_tags,
     Nullable. A freezed and optimized initializer graph.
     Nullable. A list of output node names of initializer.
   """
+  # v1 loader need empty list if there are no saved_model tags.
+  if not saved_model_tags:
+    saved_model_tags = []
+
   g = tf.Graph()
   with g.as_default():
     with tf.compat.v1.Session() as sess:
@@ -535,7 +539,10 @@ def convert_tf_saved_model(saved_model_dir,
   model = None
   # Ensure any graphs created in eager mode are able to run.
   with context.eager_mode():
-    model = load(saved_model_dir, saved_model_tags)
+    if saved_model_tags:
+      model = load(saved_model_dir, saved_model_tags)
+    else:
+      model = load(saved_model_dir)
 
   _check_signature_in_model(model, signature_def)
 


### PR DESCRIPTION
TFHub exported saved model contains no tags, and the saved model fails on
v2 loader, updated the v1 loader to take empty list.

fix https://github.com/tensorflow/tfjs/issues/4125


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4141)
<!-- Reviewable:end -->
