### PR TITLE
Modularize node.js backend kernels

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -295,8 +295,8 @@ export class Engine implements TensorTracker, DataMover {
       previous 'Promise.resolve(backend)===backend'
       as we needed to account for custom Promise
       implementations (e.g. Angular) */
-      if (backend && !(backend instanceof KernelBackend)
-          && typeof backend.then === 'function') {
+      if (backend && !(backend instanceof KernelBackend) &&
+          typeof backend.then === 'function') {
         const promiseId = ++this.pendingBackendInitId;
         const success =
             backend
@@ -583,9 +583,17 @@ export class Engine implements TensorTracker, DataMover {
         if (this.shouldCheckForMemLeaks()) {
           this.checkKernelForMemLeak(kernelName, numDataIdsBefore, outInfos);
         }
-        const outTensors = outInfos.map(
-            ({dataId, shape, dtype}) =>
-                this.makeTensorFromDataId(dataId, shape, dtype));
+
+        const outTensors = outInfos.map((outInfo: TensorInfo|Tensor) => {
+          // todo (yassogba) remove this option (Tensor) when node backend
+          // methods have been modularized and they all return tensorInfo.
+          // TensorInfos do not have a rank attribute.
+          if ((outInfo as Tensor).rank != null) {
+            return outInfo as Tensor;
+          }
+          const {dataId, shape, dtype} = outInfo as TensorInfo;
+          return this.makeTensorFromDataId(dataId, shape, dtype);
+        });
 
         // Save the inputs and outputs.
         // Do not save unless we are recording to the tape. Otherwise it would

--- a/tfjs-node/src/kernels/Abs.ts
+++ b/tfjs-node/src/kernels/Abs.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Abs, AbsInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const absConfig: KernelConfig = {
+  kernelName: Abs,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AbsInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    if (x.dtype === 'complex64') {
+      const opAttrs = [
+        createTensorsTypeOpAttr('T', x.dtype),
+        createTensorsTypeOpAttr('Tout', 'float32')
+      ];
+      return backend.executeSingleOutput('ComplexAbs', opAttrs, [x]);
+    }
+    return backend.executeSingleInput(Abs, x);
+  }
+};

--- a/tfjs-node/src/kernels/Acos.ts
+++ b/tfjs-node/src/kernels/Acos.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Acos, AcosInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const acosConfig: KernelConfig = {
+  kernelName: Acos,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AcosInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Acos, x);
+  }
+};

--- a/tfjs-node/src/kernels/Acosh.ts
+++ b/tfjs-node/src/kernels/Acosh.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Acosh, AcoshInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const acoshConfig: KernelConfig = {
+  kernelName: Acosh,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AcoshInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Acosh, x);
+  }
+};

--- a/tfjs-node/src/kernels/Asin.ts
+++ b/tfjs-node/src/kernels/Asin.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Asin, AsinInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const asinConfig: KernelConfig = {
+  kernelName: Asin,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AsinInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Asin, x);
+  }
+};

--- a/tfjs-node/src/kernels/Asinh.ts
+++ b/tfjs-node/src/kernels/Asinh.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Asinh, AsinhInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const asinhConfig: KernelConfig = {
+  kernelName: Asinh,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AsinhInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Asinh, x);
+  }
+};

--- a/tfjs-node/src/kernels/Atan.ts
+++ b/tfjs-node/src/kernels/Atan.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Atan, AtanInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const atanConfig: KernelConfig = {
+  kernelName: Atan,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AtanInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Atan, x);
+  }
+};

--- a/tfjs-node/src/kernels/Atanh.ts
+++ b/tfjs-node/src/kernels/Atanh.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Atanh, AtanhInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const atanhConfig: KernelConfig = {
+  kernelName: Atanh,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as AtanhInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Atanh, x);
+  }
+};

