### PR TITLE
modularize conv2d, depthwiseConv2d

### DIFF
--- a/tfjs-node/scripts/extract-kernel.ts
+++ b/tfjs-node/scripts/extract-kernel.ts
@@ -30,8 +30,13 @@ export function getAttrs(
 }
 
 function getInputs(kernelName: string, kernelNamesFile: SourceFile): string[] {
-  const inputDecl = kernelNamesFile.getTypeAlias(
+  let inputDecl;
+  inputDecl = kernelNamesFile.getTypeAlias(
       s => s.getText().includes(`type ${kernelName}Inputs`));
+  if (inputDecl == null) {
+    inputDecl = kernelNamesFile.getInterface(
+        s => s.getText().includes(`interface ${kernelName}Inputs`));
+  }
   if (inputDecl == null) {
     // There are a small number of kernels that don't have inputs but
     // we can deal with those separately as the most likely issue is

--- a/tfjs-node/src/kernels/Conv2D.ts
+++ b/tfjs-node/src/kernels/Conv2D.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Conv2D, Conv2DAttrs, Conv2DInputs, KernelConfig, Tensor4D, TensorInfo} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const conv2DConfig: KernelConfig = {
+  kernelName: Conv2D,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x, filter} = args.inputs as Conv2DInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, pad, dataFormat, dilations, dimRoundingMode} =
+        args.attrs as {} as Conv2DAttrs;
+
+    const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+    const convInfo = backend_util.computeConv2DInfo(
+        x.shape as [number, number, number, number],
+        filter.shape as [number, number, number, number], strides, dilations,
+        pad, dimRoundingMode, false /* depthwise */, $dataFormat);
+
+    return conv2dImpl(x, filter, convInfo, backend);
+  }
+};
+
+export function conv2dImpl(
+    x: TensorInfo, filter: TensorInfo, convInfo: backend_util.Conv2DInfo,
+    backend: NodeJSKernelBackend): Tensor4D {
+  if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME' &&
+      convInfo.padInfo.type !== 'EXPLICIT') {
+    throw new Error(
+        `TF Backend supports only 'valid' and 'same' padding ` +
+        `while padding was ${convInfo.padInfo.type}`);
+  }
+  const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
+  const padding = convInfo.padInfo.type;
+  const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
+  const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
+  const opAttrs = [
+    createTensorsTypeOpAttr('T', x.dtype),
+    {name: 'strides', type: backend.binding.TF_ATTR_INT, value: strides},
+    {name: 'padding', type: backend.binding.TF_ATTR_STRING, value: padding},
+    {
+      name: 'data_format',
+      type: backend.binding.TF_ATTR_STRING,
+      value: dataFormat
+    },
+    {name: 'use_cudnn_on_gpu', type: backend.binding.TF_ATTR_BOOL, value: true},
+    {name: 'dilations', type: backend.binding.TF_ATTR_INT, value: dilations},
+  ];
+  if (padding === 'EXPLICIT') {
+    const padValue = [
+      convInfo.padInfo.top, convInfo.padInfo.bottom, convInfo.padInfo.left,
+      convInfo.padInfo.right
+    ];
+    opAttrs.push({
+      name: 'explicit_paddings',
+      type: backend.binding.TF_ATTR_INT,
+      value: dataFormat === 'NHWC' ? [0, 0, ...padValue, 0, 0] :
+                                     [0, 0, 0, 0, ...padValue]
+    });
+  }
+  return backend.executeSingleOutput(Conv2D, opAttrs, [x, filter]) as Tensor4D;
+}

