### PR TITLE
Rebuild tfjs-node in CI as a workaround for e2e N-API issues

### DIFF
--- a/e2e/cloudbuild.yml
+++ b/e2e/cloudbuild.yml
@@ -14,6 +14,19 @@ steps:
   id: 'build-deps'
   args: ['build-deps-ci']
 
+# Build tfjs-node.
+# This is a workaround for CI runs, which don't run
+# build-deps. For some reason, there's an N-API mismatch
+# between the tfjs-node node bindings and this image's
+# node version. Rebuilding the bindings with e2e's node
+# version fixes the problem and adds ~8 seconds to build time.
+# TODO(mattsoulanille): Fix the N-API issue and remove this step.
+- name: 'gcr.io/learnjs-174218/release'
+  dir: 'e2e'
+  entrypoint: 'yarn'
+  id: 'build-node'
+  args: ['build-node-ci']
+
 # Test.
 - name: 'gcr.io/learnjs-174218/release'
   dir: 'e2e'

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -60,7 +60,7 @@
     "build-node": "cd ../tfjs-node && yarn && yarn build",
     "build-node-ci": "cd ../tfjs-node && yarn && yarn build-ci",
     "build-deps": "yarn build-core && yarn build-backend-cpu && yarn build-backend-webgl && yarn build-layers && yarn build-converter && yarn build-data && yarn build-union && yarn build-node",
-    "build-deps-ci": "yarn build-core-ci && yarn build-backend-cpu-ci && yarn build-backend-webgl-ci && yarn build-layers-ci && yarn build-converter-ci && yarn build-data-ci && yarn build-union-ci && yarn build-node-ci",
+    "build-deps-ci": "./scripts/build-deps-ci.sh",
     "lint": "tslint -p . -t verbose",
     "run-browserstack": "karma start --browserstack",
     "test": "./scripts/test.sh",

--- a/e2e/scripts/build-deps-ci.sh
+++ b/e2e/scripts/build-deps-ci.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+yarn build-core-ci
+yarn build-backend-cpu-ci
+yarn build-backend-webgl-ci
+yarn build-layers-ci
+yarn build-converter-ci
+yarn build-data-ci
+yarn build-union-ci
+yarn build-node-ci
+
+if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
+  # Build the wasm backend
+  yarn build-backend-wasm-ci
+fi

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -47,9 +47,6 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
 
   cd ..
 
-  # Build the wasm backend
-  yarn build-backend-wasm-ci
-
   # Generate custom bundle files for tests
   ./scripts/run-custom-builds.sh
 fi

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -1020,6 +1020,45 @@ steps:
   - name: gcr.io/learnjs-174218/release
     dir: e2e
     entrypoint: yarn
+    id: build-node-e2e
+    args:
+      - build-node-ci
+    waitFor:
+      - yarn-common
+      - yarn-tfjs
+      - build-tfjs
+      - lint-tfjs
+      - yarn-tfjs-backend-cpu
+      - build-tfjs-backend-cpu
+      - lint-tfjs-backend-cpu
+      - yarn-tfjs-backend-webgl
+      - build-tfjs-backend-webgl
+      - lint-tfjs-backend-webgl
+      - yarn-tfjs-converter
+      - build-tfjs-converter
+      - lint-tfjs-converter
+      - yarn-tfjs-core
+      - build-deps-always-tfjs-core
+      - build-tfjs-core
+      - lint-tfjs-core
+      - yarn-tfjs-data
+      - build-tfjs-data
+      - lint-tfjs-data
+      - yarn-tfjs-layers
+      - build-tfjs-layers
+      - lint-tfjs-layers
+      - yarn-tfjs-node
+      - build-addon-tfjs-node
+      - build-tfjs-node
+      - lint-tfjs-node
+      - ensure-cpu-gpu-packages-align-tfjs-node
+      - yarn-tfjs-backend-wasm
+      - build-tfjs-backend-wasm
+      - lint-tfjs-backend-wasm
+      - buildifier-tfjs-backend-wasm
+  - name: gcr.io/learnjs-174218/release
+    dir: e2e
+    entrypoint: yarn
     id: test-e2e
     args:
       - test-ci

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -501,6 +501,41 @@ steps:
   - name: gcr.io/learnjs-174218/release
     dir: e2e
     entrypoint: yarn
+    id: build-node-e2e
+    args:
+      - build-node-ci
+    waitFor:
+      - yarn-common
+      - yarn-tfjs
+      - build-tfjs
+      - lint-tfjs
+      - yarn-tfjs-backend-cpu
+      - build-tfjs-backend-cpu
+      - lint-tfjs-backend-cpu
+      - yarn-tfjs-backend-webgl
+      - build-tfjs-backend-webgl
+      - lint-tfjs-backend-webgl
+      - yarn-tfjs-converter
+      - build-tfjs-converter
+      - lint-tfjs-converter
+      - yarn-tfjs-core
+      - build-deps-always-tfjs-core
+      - build-tfjs-core
+      - lint-tfjs-core
+      - yarn-tfjs-data
+      - build-tfjs-data
+      - lint-tfjs-data
+      - yarn-tfjs-layers
+      - build-tfjs-layers
+      - lint-tfjs-layers
+      - yarn-tfjs-node
+      - build-addon-tfjs-node
+      - build-tfjs-node
+      - lint-tfjs-node
+      - ensure-cpu-gpu-packages-align-tfjs-node
+  - name: gcr.io/learnjs-174218/release
+    dir: e2e
+    entrypoint: yarn
     id: test-e2e
     args:
       - test-ci


### PR DESCRIPTION
Running tfjs-node with node:12 has not actually fixed N-API issues. This PR makes e2e tests rebuild tfjs-node to make sure the correct N-API bindings are created. Ideally, we would just build the correct bindings in the tfjs-node package's cloudbuild steps, but using node:12 or our custom docker image doesn't seem to build the correct bindings. This fix should work for now, and only adds ~8 seconds to build time.

Also, refactor e2e tests to not unnecessarily rebuild tfjs-bakend-wasm during CI.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4224)
<!-- Reviewable:end -->