--- a/tfjs-node/src/kernels/Ceil.ts
+++ b/tfjs-node/src/kernels/Ceil.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Ceil, CeilInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const ceilConfig: KernelConfig = {
+  kernelName: Ceil,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as CeilInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Ceil, x);
+  }
+};

--- a/tfjs-node/src/kernels/Cos.ts
+++ b/tfjs-node/src/kernels/Cos.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Cos, CosInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const cosConfig: KernelConfig = {
+  kernelName: Cos,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as CosInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Cos, x);
+  }
+};

--- a/tfjs-node/src/kernels/Cosh.ts
+++ b/tfjs-node/src/kernels/Cosh.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Cosh, CoshInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const coshConfig: KernelConfig = {
+  kernelName: Cosh,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as CoshInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Cosh, x);
+  }
+};

--- a/tfjs-node/src/kernels/Elu.ts
+++ b/tfjs-node/src/kernels/Elu.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Elu, EluInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const eluConfig: KernelConfig = {
+  kernelName: Elu,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as EluInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Elu, x);
+  }
+};

--- a/tfjs-node/src/kernels/Erf.ts
+++ b/tfjs-node/src/kernels/Erf.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Erf, ErfInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const erfConfig: KernelConfig = {
+  kernelName: Erf,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as ErfInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Erf, x);
+  }
+};

--- a/tfjs-node/src/kernels/Exp.ts
+++ b/tfjs-node/src/kernels/Exp.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Exp, ExpInputs, KernelConfig, Tensor} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const expConfig: KernelConfig = {
+  kernelName: Exp,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as ExpInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    const xTensor = x.dtype === 'int32' ? (x as Tensor).toFloat() : x;
+    return backend.executeSingleInput(Exp, xTensor);
+  }
+};

--- a/tfjs-node/src/kernels/Floor.ts
+++ b/tfjs-node/src/kernels/Floor.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Floor, FloorInputs, KernelConfig} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const floorConfig: KernelConfig = {
+  kernelName: Floor,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as FloorInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Floor, x);
+  }
+};

--- a/tfjs-node/src/kernels/Log.ts
+++ b/tfjs-node/src/kernels/Log.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Log, LogInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const logConfig: KernelConfig = {
+  kernelName: Log,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as LogInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Log, x);
+  }
+};

--- a/tfjs-node/src/kernels/Log1p.ts
+++ b/tfjs-node/src/kernels/Log1p.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Log1p, Log1pInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const log1pConfig: KernelConfig = {
+  kernelName: Log1p,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as Log1pInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Log1p, x);
+  }
+};

--- a/tfjs-node/src/kernels/Prelu.ts
+++ b/tfjs-node/src/kernels/Prelu.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {abs, KernelConfig, Prelu, PreluInputs, relu, Tensor, tidy} from '@tensorflow/tfjs';
+
+export const preluConfig: KernelConfig = {
+  kernelName: Prelu,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const inputs = args.inputs as PreluInputs;
+    const x = inputs.x as Tensor;
+    const alpha = inputs.alpha as Tensor;
+
+    return tidy(() => {
+      const pos = relu(x);
+      const neg = alpha.mul(x.sub(abs(x))).mul(0.5);
+      return pos.add(neg);
+    });
+  }
+};

--- a/tfjs-node/src/kernels/Relu.ts
+++ b/tfjs-node/src/kernels/Relu.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Relu, ReluInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const reluConfig: KernelConfig = {
+  kernelName: Relu,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as ReluInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Relu, x);
+  }
+};

--- a/tfjs-node/src/kernels/Relu6.ts
+++ b/tfjs-node/src/kernels/Relu6.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Relu6, Relu6Inputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const relu6Config: KernelConfig = {
+  kernelName: Relu6,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as Relu6Inputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Relu6, x);
+  }
+};

--- a/tfjs-node/src/kernels/Round.ts
+++ b/tfjs-node/src/kernels/Round.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Round, RoundInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const roundConfig: KernelConfig = {
+  kernelName: Round,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as RoundInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Round, x);
+  }
+};