--- a/tfjs-node/src/kernels/Conv2DBackpropFilter.ts
+++ b/tfjs-node/src/kernels/Conv2DBackpropFilter.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Conv2DBackpropFilter, Conv2DBackpropFilterAttrs, Conv2DBackpropFilterInputs, KernelConfig, tensor1d, Tensor4D, TensorInfo} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const conv2DBackpropFilterConfig: KernelConfig = {
+  kernelName: Conv2DBackpropFilter,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x, dy} = args.inputs as Conv2DBackpropFilterInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, pad, dataFormat, dimRoundingMode, filterShape} =
+        args.attrs as {} as Conv2DBackpropFilterAttrs;
+
+    const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+    const convInfo = backend_util.computeConv2DInfo(
+        x.shape as [number, number, number, number], filterShape, strides,
+        1 /* dilations */, pad, dimRoundingMode, false /* depthwise */,
+        $dataFormat);
+
+    return conv2DBackpropFilterImpl(dy, x, convInfo, backend);
+  }
+};
+
+function conv2DBackpropFilterImpl(
+    dy: TensorInfo, filter: TensorInfo, convInfo: backend_util.Conv2DInfo,
+    backend: NodeJSKernelBackend): Tensor4D {
+  if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME') {
+    throw new Error(
+        `TF Backend supports only 'valid' and 'same' padding ` +
+        `while padding was ${convInfo.padInfo.type}`);
+  }
+  const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
+  const padding = convInfo.padInfo.type;
+  const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
+  const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
+  const opAttrs = [
+    createTensorsTypeOpAttr('T', 'float32'),
+    {name: 'strides', type: backend.binding.TF_ATTR_INT, value: strides},
+    {name: 'padding', type: backend.binding.TF_ATTR_STRING, value: padding}, {
+      name: 'data_format',
+      type: backend.binding.TF_ATTR_STRING,
+      value: dataFormat
+    },
+    {name: 'use_cudnn_on_gpu', type: backend.binding.TF_ATTR_BOOL, value: true},
+    {name: 'dilations', type: backend.binding.TF_ATTR_INT, value: dilations}
+  ];
+  const filterSizes = tensor1d(convInfo.filterShape, 'int32');
+  const res =
+      backend.executeSingleOutput(
+          Conv2DBackpropFilter, opAttrs, [filter, filterSizes, dy]) as Tensor4D;
+  filterSizes.dispose();
+  return res;
+}

--- a/tfjs-node/src/kernels/Conv2DBackpropInput.ts
+++ b/tfjs-node/src/kernels/Conv2DBackpropInput.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Conv2DBackpropInput, Conv2DBackpropInputAttrs, Conv2DBackpropInputInputs, KernelConfig, tensor1d, Tensor4D, TensorInfo} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const conv2DBackpropInputConfig: KernelConfig = {
+  kernelName: Conv2DBackpropInput,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {dy, filter} = args.inputs as Conv2DBackpropInputInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, pad, dataFormat, dimRoundingMode, inputShape} =
+        args.attrs as {} as Conv2DBackpropInputAttrs;
+
+    const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+    const convInfo = backend_util.computeConv2DInfo(
+        inputShape, filter.shape as [number, number, number, number], strides,
+        1 /* dilations */, pad, dimRoundingMode, false, $dataFormat);
+
+    return conv2DBackpropInputImpl(dy, filter, convInfo, backend);
+  }
+};
+
+function conv2DBackpropInputImpl(
+    dy: TensorInfo, filter: TensorInfo, convInfo: backend_util.Conv2DInfo,
+    backend: NodeJSKernelBackend): Tensor4D {
+  if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME') {
+    throw new Error(
+        `TF Backend supports only 'valid' and 'same' padding ` +
+        `while padding was ${convInfo.padInfo.type}`);
+  }
+  const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
+  const padding = convInfo.padInfo.type;
+  const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
+  const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
+  const opAttrs = [
+    createTensorsTypeOpAttr('T', 'float32'),
+    {name: 'strides', type: backend.binding.TF_ATTR_INT, value: strides},
+    {name: 'padding', type: backend.binding.TF_ATTR_STRING, value: padding}, {
+      name: 'data_format',
+      type: backend.binding.TF_ATTR_STRING,
+      value: dataFormat
+    },
+    {name: 'use_cudnn_on_gpu', type: backend.binding.TF_ATTR_BOOL, value: true},
+    {name: 'dilations', type: backend.binding.TF_ATTR_INT, value: dilations}
+  ];
+  const inputSizes = tensor1d(convInfo.inShape, 'int32');
+  const res =
+      backend.executeSingleOutput(
+          Conv2DBackpropInput, opAttrs, [inputSizes, filter, dy]) as Tensor4D;
+  inputSizes.dispose();
+  return res;
+}

