### PR TITLE
conv2d ops with explicit padding support

### DIFF
--- a/tfjs-converter/python/tensorflowjs/op_list/convolution.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/convolution.json
@@ -72,6 +72,13 @@
         "type": "number[]"
       },
       {
+        "tfName": "explicit_paddings",
+        "name": "explicitPaddings",
+        "type": "number[]",
+        "defaultValue": [],
+        "notSupported": true
+      },
+      {
         "tfName": "T",
         "name": "dtype",
         "type": "dtype",
@@ -428,6 +435,12 @@
         "name": "explicitPaddings",
         "type": "number[]",
         "defaultValue": []
+      },
+      {
+        "tfName": "dilations",
+        "name": "dilations",
+        "type": "number[]",
+        "notSupported": true
       }
     ]
   },
@@ -585,6 +598,12 @@
         "tfName": "fused_ops",
         "name": "fusedOps",
         "type": "string[]",
+        "defaultValue": []
+      },
+      {
+        "tfName": "explicit_paddings",
+        "name": "explicitPaddings",
+        "type": "number[]",
         "defaultValue": []
       }
     ]

--- a/tfjs-converter/src/operations/op_list/convolution.ts
+++ b/tfjs-converter/src/operations/op_list/convolution.ts
@@ -50,7 +50,13 @@ export const json: OpMapper[] = [
         'type': 'string',
         'notSupported': true
       },
-      {'tfName': 'ksize', 'name': 'kernelSize', 'type': 'number[]'},
+      {'tfName': 'ksize', 'name': 'kernelSize', 'type': 'number[]'}, {
+        'tfName': 'explicit_paddings',
+        'name': 'explicitPaddings',
+        'type': 'number[]',
+        'defaultValue': [],
+        'notSupported': true
+      },
       {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
     ]
   },
@@ -217,8 +223,7 @@ export const json: OpMapper[] = [
     ],
     'attrs': [
       {'tfName': 'strides', 'name': 'strides', 'type': 'number[]'},
-      {'tfName': 'padding', 'name': 'pad', 'type': 'string'},
-      {
+      {'tfName': 'padding', 'name': 'pad', 'type': 'string'}, {
         'tfName': 'data_format',
         'name': 'dataFormat',
         'type': 'string',
@@ -230,6 +235,12 @@ export const json: OpMapper[] = [
         'type': 'number[]',
         'defaultValue': []
       },
+      {
+        'tfName': 'dilations',
+        'name': 'dilations',
+        'type': 'number[]',
+        'notSupported': true
+      }
     ]
   },
   {
@@ -308,6 +319,12 @@ export const json: OpMapper[] = [
         'tfName': 'fused_ops',
         'name': 'fusedOps',
         'type': 'string[]',
+        'defaultValue': []
+      },
+      {
+        'tfName': 'explicit_paddings',
+        'name': 'explicitPaddings',
+        'type': 'number[]',
         'defaultValue': []
       }
     ]


### PR DESCRIPTION
Add missing explicit padding param for fused depthwise conv2d and conv2d backdrop input ops.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4255)
<!-- Reviewable:end -->