--- a/tfjs-node/src/kernels/Rsqrt.ts
+++ b/tfjs-node/src/kernels/Rsqrt.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Rsqrt, RsqrtInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const rsqrtConfig: KernelConfig = {
+  kernelName: Rsqrt,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as RsqrtInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Rsqrt, x);
+  }
+};

--- a/tfjs-node/src/kernels/Selu.ts
+++ b/tfjs-node/src/kernels/Selu.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Selu, SeluInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const seluConfig: KernelConfig = {
+  kernelName: Selu,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SeluInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Selu, x);
+  }
+};

--- a/tfjs-node/src/kernels/Sigmoid.ts
+++ b/tfjs-node/src/kernels/Sigmoid.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Sigmoid, SigmoidInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const sigmoidConfig: KernelConfig = {
+  kernelName: Sigmoid,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SigmoidInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Sigmoid, x);
+  }
+};

--- a/tfjs-node/src/kernels/Sign.ts
+++ b/tfjs-node/src/kernels/Sign.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Sign, SignInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const signConfig: KernelConfig = {
+  kernelName: Sign,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SignInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Sign, x);
+  }
+};

--- a/tfjs-node/src/kernels/Sin.ts
+++ b/tfjs-node/src/kernels/Sin.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Sin, SinInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const sinConfig: KernelConfig = {
+  kernelName: Sin,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SinInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Sin, x);
+  }
+};

--- a/tfjs-node/src/kernels/Sinh.ts
+++ b/tfjs-node/src/kernels/Sinh.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Sinh, SinhInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const sinhConfig: KernelConfig = {
+  kernelName: Sinh,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SinhInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Sinh, x);
+  }
+};

--- a/tfjs-node/src/kernels/Sqrt.ts
+++ b/tfjs-node/src/kernels/Sqrt.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Sqrt, SqrtInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const sqrtConfig: KernelConfig = {
+  kernelName: Sqrt,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SqrtInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Sqrt, x);
+  }
+};

--- a/tfjs-node/src/kernels/Square.ts
+++ b/tfjs-node/src/kernels/Square.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Square, SquareInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const squareConfig: KernelConfig = {
+  kernelName: Square,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as SquareInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Square, x);
+  }
+};

--- a/tfjs-node/src/kernels/Tan.ts
+++ b/tfjs-node/src/kernels/Tan.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Tan, TanInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const tanConfig: KernelConfig = {
+  kernelName: Tan,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as TanInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Tan, x);
+  }
+};

--- a/tfjs-node/src/kernels/Tanh.ts
+++ b/tfjs-node/src/kernels/Tanh.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Tanh, TanhInputs} from '@tensorflow/tfjs';
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const tanhConfig: KernelConfig = {
+  kernelName: Tanh,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as TanhInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+
+    return backend.executeSingleInput(Tanh, x);
+  }
+};

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -105,6 +105,11 @@ export class NodeJSKernelBackend extends KernelBackend {
       default:
         throw new Error(`Unknown dtype enum ${metadata.dtype}`);
     }
+
+    // TODO(yassogba) Enable this once all the kernels are removed from backend.
+    // We can then change the return type from Tensor to TensorInfo.
+    // return {dataId: newId, shape: metadata.shape, dtype};
+
     return tf.engine().makeTensorFromDataId(newId, metadata.shape, dtype);
   }
 