--- a/tfjs-node/src/kernels/DepthwiseConv2dNative.ts
+++ b/tfjs-node/src/kernels/DepthwiseConv2dNative.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, DepthwiseConv2dNative, DepthwiseConv2dNativeAttrs, DepthwiseConv2dNativeInputs, KernelConfig, Tensor4D, TensorInfo} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const depthwiseConv2dNativeConfig: KernelConfig = {
+  kernelName: DepthwiseConv2dNative,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x, filter} = args.inputs as DepthwiseConv2dNativeInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, pad, dilations, dimRoundingMode} =
+        args.attrs as {} as DepthwiseConv2dNativeAttrs;
+
+    let $dilations = dilations;
+    if ($dilations == null) {
+      $dilations = [1, 1];
+    }
+
+    const convInfo = backend_util.computeConv2DInfo(
+        x.shape as [number, number, number, number],
+        filter.shape as [number, number, number, number], strides, $dilations,
+        pad, dimRoundingMode, true /* depthwise */);
+
+    return depthwiseConv2dNativeImpl(x, filter, convInfo, backend);
+  }
+};
+
+export function depthwiseConv2dNativeImpl(
+    input: TensorInfo, filter: TensorInfo, convInfo: backend_util.Conv2DInfo,
+    backend: NodeJSKernelBackend): Tensor4D {
+  if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME') {
+    throw new Error(
+        `TF Backend supports only 'valid' and 'same' padding ` +
+        `while padding was ${convInfo.padInfo.type}`);
+  }
+  const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
+  const padding = convInfo.padInfo.type;
+  const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
+  const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
+  const opAttrs = [
+    createTensorsTypeOpAttr('T', input.dtype),
+    {name: 'strides', type: backend.binding.TF_ATTR_INT, value: strides},
+    {name: 'padding', type: backend.binding.TF_ATTR_STRING, value: padding}, {
+      name: 'data_format',
+      type: backend.binding.TF_ATTR_STRING,
+      value: dataFormat
+    },
+    {name: 'dilations', type: backend.binding.TF_ATTR_INT, value: dilations}
+  ];
+  return backend.executeSingleOutput(
+             DepthwiseConv2dNative, opAttrs, [input, filter]) as Tensor4D;
+}

--- a/tfjs-node/src/kernels/DepthwiseConv2dNativeBackpropFilter.ts
+++ b/tfjs-node/src/kernels/DepthwiseConv2dNativeBackpropFilter.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, DepthwiseConv2dNativeBackpropFilter, DepthwiseConv2dNativeBackpropFilterAttrs, DepthwiseConv2dNativeBackpropFilterInputs, KernelConfig, tensor1d, Tensor4D, TensorInfo} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const depthwiseConv2dNativeBackpropFilterConfig: KernelConfig = {
+  kernelName: DepthwiseConv2dNativeBackpropFilter,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x, dy} = args.inputs as DepthwiseConv2dNativeBackpropFilterInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, dilations, pad, dimRoundingMode, filterShape} =
+        args.attrs as {} as DepthwiseConv2dNativeBackpropFilterAttrs;
+
+    const convInfo = backend_util.computeConv2DInfo(
+        x.shape as [number, number, number, number], filterShape, strides,
+        dilations, pad, dimRoundingMode, true /* depthwise */);
+
+    return depthwiseConv2dNativeBackpropFilterImpl(x, dy, convInfo, backend);
+  }
+};
+
+function depthwiseConv2dNativeBackpropFilterImpl(
+    x: TensorInfo, dy: TensorInfo, convInfo: backend_util.Conv2DInfo,
+    backend: NodeJSKernelBackend): Tensor4D {
+  const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
+  const padding = convInfo.padInfo.type;
+  const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
+  const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
+  const opAttrs = [
+    createTensorsTypeOpAttr('T', 'float32'),
+    {name: 'strides', type: backend.binding.TF_ATTR_INT, value: strides},
+    {name: 'padding', type: backend.binding.TF_ATTR_STRING, value: padding}, {
+      name: 'data_format',
+      type: backend.binding.TF_ATTR_STRING,
+      value: dataFormat
+    },
+    {name: 'dilations', type: backend.binding.TF_ATTR_INT, value: dilations}
+  ];
+  const filterSizes = tensor1d(convInfo.filterShape, 'int32');
+  const res = backend.executeSingleOutput(
+                  DepthwiseConv2dNativeBackpropFilter, opAttrs,
+                  [x, filterSizes, dy]) as Tensor4D;
+  filterSizes.dispose();
+  return res;
+}

