### PR TITLE
clean up relu6 and clipByValue ops

### DIFF
--- a/tfjs-converter/metadata/kernel2op.json
+++ b/tfjs-converter/metadata/kernel2op.json
@@ -371,7 +371,7 @@
     "relu"
   ],
   "Relu6": [
-    "clipByValue"
+    "relu6"
   ],
   "Reshape": [
     "reshape"

--- a/tfjs-converter/python/tensorflowjs/op_list/arithmetic.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/arithmetic.json
@@ -80,6 +80,12 @@
         "name": "dtype",
         "type": "dtype",
         "notSupported": true
+      },
+      {
+        "tfName": "data_format",
+        "name": "dataFormat",
+        "type": "string",
+        "notSupported": true
       }
     ]
   },
@@ -241,6 +247,14 @@
         "name": "b",
         "type": "tensor"
       }
+    ],
+    "attrs": [
+      {
+        "tfName": "T",
+        "name": "dtype",
+        "type": "dtype",
+        "notSupported": true
+      }
     ]
   },
   {
@@ -256,6 +270,14 @@
         "start": 1,
         "name": "b",
         "type": "tensor"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "T",
+        "name": "dtype",
+        "type": "dtype",
+        "notSupported": true
       }
     ]
   },

--- a/tfjs-converter/python/tensorflowjs/op_list/basic_math.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/basic_math.json
@@ -126,18 +126,24 @@
         "start": 0,
         "name": "x",
         "type": "tensor"
-      }
-    ],
-    "attrs": [
+      },
       {
-        "tfName": "clip_value_min",
+        "start": 1,
         "name": "clipValueMin",
         "type": "number"
       },
       {
-        "tfName": "clip_value_max",
+        "start": 2,
         "name": "clipValueMax",
         "type": "number"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "T",
+        "name": "dtype",
+        "type": "dtype",
+        "notSupported": true
       }
     ]
   },
@@ -426,18 +432,6 @@
         "name": "dtype",
         "type": "dtype",
         "notSupported": true
-      },
-      {
-        "tfName": "clipValueMin",
-        "name": "clipValueMin",
-        "type": "number",
-        "defaultValue": 0
-      },
-      {
-        "tfName": "clipValueMax",
-        "name": "clipValueMax",
-        "type": "number",
-        "defaultValue": 6
       }
     ]
   },

--- a/tfjs-converter/src/operations/executors/basic_math_executor.ts
+++ b/tfjs-converter/src/operations/executors/basic_math_executor.ts
@@ -148,13 +148,15 @@ export const executeOp: InternalOpExecutor =
         case 'Tan':
           return [tfOps.tan(
               getParamValue('x', node, tensorMap, context) as Tensor)];
-        case 'Relu6':
         case 'ClipByValue':
           return [tfOps.clipByValue(
               getParamValue('x', node, tensorMap, context) as Tensor,
               getParamValue('clipValueMin', node, tensorMap, context) as number,
               getParamValue('clipValueMax', node, tensorMap, context) as
                   number)];
+        case 'Relu6':
+          return [tfOps.relu6(
+              getParamValue('x', node, tensorMap, context) as Tensor)];
         case 'Rsqrt':
           return [tfOps.rsqrt(
               getTensor(node.inputNames[0], tensorMap, context))];

--- a/tfjs-converter/src/operations/executors/basic_math_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/basic_math_executor_test.ts
@@ -23,7 +23,7 @@ import * as basic_math from '../op_list/basic_math';
 import {Node} from '../types';
 
 import {executeOp} from './basic_math_executor';
