### PR TITLE
core: Disable checkComputationForErrors for webgpu backend.

### DIFF
--- a/tfjs-backend-webgpu/src/index.ts
+++ b/tfjs-backend-webgpu/src/index.ts
@@ -18,19 +18,22 @@
 import './flags_webgpu';
 import './register_all_kernels';
 
-import * as tf from '@tensorflow/tfjs-core';
+import {env, registerBackend} from '@tensorflow/tfjs-core';
 import glslangInit from '@webgpu/glslang/dist/web-devel/glslang.onefile';
 
 import {WebGPUBackend} from './backend_webgpu';
 import {fromPixelsAsync} from './ops/from_pixels_async';
 import * as webgpu from './webgpu';
 
-tf.registerBackend('webgpu', async () => {
+registerBackend('webgpu', async () => {
+  // Remove it once we figure out how to correctly read the tensor data before
+  // the tensor is disposed in profiling mode.
+  env().setFlags({'CHECK_COMPUTATION_FOR_ERRORS': false});
+
   const glslang = await glslangInit();
   const gpuDescriptor: GPURequestAdapterOptions = {
-    powerPreference: tf.env().get('WEBGPU_USE_LOW_POWER_GPU') ?
-        'low-power' :
-        'high-performance'
+    powerPreference: env().get('WEBGPU_USE_LOW_POWER_GPU') ? 'low-power' :
+                                                             'high-performance'
   };
 
   const adapter = await navigator.gpu.requestAdapter(gpuDescriptor);

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -557,12 +557,6 @@ export class Engine implements TensorTracker, DataMover {
     }
   }
 
-  private shouldCheckComputationForErrors(): boolean {
-    // Don't do checkComputationForErrors for webgpu backend since it's in an
-    // async function. It may result the tensor is disposed before it's read.
-    return this.backendName !== 'webgpu';
-  }
-
   /**
    * @deprecated Use `runKernel` for newly added kernels. Keep using this method
    *     only for kernels that are not yet fully modularized.
@@ -666,8 +660,7 @@ export class Engine implements TensorTracker, DataMover {
             outputs = kernelFunc();
           } else {
             kernelProfile = this.profiler.profileKernel(
-                kernelName, inputs, () => kernelFunc(),
-                this.shouldCheckComputationForErrors());
+                kernelName, inputs, () => kernelFunc());
             if (this.ENV.getBool('DEBUG')) {
               this.profiler.logKernelProfile(kernelProfile);
             }

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -557,6 +557,12 @@ export class Engine implements TensorTracker, DataMover {
     }
   }
 
+  private shouldCheckComputationForErrors(): boolean {
+    // Don't do checkComputationForErrors for webgpu backend since it's in an
+    // async function. It may result the tensor is disposed before it's read.
+    return this.backendName !== 'webgpu';
+  }
+
   /**
    * @deprecated Use `runKernel` for newly added kernels. Keep using this method
    *     only for kernels that are not yet fully modularized.
@@ -660,7 +666,8 @@ export class Engine implements TensorTracker, DataMover {
             outputs = kernelFunc();
           } else {
             kernelProfile = this.profiler.profileKernel(
-                kernelName, inputs, () => kernelFunc());
+                kernelName, inputs, () => kernelFunc(),
+                this.shouldCheckComputationForErrors());
             if (this.ENV.getBool('DEBUG')) {
               this.profiler.logKernelProfile(kernelProfile);
             }

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-import './engine';
-
 import * as device_util from './device_util';
+import {ENGINE} from './engine';
 import {env} from './environment';
 
 const ENV = env();
@@ -70,3 +69,7 @@ ENV.registerFlag('DEPRECATION_WARNINGS_ENABLED', () => true);
 
 /** True if running unit tests. */
 ENV.registerFlag('IS_TEST', () => false);
+
+/**Whether to check computation result for errors. */
+ENV.registerFlag(
+    'CHECK_COMPUTATION_FOR_ERRORS', () => ENGINE.backendName !== 'webgpu');

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -70,6 +70,6 @@ ENV.registerFlag('DEPRECATION_WARNINGS_ENABLED', () => true);
 /** True if running unit tests. */
 ENV.registerFlag('IS_TEST', () => false);
 
-/**Whether to check computation result for errors. */
+/** Whether to check computation result for errors. */
 ENV.registerFlag(
     'CHECK_COMPUTATION_FOR_ERRORS', () => ENGINE.backendName !== 'webgpu');

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
+import './engine';
+
 import * as device_util from './device_util';
-import {ENGINE} from './engine';
 import {env} from './environment';
 
 const ENV = env();
@@ -71,5 +72,4 @@ ENV.registerFlag('DEPRECATION_WARNINGS_ENABLED', () => true);
 ENV.registerFlag('IS_TEST', () => false);
 
 /** Whether to check computation result for errors. */
-ENV.registerFlag(
-    'CHECK_COMPUTATION_FOR_ERRORS', () => ENGINE.backendName !== 'webgpu');
+ENV.registerFlag('CHECK_COMPUTATION_FOR_ERRORS', () => true);

--- a/tfjs-core/src/profiler.ts
+++ b/tfjs-core/src/profiler.ts
@@ -16,6 +16,7 @@
  */
 
 import {BackendTimer} from './backends/backend';
+import {env} from './environment';
 import {Tensor} from './tensor';
 import {NamedTensorMap} from './tensor_types';
 import {DataType, DataTypeMap, TypedArray} from './types';
@@ -36,16 +37,15 @@ export class Profiler {
     }
   }
 
-  profileKernel(
-      kernelName: string, inputs: NamedTensorMap, f: () => Tensor[],
-      shouldCheckComputationForErrors = true): KernelProfile {
+  profileKernel(kernelName: string, inputs: NamedTensorMap, f: () => Tensor[]):
+      KernelProfile {
     let outputs: Tensor[];
     const holdResultWrapperFn = () => {
       outputs = f();
     };
     const timer = this.backendTimer.time(holdResultWrapperFn);
 
-    if (shouldCheckComputationForErrors) {
+    if (env().getBool('CHECK_COMPUTATION_FOR_ERRORS')) {
       for (let i = 0; i < outputs.length; i++) {
         const output = outputs[i];
         // Dangling promise here because we don't want to propagate up


### PR DESCRIPTION
BUG

Add a flag shouldCheckComputationForErrors to control checkComputationForErrors.
Disable checkComputationForErrors for webgpu backend sine it may result the tensor
is disposed before it is read.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4303)
<!-- Reviewable:end -->