--- a/tfjs-node/src/kernels/DepthwiseConv2dNativeBackpropInput.ts
+++ b/tfjs-node/src/kernels/DepthwiseConv2dNativeBackpropInput.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, DepthwiseConv2dNativeBackpropInput, DepthwiseConv2dNativeBackpropInputAttrs, DepthwiseConv2dNativeBackpropInputInputs, KernelConfig, tensor1d, Tensor4D, TensorInfo} from '@tensorflow/tfjs';
+
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const depthwiseConv2dNativeBackpropInputConfig: KernelConfig = {
+  kernelName: DepthwiseConv2dNativeBackpropInput,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {dy, filter} =
+        args.inputs as DepthwiseConv2dNativeBackpropInputInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, dilations, pad, dimRoundingMode, inputShape} =
+        args.attrs as {} as DepthwiseConv2dNativeBackpropInputAttrs;
+
+    const convInfo = backend_util.computeConv2DInfo(
+        inputShape, filter.shape as [number, number, number, number], strides,
+        dilations, pad, dimRoundingMode, true /* depthwise */);
+
+    return depthwiseConv2dNativeBackpropInputImpl(
+        dy, filter, convInfo, backend);
+  }
+};
+
+function depthwiseConv2dNativeBackpropInputImpl(
+    dy: TensorInfo, filter: TensorInfo, convInfo: backend_util.Conv2DInfo,
+    backend: NodeJSKernelBackend): Tensor4D {
+  const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
+  const padding = convInfo.padInfo.type;
+  const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
+  const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
+  const opAttrs = [
+    createTensorsTypeOpAttr('T', 'float32'),
+    {name: 'strides', type: backend.binding.TF_ATTR_INT, value: strides},
+    {name: 'padding', type: backend.binding.TF_ATTR_STRING, value: padding}, {
+      name: 'data_format',
+      type: backend.binding.TF_ATTR_STRING,
+      value: dataFormat
+    },
+    {name: 'dilations', type: backend.binding.TF_ATTR_INT, value: dilations}
+  ];
+
+  const inputSizes = tensor1d(convInfo.inShape, 'int32');
+  const res = backend.executeSingleOutput(
+                  DepthwiseConv2dNativeBackpropInput, opAttrs,
+                  [inputSizes, filter, dy]) as Tensor4D;
+  inputSizes.dispose();
+  return res;
+}

--- a/tfjs-node/src/kernels/FusedConv2D.ts
+++ b/tfjs-node/src/kernels/FusedConv2D.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {add, backend_util, FusedConv2D, FusedConv2DAttrs, FusedConv2DInputs, KernelConfig, Tensor} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+import {conv2dImpl} from './Conv2D';
+
+export const fusedConv2DConfig: KernelConfig = {
+  kernelName: FusedConv2D,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x, filter, bias, preluActivationWeights} =
+        args.inputs as FusedConv2DInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, pad, dataFormat, dilations, dimRoundingMode, activation} =
+        args.attrs as {} as FusedConv2DAttrs;
+
+    const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+    const convInfo = backend_util.computeConv2DInfo(
+        x.shape as [number, number, number, number],
+        filter.shape as [number, number, number, number], strides, dilations,
+        pad, dimRoundingMode, false /* depthwise */, $dataFormat);
+
+    let result = conv2dImpl(x, filter, convInfo, backend);
+
+    const toDispose = [];
+    if (bias != null) {
+      toDispose.push(result);
+      result = add(result, bias as Tensor);
+    }
+
+    const temp = result;
+    result = backend.applyActivation(
+        result, activation, preluActivationWeights as Tensor);
+    if (temp !== result) {
+      toDispose.push(temp);
+    }
+
+    toDispose.forEach(t => t.dispose());
+    return result;
+  }
+};

--- a/tfjs-node/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-node/src/kernels/FusedDepthwiseConv2D.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {add, backend_util, FusedDepthwiseConv2D, FusedDepthwiseConv2DAttrs, FusedDepthwiseConv2DInputs, KernelConfig, Tensor} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+import {depthwiseConv2dNativeImpl} from './DepthwiseConv2dNative';
+
+export const fusedDepthwiseConv2DConfig: KernelConfig = {
+  kernelName: FusedDepthwiseConv2D,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x, filter, bias, preluActivationWeights} =
+        args.inputs as FusedDepthwiseConv2DInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {strides, pad, dilations, dimRoundingMode, activation} =
+        args.attrs as {} as FusedDepthwiseConv2DAttrs;
+
+    let $dilations = dilations;
+    if ($dilations == null) {
+      $dilations = [1, 1];
+    }
+
+    const convInfo = backend_util.computeConv2DInfo(
+        x.shape as [number, number, number, number],
+        filter.shape as [number, number, number, number], strides, $dilations,
+        pad, dimRoundingMode, true /* depthwise */);
+
+    let result = depthwiseConv2dNativeImpl(x, filter, convInfo, backend);
+
+    const toDispose = [];
+    if (bias != null) {
+      toDispose.push(result);
+      result = add(result, bias as Tensor);
+    }
+
+    const temp = result;
+    result = backend.applyActivation(
+        result, activation, preluActivationWeights as Tensor);
+    if (temp !== result) {
+      toDispose.push(temp);
+    }
+
+    toDispose.forEach(t => t.dispose());
+    return result;
+  }
+};

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -303,7 +303,7 @@ export class NodeJSKernelBackend extends KernelBackend {
                [x, beginTensor, endTensor, stridesTensor]) as T;
   }
 
