### PR TITLE
make attrs argument in runKernel optional

### DIFF
--- a/tfjs-backend-cpu/src/kernels/Reshape_test.ts
+++ b/tfjs-backend-cpu/src/kernels/Reshape_test.ts
@@ -28,6 +28,7 @@ describeWithFlags('Reshape.', ALL_ENVS, () => {
 
     const x = tf.tensor1d([1, 1, 1, 1]);
     const res =
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel('Reshape', {x}, {shape: [2, 2]}) as Tensor;
 
     expectArraysClose(await res.data(), [1, 1, 1, 1]);
@@ -51,12 +52,14 @@ describeWithFlags('Reshape.', ALL_ENVS, () => {
 
     // Does not add new dataId;
     const res =
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel('Reshape', {x}, {shape: [2, 2]}) as Tensor;
 
     expectArraysEqual(res.shape, [2, 2]);
 
     // Does not add new dataId.
     const res2 =
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel('Reshape', {x: res}, {shape: [1, 4]}) as Tensor;
     expectArraysEqual(res2.shape, [1, 4]);
 

--- a/tfjs-backend-webgl/src/kernels/Reshape_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Reshape_test.ts
@@ -28,6 +28,7 @@ describeWithFlags('Reshape.', ALL_ENVS, () => {
 
     const x = tf.tensor1d([1, 1, 1, 1]);
     const res =
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel('Reshape', {x}, {shape: [2, 2]}) as Tensor;
 
     expectArraysClose(await res.data(), [1, 1, 1, 1]);
@@ -51,12 +52,14 @@ describeWithFlags('Reshape.', ALL_ENVS, () => {
 
     // Does not add new dataId;
     const res =
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel('Reshape', {x}, {shape: [2, 2]}) as Tensor;
 
     expectArraysEqual(res.shape, [2, 2]);
 
     // Does not add new dataId.
     const res2 =
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel('Reshape', {x: res}, {shape: [1, 4]}) as Tensor;
     expectArraysEqual(res2.shape, [1, 4]);
 

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -511,9 +511,9 @@ export class Engine implements TensorTracker, DataMover {
    *     for the backprop computation. These are booleans since the output
    * tensors are not visible to the user.
    */
-  runKernel(
-      kernelName: string, inputs: NamedTensorMap, attrs: NamedAttrMap,
-      inputsToSave?: Tensor[], outputsToSave?: boolean[]): Tensor|Tensor[] {
+  runKernel<T extends Tensor|Tensor[]>(
+      kernelName: string, inputs: NamedTensorMap, attrs?: NamedAttrMap,
+      inputsToSave?: Tensor[], outputsToSave?: boolean[]): T {
     const forwardFunc: null = null;
     const backwardsFunc: null = null;
     // Call runKernel as a stop-gap until we modularize all kernels.
@@ -627,6 +627,10 @@ export class Engine implements TensorTracker, DataMover {
         return outTensors;
       };
     } else {
+      if (forwardFunc == null) {
+        throw new Error(`Error running ${
+            kernelName}: Neither modular kernel nor forward func passed`);
+      }
       const saveFunc: GradSaveFunc = (tensors) => {
         // Do not save unless we are recording to the tape. Otherwise it would
         // cause a mem leak since we would never run backprop, which disposes

--- a/tfjs-core/src/gradients/Dilation2D_grad.ts
+++ b/tfjs-core/src/gradients/Dilation2D_grad.ts
@@ -32,11 +32,9 @@ export const dilation2dGradConfig: GradConfig = {
 
     return {
       x: () => ENGINE.runKernel(
-                   Dilation2DBackpropInput, inputInputs as {} as NamedTensorMap,
-                   attrs) as Tensor,
+          Dilation2DBackpropInput, inputInputs as {} as NamedTensorMap, attrs),
       filter: () => ENGINE.runKernel(
-                        Dilation2DBackpropFilter,
-                        filterInputs as {} as NamedTensorMap, attrs) as Tensor
+          Dilation2DBackpropFilter, filterInputs as {} as NamedTensorMap, attrs)
     };
   }
 };

--- a/tfjs-core/src/kernel_registry_test.ts
+++ b/tfjs-core/src/kernel_registry_test.ts
@@ -217,8 +217,7 @@ describeWithFlags('gradient registry', ALL_ENVS, () => {
 
     const gradFunc = tf.grad(
         x => tf.engine().runKernel(
-                 kernelName, {x}, {} /* attrs */, [x] /* inputsToSave */) as
-            tf.Tensor);
+            kernelName, {x}, {} /* attrs */, [x] /* inputsToSave */));
     const dx = gradFunc(x);
     expect(kernelWasCalled).toBe(true);
     expect(gradientWasCalled).toBe(true);
@@ -264,8 +263,8 @@ describeWithFlags('gradient registry', ALL_ENVS, () => {
 
        const gradFunc = tf.grad(
            x => tf.engine().runKernel(
-                    kernelName, {x}, {} /* attrs */
-                    ) as tf.Tensor);
+               kernelName, {x}, {} /* attrs */
+               ));
        const x = tf.zeros([2, 2]);
        const dx = gradFunc(x);
        expect(kernelWasCalled).toBe(true);
@@ -308,6 +307,7 @@ describeWithFlags('gradient registry', ALL_ENVS, () => {
 
     // Inputs as array.
     const z = (...x: tf.Tensor[]) =>
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         tf.engine().runKernel(
             kernelName, x as {} as tf.NamedTensorMap, {} /* attrs */) as
         tf.Tensor;
@@ -360,6 +360,7 @@ describeWithFlags('gradient registry', ALL_ENVS, () => {
 
        // Inputs as map.
        const z = (x0: tf.Tensor, x1: tf.Tensor) =>
+           // tslint:disable-next-line: no-unnecessary-type-assertion
            tf.engine().runKernel(kernelName, {x0, x1}, {} /* attrs */) as
            tf.Tensor;
        const gradFunc = tf.grads(z);
@@ -382,8 +383,7 @@ describeWithFlags('gradient registry', ALL_ENVS, () => {
 
     const gradFunc = tf.grad(
         x => tf.engine().runKernel(
-                 kernelName, {x}, {} /* attrs */, [x] /* inputsToSave */) as
-            tf.Tensor);
+            kernelName, {x}, {} /* attrs */, [x] /* inputsToSave */));
     expect(() => gradFunc(x))
         .toThrowError(/gradient function not found for MyKernel/);
 

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -110,8 +110,8 @@ function fromPixels_(
     const inputs: FromPixelsInputs = {pixels};
     const attrs: FromPixelsAttrs = {numChannels};
     return ENGINE.runKernel(
-               FromPixels, inputs as {} as NamedTensorMap,
-               attrs as {} as NamedAttrMap) as Tensor3D;
+        FromPixels, inputs as {} as NamedTensorMap,
+        attrs as {} as NamedAttrMap);
   }
 
   const [width, height] = isVideo ?

--- a/tfjs-core/src/ops/dilation2d.ts
+++ b/tfjs-core/src/ops/dilation2d.ts
@@ -90,6 +90,7 @@ function dilation2d_<T extends Tensor3D|Tensor4D>(
   const inputs: Dilation2DInputs = {x: x4D, filter: $filter};
   const attrs: Dilation2DAttrs = {strides, pad, dilations};
 
+  // tslint:disable-next-line: no-unnecessary-type-assertion
   const res = ENGINE.runKernel(
                   Dilation2D, inputs as {} as NamedTensorMap,
                   attrs as {} as NamedAttrMap) as T;

--- a/tfjs-core/src/ops/expand_dims.ts
+++ b/tfjs-core/src/ops/expand_dims.ts
@@ -52,8 +52,7 @@ function expandDims_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
   const attrs: ExpandDimsAttrs = {dim: axis};
 
   return ENGINE.runKernel(
-             ExpandDims, inputs as {} as NamedTensorMap,
-             attrs as {} as NamedAttrMap) as T;
+      ExpandDims, inputs as {} as NamedTensorMap, attrs as {} as NamedAttrMap);
 }
 
 export const expandDims = op({expandDims_});

--- a/tfjs-core/src/ops/image/non_max_suppression_padded.ts
+++ b/tfjs-core/src/ops/image/non_max_suppression_padded.ts
@@ -72,6 +72,7 @@ function nonMaxSuppressionPadded_(
     padToMaxOutputSize
   };
 
+  // tslint:disable-next-line: no-unnecessary-type-assertion
   const result = ENGINE.runKernel(
                      NonMaxSuppressionV4, inputs as {} as NamedTensorMap,
                      attrs as {} as NamedAttrMap) as Tensor[];

--- a/tfjs-core/src/ops/image/non_max_suppression_with_score.ts
+++ b/tfjs-core/src/ops/image/non_max_suppression_with_score.ts
@@ -75,6 +75,7 @@ function nonMaxSuppressionWithScore_(
   const attrs: NonMaxSuppressionV5Attrs =
       {maxOutputSize, iouThreshold, scoreThreshold, softNmsSigma};
 
+  // tslint:disable-next-line: no-unnecessary-type-assertion
   const result = ENGINE.runKernel(
                      NonMaxSuppressionV5, inputs as {} as NamedTensorMap,
                      attrs as {} as NamedAttrMap) as Tensor[];

--- a/tfjs-core/src/ops/leaky_relu.ts
+++ b/tfjs-core/src/ops/leaky_relu.ts
@@ -49,8 +49,7 @@ function leakyRelu_<T extends Tensor>(x: T|TensorLike, alpha = 0.2): T {
   const attrs: LeakyReluAttrs = {alpha};
 
   return ENGINE.runKernel(
-             LeakyRelu, inputs as {} as NamedTensorMap,
-             attrs as {} as NamedAttrMap) as T;
+      LeakyRelu, inputs as {} as NamedTensorMap, attrs as {} as NamedAttrMap);
 }
 
 export const leakyRelu = op({leakyRelu_});

--- a/tfjs-core/src/ops/max_pool_with_argmax.ts
+++ b/tfjs-core/src/ops/max_pool_with_argmax.ts
@@ -68,6 +68,7 @@ function maxPoolWithArgmax_<T extends Tensor4D>(
   const attrs:
       MaxPoolWithArgmaxAttrs = {filterSize, strides, pad, includeBatchInIndex};
 
+  // tslint:disable-next-line: no-unnecessary-type-assertion
   const result = ENGINE.runKernel(
                      MaxPoolWithArgmax, inputs as {} as NamedTensorMap,
                      attrs as {} as NamedAttrMap) as Tensor[];

--- a/tfjs-core/src/ops/mirror_pad.ts
+++ b/tfjs-core/src/ops/mirror_pad.ts
@@ -85,8 +85,7 @@ function mirrorPad_<T extends Tensor>(
   const attrs: MirrorPadAttrs = {paddings, mode};
   const inputs: MirrorPadInputs = {x: $x};
   return ENGINE.runKernel(
-             MirrorPad, inputs as {} as NamedTensorMap,
-             attrs as {} as NamedAttrMap) as T;
+      MirrorPad, inputs as {} as NamedTensorMap, attrs as {} as NamedAttrMap);
 }
 
 export const mirrorPad = op({mirrorPad_});

--- a/tfjs-core/src/ops/stack.ts
+++ b/tfjs-core/src/ops/stack.ts
@@ -57,8 +57,7 @@ function stack_<T extends Tensor>(
   const attrs: PackAttrs = {axis};
 
   return ENGINE.runKernel(
-             Pack, inputs as {} as NamedTensorMap,
-             attrs as {} as NamedAttrMap) as Tensor;
+      Pack, inputs as {} as NamedTensorMap, attrs as {} as NamedAttrMap);
 }
 
 export const stack = op({stack_});


### PR DESCRIPTION
And improve the typing of runKernel.

Context: This is __part one__ of [a much larger PR](https://github.com/tensorflow/tfjs/pull/4358) (I'm breaking that PR up into a set of smaller PRs). This step includes changes to runKernel to enable to changes to all the other ops present in that PR. 

In particular this change accommodates kernels that have no attrs. It also changes the typing to reduce the overall number of casts to `T/T[]/Tensor/Tensor[]` in ops. As is visible in the main PR, this doesn't eliminate all casts but will overall have less casting than keeping the types as is. Along with the change to engine this PR includes updates to _existing_ uses of runKernel

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4365)
<!-- Reviewable:end -->