@@ -349,13 +354,13 @@ export class NodeJSKernelBackend extends KernelBackend {
       if (activation === 'linear') {
         // No-op
       } else if (activation === 'relu') {
-        result = this.relu(result);
+        result = tf.relu(result);
       } else if (activation === 'prelu') {
-        result = this.prelu(result, preluActivationWeights) as T;
+        result = tf.prelu(result, preluActivationWeights) as T;
       } else if (activation === 'elu') {
-        result = this.elu(result);
+        result = tf.elu(result);
       } else if (activation === 'relu6') {
-        result = this.relu6(result);
+        result = tf.relu6(result);
       } else {
         throw new Error(`Activation: ${
             activation} has not been implemented for the Node.js backend`);
@@ -509,14 +514,6 @@ export class NodeJSKernelBackend extends KernelBackend {
     return this.executeSingleOutput('Any', opAttrs, [x, axesTensor]);
   }
 
-  ceil<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Ceil', x) as T;
-  }
-
-  floor<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Floor', x) as T;
-  }
-
   pow<T extends Tensor>(a: T, b: Tensor): T {
     const dtype = backend_util.upcastType(a.dtype, b.dtype);
     const opAttrs = [createTensorsTypeOpAttr('T', dtype)];
@@ -524,37 +521,8 @@ export class NodeJSKernelBackend extends KernelBackend {
                'Pow', opAttrs, [a.cast(dtype), b.cast(dtype)]) as T;
   }
 
-  exp<T extends Tensor>(x: T): T {
-    const xTensor = x.dtype === 'int32' ? x.toFloat() : x;
-    return this.executeSingleInput('Exp', xTensor) as T;
-  }
-
-  log<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Log', x) as T;
-  }
-
-  log1p<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Log1p', x) as T;
-  }
-
-  sqrt<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Sqrt', x) as T;
-  }
-
-  square<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Square', x) as T;
-  }
-
-  relu<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Relu', x) as T;
-  }
-
-  relu6<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Relu6', x) as T;
-  }
-
   prelu<T extends Tensor>(x: T, a: T): T {
-    const pos = this.relu(x);
+    const pos = tf.relu(x);
     const neg = a.mul(x.sub(this.abs(x))).mul(0.5);
     return pos.add(neg);
   }

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -543,32 +543,11 @@ export class NodeJSKernelBackend extends KernelBackend {
     return this.executeSingleOutput('ComplexAbs', opAttrs, [x]) as T;
   }
 
-  atan<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Atan', x) as T;
-  }
-
-  sinh<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Sinh', x) as T;
-  }
-
-  cosh<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Cosh', x) as T;
-  }
-
-  tanh<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Tanh', x) as T;
-  }
-
   mod(a: Tensor, b: Tensor): Tensor {
     const opAttrs = [createTensorsTypeOpAttr('T', a.dtype)];
     return this.executeSingleOutput('FloorMod', opAttrs, [a, b]);
   }
-  round<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Round', x) as T;
-  }
-  sign<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Sign', x) as T;
-  }
+
   isNaN<T extends Tensor>(x: T): T {
     return this.executeSingleInput('IsNan', x) as T;
   }
@@ -578,24 +557,9 @@ export class NodeJSKernelBackend extends KernelBackend {
   isFinite<T extends Tensor>(x: T): T {
     return this.executeSingleInput('IsFinite', x) as T;
   }
-  rsqrt<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Rsqrt', x) as T;
-  }
+
   reciprocal<T extends Tensor>(x: T): T {
     return this.executeSingleInput('Reciprocal', x) as T;
-  }
-  asinh<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Asinh', x) as T;
-  }
-  acosh<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Acosh', x) as T;
-  }
-  atanh<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Atanh', x) as T;
-  }
-
-  erf<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Erf', x) as T;
   }
 
   squaredDifference(a: Tensor, b: Tensor): Tensor {

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -521,23 +521,9 @@ export class NodeJSKernelBackend extends KernelBackend {
                'Pow', opAttrs, [a.cast(dtype), b.cast(dtype)]) as T;
   }
 
