### PR TITLE
allow data range for input generation for custom model benchmark

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -53,7 +53,12 @@ function generateInput(model) {
         return shapeValue;
       }
     });
-    return {shape: inputShape, name: inputNode.name, dtype: inputNode.dtype};
+    return {
+      shape: inputShape,
+      name: inputNode.name,
+      dtype: inputNode.dtype,
+      range: [0, 1000]
+    };
   });
 
   return generateInputFromDef(inputDefs, model instanceof tf.GraphModel);
@@ -85,7 +90,8 @@ function generateInputFromDef(inputDefs, isForGraphModel = false) {
       // Construct the input tensor.
       let inputTensor;
       if (inputDef.dtype === 'float32' || inputDef.dtype === 'int32') {
-        inputTensor = tf.randomNormal(inputShape, 0, 1000, inputDef.dtype);
+        inputTensor = tf.randomNormal(
+            inputShape, inputDef.range[0], inputDef.range[1], inputDef.dtype);
       } else {
         throw new Error(
             `The ${inputDef.dtype} dtype of '${inputDef.name}' input ` +

--- a/e2e/benchmarks/benchmark_util_test.js
+++ b/e2e/benchmarks/benchmark_util_test.js
@@ -38,6 +38,31 @@ describe('benchmark_util', () => {
     });
   });
 
+  describe('generateInputFromDef', () => {
+    it('should respect int32 data range', async () => {
+      const inputDef =
+          [{shape: [1, 1, 10], dtype: 'int32', range: [0, 255], name: 'test'}];
+      const input = generateInputFromDef(inputDef);
+      expect(input.length).toEqual(1);
+      expect(input[0]).toBeInstanceOf(tf.Tensor);
+      expect(input[0].shape).toEqual([1, 1, 10]);
+      expect(input[0].dtype).toEqual('int32');
+      const data = await input[0].dataSync();
+      expect(data.every(value => value >= 0 && value <= 255));
+    });
+    it('should respect flaot32 data range', async () => {
+      const inputDef =
+          [{shape: [1, 1, 10], dtype: 'float32', range: [0, 1], name: 'test'}];
+      const input = generateInputFromDef(inputDef);
+      expect(input.length).toEqual(1);
+      expect(input[0]).toBeInstanceOf(tf.Tensor);
+      expect(input[0].shape).toEqual([1, 1, 10]);
+      expect(input[0].dtype).toEqual('float32');
+      const data = await input[0].dataSync();
+      expect(data.every(value => value >= 0 && value <= 1));
+    });
+  });
+
   describe('profile inference time', () => {
     describe('timeInference', () => {
       it('throws when passing in invalid predict', async () => {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -307,6 +307,20 @@ limitations under the License.
             appendRow(modelInputsTable, 'name', modelInput.name);
             appendRow(modelInputsTable, 'shape', shape);
             appendRow(modelInputsTable, 'data type', modelInput.dtype);
+            // add data range for input generator
+            if (state.benchmark === 'custom') {
+              const minInput = createRangeInput(state.inputs[inputIndex].range,
+                    0);
+              const maxInput = createRangeInput(state.inputs[inputIndex].range,
+                    1);
+              const seperator = document.createElement('span');
+              seperator.textContent = ' - '
+              const div = document.createElement('div');
+              div.appendChild(minInput);
+              div.appendChild(seperator);
+              div.appendChild(maxInput);
+              appendRow(modelInputsTable, 'data range', div);
+            }
             appendRow(modelInputsTable, '', '');
           }
         });
@@ -316,6 +330,15 @@ limitations under the License.
       return variableShape;
     }
 
+    function createRangeInput(range, index) {
+      const input = document.createElement("INPUT");
+      input.setAttribute('type', 'text');
+      input.setAttribute('value', range[index]);
+      input.addEventListener('focusout', () => {
+        range[index] = +input.value;
+      });
+      return input;
+    }
     async function loadModelAndRecordTime() {
       const benchmark = benchmarks[state.benchmark];
       state.modelType = benchmark['type'];
@@ -338,7 +361,8 @@ limitations under the License.
             state.inputs.push({
               name: modelInput.name,
               shape: [...shape],
-              dtype: modelInput.dtype
+              dtype: modelInput.dtype,
+              range: [0, 1000]
             });
         }
       }


### PR DESCRIPTION
You can try out the demo [here](https://storage.googleapis.com/tfjs-testing/custom-shape-benchmark/benchmarks/local-benchmark/index.html) with following steps:

1. select custom model type
2. use mobilenet model https://storage.googleapis.com/learnjs-data/mobilenet_v2_100_fused/model.json
3. click benchmark button
3. update the data range with your own
4. click benchmark button again

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4169)
<!-- Reviewable:end -->