-  private applyActivation<T extends Tensor>(
+  applyActivation<T extends Tensor>(
       input: T, activation: string, preluActivationWeights?: Tensor): T {
     let result = input;
     if (activation != null) {
@@ -322,20 +322,6 @@ export class NodeJSKernelBackend extends KernelBackend {
             activation} has not been implemented for the Node.js backend`);
       }
     }
-    return result;
-  }
-
-  fusedConv2d(
-      {input, filter, convInfo, bias, activation, preluActivationWeights}:
-          backend_util.FusedConv2DConfig): Tensor4D {
-    let result = this.conv2d(input, filter, convInfo);
-
-    if (bias != null) {
-      result = tf.add(result, bias);
-    }
-
-    result = this.applyActivation(result, activation, preluActivationWeights);
-
     return result;
   }
 
@@ -419,188 +405,6 @@ export class NodeJSKernelBackend extends KernelBackend {
         tf.greater(x, scalar(0, dtype)), ones(x.shape),
         fill(x.shape, alpha, dtype));
     return this.select(nans, x, stepNoNans) as T;
-  }
-
-  conv2d(x: Tensor4D, filter: Tensor4D, convInfo: backend_util.Conv2DInfo):
-      Tensor4D {
-    if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME' &&
-        convInfo.padInfo.type !== 'EXPLICIT') {
-      throw new Error(
-          `TF Backend supports only 'valid' and 'same' padding ` +
-          `while padding was ${convInfo.padInfo.type}`);
-    }
-    const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
-    const padding = convInfo.padInfo.type;
-    const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
-    const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
-    const opAttrs = [
-      createTensorsTypeOpAttr('T', x.dtype),
-      {name: 'strides', type: this.binding.TF_ATTR_INT, value: strides},
-      {name: 'padding', type: this.binding.TF_ATTR_STRING, value: padding},
-      {
-        name: 'data_format',
-        type: this.binding.TF_ATTR_STRING,
-        value: dataFormat
-      },
-      {name: 'use_cudnn_on_gpu', type: this.binding.TF_ATTR_BOOL, value: true},
-      {name: 'dilations', type: this.binding.TF_ATTR_INT, value: dilations},
-    ];
-    if (padding === 'EXPLICIT') {
-      const padValue = [
-        convInfo.padInfo.top, convInfo.padInfo.bottom, convInfo.padInfo.left,
-        convInfo.padInfo.right
-      ];
-      opAttrs.push({
-        name: 'explicit_paddings',
-        type: this.binding.TF_ATTR_INT,
-        value: dataFormat === 'NHWC' ? [0, 0, ...padValue, 0, 0] :
-                                       [0, 0, 0, 0, ...padValue]
-      });
-    }
-    return this.executeSingleOutput('Conv2D', opAttrs, [x, filter]) as Tensor4D;
-  }
-
-  conv2dDerInput(
-      dy: Tensor4D, filter: Tensor4D,
-      convInfo: backend_util.Conv2DInfo): Tensor4D {
-    if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME') {
-      throw new Error(
-          `TF Backend supports only 'valid' and 'same' padding ` +
-          `while padding was ${convInfo.padInfo.type}`);
-    }
-    const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
-    const padding = convInfo.padInfo.type;
-    const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
-    const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
-    const opAttrs = [
-      createTensorsTypeOpAttr('T', 'float32'),
-      {name: 'strides', type: this.binding.TF_ATTR_INT, value: strides},
-      {name: 'padding', type: this.binding.TF_ATTR_STRING, value: padding}, {
-        name: 'data_format',
-        type: this.binding.TF_ATTR_STRING,
-        value: dataFormat
-      },
-      {name: 'use_cudnn_on_gpu', type: this.binding.TF_ATTR_BOOL, value: true},
-      {name: 'dilations', type: this.binding.TF_ATTR_INT, value: dilations}
-    ];
-    const inputSizes = tensor1d(convInfo.inShape, 'int32');
-    return this.executeSingleOutput(
-               'Conv2DBackpropInput', opAttrs, [inputSizes, filter, dy]) as
-        Tensor4D;
-  }
-
-  conv2dDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: backend_util.Conv2DInfo):
-      Tensor4D {
-    if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME') {
-      throw new Error(
-          `TF Backend supports only 'valid' and 'same' padding ` +
-          `while padding was ${convInfo.padInfo.type}`);
-    }
-    const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
-    const padding = convInfo.padInfo.type;
-    const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
-    const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
-    const opAttrs = [
-      createTensorsTypeOpAttr('T', 'float32'),
-      {name: 'strides', type: this.binding.TF_ATTR_INT, value: strides},
-      {name: 'padding', type: this.binding.TF_ATTR_STRING, value: padding}, {
-        name: 'data_format',
-        type: this.binding.TF_ATTR_STRING,
-        value: dataFormat
-      },
-      {name: 'use_cudnn_on_gpu', type: this.binding.TF_ATTR_BOOL, value: true},
-      {name: 'dilations', type: this.binding.TF_ATTR_INT, value: dilations}
-    ];
-    const filterSizes = tensor1d(convInfo.filterShape, 'int32');
-    return this.executeSingleOutput(
-               'Conv2DBackpropFilter', opAttrs, [x, filterSizes, dy]) as
-        Tensor4D;
-  }
-
-  depthwiseConv2DDerInput(
-      dy: Tensor4D, filter: Tensor4D,
-      convInfo: backend_util.Conv2DInfo): Tensor4D {
-    const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
-    const padding = convInfo.padInfo.type;
-    const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
-    const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
-    const opAttrs = [
-      createTensorsTypeOpAttr('T', 'float32'),
-      {name: 'strides', type: this.binding.TF_ATTR_INT, value: strides},
-      {name: 'padding', type: this.binding.TF_ATTR_STRING, value: padding}, {
-        name: 'data_format',
-        type: this.binding.TF_ATTR_STRING,
-        value: dataFormat
-      },
-      {name: 'dilations', type: this.binding.TF_ATTR_INT, value: dilations}
-    ];
-
-    const inputSizes = tensor1d(convInfo.inShape, 'int32');
-    return this.executeSingleOutput(
-               'DepthwiseConv2dNativeBackpropInput', opAttrs,
-               [inputSizes, filter, dy]) as Tensor4D;
-  }
-
-  depthwiseConv2DDerFilter(
-      x: Tensor4D, dY: Tensor4D, convInfo: backend_util.Conv2DInfo): Tensor4D {
-    const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
-    const padding = convInfo.padInfo.type;
-    const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
-    const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
-    const opAttrs = [
-      createTensorsTypeOpAttr('T', 'float32'),
-      {name: 'strides', type: this.binding.TF_ATTR_INT, value: strides},
-      {name: 'padding', type: this.binding.TF_ATTR_STRING, value: padding}, {
-        name: 'data_format',
-        type: this.binding.TF_ATTR_STRING,
-        value: dataFormat
-      },
-      {name: 'dilations', type: this.binding.TF_ATTR_INT, value: dilations}
-    ];
-    const filterSizes = tensor1d(convInfo.filterShape, 'int32');
-    return this.executeSingleOutput(
-               'DepthwiseConv2dNativeBackpropFilter', opAttrs,
-               [x, filterSizes, dY]) as Tensor4D;
-  }
-
-  fusedDepthwiseConv2D(
-      {input, filter, convInfo, bias, activation, preluActivationWeights}:
-          backend_util.FusedConv2DConfig): Tensor4D {
-    let result = this.depthwiseConv2D(input, filter, convInfo);
-
-    if (bias != null) {
-      result = tf.add(result, bias);
-    }
-
-    result = this.applyActivation(result, activation, preluActivationWeights);
-
-    return result;
-  }
-
-  depthwiseConv2D(
-      input: Tensor4D, filter: Tensor4D,
-      convInfo: backend_util.Conv2DInfo): Tensor4D {
-    if (convInfo.padInfo.type !== 'VALID' && convInfo.padInfo.type !== 'SAME') {
-      throw new Error(
-          `TF Backend supports only 'valid' and 'same' padding ` +
-          `while padding was ${convInfo.padInfo.type}`);
-    }
-    const strides = [1, convInfo.strideHeight, convInfo.strideWidth, 1];
-    const padding = convInfo.padInfo.type;
-    const dataFormat = convInfo.dataFormat === 'channelsLast' ? 'NHWC' : 'NCHW';
-    const dilations = [1, convInfo.dilationHeight, convInfo.dilationWidth, 1];
-    const opAttrs = [
-      createTensorsTypeOpAttr('T', input.dtype),
-      {name: 'strides', type: this.binding.TF_ATTR_INT, value: strides},
-      {name: 'padding', type: this.binding.TF_ATTR_STRING, value: padding}, {
-        name: 'data_format',
-        type: this.binding.TF_ATTR_STRING,
-        value: dataFormat
-      },
-      {name: 'dilations', type: this.binding.TF_ATTR_INT, value: dilations}
-    ];
-    return this.executeSingleOutput(
-               'DepthwiseConv2dNative', opAttrs, [input, filter]) as Tensor4D;
   }
 
   conv3d(

--- a/tfjs-node/src/register_all_kernels.ts
+++ b/tfjs-node/src/register_all_kernels.ts
@@ -37,8 +37,14 @@ import {batchMatMulConfig} from './kernels/BatchMatMul';
 import {batchToSpaceNDConfig} from './kernels/BatchToSpaceND';
 import {ceilConfig} from './kernels/Ceil';
 import {concatConfig} from './kernels/Concat';
+import {conv2DConfig} from './kernels/Conv2D';
+import {conv2DBackpropFilterConfig} from './kernels/Conv2DBackpropFilter';
+import {conv2DBackpropInputConfig} from './kernels/Conv2DBackpropInput';
 import {cosConfig} from './kernels/Cos';
 import {coshConfig} from './kernels/Cosh';
+import {depthwiseConv2dNativeConfig} from './kernels/DepthwiseConv2dNative';
+import {depthwiseConv2dNativeBackpropFilterConfig} from './kernels/DepthwiseConv2dNativeBackpropFilter';
+import {depthwiseConv2dNativeBackpropInputConfig} from './kernels/DepthwiseConv2dNativeBackpropInput';
 import {diagConfig} from './kernels/Diag';
 import {dilation2dConfig} from './kernels/Dilation2D';
 import {dilation2dBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
@@ -51,6 +57,8 @@ import {expConfig} from './kernels/Exp';
 import {expm1Config} from './kernels/Expm1';
 import {floorConfig} from './kernels/Floor';
 import {floorDivConfig} from './kernels/FloorDiv';
+import {fusedConv2DConfig} from './kernels/FusedConv2D';
+import {fusedDepthwiseConv2DConfig} from './kernels/FusedDepthwiseConv2D';
 import {gatherNdConfig} from './kernels/GatherNd';
 import {greaterConfig} from './kernels/Greater';
 import {greaterEqualConfig} from './kernels/GreaterEqual';
@@ -129,8 +137,14 @@ const kernelConfigs: KernelConfig[] = [
   batchToSpaceNDConfig,
   ceilConfig,
   concatConfig,
+  conv2DBackpropFilterConfig,
+  conv2DBackpropInputConfig,
+  conv2DConfig,
   cosConfig,
   coshConfig,
+  depthwiseConv2dNativeBackpropFilterConfig,
+  depthwiseConv2dNativeBackpropInputConfig,
+  depthwiseConv2dNativeConfig,
   diagConfig,
   dilation2dBackpropFilterConfig,
   dilation2dBackpropInputConfig,
@@ -143,6 +157,8 @@ const kernelConfigs: KernelConfig[] = [
   expm1Config,
   floorConfig,
   floorDivConfig,
+  fusedConv2DConfig,
+  fusedDepthwiseConv2DConfig,
   gatherNdConfig,
   greaterConfig,
   greaterEqualConfig,


### PR DESCRIPTION
modularize conv2d, depthwiseConv2d and their gradient and fused counterparts.

This conversion sticks to the api convention as currently defined and driven by existing public API.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4170)
<!-- Reviewable:end -->