-  prelu<T extends Tensor>(x: T, a: T): T {
-    const pos = tf.relu(x);
-    const neg = a.mul(x.sub(this.abs(x))).mul(0.5);
-    return pos.add(neg);
-  }
-
-  elu<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Elu', x) as T;
-  }
-
   eluDer<T extends Tensor>(dy: T, y: T): T {
     const opAttrs = [createTensorsTypeOpAttr('T', y.dtype)];
     return this.executeSingleOutput('EluGrad', opAttrs, [dy, y]) as T;
-  }
-
-  selu<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Selu', x) as T;
   }
 
   int<T extends Tensor>(x: T): T {
@@ -549,40 +535,12 @@ export class NodeJSKernelBackend extends KernelBackend {
     return tf.maximum(xMin, scalar(min, x.dtype));
   }
 
-  abs<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Abs', x) as T;
-  }
-
   complexAbs<T extends Tensor>(x: T): T {
     const opAttrs = [
       createTensorsTypeOpAttr('T', x.dtype),
       createTensorsTypeOpAttr('Tout', 'float32')
     ];
     return this.executeSingleOutput('ComplexAbs', opAttrs, [x]) as T;
-  }
-
-  sigmoid<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Sigmoid', x) as T;
-  }
-
-  sin<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Sin', x) as T;
-  }
-
-  cos<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Cos', x) as T;
-  }
-
-  tan<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Tan', x) as T;
-  }
-
-  asin<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Asin', x) as T;
-  }
-
-  acos<T extends Tensor>(x: T): T {
-    return this.executeSingleInput('Acos', x) as T;
   }
 
   atan<T extends Tensor>(x: T): T {

--- a/tfjs-node/src/register_all_kernels.ts
+++ b/tfjs-node/src/register_all_kernels.ts
@@ -19,15 +19,20 @@
 // the contents of this file and import only the kernels that are needed.
 import {KernelConfig, registerKernel} from '@tensorflow/tfjs-core';
 
+import {absConfig} from './kernels/Abs';
+import {acosConfig} from './kernels/Acos';
 import {addConfig} from './kernels/Add';
 import {addNConfig} from './kernels/AddN';
 import {argMaxConfig} from './kernels/ArgMax';
 import {argMinConfig} from './kernels/ArgMin';
+import {asinConfig} from './kernels/Asin';
 import {ceilConfig} from './kernels/Ceil';
+import {cosConfig} from './kernels/Cos';
 import {diagConfig} from './kernels/Diag';
 import {dilation2dConfig} from './kernels/Dilation2D';
 import {dilation2dBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
 import {dilation2dBackpropInputConfig} from './kernels/Dilation2DBackpropInput';
+import {eluConfig} from './kernels/Elu';
 import {equalConfig} from './kernels/Equal';
 import {expConfig} from './kernels/Exp';
 import {floorConfig} from './kernels/Floor';
@@ -50,27 +55,37 @@ import {multiplyConfig} from './kernels/Multiply';
 import {nonMaxSuppressionV4Config} from './kernels/NonMaxSuppressionV4';
 import {nonMaxSuppressionV5Config} from './kernels/NonMaxSuppressionV5';
 import {notEqualConfig} from './kernels/NotEqual';
+import {preluConfig} from './kernels/Prelu';
 import {prodConfig} from './kernels/Prod';
 import {reluConfig} from './kernels/Relu';
 import {relu6Config} from './kernels/Relu6';
+import {seluConfig} from './kernels/Selu';
+import {sigmoidConfig} from './kernels/Sigmoid';
+import {sinConfig} from './kernels/Sin';
 import {softmaxConfig} from './kernels/Softmax';
 import {sqrtConfig} from './kernels/Sqrt';
 import {squareConfig} from './kernels/Square';
 import {squaredDifferenceConfig} from './kernels/SquaredDifference';
 import {sumConfig} from './kernels/Sum';
+import {tanConfig} from './kernels/Tan';
 import {unsortedSegmentSumConfig} from './kernels/UnsortedSegmentSum';
 
 // List all kernel configs here
 const kernelConfigs: KernelConfig[] = [
+  absConfig,
+  acosConfig,
   addConfig,
   addNConfig,
   argMaxConfig,
   argMinConfig,
+  asinConfig,
   ceilConfig,
+  cosConfig,
   diagConfig,
   dilation2dBackpropFilterConfig,
   dilation2dBackpropInputConfig,
   dilation2dConfig,
+  eluConfig,
   equalConfig,
   expConfig,
   floorConfig,
@@ -93,14 +108,19 @@ const kernelConfigs: KernelConfig[] = [
   nonMaxSuppressionV4Config,
   nonMaxSuppressionV5Config,
   notEqualConfig,
+  preluConfig,
   prodConfig,
   relu6Config,
   reluConfig,
+  seluConfig,
+  sigmoidConfig,
+  sinConfig,
   softmaxConfig,
   sqrtConfig,
   squareConfig,
   squaredDifferenceConfig,
   sumConfig,
+  tanConfig,
   unsortedSegmentSumConfig
 ];
 

--- a/tfjs-node/src/register_all_kernels.ts
+++ b/tfjs-node/src/register_all_kernels.ts
@@ -23,16 +23,21 @@ import {addConfig} from './kernels/Add';
 import {addNConfig} from './kernels/AddN';
 import {argMaxConfig} from './kernels/ArgMax';
 import {argMinConfig} from './kernels/ArgMin';
+import {ceilConfig} from './kernels/Ceil';
 import {diagConfig} from './kernels/Diag';
 import {dilation2dConfig} from './kernels/Dilation2D';
 import {dilation2dBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
 import {dilation2dBackpropInputConfig} from './kernels/Dilation2DBackpropInput';
 import {equalConfig} from './kernels/Equal';
+import {expConfig} from './kernels/Exp';
+import {floorConfig} from './kernels/Floor';
 import {floorDivConfig} from './kernels/FloorDiv';
 import {greaterConfig} from './kernels/Greater';
 import {greaterEqualConfig} from './kernels/GreaterEqual';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
+import {logConfig} from './kernels/Log';
+import {log1pConfig} from './kernels/Log1p';
 import {logicalAndConfig} from './kernels/LogicalAnd';
 import {logicalNotConfig} from './kernels/LogicalNot';
 import {logicalOrConfig} from './kernels/LogicalOr';
@@ -46,7 +51,11 @@ import {nonMaxSuppressionV4Config} from './kernels/NonMaxSuppressionV4';
 import {nonMaxSuppressionV5Config} from './kernels/NonMaxSuppressionV5';
 import {notEqualConfig} from './kernels/NotEqual';
 import {prodConfig} from './kernels/Prod';
+import {reluConfig} from './kernels/Relu';
+import {relu6Config} from './kernels/Relu6';
 import {softmaxConfig} from './kernels/Softmax';
+import {sqrtConfig} from './kernels/Sqrt';
+import {squareConfig} from './kernels/Square';
 import {squaredDifferenceConfig} from './kernels/SquaredDifference';
 import {sumConfig} from './kernels/Sum';
 import {unsortedSegmentSumConfig} from './kernels/UnsortedSegmentSum';
@@ -57,16 +66,21 @@ const kernelConfigs: KernelConfig[] = [
   addNConfig,
   argMaxConfig,
   argMinConfig,
+  ceilConfig,
   diagConfig,
   dilation2dBackpropFilterConfig,
   dilation2dBackpropInputConfig,
   dilation2dConfig,
   equalConfig,
+  expConfig,
+  floorConfig,
   floorDivConfig,
   greaterConfig,
   greaterEqualConfig,
   lessConfig,
   lessEqualConfig,
+  log1pConfig,
+  logConfig,
   logicalAndConfig,
   logicalNotConfig,
   logicalOrConfig,
@@ -80,7 +94,11 @@ const kernelConfigs: KernelConfig[] = [
   nonMaxSuppressionV5Config,
   notEqualConfig,
   prodConfig,
+  relu6Config,
+  reluConfig,
   softmaxConfig,
+  sqrtConfig,
+  squareConfig,
   squaredDifferenceConfig,
   sumConfig,
   unsortedSegmentSumConfig

--- a/tfjs-node/src/register_all_kernels.ts
+++ b/tfjs-node/src/register_all_kernels.ts
@@ -21,19 +21,25 @@ import {KernelConfig, registerKernel} from '@tensorflow/tfjs-core';
 
 import {absConfig} from './kernels/Abs';
 import {acosConfig} from './kernels/Acos';
+import {acoshConfig} from './kernels/Acosh';
 import {addConfig} from './kernels/Add';
 import {addNConfig} from './kernels/AddN';
 import {argMaxConfig} from './kernels/ArgMax';
 import {argMinConfig} from './kernels/ArgMin';
 import {asinConfig} from './kernels/Asin';
+import {asinhConfig} from './kernels/Asinh';
+import {atanConfig} from './kernels/Atan';
+import {atanhConfig} from './kernels/Atanh';
 import {ceilConfig} from './kernels/Ceil';
 import {cosConfig} from './kernels/Cos';
+import {coshConfig} from './kernels/Cosh';
 import {diagConfig} from './kernels/Diag';
 import {dilation2dConfig} from './kernels/Dilation2D';
 import {dilation2dBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
 import {dilation2dBackpropInputConfig} from './kernels/Dilation2DBackpropInput';
 import {eluConfig} from './kernels/Elu';
 import {equalConfig} from './kernels/Equal';
+import {erfConfig} from './kernels/Erf';
 import {expConfig} from './kernels/Exp';
 import {floorConfig} from './kernels/Floor';
 import {floorDivConfig} from './kernels/FloorDiv';
@@ -59,34 +65,45 @@ import {preluConfig} from './kernels/Prelu';
 import {prodConfig} from './kernels/Prod';
 import {reluConfig} from './kernels/Relu';
 import {relu6Config} from './kernels/Relu6';
+import {roundConfig} from './kernels/Round';
+import {rsqrtConfig} from './kernels/Rsqrt';
 import {seluConfig} from './kernels/Selu';
 import {sigmoidConfig} from './kernels/Sigmoid';
+import {signConfig} from './kernels/Sign';
 import {sinConfig} from './kernels/Sin';
+import {sinhConfig} from './kernels/Sinh';
 import {softmaxConfig} from './kernels/Softmax';
 import {sqrtConfig} from './kernels/Sqrt';
 import {squareConfig} from './kernels/Square';
 import {squaredDifferenceConfig} from './kernels/SquaredDifference';
 import {sumConfig} from './kernels/Sum';
 import {tanConfig} from './kernels/Tan';
+import {tanhConfig} from './kernels/Tanh';
 import {unsortedSegmentSumConfig} from './kernels/UnsortedSegmentSum';
 
 // List all kernel configs here
 const kernelConfigs: KernelConfig[] = [
   absConfig,
   acosConfig,
+  acoshConfig,
   addConfig,
   addNConfig,
   argMaxConfig,
   argMinConfig,
   asinConfig,
+  asinhConfig,
+  atanConfig,
+  atanhConfig,
   ceilConfig,
   cosConfig,
+  coshConfig,
   diagConfig,
   dilation2dBackpropFilterConfig,
   dilation2dBackpropInputConfig,
   dilation2dConfig,
   eluConfig,
   equalConfig,
+  erfConfig,
   expConfig,
   floorConfig,
   floorDivConfig,
@@ -112,15 +129,20 @@ const kernelConfigs: KernelConfig[] = [
   prodConfig,
   relu6Config,
   reluConfig,
+  roundConfig,
+  rsqrtConfig,
   seluConfig,
   sigmoidConfig,
+  signConfig,
   sinConfig,
+  sinhConfig,
   softmaxConfig,
   sqrtConfig,
   squareConfig,
   squaredDifferenceConfig,
   sumConfig,
   tanConfig,
+  tanhConfig,
   unsortedSegmentSumConfig
 ];
 


### PR DESCRIPTION
Modularizes ceil, floor, exp, log, log1p, sqrt, square, relu, relu6, prelu, elu, selu, abs, sigmoid, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, round, sign, asinh, acosh, atanh, rsqrt, erf

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.