### PR TITLE
added support of halpPixelCenters to resizeNearestNeighbor op

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -1758,10 +1758,10 @@ export class MathBackendWebGL extends KernelBackend {
   }
 
   resizeNearestNeighbor(
-      x: Tensor4D, newHeight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D {
+      x: Tensor4D, newHeight: number, newWidth: number, alignCorners: boolean,
+      halfPixelCenters: boolean): Tensor4D {
     const program = new ResizeNearestNeighborProgram(
-        x.shape, newHeight, newWidth, alignCorners);
+        x.shape, newHeight, newWidth, alignCorners, halfPixelCenters);
     return this.compileAndRun(program, [x]);
   }
 

--- a/tfjs-converter/python/tensorflowjs/op_list/image.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/image.json
@@ -55,6 +55,11 @@
         "type": "bool"
       },
       {
+        "tfName": "half_pixel_centers",
+        "name": "halfPixelCenters",
+        "type": "bool"
+      },
+      {
         "tfName": "T",
         "name": "dtype",
         "type": "dtype",

--- a/tfjs-converter/src/operations/executors/image_executor.ts
+++ b/tfjs-converter/src/operations/executors/image_executor.ts
@@ -52,8 +52,12 @@ export const executeOp: InternalOpExecutor =
           const alignCorners =
               getParamValue('alignCorners', node, tensorMap, context) as
               boolean;
+          const halfPixelCenters =
+              getParamValue('halfPixelCenters', node, tensorMap, context) as
+              boolean;
           return [tfOps.image.resizeNearestNeighbor(
-              images as Tensor3D | Tensor4D, [size[0], size[1]], alignCorners)];
+              images as Tensor3D | Tensor4D, [size[0], size[1]], alignCorners,
+              halfPixelCenters)];
         }
         case 'CropAndResize': {
           const image =

--- a/tfjs-converter/src/operations/executors/image_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/image_executor_test.ts
@@ -73,18 +73,20 @@ describe('image', () => {
         node.inputParams['images'] = createTensorAttr(0);
         node.inputParams['size'] = createNumericArrayAttrFromIndex(1);
         node.attrParams['alignCorners'] = createBoolAttr(true);
+        node.attrParams['halfPixelCenters'] = createBoolAttr(true);
         node.inputNames = ['input1', 'input2'];
         const input2 = [tfOps.tensor1d([1, 2])];
         spyOn(tfOps.image, 'resizeNearestNeighbor');
         executeOp(node, {input1, input2}, context);
         expect(tfOps.image.resizeNearestNeighbor)
-            .toHaveBeenCalledWith(input1[0], [1, 2], true);
+            .toHaveBeenCalledWith(input1[0], [1, 2], true, true);
       });
       it('should match json def', () => {
         node.op = 'ResizeNearestNeighbor';
         node.inputParams['images'] = createTensorAttr(0);
         node.inputParams['size'] = createNumericArrayAttrFromIndex(1);
         node.attrParams['alignCorners'] = createBoolAttr(true);
+        node.attrParams['halfPixelCenters'] = createBoolAttr(true);
 
         expect(validateParam(node, image.json)).toBeTruthy();
       });

--- a/tfjs-converter/src/operations/op_list/image.ts
+++ b/tfjs-converter/src/operations/op_list/image.ts
@@ -42,7 +42,11 @@ export const json: OpMapper[] = [
       {'start': 1, 'name': 'size', 'type': 'number[]'},
     ],
     'attrs': [
-      {'tfName': 'align_corners', 'name': 'alignCorners', 'type': 'bool'},
+      {'tfName': 'align_corners', 'name': 'alignCorners', 'type': 'bool'}, {
+        'tfName': 'half_pixel_centers',
+        'name': 'halfPixelCenters',
+        'type': 'bool'
+      },
       {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true}
     ]
   },

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -547,8 +547,8 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   }
 
   resizeNearestNeighbor(
-      x: Tensor4D, newHEight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D {
+      x: Tensor4D, newHEight: number, newWidth: number, alignCorners: boolean,
+      halfPixelCenters: boolean): Tensor4D {
     return notYetImplemented('resizeNearestNeighbor');
   }
 

--- a/tfjs-core/src/kernel_names.ts
+++ b/tfjs-core/src/kernel_names.ts
@@ -634,6 +634,7 @@ export const ResizeNearestNeighbor = 'ResizeNearestNeighbor';
 export type ResizeNearestNeighborInputs = Pick<NamedTensorInfoMap, 'images'>;
 export interface ResizeNearestNeighborAttrs {
   alignCorners: boolean;
+  halfPixelCenters: boolean;
   size: [number, number];
 }
 

--- a/tfjs-core/src/ops/image/resize_nearest_neighbor.ts
+++ b/tfjs-core/src/ops/image/resize_nearest_neighbor.ts
@@ -38,9 +38,10 @@ import {reshape} from '../reshape';
  *     input by `(new_height - 1) / (height - 1)`, which exactly aligns the 4
  *     corners of images and resized images. If false, rescale by
  *     `new_height / height`. Treat similarly the width dimension.
- * @param halfPixelCenters Defaults to `false`. Whether to assume pixel centers
- *     are at 0.5, which would make the floating point coordinates of the top
- *     left pixel 0.5, 0.5.
+ * @param halfPixelCenters Defaults to `false`. Whether to assumes pixels are of
+ *      half the actual dimensions, and yields more accurate resizes. This flag
+ *      would also make the floating point coordinates of the top left pixel
+ *      0.5, 0.5.
  *
  * @doc {heading: 'Operations', subheading: 'Images', namespace: 'image'}
  */

--- a/tfjs-core/src/ops/image/resize_nearest_neighbor.ts
+++ b/tfjs-core/src/ops/image/resize_nearest_neighbor.ts
@@ -38,11 +38,15 @@ import {reshape} from '../reshape';
  *     input by `(new_height - 1) / (height - 1)`, which exactly aligns the 4
  *     corners of images and resized images. If false, rescale by
  *     `new_height / height`. Treat similarly the width dimension.
+ * @param halfPixelCenters Defaults to `false`. Whether to assume pixel centers
+ *     are at 0.5, which would make the floating point coordinates of the top
+ *     left pixel 0.5, 0.5.
  *
  * @doc {heading: 'Operations', subheading: 'Images', namespace: 'image'}
  */
 function resizeNearestNeighbor_<T extends Tensor3D|Tensor4D>(
-    images: T|TensorLike, size: [number, number], alignCorners = false): T {
+    images: T|TensorLike, size: [number, number], alignCorners = false,
+    halfPixelCenters = false): T {
   const $images = convertToTensor(images, 'images', 'resizeNearestNeighbor');
 
   util.assert(
@@ -57,7 +61,10 @@ function resizeNearestNeighbor_<T extends Tensor3D|Tensor4D>(
   util.assert(
       $images.dtype === 'float32' || $images.dtype === 'int32',
       () => '`images` must have `int32` or `float32` as dtype');
-
+  util.assert(
+      halfPixelCenters === false || alignCorners === false,
+      () => `Error in resizeNearestNeighbor: If halfPixelCenters is true, ` +
+          `alignCorners must be false.`);
   let batchImages = $images as Tensor4D;
   let reshapedTo4D = false;
   if ($images.rank === 3) {
@@ -68,12 +75,13 @@ function resizeNearestNeighbor_<T extends Tensor3D|Tensor4D>(
   const [newHeight, newWidth] = size;
 
   const inputs: ResizeNearestNeighborInputs = {images: batchImages};
-  const attrs: ResizeNearestNeighborAttrs = {alignCorners, size};
+  const attrs:
+      ResizeNearestNeighborAttrs = {alignCorners, halfPixelCenters, size};
 
   const forward: ForwardFunc<Tensor4D> = (backend, save) => {
     save([batchImages]);
     return backend.resizeNearestNeighbor(
-        batchImages, newHeight, newWidth, alignCorners);
+        batchImages, newHeight, newWidth, alignCorners, halfPixelCenters);
   };
 
   const res = ENGINE.runKernelFunc(

--- a/tfjs-core/src/ops/image/resize_nearest_neighbor_test.ts
+++ b/tfjs-core/src/ops/image/resize_nearest_neighbor_test.ts
@@ -41,7 +41,6 @@ describeWithFlags('resizeNearestNeighbor', ALL_ENVS, () => {
     expectArraysClose(await output.data(), [2, 4, 2, 4]);
   });
 
-
   it('2x2To1x1 alignCorners=false halfPixelCenters=true', async () => {
     const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
     const output = input.resizeNearestNeighbor([1, 1], false, true);
@@ -84,7 +83,6 @@ describeWithFlags('resizeNearestNeighbor', ALL_ENVS, () => {
 
     expectArraysClose(await output.data(), [1, 2, 1, 2, 3, 4, 3, 4, 3, 4]);
   });
-
 
   it('2x2To4x4 alignCorners=false halfPixelCenters=true', async () => {
     const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);

--- a/tfjs-core/src/ops/image/resize_nearest_neighbor_test.ts
+++ b/tfjs-core/src/ops/image/resize_nearest_neighbor_test.ts
@@ -34,6 +34,66 @@ describeWithFlags('resizeNearestNeighbor', ALL_ENVS, () => {
     expectArraysClose(await output.data(), [2, 2, 2, 4, 4, 4, 4, 4, 4]);
   });
 
+  it('5x2To2x2 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4, 5, 1, 2, 3, 4, 5], [1, 2, 5, 1]);
+    const output = input.resizeNearestNeighbor([2, 2], false, true);
+
+    expectArraysClose(await output.data(), [2, 4, 2, 4]);
+  });
+
+
+  it('2x2To1x1 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const output = input.resizeNearestNeighbor([1, 1], false, true);
+
+    expectArraysClose(await output.data(), [4]);
+  });
+
+  it('2x2To3x3 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const output = input.resizeNearestNeighbor([3, 3], false, true);
+
+    expectArraysClose(await output.data(), [1, 2, 2, 3, 4, 4, 3, 4, 4]);
+  });
+
+  it('3x3To2x2 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 3, 3, 1]);
+    const output = input.resizeNearestNeighbor([2, 2], false, true);
+
+    expectArraysClose(await output.data(), [1, 3, 7, 9]);
+  });
+
+  it('2x2To2x5 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const output = input.resizeNearestNeighbor([2, 5], false, true);
+
+    expectArraysClose(await output.data(), [1, 1, 2, 2, 2, 3, 3, 4, 4, 4]);
+  });
+
+  it('4x4To3x3 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [1, 4, 4, 1]);
+    const output = input.resizeNearestNeighbor([3, 3], false, true);
+
+    expectArraysClose(await output.data(), [1, 3, 4, 9, 11, 12, 13, 15, 16]);
+  });
+
+  it('2x2To5x2 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const output = input.resizeNearestNeighbor([5, 2], false, true);
+
+    expectArraysClose(await output.data(), [1, 2, 1, 2, 3, 4, 3, 4, 3, 4]);
+  });
+
+
+  it('2x2To4x4 alignCorners=false halfPixelCenters=true', async () => {
+    const input = tf.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]);
+    const output = input.resizeNearestNeighbor([4, 4], false, true);
+
+    expectArraysClose(
+        await output.data(), [1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4]);
+  });
+
   it('matches tensorflow w/ random numbers alignCorners=false', async () => {
     const input = tf.tensor3d(
         [

--- a/tfjs-core/src/public/chained_ops/resize_nearest_neighbor.ts
+++ b/tfjs-core/src/public/chained_ops/resize_nearest_neighbor.ts
@@ -21,12 +21,15 @@ import {Rank} from '../../types';
 declare module '../../tensor' {
   interface Tensor<R extends Rank = Rank> {
     resizeNearestNeighbor<T extends Tensor3D|Tensor4D>(
-        newShape2D: [number, number], alignCorners?: boolean): T;
+        newShape2D: [number, number], alignCorners?: boolean,
+        halfFloatCenters?: boolean): T;
   }
 }
 
 Tensor.prototype.resizeNearestNeighbor = function<T extends Tensor3D|Tensor4D>(
-    this: T, newShape2D: [number, number], alignCorners?: boolean): T {
+    this: T, newShape2D: [number, number], alignCorners?: boolean,
+    halfFloatCenters?: boolean): T {
   this.throwIfDisposed();
-  return resizeNearestNeighbor(this, newShape2D, alignCorners);
+  return resizeNearestNeighbor(
+      this, newShape2D, alignCorners, halfFloatCenters);
 };

--- a/tfjs-node/src/kernels/ResizeNearestNeighbor.ts
+++ b/tfjs-node/src/kernels/ResizeNearestNeighbor.ts
@@ -25,7 +25,8 @@ export const resizeNearestNeighborConfig: KernelConfig = {
   kernelFunc: (args) => {
     const {images} = args.inputs as ResizeNearestNeighborInputs;
     const backend = args.backend as NodeJSKernelBackend;
-    const {alignCorners, size} = args.attrs as {} as ResizeNearestNeighborAttrs;
+    const {alignCorners, halfPixelCenters, size} =
+        args.attrs as {} as ResizeNearestNeighborAttrs;
 
     const opAttrs = [
       createTensorsTypeOpAttr('T', images.dtype),
@@ -33,6 +34,11 @@ export const resizeNearestNeighborConfig: KernelConfig = {
         name: 'align_corners',
         type: backend.binding.TF_ATTR_BOOL,
         value: alignCorners
+      },
+      {
+        name: 'half_pixel_centers',
+        type: backend.binding.TF_ATTR_BOOL,
+        value: halfPixelCenters
       },
     ];
     const [newHeight, newWidth] = size;


### PR DESCRIPTION
ResizeNearestNeighbor op supports half_pixel_centers param, which we have added support for resizeBilinear op recently.

https://www.tensorflow.org/api_docs/python/tf/raw_ops/ResizeNearestNeighbor?hl=en

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4262)
<!-- Reviewable:end -->
