### PR TITLE
Add Leakyrelu support to fused ops.

### DIFF
--- a/tfjs-backend-cpu/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-cpu/src/kernels/FusedConv2D.ts
@@ -29,8 +29,15 @@ export function fusedConv2D(args: {
 }): TensorInfo {
   const {inputs, backend, attrs} = args;
   const {x, filter, bias, preluActivationWeights} = inputs;
-  const {strides, pad, dataFormat, dilations, dimRoundingMode, activation} =
-      attrs;
+  const {
+    strides,
+    pad,
+    dataFormat,
+    dilations,
+    dimRoundingMode,
+    activation,
+    leakyreluAlpha
+  } = attrs;
 
   let result = conv2D({
     inputs: {x, filter},
@@ -46,8 +53,8 @@ export function fusedConv2D(args: {
 
   if (activation) {
     const resultOld = result;
-    result =
-        applyActivation(backend, result, activation, preluActivationWeights);
+    result = applyActivation(
+        backend, result, activation, preluActivationWeights, leakyreluAlpha);
     backend.disposeIntermediateTensorInfo(resultOld);
   }
 

--- a/tfjs-backend-cpu/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-cpu/src/kernels/FusedDepthwiseConv2D.ts
@@ -29,8 +29,15 @@ export function fusedDepthwiseConv2D(args: {
 }): TensorInfo {
   const {inputs, backend, attrs} = args;
   const {x, filter, bias, preluActivationWeights} = inputs;
-  const {strides, pad, dataFormat, dilations, dimRoundingMode, activation} =
-      attrs;
+  const {
+    strides,
+    pad,
+    dataFormat,
+    dilations,
+    dimRoundingMode,
+    activation,
+    leakyreluAlpha
+  } = attrs;
 
   let result = depthwiseConv2dNative({
     inputs: {x, filter},
@@ -45,8 +52,8 @@ export function fusedDepthwiseConv2D(args: {
   }
   if (activation) {
     const oldResult = result;
-    result =
-        applyActivation(backend, result, activation, preluActivationWeights);
+    result = applyActivation(
+        backend, result, activation, preluActivationWeights, leakyreluAlpha);
     backend.disposeIntermediateTensorInfo(oldResult);
   }
 

--- a/tfjs-backend-cpu/src/kernels/LeakyRelu.ts
+++ b/tfjs-backend-cpu/src/kernels/LeakyRelu.ts
@@ -33,7 +33,7 @@ export function leakyRelu(args: {
 
   const xSize = util.sizeFromShape(x.shape);
   const xVals = backend.data.get(x.dataId).values as TypedArray;
-  const outVals = util.makeZerosTypedArray(xSize, 'float32');
+  const outVals = util.getTypedArrayFromDType('float32', xSize);
 
   for (let i = 0; i < xVals.length; i++) {
     outVals[i] = xVals[i] < 0 ? alpha * xVals[i] : xVals[i];

--- a/tfjs-backend-cpu/src/kernels/LeakyRelu.ts
+++ b/tfjs-backend-cpu/src/kernels/LeakyRelu.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, KernelFunc, LeakyRelu, LeakyReluAttrs, LeakyReluInputs, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+
+import {MathBackendCPU} from '../backend_cpu';
+import {assertNotComplex} from '../cpu_util';
+import {createSimpleBinaryKernelImpl} from '../utils/binary_impl';
+
+const leakyReluImpl = createSimpleBinaryKernelImpl(
+    (xValue: number, aValue: number) => xValue < 0 ? aValue * xValue : xValue);
+
+export function leakyRelu(args: {
+  inputs: LeakyReluInputs,
+  backend: MathBackendCPU,
+  attrs: LeakyReluAttrs
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x} = inputs;
+  const {alpha} = attrs;
+
+  assertNotComplex([x], 'leakyRelu');
+
+  const $alpha = backend.makeTensorInfo(
+      [], 'float32',
+      util.createScalarValue(alpha as {} as 'float32', 'float32'));
+
+  const xVals = backend.data.get(x.dataId).values as TypedArray;
+  const $alphaVals = backend.data.get($alpha.dataId).values as TypedArray;
+  const [resultData, resultShape] =
+      leakyReluImpl(x.shape, $alpha.shape, xVals, $alphaVals, x.dtype);
+
+  backend.disposeIntermediateTensorInfo($alpha);
+
+  return backend.makeTensorInfo(resultShape, x.dtype, resultData);
+}
+
+export const leakyReluConfig: KernelConfig = {
+  kernelName: LeakyRelu,
+  backendName: 'cpu',
+  kernelFunc: leakyRelu as {} as KernelFunc
+};

--- a/tfjs-backend-cpu/src/kernels/_FusedMatMul.ts
+++ b/tfjs-backend-cpu/src/kernels/_FusedMatMul.ts
@@ -30,7 +30,7 @@ export function _fusedMatMul(args: {
 }) {
   const {inputs, backend, attrs} = args;
   const {a, b, bias, preluActivationWeights} = inputs;
-  const {transposeA, transposeB, activation} = attrs;
+  const {transposeA, transposeB, activation, leakyreluAlpha} = attrs;
 
   let current;
   let addRes;
@@ -48,8 +48,8 @@ export function _fusedMatMul(args: {
     current = addRes;
   }
   if (activation) {
-    activationRes =
-        applyActivation(backend, current, activation, preluActivationWeights);
+    activationRes = applyActivation(
+        backend, current, activation, preluActivationWeights, leakyreluAlpha);
     intermediates.push(current);
     current = activationRes;
   }

--- a/tfjs-backend-cpu/src/register_all_kernels.ts
+++ b/tfjs-backend-cpu/src/register_all_kernels.ts
@@ -89,6 +89,7 @@ import {imagConfig} from './kernels/Imag';
 import {isFiniteConfig} from './kernels/IsFinite';
 import {isInfConfig} from './kernels/IsInf';
 import {isNaNConfig} from './kernels/IsNaN';
+import {leakyReluConfig} from './kernels/LeakyRelu';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
 import {linSpaceConfig} from './kernels/LinSpace';
@@ -242,6 +243,7 @@ const kernelConfigs: KernelConfig[] = [
   isFiniteConfig,
   isInfConfig,
   isNaNConfig,
+  leakyReluConfig,
   lessConfig,
   lessEqualConfig,
   linSpaceConfig,

--- a/tfjs-backend-cpu/src/utils/fused_utils.ts
+++ b/tfjs-backend-cpu/src/utils/fused_utils.ts
@@ -20,13 +20,14 @@ import {_FusedMatMul, _FusedMatMulAttrs, _FusedMatMulInputs, backend_util, Tenso
 import {MathBackendCPU} from '../backend_cpu';
 import {elu} from '../kernels/Elu';
 import {identity} from '../kernels/Identity';
+import {leakyRelu} from '../kernels/LeakyRelu';
 import {prelu} from '../kernels/Prelu';
 import {relu} from '../kernels/Relu';
 import {relu6} from '../kernels/Relu6';
 
 export function applyActivation(
     backend: MathBackendCPU, x: TensorInfo, activation: backend_util.Activation,
-    preluActivationWeights?: TensorInfo): TensorInfo {
+    preluActivationWeights?: TensorInfo, leakyreluAlpha?: number): TensorInfo {
   if (activation === 'linear') {
     return identity({inputs: {x}, backend});
   } else if (activation === 'relu') {
@@ -37,6 +38,8 @@ export function applyActivation(
     return relu6({inputs: {x}, backend}) as TensorInfo;
   } else if (activation === 'prelu') {
     return prelu({inputs: {x, alpha: preluActivationWeights}, backend});
+  } else if (activation === 'leakyrelu') {
+    return leakyRelu({inputs: {x}, backend, attrs: {alpha: leakyreluAlpha}});
   }
   throw new Error(
       `Activation ${activation} has not been implemented for the CPU backend.`);

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -594,8 +594,8 @@ tfjs_cc_library(
 
 tfjs_cc_library(
     name = "LeakyRelu",
-    hdrs = ["kernels/LeakyRelu.h"],
     srcs = ["kernels/LeakyRelu.cc"],
+    hdrs = ["kernels/LeakyRelu.h"],
     deps = [
         ":backend",
         ":leakyrelu_impl",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -134,6 +134,7 @@ tfjs_cc_library(
     hdrs = ["conv2d_impl.h"],
     deps = [
         ":backend",
+        ":leakyrelu_impl",
         ":prelu_impl",
         ":transpose_impl",
         ":util",
@@ -146,6 +147,7 @@ tfjs_cc_library(
     hdrs = ["batch_mat_mul_impl.h"],
     deps = [
         ":backend",
+        ":leakyrelu_impl",
         ":prelu_impl",
         ":transpose_impl",
         ":util",
@@ -156,6 +158,16 @@ tfjs_cc_library(
     name = "interpolate_bilinear_impl",
     srcs = ["interpolate_bilinear_impl.cc"],
     hdrs = ["interpolate_bilinear_impl.h"],
+    deps = [
+        ":backend",
+        ":util",
+    ],
+)
+
+tfjs_cc_library(
+    name = "leakyrelu_impl",
+    srcs = ["leakyrelu_impl.cc"],
+    hdrs = ["leakyrelu_impl.h"],
     deps = [
         ":backend",
         ":util",
@@ -233,6 +245,7 @@ tfjs_cc_library(
         ":GatherNd",
         ":Greater",
         ":GreaterEqual",
+        ":LeakyRelu",
         ":Less",
         ":LessEqual",
         ":Max",
@@ -575,6 +588,17 @@ tfjs_cc_library(
     deps = [
         ":backend",
         ":binary",
+        ":util",
+    ],
+)
+
+tfjs_cc_library(
+    name = "LeakyRelu",
+    hdrs = ["kernels/LeakyRelu.h"],
+    srcs = ["kernels/LeakyRelu.cc"],
+    deps = [
+        ":backend",
+        ":leakyrelu_impl",
         ":util",
     ],
 )

--- a/tfjs-backend-wasm/src/cc/backend.h
+++ b/tfjs-backend-wasm/src/cc/backend.h
@@ -29,7 +29,13 @@ enum DType {
 };
 
 // Must match enum in kernels/types.ts.
-enum FusableActivation { LINEAR = 0, RELU = 1, RELU6 = 2, PRELU = 3 };
+enum FusableActivation {
+  LINEAR = 0,
+  RELU = 1,
+  RELU6 = 2,
+  PRELU = 3,
+  LEAKYRELU = 4
+};
 
 // Holds the memory offset and the size of a tensor.
 struct TensorInfo {

--- a/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
+++ b/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
@@ -275,10 +275,8 @@ void fused_batch_mat_mul(const size_t a_id, const size_t* a_shape_ptr,
                          const size_t bias_id, const size_t prelu_weights_id,
                          const float leakyrelu_alpha, const size_t out_id) {
   FusableActivation clamp_method = activation;
-  if (activation == FusableActivation::PRELU) {
-    clamp_method = FusableActivation::LINEAR;
-  }
-  if (activation == FusableActivation::LEAKYRELU) {
+  if (activation == FusableActivation::PRELU ||
+      activation == FusableActivation::LEAKYRELU) {
     clamp_method = FusableActivation::LINEAR;
   }
 

--- a/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
+++ b/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "src/cc/backend.h"
+#include "src/cc/leakyrelu_impl.h"
 #include "src/cc/prelu_impl.h"
 #include "src/cc/util.h"
 
@@ -272,9 +273,12 @@ void fused_batch_mat_mul(const size_t a_id, const size_t* a_shape_ptr,
                          const bool transpose_a, const bool transpose_b,
                          const FusableActivation activation,
                          const size_t bias_id, const size_t prelu_weights_id,
-                         const size_t out_id) {
+                         const float leakyrelu_alpha, const size_t out_id) {
   FusableActivation clamp_method = activation;
   if (activation == FusableActivation::PRELU) {
+    clamp_method = FusableActivation::LINEAR;
+  }
+  if (activation == FusableActivation::LEAKYRELU) {
     clamp_method = FusableActivation::LINEAR;
   }
 
@@ -302,6 +306,9 @@ void fused_batch_mat_mul(const size_t a_id, const size_t* a_shape_ptr,
   float* out_buf = out_info.f32_write();
   if (activation == FusableActivation::PRELU) {
     prelu(out_buf, out_info.size, prelu_weights_id, out_id);
+  }
+  if (activation == FusableActivation::LEAKYRELU) {
+    leakyrelu(out_buf, out_info.size, leakyrelu_alpha, out_id);
   }
 }
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/conv2d_impl.cc
+++ b/tfjs-backend-wasm/src/cc/conv2d_impl.cc
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "src/cc/backend.h"
+#include "src/cc/leakyrelu_impl.h"
 #include "src/cc/prelu_impl.h"
 #include "src/cc/transpose_impl.h"
 #include "src/cc/util.h"
@@ -118,7 +119,7 @@ void conv2d(const size_t x_id, const size_t batch_size,
             const size_t stride_width, const size_t input_channels,
             const size_t output_channels, const bool is_depthwise,
             const FusableActivation activation, const size_t prelu_weights_id,
-            const size_t leaky_relu_alpha_id, const size_t out_id) {
+            const float leakyrelu_alpha, const size_t out_id) {
   auto& x_info = backend::get_tensor_info(x_id);
   auto& filter_info = backend::get_tensor_info(filter_id);
   auto& out_info = backend::get_tensor_info_out(out_id);
@@ -138,7 +139,7 @@ void conv2d(const size_t x_id, const size_t batch_size,
     out_buf = intermediate_output.data();
   }
 
-  if (leaky_relu_alpha_id != 0) {
+  if (activation == FusableActivation::LEAKYRELU) {
     intermediate_output.resize(out_info.size);
     out_buf = intermediate_output.data();
   }
@@ -281,7 +282,7 @@ void conv2d(const size_t x_id, const size_t batch_size,
     prelu(out_buf, out_info.size, prelu_weights_id, out_id);
   }
   if (activation == FusableActivation::LEAKYRELU) {
-    leakyrelu(out_buf, out_info.size, leaky_relu_alpha_id, out_id);
+    leakyrelu(out_buf, out_info.size, leakyrelu_alpha, out_id);
   }
 }
 

--- a/tfjs-backend-wasm/src/cc/conv2d_impl.cc
+++ b/tfjs-backend-wasm/src/cc/conv2d_impl.cc
@@ -134,12 +134,7 @@ void conv2d(const size_t x_id, const size_t batch_size,
   float* out_buf = out_info.f32_write();
   std::vector<float> intermediate_output;
 
-  if (prelu_weights_id != 0) {
-    intermediate_output.resize(out_info.size);
-    out_buf = intermediate_output.data();
-  }
-
-  if (activation == FusableActivation::LEAKYRELU) {
+  if (prelu_weights_id != 0 || activation == FusableActivation::LEAKYRELU) {
     intermediate_output.resize(out_info.size);
     out_buf = intermediate_output.data();
   }
@@ -169,10 +164,8 @@ void conv2d(const size_t x_id, const size_t batch_size,
   }
 
   FusableActivation clamp_method = activation;
-  if (activation == FusableActivation::PRELU) {
-    clamp_method = FusableActivation::LINEAR;
-  }
-  if (activation == FusableActivation::LEAKYRELU) {
+  if (activation == FusableActivation::PRELU ||
+      activation == FusableActivation::LEAKYRELU) {
     clamp_method = FusableActivation::LINEAR;
   }
 

--- a/tfjs-backend-wasm/src/cc/conv2d_impl.h
+++ b/tfjs-backend-wasm/src/cc/conv2d_impl.h
@@ -32,7 +32,7 @@ void conv2d(const size_t x_id, const size_t batch_size,
             const size_t stride_width, const size_t input_channels,
             const size_t output_channels, const bool is_depthwise,
             const FusableActivation activation, const size_t prelu_weighs_id,
-            const size_t out_id);
+            const float leakyrelu_alpha, const size_t out_id);
 }  // namespace wasm
 }  // namespace tfjs
 

--- a/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/BatchMatMul.cc
@@ -37,10 +37,12 @@ void BatchMatMul(const size_t a_id, const size_t* a_shape_ptr,
                  const size_t out_id) {
   const size_t bias_id = 0;
   const size_t prelu_weights_id = 0;
+  const float leakyrelu_alpha = 0;
   const FusableActivation activation = FusableActivation::LINEAR;
-  tfjs::wasm::fused_batch_mat_mul(
-      a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr, b_shape_len,
-      transpose_a, transpose_b, activation, bias_id, prelu_weights_id, out_id);
+  tfjs::wasm::fused_batch_mat_mul(a_id, a_shape_ptr, a_shape_len, b_id,
+                                  b_shape_ptr, b_shape_len, transpose_a,
+                                  transpose_b, activation, bias_id,
+                                  prelu_weights_id, leakyrelu_alpha, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2D.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2D.cc
@@ -41,6 +41,7 @@ void Conv2D(const size_t x_id, const size_t batch_size,
             const size_t out_id) {
   const size_t bias_id = 0;
   const size_t prelu_weights_id = 0;
+  const float leakyrelu_alpha = 0;
   const bool is_depthwise = false;
   const FusableActivation activation = FusableActivation::LINEAR;
   tfjs::wasm::conv2d(x_id, batch_size, input_height, input_width, filter_id,
@@ -48,7 +49,7 @@ void Conv2D(const size_t x_id, const size_t batch_size,
                      pad_bottom, pad_left, is_same_pad, dilation_height,
                      dilation_width, stride_height, stride_width,
                      input_channels, output_channels, is_depthwise, activation,
-                     prelu_weights_id, out_id);
+                     prelu_weights_id, leakyrelu_alpha, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/DepthwiseConv2dNative.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/DepthwiseConv2dNative.cc
@@ -41,6 +41,7 @@ void DepthwiseConv2dNative(
     const size_t output_channels, const size_t out_id) {
   const size_t bias_id = 0;
   const size_t prelu_weights_id = 0;
+  const float leakyrelu_alpha = 0;
   const bool is_depthwise = true;
   const FusableActivation activation = FusableActivation::LINEAR;
   tfjs::wasm::conv2d(x_id, batch_size, input_height, input_width, filter_id,
@@ -48,7 +49,7 @@ void DepthwiseConv2dNative(
                      pad_bottom, pad_left, is_same_pad, dilation_height,
                      dilation_width, stride_height, stride_width,
                      input_channels, output_channels, is_depthwise, activation,
-                     prelu_weights_id, out_id);
+                     prelu_weights_id, leakyrelu_alpha, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.cc
@@ -40,15 +40,15 @@ void FusedConv2D(const size_t x_id, const size_t batch_size,
                  const size_t stride_height, const size_t stride_width,
                  const size_t input_channels, const size_t output_channels,
                  const FusableActivation activation,
-                 const size_t prelu_weights_id,
-                 const size_t leaky_relu_alpha_id, const size_t out_id) {
+                 const size_t prelu_weights_id, const float leakyrelu_alpha,
+                 const size_t out_id) {
   const bool is_depthwise = false;
   tfjs::wasm::conv2d(x_id, batch_size, input_height, input_width, filter_id,
                      filter_height, filter_width, bias_id, pad_top, pad_right,
                      pad_bottom, pad_left, is_same_pad, dilation_height,
                      dilation_width, stride_height, stride_width,
                      input_channels, output_channels, is_depthwise, activation,
-                     prelu_weights_id, leaky_relu_alpha_id, out_id);
+                     prelu_weights_id, leakyrelu_alpha, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.cc
@@ -40,14 +40,15 @@ void FusedConv2D(const size_t x_id, const size_t batch_size,
                  const size_t stride_height, const size_t stride_width,
                  const size_t input_channels, const size_t output_channels,
                  const FusableActivation activation,
-                 const size_t prelu_weights_id, const size_t out_id) {
+                 const size_t prelu_weights_id,
+                 const size_t leaky_relu_alpha_id, const size_t out_id) {
   const bool is_depthwise = false;
   tfjs::wasm::conv2d(x_id, batch_size, input_height, input_width, filter_id,
                      filter_height, filter_width, bias_id, pad_top, pad_right,
                      pad_bottom, pad_left, is_same_pad, dilation_height,
                      dilation_width, stride_height, stride_width,
                      input_channels, output_channels, is_depthwise, activation,
-                     prelu_weights_id, out_id);
+                     prelu_weights_id, leaky_relu_alpha_id, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.h
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.h
@@ -33,7 +33,8 @@ void FusedConv2D(const size_t x_id, const size_t batch_size,
                  const size_t stride_height, const size_t stride_width,
                  const size_t input_channels, const size_t output_channels,
                  const FusableActivation activation,
-                 const size_t prelu_weights_id, const size_t out_id);
+                 const size_t prelu_weights_id,
+                 const size_t leaky_relu_alpha_id, const size_t out_id);
 }
 
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.h
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedConv2D.h
@@ -33,8 +33,8 @@ void FusedConv2D(const size_t x_id, const size_t batch_size,
                  const size_t stride_height, const size_t stride_width,
                  const size_t input_channels, const size_t output_channels,
                  const FusableActivation activation,
-                 const size_t prelu_weights_id,
-                 const size_t leaky_relu_alpha_id, const size_t out_id);
+                 const size_t prelu_weights_id, const float leakyrelu_alpha,
+                 const size_t out_id);
 }
 
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/kernels/FusedConv2D_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedConv2D_test.cc
@@ -83,7 +83,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for the second call to conv2d with
@@ -93,7 +93,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for the second call to conv2d with
@@ -103,7 +103,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // One new xnn_operator should be created for the next call to conv2d with the
@@ -115,7 +115,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top1, pad_right, pad_bottom1, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -125,7 +125,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(3, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -135,7 +135,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, bias0_id, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(4, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -145,7 +145,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(5, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -156,7 +156,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad1, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(6, tfjs::backend::xnn_operator_count);
 
   // No new XNN operators should be created for the next call to conv2d with
@@ -166,7 +166,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top1, pad_right, pad_bottom1, pad_left,
       is_same_pad1, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(6, tfjs::backend::xnn_operator_count);
 
   // One new XNN operator should be created for the next call to conv2d with a
@@ -177,7 +177,7 @@ TEST(FUSEDCONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top1, pad_right, pad_bottom1, pad_left,
       is_same_pad1, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation2,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(7, tfjs::backend::xnn_operator_count);
 
   // Disposing the first weights should remove 2 operators.

--- a/tfjs-backend-wasm/src/cc/kernels/FusedDepthwiseConv2D.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedDepthwiseConv2D.cc
@@ -40,14 +40,15 @@ void FusedDepthwiseConv2D(
     const size_t dilation_width, const size_t stride_height,
     const size_t stride_width, const size_t input_channels,
     const size_t output_channels, const FusableActivation activation,
-    const size_t prelu_weights_id, const size_t out_id) {
+    const size_t prelu_weights_id, const float leakyrelu_alpha,
+    const size_t out_id) {
   const bool is_depthwise = true;
   tfjs::wasm::conv2d(x_id, batch_size, input_height, input_width, filter_id,
                      filter_height, filter_width, bias_id, pad_top, pad_right,
                      pad_bottom, pad_left, is_same_pad, dilation_height,
                      dilation_width, stride_height, stride_width,
                      input_channels, output_channels, is_depthwise, activation,
-                     prelu_weights_id, out_id);
+                     prelu_weights_id, leakyrelu_alpha, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/FusedDepthwiseConv2D.h
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedDepthwiseConv2D.h
@@ -32,7 +32,8 @@ void FusedDepthwiseConv2D(
     const size_t dilation_width, const size_t stride_height,
     const size_t stride_width, const size_t input_channels,
     const size_t output_channels, const FusableActivation activation,
-    const size_t prelu_weights_id, const size_t out_id);
+    const size_t prelu_weights_id, const float leakyrelu_alpha,
+    const size_t out_id);
 }
 
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/kernels/FusedDepthwiseConv2D_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/FusedDepthwiseConv2D_test.cc
@@ -83,7 +83,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      0 /* prelu weights */, out_id);
+      0 /* prelu weights */, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // One new xnn operator should be created for second call to conv2d with no
@@ -100,7 +100,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, prelu_activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for the second call to conv2d with
@@ -110,7 +110,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for the second call to conv2d with
@@ -120,7 +120,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
   // One new xnn_operator should be created for the next call to conv2d with the
@@ -132,7 +132,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top1, pad_right, pad_bottom1, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(3, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -142,7 +142,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, 0 /* bias */, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(4, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -152,7 +152,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, bias0_id, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(5, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -162,7 +162,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad0, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(6, tfjs::backend::xnn_operator_count);
 
   // One more xnn operator should be created for the next call to conv2d with
@@ -173,7 +173,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top0, pad_right, pad_bottom0, pad_left,
       is_same_pad1, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(7, tfjs::backend::xnn_operator_count);
 
   // No new XNN operators should be created for the next call to conv2d with
@@ -183,7 +183,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top1, pad_right, pad_bottom1, pad_left,
       is_same_pad1, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(7, tfjs::backend::xnn_operator_count);
 
   // One new XNN operator should be created for the next call to conv2d with a
@@ -194,7 +194,7 @@ TEST(FUSEDDEPTHWISECONV2D, xnn_operator_lifetime) {
       filter_width, bias1_id, pad_top1, pad_right, pad_bottom1, pad_left,
       is_same_pad1, dilation_height, dilation_width, stride_height,
       stride_width, input_channels, output_channels, activation2,
-      prelu_weights_id, out_id);
+      prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(8, tfjs::backend::xnn_operator_count);
 
   // Disposing the first weights should remove 2 operators.

--- a/tfjs-backend-wasm/src/cc/kernels/LeakyRelu.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/LeakyRelu.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 Google LLC. All Rights Reserved.
+/* Copyright 2019 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,23 +12,34 @@
  * limitations under the License.
  * ===========================================================================*/
 
-#ifndef BATCH_MAT_MUL_IMPL_H_
-#define BATCH_MAT_MUL_IMPL_H_
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+#include "src/cc/kernels/LeakyRelu.h"
 
 #include <cstddef>
 
+#include "src/cc/backend.h"
+#include "src/cc/leakyrelu_impl.h"
+#include "src/cc/util.h"
+
 namespace tfjs {
 namespace wasm {
+// We use C-style API to interface with Javascript.
+extern "C" {
 
-void fused_batch_mat_mul(const size_t a_id, const size_t* a_shape_ptr,
-                         const size_t a_shape_len, const size_t b_id,
-                         const size_t* b_shape_ptr, const size_t b_shape_len,
-                         const bool transpose_a, const bool transpose_b,
-                         const FusableActivation activation,
-                         const size_t bias_id, const size_t prelu_weights_id,
-                         const float leakyrelu_alpha, const size_t out_id);
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+void LeakyRelu(const size_t x_id, const float leakyrelu_alpha,
+               const size_t out_id) {
+  auto& x_info = backend::get_tensor_info(x_id);
+  const float* x_buf = x_info.f32();
 
+  tfjs::wasm::leakyrelu(x_buf, x_info.size, leakyrelu_alpha, out_id);
+}
+
+}  // extern "C"
 }  // namespace wasm
 }  // namespace tfjs
-
-#endif  // BATCH_MAT_MUL_IMPL_H_

--- a/tfjs-backend-wasm/src/cc/kernels/LeakyRelu.h
+++ b/tfjs-backend-wasm/src/cc/kernels/LeakyRelu.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Google LLC. All Rights Reserved.
+/* Copyright 2019 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,23 +12,20 @@
  * limitations under the License.
  * ===========================================================================*/
 
-#ifndef BATCH_MAT_MUL_IMPL_H_
-#define BATCH_MAT_MUL_IMPL_H_
+#ifndef KERNELS_LEAKYRELU_H_
+#define KERNELS_LEAKYRELU_H_
 
 #include <cstddef>
 
 namespace tfjs {
 namespace wasm {
+extern "C" {
 
-void fused_batch_mat_mul(const size_t a_id, const size_t* a_shape_ptr,
-                         const size_t a_shape_len, const size_t b_id,
-                         const size_t* b_shape_ptr, const size_t b_shape_len,
-                         const bool transpose_a, const bool transpose_b,
-                         const FusableActivation activation,
-                         const size_t bias_id, const size_t prelu_weights_id,
-                         const float leakyrelu_alpha, const size_t out_id);
+void LeakyRelu(const size_t x_id, const float leakyrelu_alpha,
+               const size_t out_id);
+}
 
 }  // namespace wasm
 }  // namespace tfjs
 
-#endif  // BATCH_MAT_MUL_IMPL_H_
+#endif  // KERNELS_LEAKYRELU_H_

--- a/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul.cc
@@ -35,10 +35,12 @@ void _FusedMatMul(const size_t a_id, const size_t* a_shape_ptr,
                   const size_t* b_shape_ptr, const size_t b_shape_len,
                   const bool transpose_a, const bool transpose_b,
                   const FusableActivation activation, const size_t bias_id,
-                  const size_t prelu_weights_id, const size_t out_id) {
-  tfjs::wasm::fused_batch_mat_mul(
-      a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr, b_shape_len,
-      transpose_a, transpose_b, activation, bias_id, prelu_weights_id, out_id);
+                  const size_t prelu_weights_id, const float leakyrelu_alpha,
+                  const size_t out_id) {
+  tfjs::wasm::fused_batch_mat_mul(a_id, a_shape_ptr, a_shape_len, b_id,
+                                  b_shape_ptr, b_shape_len, transpose_a,
+                                  transpose_b, activation, bias_id,
+                                  prelu_weights_id, leakyrelu_alpha, out_id);
 }
 
 }  // extern "C"

--- a/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul.h
+++ b/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul.h
@@ -26,7 +26,8 @@ void _FusedMatMul(const size_t a_id, const size_t* a_shape_ptr,
                   const size_t* b_shape_ptr, const size_t b_shape_len,
                   const bool transpose_a, const bool transpose_b,
                   const FusableActivation activation, const size_t bias_id,
-                  const size_t prelu_weights_id, const size_t out_id);
+                  const size_t prelu_weights_id, const float leakyrelu_alpha,
+                  const size_t out_id);
 }
 
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul_test.cc
@@ -59,7 +59,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a0_id, a_shape_ptr, a_shape.size(), b0_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation, bias_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for the second call to
@@ -67,7 +67,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a0_id, a_shape_ptr, a_shape.size(), b0_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation, bias_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for calling _FusedMatMul
@@ -75,7 +75,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a1_id, a_shape_ptr, a_shape.size(), b0_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation, bias_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(1, tfjs::backend::xnn_operator_count);
 
   // One new xnn_operator should be created for calling _FusedMatMul
@@ -83,7 +83,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a0_id, a_shape_ptr, a_shape.size(), b1_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation, bias_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
   // No new xnn_operators should be created for the next call to
@@ -91,7 +91,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a0_id, a_shape_ptr, a_shape.size(), b1_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation, bias_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(2, tfjs::backend::xnn_operator_count);
 
   const size_t bias1_id = 6;
@@ -103,7 +103,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a0_id, a_shape_ptr, a_shape.size(), b1_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation, bias1_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(3, tfjs::backend::xnn_operator_count);
 
   // One new xnn_operator should be created for calling _FusedMatMul with a
@@ -112,7 +112,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lfietime) {
   tfjs::wasm::_FusedMatMul(a0_id, a_shape_ptr, a_shape.size(), b1_id,
                            b_shape_ptr, b_shape.size(), false /* transpose_a */,
                            false /* transpose_b */, activation2, bias1_id,
-                           prelu_weights_id, out_id);
+                           prelu_weights_id, 0 /* leakyrelu alpha */, out_id);
   ASSERT_EQ(4, tfjs::backend::xnn_operator_count);
 
   // Disposing a's should not remove xnn operators.

--- a/tfjs-backend-wasm/src/cc/leakyrelu_impl.h
+++ b/tfjs-backend-wasm/src/cc/leakyrelu_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 Google LLC. All Rights Reserved.
+/* Copyright 2019 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,23 +12,18 @@
  * limitations under the License.
  * ===========================================================================*/
 
-#ifndef BATCH_MAT_MUL_IMPL_H_
-#define BATCH_MAT_MUL_IMPL_H_
+#ifndef LEAKYRELU_IMPL_H_
+#define LEAKYRELU_IMPL_H_
 
 #include <cstddef>
 
 namespace tfjs {
 namespace wasm {
 
-void fused_batch_mat_mul(const size_t a_id, const size_t* a_shape_ptr,
-                         const size_t a_shape_len, const size_t b_id,
-                         const size_t* b_shape_ptr, const size_t b_shape_len,
-                         const bool transpose_a, const bool transpose_b,
-                         const FusableActivation activation,
-                         const size_t bias_id, const size_t prelu_weights_id,
-                         const float leakyrelu_alpha, const size_t out_id);
+void leakyrelu(const float* x_buf, const size_t x_size,
+               const float leakyrelu_alpha, const size_t out_id);
 
 }  // namespace wasm
 }  // namespace tfjs
 
-#endif  // BATCH_MAT_MUL_IMPL_H_
+#endif  // LEAKYRELU_IMPL_H_

--- a/tfjs-backend-wasm/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-wasm/src/kernels/FusedConv2D.ts
@@ -53,6 +53,7 @@ function setup(backend: BackendWasm) {
     'number',  // outputChannels
     'number',  // activation
     'number',  // preluActivationWeightsId
+    'number',  // leakyreluAlphaId
     'number',  // outId
   ]);
 }
@@ -63,7 +64,7 @@ function fusedConv2d(args: {
   attrs: FusedConv2DAttrs
 }) {
   const {inputs, attrs, backend} = args;
-  const {x, filter, bias, preluActivationWeights} = inputs;
+  const {x, filter, bias, preluActivationWeights, leakyreluAlpha} = inputs;
   const {strides, pad, dilations, dataFormat, dimRoundingMode, activation} =
       attrs;
 
@@ -127,11 +128,14 @@ function fusedConv2d(args: {
   const preluActivationWeightsId = preluActivationWeights == null ?
       0 :
       backend.dataIdMap.get(preluActivationWeights.dataId).id;
+  const leakyreluAlphaId = leakyreluAlpha == null ?
+      0 :
+      backend.dataIdMap.get(leakyreluAlpha.dataId).id;
   wasmFusedConv2d(
       xId, batchSize, inHeight, inWidth, filterId, filterHeight, filterWidth,
       biasId, padTop, padRight, padBottom, padLeft, isSamePad, dilationHeight,
       dilationWidth, strideHeight, strideWidth, inputChannels, outputChannels,
-      fusedActivation, preluActivationWeightsId, outId);
+      fusedActivation, preluActivationWeightsId, leakyreluAlphaId, outId);
   return out;
 }
 

--- a/tfjs-backend-wasm/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-wasm/src/kernels/FusedDepthwiseConv2D.ts
@@ -21,14 +21,15 @@ import {BackendWasm} from '../backend_wasm';
 
 import {FusableActivation} from './types';
 
-let wasmFusedDepthwiseConv2d: (
-    xId: number, batchSize: number, inputHeight: number, inputWidth: number,
-    filterId: number, filterHeight: number, filterWidth: number, biasId: number,
-    padTop: number, padRight: number, padBottom: number, padLeft: number,
-    isSamePad: number, dilationHeight: number, dilationWidth: number,
-    strideHeight: number, strideWidth: number, inputChannels: number,
-    outputChannels: number, activation: number,
-    preluActivationWeightsId: number, outId: number) => void;
+let wasmFusedDepthwiseConv2d:
+    (xId: number, batchSize: number, inputHeight: number, inputWidth: number,
+     filterId: number, filterHeight: number, filterWidth: number,
+     biasId: number, padTop: number, padRight: number, padBottom: number,
+     padLeft: number, isSamePad: number, dilationHeight: number,
+     dilationWidth: number, strideHeight: number, strideWidth: number,
+     inputChannels: number, outputChannels: number, activation: number,
+     preluActivationWeightsId: number, leakyreluAlpha: number, outId: number) =>
+        void;
 
 function setup(backend: BackendWasm) {
   wasmFusedDepthwiseConv2d =
@@ -54,6 +55,7 @@ function setup(backend: BackendWasm) {
         'number',  // outputChannels
         'number',  // activation
         'number',  // preluActivationWeightsId
+        'number',  // leakyreluAlpha
         'number',  // outId
       ]);
 }
@@ -65,8 +67,15 @@ function fusedDepthwiseConv2d(args: {
 }) {
   const {inputs, attrs, backend} = args;
   const {x, filter, bias, preluActivationWeights} = inputs;
-  const {strides, pad, dilations, dataFormat, dimRoundingMode, activation} =
-      attrs;
+  const {
+    strides,
+    pad,
+    dilations,
+    dataFormat,
+    dimRoundingMode,
+    activation,
+    leakyreluAlpha
+  } = attrs;
 
   const convInfo = backend_util.computeConv2DInfo(
       (x as Tensor4D).shape, (filter as Tensor4D).shape, strides, dilations,
@@ -128,11 +137,13 @@ function fusedDepthwiseConv2d(args: {
   const preluActivationWeightsId = preluActivationWeights == null ?
       0 :
       backend.dataIdMap.get(preluActivationWeights.dataId).id;
+
   wasmFusedDepthwiseConv2d(
       xId, batchSize, inHeight, inWidth, filterId, filterHeight, filterWidth,
       biasId, padTop, padRight, padBottom, padLeft, isSamePad, dilationHeight,
       dilationWidth, strideHeight, strideWidth, inputChannels, outputChannels,
-      fusedActivation, preluActivationWeightsId, outId);
+      fusedActivation, preluActivationWeightsId, leakyreluAlpha || 0, outId);
+
   return out;
 }
 

--- a/tfjs-backend-wasm/src/kernels/LeakyRelu.ts
+++ b/tfjs-backend-wasm/src/kernels/LeakyRelu.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, KernelFunc, LeakyRelu, LeakyReluAttrs, LeakyReluInputs, util} from '@tensorflow/tfjs-core';
+import {TensorInfo} from '@tensorflow/tfjs-core';
+
+import {BackendWasm} from '../backend_wasm';
+
+let wasmFunc: (xId: number, leakyreluAlpha: number, outId: number) => void;
+
+function setupFunc(backend: BackendWasm): void {
+  wasmFunc = backend.wasm.cwrap(LeakyRelu, null /* void */, [
+    'number',  // x_id,
+    'number',  // leakyrelu_alpha
+    'number'   // out_id
+  ]);
+}
+
+export function leakyRelu(
+    args:
+        {inputs: LeakyReluInputs, attrs: LeakyReluAttrs, backend: BackendWasm}):
+    TensorInfo {
+  const {inputs: {x}, attrs: {alpha}, backend} = args;
+
+  // const intermediates: TensorInfo[] = [];
+
+  // const alphaTensorInfo = backend.makeOutput([], 'float32');
+  // const alphaVals = backend.typedArrayFromHeap(alphaTensorInfo);
+  // alphaVals.set([alpha]);
+  // intermediates.push(alphaTensorInfo);
+
+  const xId = backend.dataIdMap.get(x.dataId).id;
+  const out = backend.makeOutput(x.shape, x.dtype);
+
+  if (util.sizeFromShape(x.shape) !== 0) {
+    const outId = backend.dataIdMap.get(out.dataId).id;
+    wasmFunc(xId, alpha, outId);
+  }
+
+  // backend.disposeData(alphaTensorInfo);
+
+  return out;
+}
+
+export const leakyReluConfig: KernelConfig = {
+  kernelName: LeakyRelu,
+  backendName: 'wasm',
+  setupFunc,
+  kernelFunc: leakyRelu as {} as KernelFunc,
+};

--- a/tfjs-backend-wasm/src/kernels/LeakyRelu.ts
+++ b/tfjs-backend-wasm/src/kernels/LeakyRelu.ts
@@ -36,13 +36,6 @@ export function leakyRelu(
     TensorInfo {
   const {inputs: {x}, attrs: {alpha}, backend} = args;
 
-  // const intermediates: TensorInfo[] = [];
-
-  // const alphaTensorInfo = backend.makeOutput([], 'float32');
-  // const alphaVals = backend.typedArrayFromHeap(alphaTensorInfo);
-  // alphaVals.set([alpha]);
-  // intermediates.push(alphaTensorInfo);
-
   const xId = backend.dataIdMap.get(x.dataId).id;
   const out = backend.makeOutput(x.shape, x.dtype);
 
@@ -50,8 +43,6 @@ export function leakyRelu(
     const outId = backend.dataIdMap.get(out.dataId).id;
     wasmFunc(xId, alpha, outId);
   }
-
-  // backend.disposeData(alphaTensorInfo);
 
   return out;
 }

--- a/tfjs-backend-wasm/src/kernels/types.ts
+++ b/tfjs-backend-wasm/src/kernels/types.ts
@@ -29,5 +29,6 @@ export enum FusableActivation {
   linear = 0,
   relu = 1,
   relu6 = 2,
-  prelu = 3
+  prelu = 3,
+  leakyrelu = 4
 }

--- a/tfjs-backend-wasm/src/register_all_kernels.ts
+++ b/tfjs-backend-wasm/src/register_all_kernels.ts
@@ -51,6 +51,7 @@ import {gatherV2Config} from './kernels/GatherV2';
 import {greaterConfig} from './kernels/Greater';
 import {greaterEqualConfig} from './kernels/GreaterEqual';
 import {identityConfig} from './kernels/Identity';
+import {leakyReluConfig} from './kernels/LeakyRelu';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
 import {logConfig} from './kernels/Log';
@@ -135,6 +136,7 @@ const kernelConfigs: KernelConfig[] = [
   greaterConfig,
   greaterEqualConfig,
   identityConfig,
+  leakyReluConfig,
   lessConfig,
   lessEqualConfig,
   logConfig,

--- a/tfjs-backend-wasm/starter/parcel/index.html
+++ b/tfjs-backend-wasm/starter/parcel/index.html
@@ -1,17 +1,3 @@
-<!-- Copyright 2019 Google LLC. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-============================================================================-->
 <!DOCTYPE html>
 <html>
   <head>
@@ -19,6 +5,18 @@ limitations under the License.
     <meta charset="UTF-8" />
   </head>
   <body>
+    <section>
+      <p class='section-head'>Model Output</p>
+
+      <div id="file-container">
+        Upload an image: <input type="file" id="files" name="files[]" multiple />
+      </div>
+
+      <div id="predictions">
+        <canvas id='result' />
+      </div>
+
+    </section>
     <script src="index.js"></script>
   </body>
 </html>

--- a/tfjs-backend-wasm/starter/parcel/index.html
+++ b/tfjs-backend-wasm/starter/parcel/index.html
@@ -1,3 +1,14 @@
+<!-- Copyright 2019 Google LLC. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+============================================================================-->
 <!DOCTYPE html>
 <html>
   <head>
@@ -5,18 +16,6 @@
     <meta charset="UTF-8" />
   </head>
   <body>
-    <section>
-      <p class='section-head'>Model Output</p>
-
-      <div id="file-container">
-        Upload an image: <input type="file" id="files" name="files[]" multiple />
-      </div>
-
-      <div id="predictions">
-        <canvas id='result' />
-      </div>
-
-    </section>
     <script src="index.js"></script>
   </body>
 </html>

--- a/tfjs-backend-wasm/starter/parcel/index.js
+++ b/tfjs-backend-wasm/starter/parcel/index.js
@@ -1,4 +1,4 @@
-import '@tensorflow/tfjs-backend-webgl';
+import '@tensorflow/tfjs-backend-wasm';
 
 import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
@@ -30,8 +30,7 @@ filesElement.addEventListener('change', evt => {
 
 let global_model = null;
 async function run() {
-  tf.ENV.set('WEBGL_PACK', false);
-  await tf.setBackend('webgl');
+  await tf.setBackend('wasm');
   const modelUrl = 'http://localhost:8080/tmp_web_model/model.json';
   global_model = await tfconv.loadGraphModel(modelUrl);
 }

--- a/tfjs-backend-wasm/starter/parcel/index.js
+++ b/tfjs-backend-wasm/starter/parcel/index.js
@@ -1,77 +1,22 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
 import '@tensorflow/tfjs-backend-wasm';
-
-import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 
-const IMAGE_SIZE = 224;
-const filesElement = document.getElementById('files');
-filesElement.addEventListener('change', evt => {
-  let files = evt.target.files;
-  // Display thumbnails & issue call to predict each image.
-  for (let i = 0, f; f = files[i]; i++) {
-    // Only process image files (skip non image files)
-    if (!f.type.match('image.*')) {
-      continue;
-    }
-    let reader = new FileReader();
-    reader.onload = e => {
-      // Fill the image & call predict.
-      let img = document.createElement('img');
-      img.src = e.target.result;
-      img.width = IMAGE_SIZE;
-      img.height = IMAGE_SIZE;
-      img.onload = () => predict(img);
-    };
-
-    // Read in the image file as a data URL.
-    reader.readAsDataURL(f);
-  }
-});
-
-let global_model = null;
 async function run() {
   await tf.setBackend('wasm');
-  const modelUrl = 'http://localhost:8080/tmp_web_model/model.json';
-  global_model = await tfconv.loadGraphModel(modelUrl);
+  tf.add(5, 3).print();
 }
 run();
-
-async function predict(imgElement) {
-  // The first start time includes the time it takes to extract the image
-  // from the HTML and preprocess it, in additon to the predict() call.
-  const startTime1 = performance.now();
-  // The second start time excludes the extraction and preprocessing and
-  // includes only the predict() call.
-  let startTime2;
-  const result = tf.tidy(() => {
-    // tf.browser.fromPixels() returns a Tensor from an image element.
-    const img = tf.browser.fromPixels(imgElement).toFloat();
-
-    const offset = tf.scalar(127.5);
-    // Normalize the image from [0, 255] to [-1, 1].
-    const normalized = img.sub(offset).div(offset);
-
-    // Reshape to a single-element batch so we can pass it to predict.
-    const batched = normalized.reshape([1, IMAGE_SIZE, IMAGE_SIZE, 3]);
-
-    startTime2 = performance.now();
-    // Make a prediction through mobilenet.
-    return global_model.predict(batched);
-  });
-
-  const totalTime1 = performance.now() - startTime1;
-  const totalTime2 = performance.now() - startTime2;
-  console.log(totalTime1);
-  console.log(totalTime2);
-
-  await showResults(imgElement, result);
-}
-
-async function showResults(imgElement, result) {
-  const canvas = document.getElementById('result');
-  const [batch, height, width, channel] = result.shape;
-  const resultReshaped = result.reshape([height, width, channel]);
-  const offset = tf.scalar(127.5);
-  const denormalized = resultReshaped.mul(offset).add(offset).cast('int32');
-  await tf.browser.toPixels(denormalized, canvas);
-}

--- a/tfjs-backend-wasm/starter/parcel/index.js
+++ b/tfjs-backend-wasm/starter/parcel/index.js
@@ -1,24 +1,77 @@
-// Copyright 2019 Google LLC. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// =============================================================================
+import '@tensorflow/tfjs-backend-webgl';
 
-import '@tensorflow/tfjs-backend-wasm';
+import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 
+const IMAGE_SIZE = 224;
+const filesElement = document.getElementById('files');
+filesElement.addEventListener('change', evt => {
+  let files = evt.target.files;
+  // Display thumbnails & issue call to predict each image.
+  for (let i = 0, f; f = files[i]; i++) {
+    // Only process image files (skip non image files)
+    if (!f.type.match('image.*')) {
+      continue;
+    }
+    let reader = new FileReader();
+    reader.onload = e => {
+      // Fill the image & call predict.
+      let img = document.createElement('img');
+      img.src = e.target.result;
+      img.width = IMAGE_SIZE;
+      img.height = IMAGE_SIZE;
+      img.onload = () => predict(img);
+    };
+
+    // Read in the image file as a data URL.
+    reader.readAsDataURL(f);
+  }
+});
+
+let global_model = null;
 async function run() {
-  await tf.setBackend('wasm');
-  tf.add(5, 3).print();
+  await tf.setBackend('webgl');
+  const modelUrl = 'http://localhost:8080/tmp_web_model/model.json';
+  global_model = await tfconv.loadGraphModel(modelUrl);
+}
+run();
+
+async function predict(imgElement) {
+  // The first start time includes the time it takes to extract the image
+  // from the HTML and preprocess it, in additon to the predict() call.
+  const startTime1 = performance.now();
+  // The second start time excludes the extraction and preprocessing and
+  // includes only the predict() call.
+  let startTime2;
+  const result = tf.tidy(() => {
+    // tf.browser.fromPixels() returns a Tensor from an image element.
+    const img = tf.browser.fromPixels(imgElement).toFloat();
+
+    const offset = tf.scalar(127.5);
+    // Normalize the image from [0, 255] to [-1, 1].
+    const normalized = img.sub(offset).div(offset);
+
+    // Reshape to a single-element batch so we can pass it to predict.
+    const batched = normalized.reshape([1, IMAGE_SIZE, IMAGE_SIZE, 3]);
+
+    startTime2 = performance.now();
+    // Make a prediction through mobilenet.
+    return global_model.predict(batched);
+  });
+
+  const totalTime1 = performance.now() - startTime1;
+  const totalTime2 = performance.now() - startTime2;
+  console.log(totalTime1);
+  console.log(totalTime2);
+
+  await showResults(imgElement, result);
 }
 
-run();
+async function showResults(imgElement, result) {
+  const canvas = document.getElementById('result');
+  const [batch, height, width, channel] = result.shape;
+  const resultReshaped = result.reshape([height, width, channel]);
+  const offset = tf.scalar(127.5);
+  const denormalized = resultReshaped.mul(offset).add(offset).cast('int32');
+  await tf.browser.toPixels(denormalized, canvas);
+}

--- a/tfjs-backend-wasm/starter/parcel/index.js
+++ b/tfjs-backend-wasm/starter/parcel/index.js
@@ -30,6 +30,7 @@ filesElement.addEventListener('change', evt => {
 
 let global_model = null;
 async function run() {
+  tf.ENV.set('WEBGL_PACK', false);
   await tf.setBackend('webgl');
   const modelUrl = 'http://localhost:8080/tmp_web_model/model.json';
   global_model = await tfconv.loadGraphModel(modelUrl);

--- a/tfjs-backend-wasm/starter/parcel/package.json
+++ b/tfjs-backend-wasm/starter/parcel/package.json
@@ -7,25 +7,22 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs-backend-wasm": "link:../../../tfjs-backend-wasm",
-    "@tensorflow/tfjs-converter": "link:../../../tfjs-converter",
-    "@tensorflow/tfjs-core": "link:../../../tfjs-core"
+    "@tensorflow/tfjs-backend-wasm": "2.0.1",
+    "@tensorflow/tfjs-core": "2.0.1"
   },
   "browserslist": [
     "defaults"
   ],
   "staticFiles": {
     "staticPath": "./node_modules/@tensorflow/tfjs-backend-wasm/dist",
-    "excludeGlob": [
-      "**/!(*.wasm)"
-    ]
+    "excludeGlob": ["**/!(*.wasm)"]
   },
   "devDependencies": {
     "@babel/core": "7.7.5",
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.7.6",
     "parcel-bundler": "^1.12.4",
-    "parcel-plugin-static-files-copy": "^2.5.0"
+    "parcel-plugin-static-files-copy": "^2.2.1"
   },
   "keywords": []
 }

--- a/tfjs-backend-wasm/starter/parcel/package.json
+++ b/tfjs-backend-wasm/starter/parcel/package.json
@@ -7,7 +7,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs-backend-webgl": "link:../../../tfjs-backend-webgl",
+    "@tensorflow/tfjs-backend-wasm": "link:../../../tfjs-backend-wasm",
     "@tensorflow/tfjs-converter": "link:../../../tfjs-converter",
     "@tensorflow/tfjs-core": "link:../../../tfjs-core"
   },

--- a/tfjs-backend-wasm/starter/parcel/package.json
+++ b/tfjs-backend-wasm/starter/parcel/package.json
@@ -7,22 +7,25 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs-backend-wasm": "2.0.1",
-    "@tensorflow/tfjs-core": "2.0.1"
+    "@tensorflow/tfjs-backend-webgl": "link:../../../tfjs-backend-webgl",
+    "@tensorflow/tfjs-converter": "link:../../../tfjs-converter",
+    "@tensorflow/tfjs-core": "link:../../../tfjs-core"
   },
   "browserslist": [
     "defaults"
   ],
   "staticFiles": {
     "staticPath": "./node_modules/@tensorflow/tfjs-backend-wasm/dist",
-    "excludeGlob": ["**/!(*.wasm)"]
+    "excludeGlob": [
+      "**/!(*.wasm)"
+    ]
   },
   "devDependencies": {
     "@babel/core": "7.7.5",
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.7.6",
     "parcel-bundler": "^1.12.4",
-    "parcel-plugin-static-files-copy": "^2.2.1"
+    "parcel-plugin-static-files-copy": "^2.5.0"
   },
   "keywords": []
 }

--- a/tfjs-backend-wasm/starter/parcel/yarn.lock
+++ b/tfjs-backend-wasm/starter/parcel/yarn.lock
@@ -765,29 +765,21 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow/tfjs-backend-wasm@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-backend-wasm/-/tfjs-backend-wasm-2.0.1.tgz#6551b3bd1de7079a481750e9dafeb59555261086"
-  integrity sha512-OYMPn3wPwuV4vYlgfqMaE9CICTvUEsNP/IkwJVaArzoN7txHZGikt+SQ3+lojh4MOUTN+9wxT1xkr05k7bivGg==
-  dependencies:
-    "@types/emscripten" "~0.0.34"
+"@tensorflow/tfjs-backend-cpu@link:../../../tfjs-backend-cpu":
+  version "0.0.0"
+  uid ""
 
-"@tensorflow/tfjs-core@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-2.0.1.tgz#c64928423028e9e1821f7205367b1ff1f57ae3af"
-  integrity sha512-LCmEXeGFgR3ai+ywGDYBqt4aCOSzEBlVKEflF1gAT22YcQuYh+/X4f58jY3yXfC+cn/FfIJFc2uj8b+D0MNWLQ==
-  dependencies:
-    "@types/offscreencanvas" "~2019.3.0"
-    "@types/seedrandom" "2.4.27"
-    "@types/webgl-ext" "0.0.30"
-    "@types/webgl2" "0.0.4"
-    node-fetch "~2.1.2"
-    seedrandom "2.4.3"
+"@tensorflow/tfjs-backend-webgl@link:../../../tfjs-backend-webgl":
+  version "0.0.0"
+  uid ""
 
-"@types/emscripten@~0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@types/emscripten/-/emscripten-0.0.34.tgz#12b4a344274fb102ff2f6c877b37587bc3e46008"
-  integrity sha512-QSb9ojDincskc+uKMI0KXp8e1NALFINCrMlp8VGKGcTSxeEyRTTKyjWw75NYrCZHUsVEEEpr1tYHpbtaC++/sQ==
+"@tensorflow/tfjs-converter@link:../../../tfjs-converter":
+  version "0.0.0"
+  uid ""
+
+"@tensorflow/tfjs-core@link:../../../tfjs-core":
+  version "0.0.0"
+  uid ""
 
 "@types/offscreencanvas@~2019.3.0":
   version "2019.3.0"
@@ -809,10 +801,10 @@
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
-  integrity sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw==
+"@types/webgl2@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
+  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 abab@^2.0.0:
   version "2.0.3"
@@ -2244,21 +2236,6 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
-file-match@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/file-match/-/file-match-1.0.2.tgz#c9cad265d2c8adf3a81475b0df475859069faef7"
-  integrity sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=
-  dependencies:
-    utils-extend "^1.0.6"
-
-file-system@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/file-system/-/file-system-2.2.2.tgz#7d65833e3a2347dcd956a813c677153ed3edd987"
-  integrity sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=
-  dependencies:
-    file-match "^1.0.1"
-    utils-extend "^1.0.4"
-
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -3331,10 +3308,10 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
   integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
 
-node-fetch@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+node-fetch@~2.6.1:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.7.1:
   version "0.7.6"
@@ -3715,12 +3692,11 @@ parcel-bundler@^1.12.4:
     v8-compile-cache "^2.0.0"
     ws "^5.1.1"
 
-parcel-plugin-static-files-copy@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/parcel-plugin-static-files-copy/-/parcel-plugin-static-files-copy-2.2.1.tgz#22fdf02df427f80a6e7cad7185f2d6926286f2ec"
-  integrity sha512-Mj//+258Q05ZL72uD1VDJZ7jOW4PuwJO5WNM7ODpgHtDwXlhIURklSX0Ua8J4d/Vr1xWkNCg2HIVlhacdZ3M3w==
+parcel-plugin-static-files-copy@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/parcel-plugin-static-files-copy/-/parcel-plugin-static-files-copy-2.5.0.tgz#8ab26f331d163cd023d283fc0ef5fcd779fe5948"
+  integrity sha512-5rxOPw3iV+WXhePfByoIxsUlL4I0o95CgcF31gwgnhPuj2q6tVPuzEAJsag9bWJr5Vd/SXFPTNsUAGAg4jP07Q==
   dependencies:
-    file-system "2.2.2"
     minimatch "3.0.4"
     path "0.12.7"
 
@@ -5291,11 +5267,6 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
-
-utils-extend@^1.0.4, utils-extend@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/utils-extend/-/utils-extend-1.0.8.tgz#ccfd7b64540f8e90ee21eec57769d0651cab8a5f"
-  integrity sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8=
 
 uuid@^3.3.2:
   version "3.3.3"

--- a/tfjs-backend-wasm/starter/parcel/yarn.lock
+++ b/tfjs-backend-wasm/starter/parcel/yarn.lock
@@ -769,7 +769,7 @@
   version "0.0.0"
   uid ""
 
-"@tensorflow/tfjs-backend-webgl@link:../../../tfjs-backend-webgl":
+"@tensorflow/tfjs-backend-wasm@link:../..":
   version "0.0.0"
   uid ""
 
@@ -780,6 +780,11 @@
 "@tensorflow/tfjs-core@link:../../../tfjs-core":
   version "0.0.0"
   uid ""
+
+"@types/emscripten@~0.0.34":
+  version "0.0.34"
+  resolved "https://registry.npmjs.org/@types/emscripten/-/emscripten-0.0.34.tgz#12b4a344274fb102ff2f6c877b37587bc3e46008"
+  integrity sha512-QSb9ojDincskc+uKMI0KXp8e1NALFINCrMlp8VGKGcTSxeEyRTTKyjWw75NYrCZHUsVEEEpr1tYHpbtaC++/sQ==
 
 "@types/offscreencanvas@~2019.3.0":
   version "2019.3.0"
@@ -800,11 +805,6 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
-
-"@types/webgl2@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
-  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 abab@^2.0.0:
   version "2.0.3"

--- a/tfjs-backend-wasm/starter/parcel/yarn.lock
+++ b/tfjs-backend-wasm/starter/parcel/yarn.lock
@@ -765,21 +765,24 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow/tfjs-backend-cpu@link:../../../tfjs-backend-cpu":
-  version "0.0.0"
-  uid ""
+"@tensorflow/tfjs-backend-wasm@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@tensorflow/tfjs-backend-wasm/-/tfjs-backend-wasm-2.0.1.tgz#6551b3bd1de7079a481750e9dafeb59555261086"
+  integrity sha512-OYMPn3wPwuV4vYlgfqMaE9CICTvUEsNP/IkwJVaArzoN7txHZGikt+SQ3+lojh4MOUTN+9wxT1xkr05k7bivGg==
+  dependencies:
+    "@types/emscripten" "~0.0.34"
 
-"@tensorflow/tfjs-backend-wasm@link:../..":
-  version "0.0.0"
-  uid ""
-
-"@tensorflow/tfjs-converter@link:../../../tfjs-converter":
-  version "0.0.0"
-  uid ""
-
-"@tensorflow/tfjs-core@link:../../../tfjs-core":
-  version "0.0.0"
-  uid ""
+"@tensorflow/tfjs-core@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.0.1.tgz#c64928423028e9e1821f7205367b1ff1f57ae3af"
+  integrity sha512-LCmEXeGFgR3ai+ywGDYBqt4aCOSzEBlVKEflF1gAT22YcQuYh+/X4f58jY3yXfC+cn/FfIJFc2uj8b+D0MNWLQ==
+  dependencies:
+    "@types/offscreencanvas" "~2019.3.0"
+    "@types/seedrandom" "2.4.27"
+    "@types/webgl-ext" "0.0.30"
+    "@types/webgl2" "0.0.4"
+    node-fetch "~2.1.2"
+    seedrandom "2.4.3"
 
 "@types/emscripten@~0.0.34":
   version "0.0.34"
@@ -805,6 +808,11 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
+
+"@types/webgl2@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
+  integrity sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw==
 
 abab@^2.0.0:
   version "2.0.3"
@@ -3308,10 +3316,10 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
   integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
 
-node-fetch@~2.6.1:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-forge@^0.7.1:
   version "0.7.6"
@@ -3692,7 +3700,7 @@ parcel-bundler@^1.12.4:
     v8-compile-cache "^2.0.0"
     ws "^5.1.1"
 
-parcel-plugin-static-files-copy@^2.5.0:
+parcel-plugin-static-files-copy@^2.2.1:
   version "2.5.0"
   resolved "https://registry.npmjs.org/parcel-plugin-static-files-copy/-/parcel-plugin-static-files-copy-2.5.0.tgz#8ab26f331d163cd023d283fc0ef5fcd779fe5948"
   integrity sha512-5rxOPw3iV+WXhePfByoIxsUlL4I0o95CgcF31gwgnhPuj2q6tVPuzEAJsag9bWJr5Vd/SXFPTNsUAGAg4jP07Q==

--- a/tfjs-backend-webgl/src/conv_gpu.ts
+++ b/tfjs-backend-webgl/src/conv_gpu.ts
@@ -25,7 +25,8 @@ export class Conv2DProgram implements GPGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivationWeights = false) {
+      activation: string = null, hasPreluActivationWeights = false,
+      hasLeakyreluAlpha = false) {
     this.outputShape = convInfo.outShape;
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
@@ -51,6 +52,11 @@ export class Conv2DProgram implements GPGPUProgram {
           float b = getPreluActivationWeightsAtOutCoords();
           ${activation}
         }`;
+      } else if (hasLeakyreluAlpha) {
+        activationSnippet = `float activation(float a) {
+          float b = getLeakyreluAlphaAtOutCoords();
+          ${activation}
+        }`;
       } else {
         activationSnippet = `
           float activation(float x) {
@@ -69,6 +75,10 @@ export class Conv2DProgram implements GPGPUProgram {
 
     if (hasPreluActivationWeights) {
       this.variableNames.push('preluActivationWeights');
+    }
+
+    if (hasLeakyreluAlpha) {
+      this.variableNames.push('leakyreluAlpha');
     }
 
     this.userCode = `

--- a/tfjs-backend-webgl/src/conv_gpu_depthwise.ts
+++ b/tfjs-backend-webgl/src/conv_gpu_depthwise.ts
@@ -25,7 +25,8 @@ export class DepthwiseConv2DProgram implements GPGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivation = false) {
+      activation: string = null, hasPreluActivation = false,
+      hasLeakyReluAlpha = false) {
     this.outputShape = convInfo.outShape;
 
     const xNumRows = convInfo.inHeight;
@@ -47,6 +48,11 @@ export class DepthwiseConv2DProgram implements GPGPUProgram {
           float b = getPreluActivationWeightsAtOutCoords();
           ${activation}
         }`;
+      } else if (hasLeakyReluAlpha) {
+        activationSnippet = `float activation(float a) {
+          float b = getLeakyReluAlphaAtOutCoords();
+          ${activation}
+        }`;
       } else {
         activationSnippet = `
           float activation(float x) {
@@ -65,6 +71,9 @@ export class DepthwiseConv2DProgram implements GPGPUProgram {
 
     if (hasPreluActivation) {
       this.variableNames.push('preluActivationWeights');
+    }
+    if (hasLeakyReluAlpha) {
+      this.variableNames.push('leakyreluAlpha');
     }
 
     this.userCode = `

--- a/tfjs-backend-webgl/src/conv_gpu_depthwise.ts
+++ b/tfjs-backend-webgl/src/conv_gpu_depthwise.ts
@@ -50,7 +50,7 @@ export class DepthwiseConv2DProgram implements GPGPUProgram {
         }`;
       } else if (hasLeakyReluAlpha) {
         activationSnippet = `float activation(float a) {
-          float b = getLeakyReluAlphaAtOutCoords();
+          float b = getLeakyreluAlphaAtOutCoords();
           ${activation}
         }`;
       } else {

--- a/tfjs-backend-webgl/src/conv_packed_gpu_depthwise.ts
+++ b/tfjs-backend-webgl/src/conv_packed_gpu_depthwise.ts
@@ -286,7 +286,7 @@ export class DepthwiseConvPacked2DProgram implements GPGPUProgram {
         }`;
       } else if (hasLeakyReluAlpha) {
         activationSnippet = `vec4 activation(vec4 a) {
-          vec4 b = getLeakyReluAlphaAtOutCoords();
+          vec4 b = getLeakyreluAlphaAtOutCoords();
           ${activation}
         }`;
       } else {

--- a/tfjs-backend-webgl/src/conv_packed_gpu_depthwise.ts
+++ b/tfjs-backend-webgl/src/conv_packed_gpu_depthwise.ts
@@ -28,7 +28,8 @@ export class DepthwiseConvPacked2DProgram implements GPGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivation = false) {
+      activation: string = null, hasPreluActivation = false,
+      hasLeakyReluAlpha = false) {
     this.outputShape = convInfo.outShape;
 
     const xNumRows = convInfo.inHeight;
@@ -283,6 +284,11 @@ export class DepthwiseConvPacked2DProgram implements GPGPUProgram {
           vec4 b = getPreluActivationWeightsAtOutCoords();
           ${activation}
         }`;
+      } else if (hasLeakyReluAlpha) {
+        activationSnippet = `vec4 activation(vec4 a) {
+          vec4 b = getLeakyReluAlphaAtOutCoords();
+          ${activation}
+        }`;
       } else {
         activationSnippet = `vec4 activation(vec4 x) {
           ${activation}
@@ -299,6 +305,9 @@ export class DepthwiseConvPacked2DProgram implements GPGPUProgram {
 
     if (hasPreluActivation) {
       this.variableNames.push('preluActivationWeights');
+    }
+    if (hasLeakyReluAlpha) {
+      this.variableNames.push('leakyreluAlpha');
     }
 
     this.userCode = `

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -79,7 +79,6 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
     }
     return {name: program.variableNames[i], shapeInfo};
   });
-  console.log(inputInfos);
   const inShapeInfos = inputInfos.map(x => x.shapeInfo);
   const outShapeInfo: ShapeInfo = {
     logicalShape: output.shape,

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -79,6 +79,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
     }
     return {name: program.variableNames[i], shapeInfo};
   });
+  console.log(inputInfos);
   const inShapeInfos = inputInfos.map(x => x.shapeInfo);
   const outShapeInfo: ShapeInfo = {
     logicalShape: output.shape,

--- a/tfjs-backend-webgl/src/kernel_utils/kernel_funcs_utils.ts
+++ b/tfjs-backend-webgl/src/kernel_utils/kernel_funcs_utils.ts
@@ -21,6 +21,7 @@ import {MathBackendWebGL} from '../backend_webgl';
 import {BinaryOpProgram} from '../binaryop_gpu';
 import {BinaryOpPackedProgram} from '../binaryop_packed_gpu';
 import {complex} from '../kernels/Complex';
+import {LEAKYRELU, LEAKYRELU_PACKED} from '../kernels/LeakyRelu';
 import {PRELU, PRELU_PACKED} from '../kernels/Prelu';
 import * as unary_op from '../unaryop_gpu';
 import {UnaryOpProgram} from '../unaryop_gpu';
@@ -209,6 +210,11 @@ export function mapActivationToShaderProgram(
       return PRELU_PACKED;
     }
     return PRELU;
+  } else if (activation === 'leakyrelu') {
+    if (packed) {
+      return LEAKYRELU_PACKED;
+    }
+    return LEAKYRELU;
   }
   throw new Error(`Activation ${
       activation} has not been implemented for the WebGL backend.`);

--- a/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, fill, TensorInfo, upcastType, util} from '@tensorflow/tfjs-core';
+import {backend_util, TensorInfo, upcastType, util} from '@tensorflow/tfjs-core';
 
 import {MathBackendWebGL} from '../backend_webgl';
 import {mapActivationToShaderProgram} from '../kernel_utils/kernel_funcs_utils';
@@ -172,14 +172,24 @@ export function batchMatMulImpl({
     if (bias != null) {
       inputs.push(bias);
     }
-    if (preluActivationWeights != null) {
+    if (hasPreluActivationWeights) {
       inputs.push(preluActivationWeights);
     }
-    if (leakyreluAlpha != null) {
-      const $leakyreluAlpha = fill(bias.shape, leakyreluAlpha, 'float32');
+    if (hasLeakyreluAlpha) {
+      const $leakyreluAlpha = backend.makeTensorInfo(
+          [], 'float32',
+          util.createScalarValue(leakyreluAlpha as {} as 'float32', 'float32'));
       inputs.push($leakyreluAlpha);
+      intermediates.push($leakyreluAlpha);
     }
 
+    console.log('hellohellohello');
+    console.log(hasLeakyreluAlpha);
+    console.log(program.variableNames);
+    console.log('===');
+    console.log(fusedActivation);
+    console.log('===');
+    console.log(program.userCode);
     out = backend.runWebGLProgram(program, inputs, dtype);
   }
 

--- a/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
@@ -51,7 +51,7 @@ export function batchMatMulImpl({
   backend,
   bias = null,
   preluActivationWeights = null,
-  leakyreluAlpha = null,
+  leakyreluAlpha = 0,
   activation = null
 }: BatchMatMulConfig): TensorInfo {
   const aRank = a.shape.length;
@@ -107,8 +107,7 @@ export function batchMatMulImpl({
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha =
-      (activation === 'leakyrelu') && (leakyreluAlpha != null);
+  const hasLeakyreluAlpha = activation === 'leakyrelu';
   const fusedActivation = activation != null ?
       mapActivationToShaderProgram(activation, true) :
       null;

--- a/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
@@ -107,7 +107,7 @@ export function batchMatMulImpl({
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha = leakyreluAlpha != null;
+  const hasLeakyreluAlpha = !!leakyreluAlpha;
   const fusedActivation = activation != null ?
       mapActivationToShaderProgram(activation, true) :
       null;
@@ -183,13 +183,6 @@ export function batchMatMulImpl({
       intermediates.push($leakyreluAlpha);
     }
 
-    console.log('hellohellohello');
-    console.log(hasLeakyreluAlpha);
-    console.log(program.variableNames);
-    console.log('===');
-    console.log(fusedActivation);
-    console.log('===');
-    console.log(program.userCode);
     out = backend.runWebGLProgram(program, inputs, dtype);
   }
 

--- a/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/BatchMatMul_impl.ts
@@ -107,7 +107,8 @@ export function batchMatMulImpl({
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha = !!leakyreluAlpha;
+  const hasLeakyreluAlpha =
+      (activation === 'leakyrelu') && (leakyreluAlpha != null);
   const fusedActivation = activation != null ?
       mapActivationToShaderProgram(activation, true) :
       null;

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -240,7 +240,8 @@ export function conv2dWithIm2Row({
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha = !!leakyreluAlpha;
+  const hasLeakyreluAlpha =
+      (activation === 'leakyrelu') && (leakyreluAlpha != null);
   const fusedActivation =
       activation ? mapActivationToShaderProgram(activation, true) : null;
   const matmulProgram = new MatMulPackedProgram(

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -48,7 +48,7 @@ export function conv2dByMatMul({
   backend,
   bias = null,
   preluActivationWeights = null,
-  leakyreluAlpha = null,
+  leakyreluAlpha = 0,
   activation = null
 }: Conv2DConfig) {
   // Reshapes conv2D input to 2D tensors, uses matMul and then reshape the
@@ -187,7 +187,7 @@ export function conv2dWithIm2Row({
   backend,
   bias = null,
   preluActivationWeights = null,
-  leakyreluAlpha = null,
+  leakyreluAlpha = 0,
   activation = null
 }: Conv2DConfig) {
   // Rearranges conv2d input so each block to be convolved over forms the
@@ -240,8 +240,7 @@ export function conv2dWithIm2Row({
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha =
-      (activation === 'leakyrelu') && (leakyreluAlpha != null);
+  const hasLeakyreluAlpha = activation === 'leakyrelu';
   const fusedActivation =
       activation ? mapActivationToShaderProgram(activation, true) : null;
   const matmulProgram = new MatMulPackedProgram(

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -240,7 +240,7 @@ export function conv2dWithIm2Row({
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha = leakyreluAlpha != null;
+  const hasLeakyreluAlpha = !!leakyreluAlpha;
   const fusedActivation =
       activation ? mapActivationToShaderProgram(activation, true) : null;
   const matmulProgram = new MatMulPackedProgram(

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -260,6 +260,7 @@ export function conv2dWithIm2Row({
         [], 'float32',
         util.createScalarValue(leakyreluAlpha as {} as 'float32', 'float32'));
     inputs.push($leakyreluAlpha);
+    intermediates.push($leakyreluAlpha);
   }
   const product = backend.runWebGLProgram(matmulProgram, inputs, 'float32');
 

--- a/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
@@ -77,8 +77,7 @@ export function fusedConv2d(args: {
   } else {
     const hasBias = bias != null;
     const hasPreluActivationWeights = preluActivationWeights != null;
-    const hasLeakyreluAlpha =
-        (activation === 'leakyrelu') && (leakyreluAlpha != null);
+    const hasLeakyreluAlpha = activation === 'leakyrelu';
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, false) : null;
     const program = new Conv2DProgram(

--- a/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, env, fill, FusedConv2D, FusedConv2DAttrs, FusedConv2DInputs, KernelConfig, KernelFunc, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, env, FusedConv2D, FusedConv2DAttrs, FusedConv2DInputs, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {MathBackendWebGL} from '../backend_webgl';
 import {Conv2DProgram} from '../conv_gpu';
@@ -89,8 +89,10 @@ export function fusedConv2d(args: {
     if (preluActivationWeights) {
       inputs.push(preluActivationWeights);
     }
-    if (leakyreluAlpha) {
-      const $leakyreluAlpha = fill(x.shape, leakyreluAlpha, 'float32');
+    if (hasLeakyreluAlpha) {
+      const $leakyreluAlpha = backend.makeTensorInfo(
+          [], 'float32',
+          util.createScalarValue(leakyreluAlpha as {} as 'float32', 'float32'));
       inputs.push($leakyreluAlpha);
     }
     out = backend.runWebGLProgram(program, inputs, 'float32');

--- a/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
@@ -77,9 +77,14 @@ export function fusedConv2d(args: {
   } else {
     const hasBias = bias != null;
     const hasPreluActivationWeights = preluActivationWeights != null;
-    const hasLeakyreluAlpha = leakyreluAlpha != null;
+    const hasLeakyreluAlpha = !!leakyreluAlpha;
+    console.log('hihihi');
+    console.log(hasLeakyreluAlpha);
+    console.log(leakyreluAlpha);
+    console.log(activation);
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, false) : null;
+    console.log(fusedActivation);
     const program = new Conv2DProgram(
         convInfo, hasBias, fusedActivation, hasPreluActivationWeights,
         hasLeakyreluAlpha);

--- a/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
@@ -77,7 +77,8 @@ export function fusedConv2d(args: {
   } else {
     const hasBias = bias != null;
     const hasPreluActivationWeights = preluActivationWeights != null;
-    const hasLeakyreluAlpha = !!leakyreluAlpha;
+    const hasLeakyreluAlpha =
+        (activation === 'leakyrelu') && (leakyreluAlpha != null);
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, false) : null;
     const program = new Conv2DProgram(

--- a/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedConv2D.ts
@@ -78,13 +78,8 @@ export function fusedConv2d(args: {
     const hasBias = bias != null;
     const hasPreluActivationWeights = preluActivationWeights != null;
     const hasLeakyreluAlpha = !!leakyreluAlpha;
-    console.log('hihihi');
-    console.log(hasLeakyreluAlpha);
-    console.log(leakyreluAlpha);
-    console.log(activation);
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, false) : null;
-    console.log(fusedActivation);
     const program = new Conv2DProgram(
         convInfo, hasBias, fusedActivation, hasPreluActivationWeights,
         hasLeakyreluAlpha);

--- a/tfjs-backend-webgl/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedDepthwiseConv2D.ts
@@ -56,7 +56,7 @@ export function fusedDepthwiseConv2D(args: {
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha = leakyreluAlpha != null;
+  const hasLeakyreluAlpha = !!leakyreluAlpha;
   if (hasBias) {
     programInputs.push(bias);
   }

--- a/tfjs-backend-webgl/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedDepthwiseConv2D.ts
@@ -28,7 +28,7 @@ export function fusedDepthwiseConv2D(args: {
   backend: MathBackendWebGL
 }) {
   const {inputs, backend, attrs} = args;
-  const {x, filter, bias, preluActivationWeights} = inputs;
+  const {x, filter, bias, preluActivationWeights, leakyreluAlpha} = inputs;
   const {strides, pad, dilations, dimRoundingMode, activation} = attrs;
 
   let $dilations = dilations;
@@ -56,20 +56,26 @@ export function fusedDepthwiseConv2D(args: {
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
+  const hasLeakyreluAlpha = leakyreluAlpha != null;
   if (hasBias) {
     programInputs.push(bias);
   }
   if (hasPreluActivationWeights) {
     programInputs.push(preluActivationWeights);
   }
+  if (hasLeakyreluAlpha) {
+    programInputs.push(leakyreluAlpha);
+  }
 
   let program: DepthwiseConv2DProgram|DepthwiseConvPacked2DProgram;
   if (shouldPackDepthwiseConv) {
     program = new DepthwiseConvPacked2DProgram(
-        convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+        convInfo, hasBias, fusedActivation, hasPreluActivationWeights,
+        hasLeakyreluAlpha);
   } else {
     program = new DepthwiseConv2DProgram(
-        convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+        convInfo, hasBias, fusedActivation, hasPreluActivationWeights,
+        hasLeakyreluAlpha);
   }
 
   return backend.runWebGLProgram(program, programInputs, 'float32');

--- a/tfjs-backend-webgl/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgl/src/kernels/FusedDepthwiseConv2D.ts
@@ -59,8 +59,7 @@ export function fusedDepthwiseConv2D(args: {
 
   const hasBias = bias != null;
   const hasPreluActivationWeights = preluActivationWeights != null;
-  const hasLeakyreluAlpha =
-      (activation === 'leakyrelu') && (leakyreluAlpha != null);
+  const hasLeakyreluAlpha = activation === 'leakyrelu';
 
   if (hasBias) {
     programInputs.push(bias);

--- a/tfjs-backend-webgl/src/kernels/LeakyRelu.ts
+++ b/tfjs-backend-webgl/src/kernels/LeakyRelu.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {env, KernelConfig, KernelFunc, LeakyRelu, LeakyReluAttrs, LeakyReluInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {MathBackendWebGL} from '../backend_webgl';
+import {BinaryOpProgram} from '../binaryop_gpu';
+import {BinaryOpPackedProgram} from '../binaryop_packed_gpu';
+
+export const LEAKYRELU = `return (a < 0.) ? b * a : a;`;
+export const LEAKYRELU_PACKED = `
+  vec4 aLessThanZero = vec4(lessThan(a, vec4(0.)));
+  return (aLessThanZero * (b * a)) + ((vec4(1.0) - aLessThanZero) * a);
+`;
+
+export function leakyRelu(args: {
+  inputs: LeakyReluInputs,
+  backend: MathBackendWebGL,
+  attrs: LeakyReluAttrs
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x} = inputs;
+  const {alpha} = attrs;
+
+  const $alpha = backend.makeTensorInfo(
+      [], 'float32',
+      util.createScalarValue(alpha as {} as 'float32', 'float32'));
+
+  const program = env().getBool('WEBGL_PACK_BINARY_OPERATIONS') ?
+      new BinaryOpPackedProgram(LEAKYRELU_PACKED, x.shape, $alpha.shape) :
+      new BinaryOpProgram(LEAKYRELU, x.shape, $alpha.shape);
+  const result = backend.runWebGLProgram(program, [x, $alpha], x.dtype);
+
+  backend.disposeIntermediateTensorInfo($alpha);
+
+  return result;
+}
+
+export const leakyReluConfig: KernelConfig = {
+  kernelName: LeakyRelu,
+  backendName: 'webgl',
+  kernelFunc: leakyRelu as {} as KernelFunc
+};

--- a/tfjs-backend-webgl/src/kernels/_FusedMatMul.ts
+++ b/tfjs-backend-webgl/src/kernels/_FusedMatMul.ts
@@ -27,7 +27,7 @@ export function _fusedMatMul(args: {
 }) {
   const {inputs, backend, attrs} = args;
   const {a, b, bias, preluActivationWeights} = inputs;
-  const {transposeA, transposeB, activation} = attrs;
+  const {transposeA, transposeB, activation, leakyreluAlpha} = attrs;
 
   return batchMatMulImpl({
     a,
@@ -37,6 +37,7 @@ export function _fusedMatMul(args: {
     backend,
     bias,
     preluActivationWeights,
+    leakyreluAlpha,
     activation
   });
 }

--- a/tfjs-backend-webgl/src/kernels/_FusedMatMul.ts
+++ b/tfjs-backend-webgl/src/kernels/_FusedMatMul.ts
@@ -29,6 +29,8 @@ export function _fusedMatMul(args: {
   const {a, b, bias, preluActivationWeights} = inputs;
   const {transposeA, transposeB, activation, leakyreluAlpha} = attrs;
 
+  console.log('in _fusedMatMul');
+  console.log(leakyreluAlpha);
   return batchMatMulImpl({
     a,
     b,

--- a/tfjs-backend-webgl/src/kernels/_FusedMatMul.ts
+++ b/tfjs-backend-webgl/src/kernels/_FusedMatMul.ts
@@ -29,8 +29,6 @@ export function _fusedMatMul(args: {
   const {a, b, bias, preluActivationWeights} = inputs;
   const {transposeA, transposeB, activation, leakyreluAlpha} = attrs;
 
-  console.log('in _fusedMatMul');
-  console.log(leakyreluAlpha);
   return batchMatMulImpl({
     a,
     b,

--- a/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
@@ -28,7 +28,7 @@ export class MatMulPackedProgram implements GPGPUProgram {
       aShape: [number, number, number], bShape: [number, number, number],
       outputShape: [number, number, number], transposeA = false,
       transposeB = false, addBias = false, activation: string = null,
-      hasPreluActivation = false) {
+      hasPreluActivation = false, hasLeakyreluActivation = false) {
     this.outputShape = outputShape;
 
     const sharedDim = transposeA ? aShape[1] : aShape[2];
@@ -44,6 +44,11 @@ export class MatMulPackedProgram implements GPGPUProgram {
       if (hasPreluActivation) {
         activationSnippet = `vec4 activation(vec4 a) {
           vec4 b = getPreluActivationWeightsAtOutCoords();
+          ${activation}
+        }`;
+      } else if (hasLeakyreluActivation) {
+        activationSnippet = `vec4 activation(vec4 a) {
+          float b = getLeakyreluAlphaAtOutCoords().r;
           ${activation}
         }`;
       } else {
@@ -62,6 +67,10 @@ export class MatMulPackedProgram implements GPGPUProgram {
 
     if (hasPreluActivation) {
       this.variableNames.push('preluActivationWeights');
+    }
+
+    if (hasLeakyreluActivation) {
+      this.variableNames.push('leakyreluAlpha');
     }
 
     let batchASnippet = 'rc.x';

--- a/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
@@ -48,7 +48,7 @@ export class MatMulPackedProgram implements GPGPUProgram {
         }`;
       } else if (hasLeakyreluActivation) {
         activationSnippet = `vec4 activation(vec4 a) {
-          float b = getLeakyreluAlphaAtOutCoords().r;
+          vec4 b = getLeakyreluAlphaAtOutCoords();
           ${activation}
         }`;
       } else {

--- a/tfjs-backend-webgl/src/register_all_kernels.ts
+++ b/tfjs-backend-webgl/src/register_all_kernels.ts
@@ -84,6 +84,7 @@ import {imagConfig} from './kernels/Imag';
 import {isFiniteConfig} from './kernels/IsFinite';
 import {isInfConfig} from './kernels/IsInf';
 import {isNaNConfig} from './kernels/IsNaN';
+import {leakyReluConfig} from './kernels/LeakyRelu';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
 import {linSpaceConfig} from './kernels/LinSpace';
@@ -236,6 +237,7 @@ const kernelConfigs: KernelConfig[] = [
   isFiniteConfig,
   isInfConfig,
   isNaNConfig,
+  leakyReluConfig,
   lessConfig,
   lessEqualConfig,
   linSpaceConfig,

--- a/tfjs-converter/python/tensorflowjs/op_list/convolution.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/convolution.json
@@ -390,6 +390,11 @@
         "name": "epsilon",
         "type": "number",
         "defaultValue": 0.0001
+      },
+      {
+        "tfName": "leakyrelu_alpha",
+        "name": "leakyreluAlpha",
+        "type": "number"
       }
     ]
   },

--- a/tfjs-converter/src/operations/executors/convolution_executor.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor.ts
@@ -61,6 +61,8 @@ function fusedConvAndDepthWiseParams(
       getParamValue('dilations', node, tensorMap, context) as number[];
   const [biasArg, preluArg] =
       getParamValue('args', node, tensorMap, context) as Tensor[];
+  const leakyreluAlpha =
+      getParamValue('leakyreluAlpha', node, tensorMap, context) as number;
 
   return {
     stride,
@@ -69,7 +71,8 @@ function fusedConvAndDepthWiseParams(
     dilations,
     biasArg,
     preluArg,
-    activationFunc
+    activationFunc,
+    leakyreluAlpha
   };
 }
 
@@ -116,7 +119,8 @@ export const executeOp: InternalOpExecutor =
             dilations,
             biasArg,
             preluArg,
-            activationFunc
+            activationFunc,
+            leakyreluAlpha
           } = fusedConvAndDepthWiseParams(node, tensorMap, context);
 
           return [tfOps.fused.conv2d({
@@ -130,7 +134,8 @@ export const executeOp: InternalOpExecutor =
             dilations: [dilations[1], dilations[2]],
             bias: biasArg,
             activation: activationFunc as tfOps.fused.Activation,
-            preluActivationWeights: preluArg
+            preluActivationWeights: preluArg,
+            leakyreluAlpha
           })];
         }
 

--- a/tfjs-converter/src/operations/executors/convolution_executor.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor.ts
@@ -147,7 +147,8 @@ export const executeOp: InternalOpExecutor =
             dilations,
             biasArg,
             preluArg,
-            activationFunc
+            activationFunc,
+            leakyreluAlpha,
           } = fusedConvAndDepthWiseParams(node, tensorMap, context);
 
           return [tfOps.fused.depthwiseConv2d({
@@ -161,7 +162,8 @@ export const executeOp: InternalOpExecutor =
             dilations: [dilations[1], dilations[2]],
             bias: biasArg,
             activation: activationFunc as tfOps.fused.Activation,
-            preluActivationWeights: preluArg
+            preluActivationWeights: preluArg,
+            leakyreluAlpha
           })];
         }
         case 'Conv2DBackpropInput':

--- a/tfjs-converter/src/operations/executors/convolution_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/convolution_executor_test.ts
@@ -325,7 +325,8 @@ describe('convolution', () => {
           dilations: [2, 2],
           bias: input3[0],
           activation: 'relu',
-          preluActivationWeights: undefined
+          preluActivationWeights: undefined,
+          leakyreluAlpha: undefined
         });
       });
       it('should support explicit padding', () => {
@@ -357,7 +358,8 @@ describe('convolution', () => {
           dilations: [2, 2],
           bias: input3[0],
           activation: 'relu',
-          preluActivationWeights: undefined
+          preluActivationWeights: undefined,
+          leakyreluAlpha: undefined
         });
       });
       it('with bias and prelu activation func', () => {
@@ -387,7 +389,40 @@ describe('convolution', () => {
           dilations: [2, 2],
           bias: input3[0],
           activation: 'prelu',
-          preluActivationWeights: input4[0]
+          preluActivationWeights: input4[0],
+          leakyreluAlpha: undefined
+        });
+      });
+      it('with bias and leakyrelu activation func', () => {
+        spyOn(tfOps.fused, 'conv2d');
+        node.op = '_FusedConv2D';
+        node.inputParams['filter'] = createTensorAttr(1);
+        node.inputParams['args'] = createTensorsAttr(2, 0);
+        node.attrParams['fusedOps'] =
+            createStrArrayAttr(['biasadd', 'leakyrelu']);
+        node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
+        node.attrParams['pad'] = createStrAttr('same');
+        node.attrParams['dataFormat'] = createStrAttr('NHWC');
+        node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
+        node.attrParams['numArgs'] = createNumberAttr(1);
+        node.attrParams['leakyreluAlpha'] = createNumberAttr(0.3);
+        const input1 = [tfOps.scalar(1.0)];
+        const input2 = [tfOps.scalar(2.0)];
+        const input3 = [tfOps.scalar(3.0)];
+        node.inputNames = ['input1', 'input2', 'input3'];
+        executeOp(node, {input1, input2, input3}, context);
+
+        expect(tfOps.fused.conv2d).toHaveBeenCalledWith({
+          x: input1[0],
+          filter: input2[0],
+          strides: [2, 2],
+          pad: 'same',
+          dataFormat: 'NHWC',
+          dilations: [2, 2],
+          bias: input3[0],
+          activation: 'leakyrelu',
+          preluActivationWeights: undefined,
+          leakyreluAlpha: 0.3
         });
       });
 
@@ -418,7 +453,8 @@ describe('convolution', () => {
           dilations: [2, 2],
           bias: input3[0],
           activation: undefined,
-          preluActivationWeights: undefined
+          preluActivationWeights: undefined,
+          leakyreluAlpha: undefined
         });
       });
       it('fail with batchnorm', () => {
@@ -472,7 +508,8 @@ describe('convolution', () => {
         dilations: [2, 2],
         bias: input3[0],
         activation: 'relu',
-        preluActivationWeights: undefined
+        preluActivationWeights: undefined,
+        leakyreluAlpha: undefined
       });
     });
     it('with bias and activation func', () => {
@@ -502,7 +539,8 @@ describe('convolution', () => {
         dilations: [2, 2],
         bias: input3[0],
         activation: 'relu',
-        preluActivationWeights: undefined
+        preluActivationWeights: undefined,
+        leakyreluAlpha: undefined
       });
     });
     it('with bias and prelu activation func', () => {
@@ -532,7 +570,40 @@ describe('convolution', () => {
         dilations: [2, 2],
         bias: input3[0],
         activation: 'prelu',
-        preluActivationWeights: input4[0]
+        preluActivationWeights: input4[0],
+        leakyreluAlpha: undefined
+      });
+    });
+    it('with bias and leakyrelu activation func', () => {
+      spyOn(tfOps.fused, 'depthwiseConv2d');
+      node.op = 'FusedDepthwiseConv2dNative';
+      node.inputParams['filter'] = createTensorAttr(1);
+      node.inputParams['args'] = createTensorsAttr(2, 0);
+      node.attrParams['fusedOps'] =
+          createStrArrayAttr(['biasadd', 'leakyrelu']);
+      node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['pad'] = createStrAttr('same');
+      node.attrParams['dataFormat'] = createStrAttr('NHWC');
+      node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
+      node.attrParams['numArgs'] = createNumberAttr(1);
+      node.attrParams['leakyreluAlpha'] = createNumberAttr(0.3);
+      const input1 = [tfOps.scalar(1.0)];
+      const input2 = [tfOps.scalar(2.0)];
+      const input3 = [tfOps.scalar(3.0)];
+      node.inputNames = ['input1', 'input2', 'input3'];
+      executeOp(node, {input1, input2, input3}, context);
+
+      expect(tfOps.fused.depthwiseConv2d).toHaveBeenCalledWith({
+        x: input1[0],
+        filter: input2[0],
+        strides: [2, 2],
+        pad: 'same',
+        dataFormat: 'NHWC',
+        dilations: [2, 2],
+        bias: input3[0],
+        activation: 'leakyrelu',
+        preluActivationWeights: undefined,
+        leakyreluAlpha: 0.3
       });
     });
 
@@ -563,7 +634,8 @@ describe('convolution', () => {
         dilations: [2, 2],
         bias: input3[0],
         activation: undefined,
-        preluActivationWeights: undefined
+        preluActivationWeights: undefined,
+        leakyreluAlpha: undefined
       });
     });
   });

--- a/tfjs-converter/src/operations/executors/matrices_executor.ts
+++ b/tfjs-converter/src/operations/executors/matrices_executor.ts
@@ -53,6 +53,10 @@ export const executeOp: InternalOpExecutor =
 
           const numArgs =
               (getParamValue('numArgs', node, tensorMap, context) as number);
+          const leakyreluAlpha =
+              getParamValue('leakyreluAlpha', node, tensorMap, context) as
+              number;
+
           if (isBiasAdd) {
             if (isPrelu && numArgs !== 2) {
               throw new Error(
@@ -75,7 +79,8 @@ export const executeOp: InternalOpExecutor =
                 boolean,
             bias: biasArg,
             activation: activationFunc as tfOps.fused.Activation,
-            preluActivationWeights: preluArg
+            preluActivationWeights: preluArg,
+            leakyreluAlpha
           })];
 
         default:

--- a/tfjs-converter/src/operations/executors/matrices_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/matrices_executor_test.ts
@@ -75,7 +75,8 @@ describe('matrices', () => {
           transposeB: false,
           bias: input3[0],
           activation: 'relu',
-          preluActivationWeights: undefined
+          preluActivationWeights: undefined,
+          leakyreluAlpha: undefined
         });
       });
       it('should call tfOps.fused.matMul - prelu activation', () => {
@@ -98,7 +99,33 @@ describe('matrices', () => {
           transposeB: false,
           bias: input3[0],
           activation: 'prelu',
-          preluActivationWeights: input4[0]
+          preluActivationWeights: input4[0],
+          leakyreluAlpha: undefined
+        });
+      });
+      it('should call tfOps.fused.matMul - leakyrelu activation', () => {
+        spyOn(tfOps.fused, 'matMul');
+        node.op = '_FusedMatMul';
+        node.inputParams['args'] = createTensorsAttr(2, 0);
+        node.attrParams['fusedOps'] =
+            createStrArrayAttr(['biasadd', 'leakyrelu']);
+        node.attrParams['numArgs'] = createNumberAttr(1);
+        node.attrParams.transposeA = createBoolAttr(true);
+        node.attrParams.transposeB = createBoolAttr(false);
+        node.attrParams.leakyreluAlpha = createNumberAttr(0.3);
+        const input3 = [tfOps.scalar(3.0)];
+        node.inputNames = ['input1', 'input2', 'input3'];
+        executeOp(node, {input1, input2, input3}, context);
+
+        expect(tfOps.fused.matMul).toHaveBeenCalledWith({
+          a: input1[0],
+          b: input2[0],
+          transposeA: true,
+          transposeB: false,
+          bias: input3[0],
+          activation: 'leakyrelu',
+          preluActivationWeights: undefined,
+          leakyreluAlpha: 0.3
         });
       });
     });

--- a/tfjs-converter/src/operations/op_list/convolution.ts
+++ b/tfjs-converter/src/operations/op_list/convolution.ts
@@ -174,8 +174,7 @@ export const json: OpMapper[] = [
       {'tfName': 'num_args', 'name': 'numArgs', 'type': 'number'},
       {'tfName': 'T', 'name': 'dtype', 'type': 'dtype', 'notSupported': true},
       {'tfName': 'strides', 'name': 'strides', 'type': 'number[]'},
-      {'tfName': 'padding', 'name': 'pad', 'type': 'string'},
-      {
+      {'tfName': 'padding', 'name': 'pad', 'type': 'string'}, {
         'tfName': 'explicit_paddings',
         'name': 'explicitPaddings',
         'type': 'number[]',
@@ -211,6 +210,11 @@ export const json: OpMapper[] = [
         'type': 'number',
         'defaultValue': 0.0001
       },
+      {
+        'tfName': 'leakyrelu_alpha',
+        'name': 'leakyreluAlpha',
+        'type': 'number'
+      }
     ]
   },
   {

--- a/tfjs-core/src/gradients/LeakyRelu_grad.ts
+++ b/tfjs-core/src/gradients/LeakyRelu_grad.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {LeakyRelu, LeakyReluAttrs} from '../kernel_names';
+import {GradConfig, NamedAttrMap} from '../kernel_registry';
+import {greater} from '../ops/greater';
+import {mul} from '../ops/mul';
+import {where} from '../ops/where';
+import {Tensor} from '../tensor';
+
+export const leakyReluGradConfig: GradConfig = {
+  kernelName: LeakyRelu,
+  inputsToSave: ['x'],
+  gradFunc: (dy: Tensor, saved: Tensor[], attrs: NamedAttrMap) => {
+    const [x] = saved;
+    const {alpha} = attrs as {} as LeakyReluAttrs;
+    const mask = greater(x, 0);
+
+    // Returns `gradients * (features > 0) + alpha * gradients * (features <=
+    // 0)`.
+    return {x: () => where(mask, dy, mul(dy, alpha))};
+  }
+};

--- a/tfjs-core/src/kernel_names.ts
+++ b/tfjs-core/src/kernel_names.ts
@@ -396,6 +396,12 @@ export type IsInfInputs = UnaryInputs;
 export const IsNan = 'IsNan';
 export type IsNanInputs = UnaryInputs;
 
+export const LeakyRelu = 'LeakyRelu';
+export type LeakyReluInputs = Pick<NamedTensorInfoMap, 'x'>;
+export interface LeakyReluAttrs {
+  alpha: number;
+}
+
 export const Less = 'Less';
 export type LessInputs = BinaryInputs;
 
@@ -862,6 +868,7 @@ export interface _FusedMatMulAttrs {
   transposeA: boolean;
   transposeB: boolean;
   activation: Activation;
+  leakyreluAlpha?: number;
 }
 
 export const FusedConv2D = 'FusedConv2D';
@@ -878,6 +885,7 @@ export interface FusedConv2DAttrs {
   dilations: [number, number]|number;
   dimRoundingMode: 'floor'|'round'|'ceil';
   activation: Activation;
+  leakyreluAlpha?: number;
 }
 
 export const FusedDepthwiseConv2D = 'FusedDepthwiseConv2D';
@@ -894,4 +902,5 @@ export interface FusedDepthwiseConv2DAttrs {
   dilations: [number, number]|number;
   dimRoundingMode: 'floor'|'round'|'ceil';
   activation: Activation;
+  leakyreluAlpha?: number;
 }

--- a/tfjs-core/src/ops/fused/conv2d.ts
+++ b/tfjs-core/src/ops/fused/conv2d.ts
@@ -101,7 +101,8 @@ function fusedConv2d_<T extends Tensor3D|Tensor4D>({
   dimRoundingMode,
   bias,
   activation = 'linear',
-  preluActivationWeights
+  preluActivationWeights,
+  leakyreluAlpha
 }: {
   x: T|TensorLike,
   filter: Tensor4D|TensorLike,
@@ -112,7 +113,8 @@ function fusedConv2d_<T extends Tensor3D|Tensor4D>({
   dimRoundingMode?: 'floor'|'round'|'ceil',
   bias?: Tensor|TensorLike,
   activation?: Activation,
-  preluActivationWeights?: Tensor
+  preluActivationWeights?: Tensor,
+  leakyreluAlpha?: number
 }): T {
   activation = activation || 'linear';
 
@@ -123,7 +125,8 @@ function fusedConv2d_<T extends Tensor3D|Tensor4D>({
       result = add(result, bias);
     }
 
-    return applyActivation(result, activation, preluActivationWeights) as T;
+    return applyActivation(
+               result, activation, preluActivationWeights, leakyreluAlpha) as T;
   }
 
   const $x = convertToTensor(x, 'x', 'conv2d');
@@ -225,8 +228,15 @@ function fusedConv2d_<T extends Tensor3D|Tensor4D>({
     preluActivationWeights: $preluActivationWeights
   };
 
-  const attrs: FusedConv2DAttrs =
-      {strides, pad, dataFormat, dilations, dimRoundingMode, activation};
+  const attrs: FusedConv2DAttrs = {
+    strides,
+    pad,
+    dataFormat,
+    dilations,
+    dimRoundingMode,
+    activation,
+    leakyreluAlpha
+  };
 
   // Depending on the the params passed in we will have different number of
   // inputs and thus a a different number of elements in the gradient.

--- a/tfjs-core/src/ops/fused/conv2d.ts
+++ b/tfjs-core/src/ops/fused/conv2d.ts
@@ -90,6 +90,8 @@ import {reshape} from '../reshape';
  *      after biasAdd.
  * @param preluActivationWeights Tensor of prelu weights to be applied as part
  *     of a `prelu` activation, typically the same shape as `x`.
+ * @param leakyreluAlpha Optional. Alpha to be applied as part of a `leakyrelu`
+ *     activation.
  */
 function fusedConv2d_<T extends Tensor3D|Tensor4D>({
   x,

--- a/tfjs-core/src/ops/fused/depthwise_conv2d.ts
+++ b/tfjs-core/src/ops/fused/depthwise_conv2d.ts
@@ -85,6 +85,8 @@ import {reshape} from '../reshape';
  * @param activation Name of activation kernel (defaults to `linear`).
  * @param preluActivationWeights Tensor of prelu weights to be applied as part
  *     of a `prelu` activation, typically the same shape as `x`.
+ * @param leakyreluAlpha Optional. Alpha to be applied as part of a `leakyrelu`
+ *     activation.
  */
 function fusedDepthwiseConv2d_<T extends Tensor3D|Tensor4D>({
   x,
@@ -177,11 +179,6 @@ function fusedDepthwiseConv2d_<T extends Tensor3D|Tensor4D>({
     $preluActivationWeights = convertToTensor(
         preluActivationWeights, 'prelu weights', 'fused depthwiseConv2d');
   }
-  let $leakyreluAlpha: Tensor;
-  if (leakyreluAlpha != null) {
-    $leakyreluAlpha =
-        convertToTensor(leakyreluAlpha, 'leakyrelu alpha', 'fused conv2d');
-  }
 
   const grad = (dy: Tensor4D, saved: Tensor[]) => {
     util.assert(
@@ -214,8 +211,7 @@ function fusedDepthwiseConv2d_<T extends Tensor3D|Tensor4D>({
       convInfo,
       bias: $bias,
       activation,
-      preluActivationWeights: $preluActivationWeights,
-      leakyreluAlpha: $leakyreluAlpha
+      preluActivationWeights: $preluActivationWeights
     });
     return res;
   };
@@ -224,11 +220,17 @@ function fusedDepthwiseConv2d_<T extends Tensor3D|Tensor4D>({
     x: x4D,
     filter: $filter,
     bias: $bias,
-    preluActivationWeights: $preluActivationWeights,
-    leakyreluAlpha: $leakyreluAlpha
+    preluActivationWeights: $preluActivationWeights
   };
-  const attrs: FusedDepthwiseConv2DAttrs =
-      {strides, pad, dataFormat, dilations, dimRoundingMode, activation};
+  const attrs: FusedDepthwiseConv2DAttrs = {
+    strides,
+    pad,
+    dataFormat,
+    dilations,
+    dimRoundingMode,
+    activation,
+    leakyreluAlpha
+  };
 
   // Depending on the the params passed in we will have different number of
   // inputs and thus a a different number of elements in the gradient.

--- a/tfjs-core/src/ops/fused/fused_conv2d_test.ts
+++ b/tfjs-core/src/ops/fused/fused_conv2d_test.ts
@@ -367,6 +367,86 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
            ]));
      });
 
+  it('leakyrelu bias stride 2 x=[1,8,8,16] f=[3,3,16,1] s=[2,2] d=8 p=same',
+     async () => {
+       const inputDepth = 16;
+       const xSize = 8;
+       const inputShape: [number, number, number, number] =
+           [1, xSize, xSize, inputDepth];
+       const outputDepth = 8;
+       const fSize = 3;
+       const pad = 'same';
+       const stride: [number, number] = [2, 2];
+
+       const inputs = generateCaseInputs(
+           1 * xSize * xSize * inputDepth,
+           fSize * fSize * inputDepth * outputDepth);
+       const x = tf.tensor4d(inputs.input, inputShape);
+       const w =
+           tf.tensor4d(inputs.filter, [fSize, fSize, inputDepth, outputDepth]);
+       const bias = tf.tensor1d([1, 4, 2, 3, 9, 6, 5, 8]);
+       const leakyreluAlpha = 0.3;
+
+       const result = tf.fused.conv2d({
+         x,
+         filter: w,
+         strides: stride,
+         pad,
+         dataFormat: 'NHWC',
+         dilations: [1, 1],
+         activation: 'leakyrelu',
+         leakyreluAlpha,
+         bias
+       });
+       expect(result.shape).toEqual([1, 4, 4, 8]);
+       expectArraysClose(
+           await result.data(), new Float32Array([
+             25.75398063659668,    -6.241768836975098,   26.857805252075195,
+             -6.5729146003723145,  33.961631774902344,   -5.704063892364502,
+             30.065458297729492,   -5.135210037231445,   23.118206024169922,
+             -5.449653148651123,   24.212820053100586,   -5.778036117553711,
+             31.307422637939453,   -4.906418323516846,   27.402034759521484,
+             -4.334802627563477,   20.482431411743164,   -4.657539367675781,
+             21.567821502685547,   -4.983157157897949,   28.653217315673828,
+             -4.108772277832031,   24.73861312866211,    -3.534390687942505,
+             11.078080177307129,   -1.8312718868255615,  12.130399703979492,
+             -2.1469674110412598,  19.182720184326172,   -1.262665033340454,
+             15.235037803649902,   -0.6783602833747864,  4.6677775382995605,
+             0.31717729568481445,  5.697869777679443,    -0.21387571096420288,
+             12.727968215942383,   2.2569849491119385,   8.758066177368164,
+             4.226885795593262,    2.0319995880126953,   2.9575586318969727,
+             3.052880048751831,    1.9366796016693115,   10.073760032653809,
+             4.915799617767334,    6.094639778137207,    6.89492130279541,
+             -0.18113291263580322, 5.5979437828063965,   0.4078875780105591,
+             4.586280822753906,    7.419551849365234,    7.5746169090271,
+             3.43121600151062,     9.562952041625977,    -0.42195841670036316,
+             6.404943943023682,    -0.12100804597139359, 5.401776313781738,
+             6.5998077392578125,   8.398608207702637,    2.602976083755493,
+             10.395440101623535,   -4.925530433654785,   21.440250396728516,
+             -4.6386189460754395,  20.483882904052734,   -2.5517091751098633,
+             23.527509689331055,   -3.764799118041992,   25.571144104003906,
+             -5.7162628173828125,  24.080629348754883,   -5.432116508483887,
+             23.133480072021484,   -3.347970962524414,   26.186328887939453,
+             -4.5638251304626465,  28.239177703857422,   -6.5069966316223145,
+             26.721012115478516,   -6.225615501403809,   25.783079147338867,
+             -4.144233703613281,   28.84514808654785,    -5.36285400390625,
+             30.907209396362305,   -4.167340278625488,   18.914127349853516,
+             -3.881135940551758,   17.960111618041992,   -1.794930338859558,
+             21.006093978881836,   -3.0087265968322754,  23.052082061767578,
+             -3.8573760986328125,  17.89089584350586,    -3.5771610736846924,
+             16.95684814453125,    -1.4969470500946045,  20.022798538208008,
+             -2.7167325019836426,  22.088754653930664,   -4.207584857940674,
+             19.06132698059082,    -3.9292125701904297,  18.133424758911133,
+             -1.8508410453796387,  21.205520629882812,   -3.0724704265594482,
+             23.27761459350586,    -4.557791709899902,   20.23175811767578,
+             -4.28126335144043,    19.309999465942383,   -2.2047364711761475,
+             22.388240814208984,   -3.428208351135254,   24.46647834777832,
+             -2.567021131515503,   13.584352493286133,   -2.283590316772461,
+             12.6395845413208,     -0.20016004145145416, 15.694815635681152,
+             -1.41672945022583,    17.750045776367188
+           ]));
+     });
+
   it('basic with bias', async () => {
     const inputDepth = 2;
     const inShape: [number, number, number, number] = [2, 2, 2, inputDepth];
@@ -474,6 +554,40 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const expected = [
       -1.25, 2, -2.75, 5, -4.25, 8, -5.75, 11, -7.25, 14, -8.75, 17, -10.25, 20,
       -11.75, 23
+    ];
+
+    expectArraysClose(await result.data(), expected);
+  });
+
+  it('basic with leakyrelu', async () => {
+    const inputDepth = 2;
+    const inShape: [number, number, number, number] = [2, 2, 2, inputDepth];
+    const outputDepth = 2;
+    const fSize = 1;
+    const pad = 0;
+    const stride = 1;
+
+    const x = tf.tensor4d(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], inShape);
+    const alpha = 0.3;
+    const w =
+        tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
+
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides: stride,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'leakyrelu',
+      leakyreluAlpha: alpha
+    });
+    expect(result.shape).toEqual([2, 2, 2, 2]);
+    const expected = [
+      -1.5, 2, -3.3000001907348633, 5, -5.100000381469727, 8,
+      -6.900000095367432, 11, -8.700000762939453, 14, -10.5, 17,
+      -12.300000190734863, 20, -14.100000381469727, 23
     ];
 
     expectArraysClose(await result.data(), expected);
@@ -591,6 +705,39 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
         [10, 5, 10, 50, 25, 50, -5, -2.5, -5, -25, -12.5, -25]);
   });
 
+  it('im2row with leakyrelu', async () => {
+    const inputDepth = 1;
+    const inputShape: [number, number, number] = [4, 4, inputDepth];
+    const outputDepth = 3;
+    const fSize = 1;
+    const pad = 'same';
+    const strides: [number, number] = [2, 2];
+
+    const x = tf.tensor3d(
+        [
+          10, 30, 50, 70, 20, 40, 60, 80, -10, -30, -50, -70, -20, -40, -60, -80
+        ],
+        inputShape);
+    const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
+    const alpha = 0.3;
+
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'leakyrelu',
+      leakyreluAlpha: alpha
+    });
+
+    expectArraysClose(await result.data(), [
+      10, 5, 10, 50, 25, 50, -3, -1.5, -3, -15.000000953674316,
+      -7.500000476837158, -15.000000953674316
+    ]);
+  });
+
   it('pointwise with prelu', async () => {
     const inputDepth = 1;
     const inputShape: [number, number, number] = [4, 4, inputDepth];
@@ -623,6 +770,85 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
       20,  10,   20,  40,  20,   40,  60,  30,    60,  80,  40,    80,
       -5,  -2.5, -5,  -15, -7.5, -15, -25, -12.5, -25, -35, -17.5, -35,
       -10, -5,   -10, -20, -10,  -20, -30, -15,   -30, -40, -20,   -40
+    ]);
+  });
+
+  it('pointwise with leakyrelu', async () => {
+    const inputDepth = 1;
+    const inputShape: [number, number, number] = [4, 4, inputDepth];
+    const outputDepth = 3;
+    const fSize = 1;
+    const pad = 'same';
+    const strides: [number, number] = [1, 1];
+
+    const x = tf.tensor3d(
+        [
+          10, 30, 50, 70, 20, 40, 60, 80, -10, -30, -50, -70, -20, -40, -60, -80
+        ],
+        inputShape);
+    const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
+    const alpha = 0.3;
+
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'leakyrelu',
+      leakyreluAlpha: alpha
+    });
+
+    expectArraysClose(await result.data(), [
+      10,
+      5,
+      10,
+      30,
+      15,
+      30,
+      50,
+      25,
+      50,
+      70,
+      35,
+      70,
+      20,
+      10,
+      20,
+      40,
+      20,
+      40,
+      60,
+      30,
+      60,
+      80,
+      40,
+      80,
+      -3,
+      -1.5,
+      -3,
+      -9,
+      -4.5,
+      -9,
+      -15.000000953674316,
+      -7.500000476837158,
+      -15.000000953674316,
+      -21,
+      -10.5,
+      -21,
+      -6,
+      -3,
+      -6,
+      -12,
+      -6,
+      -12,
+      -18,
+      -9,
+      -18,
+      -24,
+      -12,
+      -24
     ]);
   });
 

--- a/tfjs-core/src/ops/fused/fused_depthwise_conv2d_test.ts
+++ b/tfjs-core/src/ops/fused/fused_depthwise_conv2d_test.ts
@@ -158,6 +158,48 @@ describeWithFlags('fused depthwiseConv2D', ALL_ENVS, () => {
     expectArraysClose(await result.data(), expected);
   });
 
+  it('leakyrelu', async () => {
+    const fSize = 3;
+    const pad = 'valid';
+    const strides = 1;
+    const chMul = 1;
+    const inDepth = 1;
+
+    const x = tf.tensor4d(
+        [
+          0.149194, 0.089009, 0.654891, 0.083324, 0.537043, 0.644331, 0.563037,
+          0.211859, 0.633501, 0.186427, 0.777034, 0.50001,  0.607341, 0.95303,
+          0.696479, 0.050387, 0.62045,  0.728049, 0.028043, 0.437009, 0.712881,
+          0.741935, 0.974474, 0.621102, 0.171411
+        ],
+        [1, 5, 5, inDepth]);
+    const alpha = 0.3;
+    const w = tf.tensor4d(
+        [
+          -0.125386, -0.975199, -0.640437, -0.281895, -0.990968, -0.347208,
+          -0.889702, -0.180695, -0.691992
+        ],
+        [fSize, fSize, inDepth, chMul],
+    );
+
+    const result = tf.fused.depthwiseConv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      activation: 'leakyrelu',
+      leakyreluAlpha: alpha
+    });
+
+    expect(result.shape).toEqual([1, 3, 3, 1]);
+    const expected = [
+      -0.7620067596435547, -0.7517655491828918, -0.7362186312675476,
+      -0.7055101990699768, -0.7378802299499512, -0.9229262471199036,
+      -0.9895440340042114, -1.031226396560669, -0.8802568912506104
+    ];
+    expectArraysClose(await result.data(), expected);
+  });
+
   it('gradient x=[2,3,3,1] f=[2,2,1,1] s=1 p=0', async () => {
     const inputDepth = 1;
     const outputDepth = 1;

--- a/tfjs-core/src/ops/fused/fused_mat_mul_test.ts
+++ b/tfjs-core/src/ops/fused/fused_mat_mul_test.ts
@@ -90,6 +90,27 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     expectArraysClose(await c.data(), [0, 8, -1.5, 20]);
   });
 
+  it('fused A x B with leakyrelu', async () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+    const alpha = 0.3;
+    const transposeA = false;
+    const transposeB = false;
+
+    const c = tf.fused.matMul({
+      a,
+      b,
+      transposeA,
+      transposeB,
+      bias: null,
+      activation: 'leakyrelu',
+      leakyreluAlpha: alpha
+    });
+
+    expect(c.shape).toEqual([2, 2]);
+    expectArraysClose(await c.data(), [0, 8, -0.9000000357627869, 20]);
+  });
+
   it('fused A x B with relu transpose', async () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [2, 3]);

--- a/tfjs-core/src/ops/fused/mat_mul.ts
+++ b/tfjs-core/src/ops/fused/mat_mul.ts
@@ -53,6 +53,7 @@ import {reshape} from '../reshape';
  * - `bias` Matrix to be added to the result.
  * - `activation` Name of activation kernel (defaults to `linear`).
  * - `preluActivationWeights` Tensor of prelu weights.
+ * - `leakyreluAlpha` Alpha of leakyrelu.
  */
 function fusedMatMul_<T extends Tensor>({
   a,

--- a/tfjs-core/src/ops/fused/mat_mul.ts
+++ b/tfjs-core/src/ops/fused/mat_mul.ts
@@ -144,12 +144,6 @@ function fusedMatMul_<T extends Tensor>({
           preluActivationWeights, 'prelu weights', 'fused matMul');
     }
 
-    let $leakyreluAlpha: Tensor;
-    if (leakyreluAlpha != null) {
-      $leakyreluAlpha =
-          convertToTensor(leakyreluAlpha, 'leakyrelu alpha', 'fused matMul');
-    }
-
     const grad = (dy: Tensor3D, saved: Tensor[]) => {
       const [a3D, b3D, y, $bias] = saved;
       // we reshape dy because the result of the forward is not
@@ -190,8 +184,7 @@ function fusedMatMul_<T extends Tensor>({
         transposeB,
         bias: $bias,
         activation,
-        preluActivationWeights: $preluActivationWeights,
-        leakyreluAlpha: $leakyreluAlpha
+        preluActivationWeights: $preluActivationWeights
       });
       return y;
     };
@@ -200,10 +193,10 @@ function fusedMatMul_<T extends Tensor>({
       a: a3D,
       b: b3D,
       bias: $bias,
-      preluActivationWeights: $preluActivationWeights,
-      leakyreluAlpha: $leakyreluAlpha
+      preluActivationWeights: $preluActivationWeights
     };
-    const attrs: _FusedMatMulAttrs = {transposeA, transposeB, activation};
+    const attrs: _FusedMatMulAttrs =
+        {transposeA, transposeB, activation, leakyreluAlpha};
 
     // Depending on the the params passed in we will have different number of
     // inputs and thus a a different number of elements in the gradient.

--- a/tfjs-core/src/ops/fused/mat_mul.ts
+++ b/tfjs-core/src/ops/fused/mat_mul.ts
@@ -61,7 +61,8 @@ function fusedMatMul_<T extends Tensor>({
   transposeB = false,
   bias,
   activation = 'linear',
-  preluActivationWeights
+  preluActivationWeights,
+  leakyreluAlpha,
 }: {
   a: T|TensorLike,
   b: T|TensorLike,
@@ -70,158 +71,168 @@ function fusedMatMul_<T extends Tensor>({
   bias?: Tensor|TensorLike,
   activation?: Activation,
   preluActivationWeights?: Tensor
+  leakyreluAlpha?: number
 }): T {
-  if (shouldFuse(ENGINE.state.gradientDepth, activation) === false) {
-    let result = unfusedMatMul(a, b, transposeA, transposeB);
+    if (shouldFuse(ENGINE.state.gradientDepth, activation) === false) {
+      let result = unfusedMatMul(a, b, transposeA, transposeB);
+      if (bias != null) {
+        result = add(result, bias);
+      }
+
+      return applyActivation(
+                 result, activation, preluActivationWeights, leakyreluAlpha) as
+          T;
+    }
+
+    let $a = convertToTensor(a, 'a', 'fused matMul');
+    let $b = convertToTensor(b, 'b', 'fused matMul');
+    [$a, $b] = makeTypesMatch($a, $b);
+
+    const innerShapeA =
+        transposeA ? $a.shape[$a.rank - 2] : $a.shape[$a.rank - 1];
+    const innerShapeB =
+        transposeB ? $b.shape[$b.rank - 1] : $b.shape[$b.rank - 2];
+
+    const outerShapeA =
+        transposeA ? $a.shape[$a.rank - 1] : $a.shape[$a.rank - 2];
+    const outerShapeB =
+        transposeB ? $b.shape[$b.rank - 2] : $b.shape[$b.rank - 1];
+
+    const outerDimsA = $a.shape.slice(0, -2);
+    const outerDimsB = $b.shape.slice(0, -2);
+    const batchDimA = util.sizeFromShape(outerDimsA);
+    const batchDimB = util.sizeFromShape(outerDimsB);
+
+    util.assert(
+        $a.rank >= 2 && $b.rank >= 2 && $a.rank === $b.rank,
+        () => `Error in fused matMul: inputs must have the same rank of at ` +
+            `least 2, got ranks ${$a.rank} and ${$b.rank}.`);
+
+    util.assert(
+        util.arraysEqual(outerDimsA, outerDimsB),
+        () => `Error in fused matMul: outer dimensions (${outerDimsA}) and (` +
+            `${outerDimsB}) of Tensors with shapes ${$a.shape} and ` +
+            `${$b.shape} must match.`);
+
+    util.assert(
+        innerShapeA === innerShapeB,
+        () => `Error in fused matMul: inner shapes (${innerShapeA}) and (` +
+            `${innerShapeB}) of Tensors with shapes ${$a.shape} and ` +
+            `${$b.shape} and transposeA=${transposeA}` +
+            ` and transposeB=${transposeB} must match.`);
+
+    const outShape = $a.shape.slice(0, -2).concat([outerShapeA, outerShapeB]);
+
+    const a3D: Tensor3D = transposeA ?
+        reshape($a, [batchDimA, innerShapeA, outerShapeA]) :
+        reshape($a, [batchDimA, outerShapeA, innerShapeA]);
+    const b3D: Tensor3D = transposeB ?
+        reshape($b, [batchDimB, outerShapeB, innerShapeB]) :
+        reshape($b, [batchDimB, innerShapeB, outerShapeB]);
+
+    let $bias: Tensor;
     if (bias != null) {
-      result = add(result, bias);
+      $bias = convertToTensor(bias, 'bias', 'fused matMul');
+      [$bias] = makeTypesMatch($bias, $a);
+
+      broadcast_util.assertAndGetBroadcastShape(outShape, $bias.shape);
     }
 
-    return applyActivation(result, activation, preluActivationWeights) as T;
-  }
-
-  let $a = convertToTensor(a, 'a', 'fused matMul');
-  let $b = convertToTensor(b, 'b', 'fused matMul');
-  [$a, $b] = makeTypesMatch($a, $b);
-
-  const innerShapeA =
-      transposeA ? $a.shape[$a.rank - 2] : $a.shape[$a.rank - 1];
-  const innerShapeB =
-      transposeB ? $b.shape[$b.rank - 1] : $b.shape[$b.rank - 2];
-
-  const outerShapeA =
-      transposeA ? $a.shape[$a.rank - 1] : $a.shape[$a.rank - 2];
-  const outerShapeB =
-      transposeB ? $b.shape[$b.rank - 2] : $b.shape[$b.rank - 1];
-
-  const outerDimsA = $a.shape.slice(0, -2);
-  const outerDimsB = $b.shape.slice(0, -2);
-  const batchDimA = util.sizeFromShape(outerDimsA);
-  const batchDimB = util.sizeFromShape(outerDimsB);
-
-  util.assert(
-      $a.rank >= 2 && $b.rank >= 2 && $a.rank === $b.rank,
-      () =>
-          `Error in fused matMul: inputs must have the same rank of at least ` +
-          `2, got ranks ${$a.rank} and ${$b.rank}.`);
-
-  util.assert(
-      util.arraysEqual(outerDimsA, outerDimsB),
-      () => `Error in fused matMul: outer dimensions (${outerDimsA}) and (` +
-          `${outerDimsB}) of Tensors with shapes ${$a.shape} and ` +
-          `${$b.shape} must match.`);
-
-  util.assert(
-      innerShapeA === innerShapeB,
-      () => `Error in fused matMul: inner shapes (${innerShapeA}) and (` +
-          `${innerShapeB}) of Tensors with shapes ${$a.shape} and ` +
-          `${$b.shape} and transposeA=${transposeA}` +
-          ` and transposeB=${transposeB} must match.`);
-
-  const outShape = $a.shape.slice(0, -2).concat([outerShapeA, outerShapeB]);
-
-  const a3D: Tensor3D = transposeA ?
-      reshape($a, [batchDimA, innerShapeA, outerShapeA]) :
-      reshape($a, [batchDimA, outerShapeA, innerShapeA]);
-  const b3D: Tensor3D = transposeB ?
-      reshape($b, [batchDimB, outerShapeB, innerShapeB]) :
-      reshape($b, [batchDimB, innerShapeB, outerShapeB]);
-
-  let $bias: Tensor;
-  if (bias != null) {
-    $bias = convertToTensor(bias, 'bias', 'fused matMul');
-    [$bias] = makeTypesMatch($bias, $a);
-
-    broadcast_util.assertAndGetBroadcastShape(outShape, $bias.shape);
-  }
-
-  let $preluActivationWeights: Tensor;
-  if (preluActivationWeights != null) {
-    $preluActivationWeights = convertToTensor(
-        preluActivationWeights, 'prelu weights', 'fused matMul');
-  }
-
-  const grad = (dy: Tensor3D, saved: Tensor[]) => {
-    const [a3D, b3D, y, $bias] = saved;
-    // we reshape dy because the result of the forward is not
-    // necessarily going to be a 3d tensor due to a reshape done at the end of
-    // the customOp.
-    const dyActivation =
-        getFusedDyActivation(reshape(dy, y.shape), y, activation);
-    let aDer: Tensor;
-    let bDer: Tensor;
-
-    if (!transposeA && !transposeB) {
-      aDer = unfusedMatMul(dyActivation, b3D, false, true);
-      bDer = unfusedMatMul(a3D, dyActivation, true, false);
-    } else if (!transposeA && transposeB) {
-      aDer = unfusedMatMul(dyActivation, b3D, false, false);
-      bDer = unfusedMatMul(dyActivation, a3D, true, false);
-    } else if (transposeA && !transposeB) {
-      aDer = unfusedMatMul(b3D, dyActivation, false, true);
-      bDer = unfusedMatMul(a3D, dyActivation, false, false);
-    } else {
-      aDer = unfusedMatMul(b3D, dyActivation, true, true);
-      bDer = unfusedMatMul(dyActivation, a3D, true, true);
+    let $preluActivationWeights: Tensor;
+    if (preluActivationWeights != null) {
+      $preluActivationWeights = convertToTensor(
+          preluActivationWeights, 'prelu weights', 'fused matMul');
     }
 
-    if (bias != null) {
-      const biasDer = getFusedBiasGradient($bias, dyActivation);
-      return [aDer, bDer, biasDer];
-    } else {
-      return [aDer, bDer];
+    let $leakyreluAlpha: Tensor;
+    if (leakyreluAlpha != null) {
+      $leakyreluAlpha =
+          convertToTensor(leakyreluAlpha, 'leakyrelu alpha', 'fused matMul');
     }
-  };
 
-  const forward: ForwardFunc<Tensor> = (backend) => {
-    const y = backend.fusedBatchMatMul({
+    const grad = (dy: Tensor3D, saved: Tensor[]) => {
+      const [a3D, b3D, y, $bias] = saved;
+      // we reshape dy because the result of the forward is not
+      // necessarily going to be a 3d tensor due to a reshape done at the end of
+      // the customOp.
+      const dyActivation =
+          getFusedDyActivation(reshape(dy, y.shape), y, activation);
+      let aDer: Tensor;
+      let bDer: Tensor;
+
+      if (!transposeA && !transposeB) {
+        aDer = unfusedMatMul(dyActivation, b3D, false, true);
+        bDer = unfusedMatMul(a3D, dyActivation, true, false);
+      } else if (!transposeA && transposeB) {
+        aDer = unfusedMatMul(dyActivation, b3D, false, false);
+        bDer = unfusedMatMul(dyActivation, a3D, true, false);
+      } else if (transposeA && !transposeB) {
+        aDer = unfusedMatMul(b3D, dyActivation, false, true);
+        bDer = unfusedMatMul(a3D, dyActivation, false, false);
+      } else {
+        aDer = unfusedMatMul(b3D, dyActivation, true, true);
+        bDer = unfusedMatMul(dyActivation, a3D, true, true);
+      }
+
+      if (bias != null) {
+        const biasDer = getFusedBiasGradient($bias, dyActivation);
+        return [aDer, bDer, biasDer];
+      } else {
+        return [aDer, bDer];
+      }
+    };
+
+    const forward: ForwardFunc<Tensor> = (backend) => {
+      const y = backend.fusedBatchMatMul({
+        a: a3D,
+        b: b3D,
+        transposeA,
+        transposeB,
+        bias: $bias,
+        activation,
+        preluActivationWeights: $preluActivationWeights,
+        leakyreluAlpha: $leakyreluAlpha
+      });
+      return y;
+    };
+
+    const inputs: _FusedMatMulInputs = {
       a: a3D,
       b: b3D,
-      transposeA,
-      transposeB,
       bias: $bias,
-      activation,
-      preluActivationWeights: $preluActivationWeights
-    });
-    return y;
-  };
+      preluActivationWeights: $preluActivationWeights,
+      leakyreluAlpha: $leakyreluAlpha
+    };
+    const attrs: _FusedMatMulAttrs = {transposeA, transposeB, activation};
 
-  const inputs: _FusedMatMulInputs = {
-    a: a3D,
-    b: b3D,
-    bias: $bias,
-    preluActivationWeights: $preluActivationWeights
-  };
-  const attrs: _FusedMatMulAttrs = {transposeA, transposeB, activation};
+    // Depending on the the params passed in we will have different number of
+    // inputs and thus a a different number of elements in the gradient.
+    if (bias == null) {
+      const customOp =
+          customGrad((a3D: Tensor3D, b3D: Tensor3D, save: GradSaveFunc) => {
+            const res = ENGINE.runKernelFunc(
+                forward, inputs as {} as NamedTensorMap, null /* grad */,
+                _FusedMatMul, attrs as {} as NamedAttrMap);
 
-  // Depending on the the params passed in we will have different number of
-  // inputs and thus a a different number of elements in the gradient.
-  if (bias == null) {
-    const customOp =
-        customGrad((a3D: Tensor3D, b3D: Tensor3D, save: GradSaveFunc) => {
-          const res = ENGINE.runKernelFunc(
-              forward, inputs as {} as NamedTensorMap, null /* grad */,
-              _FusedMatMul, attrs as {} as NamedAttrMap);
+            save([a3D, b3D, res]);
 
-          save([a3D, b3D, res]);
+            return {value: reshape(res, outShape), gradFunc: grad};
+          });
+      return customOp(a3D, b3D) as T;
+    } else {
+      const customOpWithBias = customGrad(
+          (a3D: Tensor3D, b3D: Tensor3D, $bias: Tensor, save: GradSaveFunc) => {
+            const res = ENGINE.runKernelFunc(
+                forward, inputs as {} as NamedTensorMap, null /* grad */,
+                _FusedMatMul, attrs as {} as NamedAttrMap);
 
-          return {value: reshape(res, outShape), gradFunc: grad};
-        });
-    return customOp(a3D, b3D) as T;
-  } else {
-    const customOpWithBias = customGrad(
-        (a3D: Tensor3D, b3D: Tensor3D, $bias: Tensor, save: GradSaveFunc) => {
-          const res = ENGINE.runKernelFunc(
-              forward, inputs as {} as NamedTensorMap, null /* grad */,
-              _FusedMatMul, attrs as {} as NamedAttrMap);
+            save([a3D, b3D, res, $bias]);
 
-          save([a3D, b3D, res, $bias]);
+            return {value: reshape(res, outShape), gradFunc: grad};
+          });
 
-          return {value: reshape(res, outShape), gradFunc: grad};
-        });
-
-    return customOpWithBias(a3D, b3D, $bias) as T;
+      return customOpWithBias(a3D, b3D, $bias) as T;
+    }
   }
-}
 
-export const matMul = op({fusedMatMul_});
+  export const matMul = op({fusedMatMul_});

--- a/tfjs-core/src/ops/fused_types.ts
+++ b/tfjs-core/src/ops/fused_types.ts
@@ -25,7 +25,7 @@ export type FusedConv2DConfig = {
   bias?: Tensor,
   activation?: Activation,
   preluActivationWeights?: Tensor,
-  leakyreluAlpha?: Tensor
+  leakyreluAlpha?: number
 };
 
 export type FusedBatchMatMulConfig = {
@@ -36,7 +36,7 @@ export type FusedBatchMatMulConfig = {
   bias?: Tensor,
   activation?: Activation,
   preluActivationWeights?: Tensor,
-  leakyreluAlpha?: Tensor
+  leakyreluAlpha?: number
 };
 
 export type Activation = 'linear'|'relu'|'prelu'|'elu'|'relu6'|'leakyrelu';

--- a/tfjs-core/src/ops/fused_types.ts
+++ b/tfjs-core/src/ops/fused_types.ts
@@ -24,7 +24,8 @@ export type FusedConv2DConfig = {
   convInfo: Conv2DInfo,
   bias?: Tensor,
   activation?: Activation,
-  preluActivationWeights?: Tensor
+  preluActivationWeights?: Tensor,
+  leakyreluAlpha?: Tensor
 };
 
 export type FusedBatchMatMulConfig = {
@@ -34,7 +35,8 @@ export type FusedBatchMatMulConfig = {
   transposeB: boolean,
   bias?: Tensor,
   activation?: Activation,
-  preluActivationWeights?: Tensor
+  preluActivationWeights?: Tensor,
+  leakyreluAlpha?: Tensor
 };
 
-export type Activation = 'linear'|'relu'|'prelu'|'elu'|'relu6';
+export type Activation = 'linear'|'relu'|'prelu'|'elu'|'relu6'|'leakyrelu';

--- a/tfjs-core/src/ops/fused_util.ts
+++ b/tfjs-core/src/ops/fused_util.ts
@@ -20,6 +20,7 @@ import {Tensor} from '../tensor';
 import * as broadcast_util from './broadcast_util';
 import {elu} from './elu';
 import {Activation} from './fused_types';
+import {leakyRelu} from './leaky_relu';
 import {mul} from './mul';
 import {prelu} from './prelu';
 import {relu} from './relu';
@@ -54,8 +55,8 @@ export function getFusedBiasGradient(
 }
 
 export function applyActivation(
-    x: Tensor, activation: Activation,
-    preluActivationWeights?: Tensor): Tensor {
+    x: Tensor, activation: Activation, preluActivationWeights?: Tensor,
+    leakyreluAlpha?: number): Tensor {
   if (activation === 'linear') {
     return x;
   } else if (activation === 'relu') {
@@ -66,6 +67,8 @@ export function applyActivation(
     return relu6(x);
   } else if (activation === 'prelu') {
     return prelu(x, preluActivationWeights);
+  } else if (activation === 'leakyrelu') {
+    return leakyRelu(x, leakyreluAlpha);
   }
   throw new Error(`Unknown fused activation ${activation}.`);
 }

--- a/tfjs-core/src/ops/leaky_relu.ts
+++ b/tfjs-core/src/ops/leaky_relu.ts
@@ -15,14 +15,15 @@
  * =============================================================================
  */
 
+import {ENGINE} from '../engine';
+import {LeakyRelu, LeakyReluAttrs, LeakyReluInputs} from '../kernel_names';
+import {NamedAttrMap} from '../kernel_registry';
 import {Tensor} from '../tensor';
+import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 
-import {maximum} from './maximum';
-import {mul} from './mul';
 import {op} from './operation';
-import {scalar} from './scalar';
 
 /**
  * Computes leaky rectified linear element-wise.
@@ -43,7 +44,13 @@ import {scalar} from './scalar';
  */
 function leakyRelu_<T extends Tensor>(x: T|TensorLike, alpha = 0.2): T {
   const $x = convertToTensor(x, 'x', 'leakyRelu');
-  return maximum(mul(scalar(alpha), $x), $x);
+
+  const inputs: LeakyReluInputs = {x: $x};
+  const attrs: LeakyReluAttrs = {alpha};
+
+  return ENGINE.runKernel(
+             LeakyRelu, inputs as {} as NamedTensorMap,
+             attrs as {} as NamedAttrMap) as T;
 }
 
 export const leakyRelu = op({leakyRelu_});

--- a/tfjs-core/src/ops/leaky_relu_test.ts
+++ b/tfjs-core/src/ops/leaky_relu_test.ts
@@ -19,7 +19,7 @@ import * as tf from '../index';
 import {ALL_ENVS, describeWithFlags} from '../jasmine_util';
 import {expectArraysClose} from '../test_util';
 
-describeWithFlags('leakyRelu', ALL_ENVS, () => {
+describeWithFlags('leakyrelu', ALL_ENVS, () => {
   it('basic', async () => {
     const a = tf.tensor1d([0, 1, -2]);
     const result = tf.leakyRelu(a);

--- a/tfjs-core/src/register_all_gradients.ts
+++ b/tfjs-core/src/register_all_gradients.ts
@@ -58,6 +58,7 @@ import {identityGradConfig} from './gradients/Identity_grad';
 import {isFiniteGradConfig} from './gradients/IsFinite_grad';
 import {isInfGradConfig} from './gradients/IsInf_grad';
 import {isNanGradConfig} from './gradients/IsNan_grad';
+import {leakyReluGradConfig} from './gradients/LeakyRelu_grad';
 import {log1pGradConfig} from './gradients/Log1p_grad';
 import {logGradConfig} from './gradients/Log_grad';
 import {logSoftmaxGradConfig} from './gradients/LogSoftmax_grad';
@@ -162,6 +163,7 @@ const gradConfigs: GradConfig[] = [
   isFiniteGradConfig,
   isInfGradConfig,
   isNanGradConfig,
+  leakyReluGradConfig,
   log1pGradConfig,
   logGradConfig,
   logSoftmaxGradConfig,

--- a/tfjs-node/src/kernels/FusedConv2D.ts
+++ b/tfjs-node/src/kernels/FusedConv2D.ts
@@ -28,8 +28,15 @@ export const fusedConv2DConfig: KernelConfig = {
     const {x, filter, bias, preluActivationWeights} =
         args.inputs as FusedConv2DInputs;
     const backend = args.backend as NodeJSKernelBackend;
-    const {strides, pad, dataFormat, dilations, dimRoundingMode, activation} =
-        args.attrs as {} as FusedConv2DAttrs;
+    const {
+      strides,
+      pad,
+      dataFormat,
+      dilations,
+      dimRoundingMode,
+      activation,
+      leakyreluAlpha
+    } = args.attrs as {} as FusedConv2DAttrs;
 
     const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
     const convInfo = backend_util.computeConv2DInfo(
@@ -47,7 +54,7 @@ export const fusedConv2DConfig: KernelConfig = {
 
     const temp = result;
     result = backend.applyActivation(
-        result, activation, preluActivationWeights as Tensor);
+        result, activation, preluActivationWeights as Tensor, leakyreluAlpha);
     if (temp !== result) {
       toDispose.push(temp);
     }

--- a/tfjs-node/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-node/src/kernels/FusedDepthwiseConv2D.ts
@@ -28,8 +28,14 @@ export const fusedDepthwiseConv2DConfig: KernelConfig = {
     const {x, filter, bias, preluActivationWeights} =
         args.inputs as FusedDepthwiseConv2DInputs;
     const backend = args.backend as NodeJSKernelBackend;
-    const {strides, pad, dilations, dimRoundingMode, activation} =
-        args.attrs as {} as FusedDepthwiseConv2DAttrs;
+    const {
+      strides,
+      pad,
+      dilations,
+      dimRoundingMode,
+      activation,
+      leakyreluAlpha
+    } = args.attrs as {} as FusedDepthwiseConv2DAttrs;
 
     let $dilations = dilations;
     if ($dilations == null) {
@@ -51,7 +57,7 @@ export const fusedDepthwiseConv2DConfig: KernelConfig = {
 
     const temp = result;
     result = backend.applyActivation(
-        result, activation, preluActivationWeights as Tensor);
+        result, activation, preluActivationWeights as Tensor, leakyreluAlpha);
     if (temp !== result) {
       toDispose.push(temp);
     }

--- a/tfjs-node/src/kernels/LeakyRelu.ts
+++ b/tfjs-node/src/kernels/LeakyRelu.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, LeakyRelu, LeakyReluAttrs, LeakyReluInputs, Tensor} from '@tensorflow/tfjs';
+import {createTensorsTypeOpAttr, NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const leakyReluConfig: KernelConfig = {
+  kernelName: LeakyRelu,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const inputs = args.inputs as LeakyReluInputs;
+    const attrs = args.attrs as {} as LeakyReluAttrs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const x = inputs.x as Tensor;
+    const alpha = attrs.alpha;
+
+    const opAttrs = [
+      {name: 'alpha', type: backend.binding.TF_ATTR_FLOAT, value: alpha},
+      createTensorsTypeOpAttr('T', x.dtype)
+    ];
+
+    return backend.executeSingleOutput(LeakyRelu, opAttrs, [x]);
+  }
+};

--- a/tfjs-node/src/kernels/_FusedMatMul.ts
+++ b/tfjs-node/src/kernels/_FusedMatMul.ts
@@ -26,7 +26,7 @@ export const _fusedMatMulConfig: KernelConfig = {
     const {a, b, bias, preluActivationWeights} =
         args.inputs as _FusedMatMulInputs;
     const backend = args.backend as NodeJSKernelBackend;
-    const {transposeA, transposeB, activation} =
+    const {transposeA, transposeB, activation, leakyreluAlpha} =
         args.attrs as {} as _FusedMatMulAttrs;
 
     // Core TensorFlow does not have a fused BatchMatMul op. Combine calls to
@@ -39,7 +39,7 @@ export const _fusedMatMulConfig: KernelConfig = {
       }
 
       result = backend.applyActivation(
-          result, activation, preluActivationWeights as Tensor);
+          result, activation, preluActivationWeights as Tensor, leakyreluAlpha);
 
       return result;
     });

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -246,7 +246,8 @@ export class NodeJSKernelBackend extends KernelBackend {
   }
 
   applyActivation<T extends Tensor>(
-      input: T, activation: string, preluActivationWeights?: Tensor): T {
+      input: T, activation: string, preluActivationWeights?: Tensor,
+      leakyreluAlpha?: number): T {
     let result = input;
     if (activation != null) {
       if (activation === 'linear') {
@@ -255,6 +256,8 @@ export class NodeJSKernelBackend extends KernelBackend {
         result = tf.relu(result);
       } else if (activation === 'prelu') {
         result = tf.prelu(result, preluActivationWeights) as T;
+      } else if (activation === 'leakyrelu') {
+        result = tf.leakyRelu(result, leakyreluAlpha);
       } else if (activation === 'elu') {
         result = tf.elu(result);
       } else if (activation === 'relu6') {

--- a/tfjs-node/src/register_all_kernels.ts
+++ b/tfjs-node/src/register_all_kernels.ts
@@ -87,6 +87,7 @@ import {imagConfig} from './kernels/Imag';
 import {isFiniteConfig} from './kernels/IsFinite';
 import {isInfConfig} from './kernels/IsInf';
 import {isNanConfig} from './kernels/IsNan';
+import {leakyReluConfig} from './kernels/LeakyRelu';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
 import {linSpaceConfig} from './kernels/LinSpace';
@@ -235,6 +236,7 @@ const kernelConfigs: KernelConfig[] = [
   isFiniteConfig,
   isInfConfig,
   isNanConfig,
+  leakyReluConfig,
   lessConfig,
   lessEqualConfig,
   linSpaceConfig,


### PR DESCRIPTION
Add leakyrelu support to fused ops. Starting 2.5.0, TF starts to support leakyrelu activation for fusedConv2D. We need to add the same support for our backends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4322)
<!-- Reviewable:end -->