-import {createNumberAttr, createNumericArrayAttrFromIndex, createTensorAttr, validateParam} from './test_helper';
+import {createNumberAttr, createNumberAttrFromIndex, createNumericArrayAttrFromIndex, createTensorAttr, validateParam} from './test_helper';
 
 describe('basic math', () => {
   let node: Node;
@@ -64,20 +64,37 @@ describe('basic math', () => {
           });
         });
     describe('Relu6', () => {
-      it('should call tfOps.clipByValue', () => {
-        spyOn(tfOps, 'clipByValue');
+      it('should call tfOps.relu6', () => {
+        spyOn(tfOps, 'relu6');
         node.op = 'Relu6';
-        node.attrParams['clipValueMax'] = createNumberAttr(6);
-        node.attrParams['clipValueMin'] = createNumberAttr(0);
 
         executeOp(node, {input1}, context);
 
-        expect(tfOps.clipByValue).toHaveBeenCalledWith(input1[0], 0, 6);
+        expect(tfOps.relu6).toHaveBeenCalledWith(input1[0]);
       });
       it('should match op def', () => {
         node.op = 'Relu6';
-        node.attrParams['clipValueMax'] = createNumberAttr(6);
-        node.attrParams['clipValueMin'] = createNumberAttr(0);
+
+        expect(validateParam(node, basic_math.json)).toBeTruthy();
+      });
+    });
+    describe('ClipByValue', () => {
+      it('should call tfOps.clipByValue', () => {
+        spyOn(tfOps, 'clipByValue');
+        node.op = 'ClipByValue';
+        node.inputNames = ['input1', 'input2', 'input3'];
+        node.inputParams['clipValueMin'] = createNumberAttrFromIndex(1);
+        node.inputParams['clipValueMax'] = createNumberAttrFromIndex(2);
+        const input2 = [tfOps.scalar(2)];
+        const input3 = [tfOps.scalar(3)];
+        executeOp(node, {input1, input2, input3}, context);
+
+        expect(tfOps.clipByValue).toHaveBeenCalledWith(input1[0], 2, 3);
+      });
+      it('should match op def', () => {
+        node.op = 'ClipByValue';
+        node.inputParams['clipValueMin'] = createNumberAttrFromIndex(1);
+        node.inputParams['clipValueMax'] = createNumberAttrFromIndex(2);
 
         expect(validateParam(node, basic_math.json)).toBeTruthy();
       });

--- a/tfjs-converter/src/operations/op_list/arithmetic.ts
+++ b/tfjs-converter/src/operations/op_list/arithmetic.ts
@@ -53,7 +53,12 @@ export const json: OpMapper[] = [
       {'start': 1, 'name': 'b', 'type': 'tensor'},
     ],
     'attrs': [
-      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
+      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}, {
+        'tfName': 'data_format',
+        'name': 'dataFormat',
+        'type': 'string',
+        'notSupported': true
+      }
     ]
   },
   {
@@ -128,6 +133,9 @@ export const json: OpMapper[] = [
     'inputs': [
       {'start': 0, 'name': 'a', 'type': 'tensor'},
       {'start': 1, 'name': 'b', 'type': 'tensor'}
+    ],
+    'attrs': [
+      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
     ]
   },
   {
@@ -136,6 +144,9 @@ export const json: OpMapper[] = [
     'inputs': [
       {'start': 0, 'name': 'a', 'type': 'tensor'},
       {'start': 1, 'name': 'b', 'type': 'tensor'}
+    ],
+    'attrs': [
+      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
     ]
   },
   {
@@ -178,8 +189,11 @@ export const json: OpMapper[] = [
       {'start': 0, 'name': 'a', 'type': 'tensor'},
       {'start': 1, 'name': 'b', 'type': 'tensor'},
     ],
-    'attrs': [
-      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
-    ]
+    'attrs': [{
+      'tfName': 'T',
+      'name': 'dtype',
+      'type': 'dtype',
+      'notSupported': true
+    }]
   }
 ];

--- a/tfjs-converter/src/operations/op_list/basic_math.ts
+++ b/tfjs-converter/src/operations/op_list/basic_math.ts
@@ -84,10 +84,11 @@ export const json: OpMapper[] = [
     'category': 'basic_math',
     'inputs': [
       {'start': 0, 'name': 'x', 'type': 'tensor'},
+      {'start': 1, 'name': 'clipValueMin', 'type': 'number'},
+      {'start': 2, 'name': 'clipValueMax', 'type': 'number'},
     ],
     'attrs': [
-      {'tfName': 'clip_value_min', 'name': 'clipValueMin', 'type': 'number'},
-      {'tfName': 'clip_value_max', 'name': 'clipValueMax', 'type': 'number'}
+      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
     ]
   },
   {
@@ -239,18 +240,7 @@ export const json: OpMapper[] = [
       {'start': 0, 'name': 'x', 'type': 'tensor'},
     ],
     'attrs': [
-      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}, {
-        'tfName': 'clipValueMin',
-        'name': 'clipValueMin',
-        'type': 'number',
-        'defaultValue': 0
-      },
-      {
-        'tfName': 'clipValueMax',
-        'name': 'clipValueMax',
-        'type': 'number',
-        'defaultValue': 6
-      }
+      {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
     ]
   },
   {


### PR DESCRIPTION
Relu6 used to be using clipByValue op to clip to between 0-6, since we have the op
in the core, changed it to use tfOps.relu6 directly.

Also fixed the mismatch issue on the ClipByValue op definition.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4254)
<!-- Reviewable:end -->
