### PR TITLE
use runKernel instead of runKernelFunc

### DIFF
--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -233,7 +233,6 @@ tfjs_cc_library(
         ":Cumsum",
         ":DepthToSpace",
         ":DepthwiseConv2dNative",
-        ":Div",
         ":Equal",
         ":Exp",
         ":FlipLeftRight",
@@ -263,6 +262,7 @@ tfjs_cc_library(
         ":PadV2",
         ":Pow",
         ":Prelu",
+        ":RealDiv",
         ":Relu",
         ":Relu6",
         ":ResizeBilinear",
@@ -465,8 +465,8 @@ tfjs_unit_test(
 )
 
 tfjs_cc_library(
-    name = "Div",
-    srcs = ["kernels/Div.cc"],
+    name = "RealDiv",
+    srcs = ["kernels/RealDiv.cc"],
     deps = [
         ":binary",
         ":util",

--- a/tfjs-backend-wasm/src/cc/kernels/RealDiv.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/RealDiv.cc
@@ -37,9 +37,10 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Div(const size_t a_id, const size_t* a_shape_ptr, const size_t a_shape_len,
-         const size_t b_id, const size_t* b_shape_ptr, const size_t b_shape_len,
-         const DType dtype, const size_t out_id) {
+void RealDiv(const size_t a_id, const size_t* a_shape_ptr,
+             const size_t a_shape_len, const size_t b_id,
+             const size_t* b_shape_ptr, const size_t b_shape_len,
+             const DType dtype, const size_t out_id) {
   switch (dtype) {
     case DType::float32:
       binary_xnn_f32(a_id, a_shape_ptr, a_shape_len, b_id, b_shape_ptr,

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -1224,9 +1224,5 @@ export const ENGINE = getOrMakeEngine();
 export function add(a: Tensor, b: Tensor): Tensor {
   // We duplicate Add here to avoid a circular dependency with add.ts.
   const inputs = {a, b};
-  return ENGINE.runKernelFunc((backend, save) => {
-    const res = backend.add(a, b);
-    save([a, b]);
-    return res;
-  }, inputs as {} as NamedTensorMap, null /* gradient */, Add);
+  return ENGINE.runKernel(Add, inputs as {} as NamedTensorMap);
 }

--- a/tfjs-core/src/kernel_names.ts
+++ b/tfjs-core/src/kernel_names.ts
@@ -322,7 +322,7 @@ export const Dilation2DBackpropFilter = 'Dilation2DBackpropFilter';
 export type Dilation2DBackpropFilterInputs =
     Pick<NamedTensorInfoMap, 'x'|'filter'|'dy'>;
 
-export const RealDiv = 'Div';
+export const RealDiv = 'RealDiv';
 export type RealDivInputs = BinaryInputs;
 
 export const Elu = 'Elu';

--- a/tfjs-core/src/ops/broadcast_to.ts
+++ b/tfjs-core/src/ops/broadcast_to.ts
@@ -15,9 +15,8 @@
  * =============================================================================
  */
 
-import {KernelBackend} from '../backends/backend';
 import {ENGINE} from '../engine';
-import {BroadcastTo, BroadCastToAttrs, BroadcastToInputs} from '../kernel_names';
+import {Tile, TileAttrs, TileInputs} from '../kernel_names';
 import {NamedAttrMap} from '../kernel_registry';
 import {Tensor} from '../tensor';
 import {NamedTensorMap} from '../tensor_types';
@@ -27,7 +26,6 @@ import {Rank, ShapeMap, TensorLike} from '../types';
 import {clone} from './clone';
 import {op} from './operation';
 import {reshape} from './reshape';
-import {tile} from './tile';
 
 /**
  * Broadcast an array to a compatible shape NumPy-style.
@@ -81,14 +79,11 @@ function broadcastTo_<R extends Rank>(
     return clone(input) as Tensor<R>;
   }
 
-  const forward = (backend: KernelBackend) => tile(input, reps);
-
-  const inputs: BroadcastToInputs = {x: input};
-  const attrs: BroadCastToAttrs = {shape, inputShape};
-
-  return ENGINE.runKernelFunc(
-             forward, inputs as unknown as NamedTensorMap, null /* grad */,
-             BroadcastTo, attrs as unknown as NamedAttrMap) as Tensor<R>;
+  // TODO call broadcastTo kernel directly once backends implement broadcstTo
+  const inputs: TileInputs = {x: input};
+  const attrs: TileAttrs = {reps};
+  return ENGINE.runKernel(
+      Tile, inputs as {} as NamedTensorMap, attrs as unknown as NamedAttrMap)
 }
 
 export const broadcastTo = op({broadcastTo_});

--- a/tfjs-core/src/ops/broadcast_to.ts
+++ b/tfjs-core/src/ops/broadcast_to.ts
@@ -83,7 +83,7 @@ function broadcastTo_<R extends Rank>(
   const inputs: TileInputs = {x: input};
   const attrs: TileAttrs = {reps};
   return ENGINE.runKernel(
-      Tile, inputs as {} as NamedTensorMap, attrs as unknown as NamedAttrMap)
+      Tile, inputs as {} as NamedTensorMap, attrs as unknown as NamedAttrMap);
 }
 
 export const broadcastTo = op({broadcastTo_});

--- a/tfjs-core/src/ops/clone.ts
+++ b/tfjs-core/src/ops/clone.ts
@@ -40,15 +40,11 @@ import {op} from './operation';
  */
 function clone_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'clone', null);
-  const forward = () =>
-      ENGINE.makeTensorFromDataId($x.dataId, $x.shape, $x.dtype) as T;
-
   const inputs: IdentityInputs = {x: $x};
 
   // Note this op is called tf.identity in python. Hence the kernel name used
   // here.
-  return ENGINE.runKernelFunc(
-      forward, inputs as {} as NamedTensorMap, null /* grad */, Identity);
+  return ENGINE.runKernel(Identity, inputs as {} as NamedTensorMap);
 }
 
 export const clone = op({clone_});

--- a/tfjs-core/src/ops/log_softmax.ts
+++ b/tfjs-core/src/ops/log_softmax.ts
@@ -15,11 +15,10 @@
  * =============================================================================
  */
 
-import {ENGINE, ForwardFunc} from '../engine';
-import {LogSoftmax, LogSoftmaxAttrs, LogSoftmaxInputs} from '../kernel_names';
-import {NamedAttrMap} from '../kernel_registry';
+import {customGrad} from '../gradients';
+
 import {Tensor} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
+import {GradSaveFunc} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 
@@ -27,6 +26,7 @@ import {cast} from './cast';
 import {exp} from './exp';
 import {log} from './log';
 import {max} from './max';
+import {mul} from './mul';
 import {op} from './operation';
 import {sub} from './sub';
 import {sum} from './sum';
@@ -64,22 +64,43 @@ function logSoftmax_<T extends Tensor>(logits: T|TensorLike, axis = -1): T {
         `Logits was rank ${$logits.rank} and axis was ${axis}`);
   }
 
-  const forward: ForwardFunc<Tensor> = (backend, save) => {
+  // const forward: ForwardFunc<Tensor> = (backend, save) => {
+  //   const keepDims = true;
+  //   const xMax = max(logits, axis, true);
+  //   const shifted = sub(logits, xMax);
+  //   const value =
+  //       sub(cast(shifted, 'float32'), log(sum(exp(shifted), axis,
+  //       keepDims)));
+  //   save([value]);
+  //   return value;
+  // };
+
+  // Use a custom gradient for numerical stability.
+  const customOp = customGrad((logits: Tensor, save: GradSaveFunc) => {
     const keepDims = true;
     const xMax = max(logits, axis, true);
     const shifted = sub(logits, xMax);
     const value =
         sub(cast(shifted, 'float32'), log(sum(exp(shifted), axis, keepDims)));
     save([value]);
-    return value;
-  };
 
-  const inputs: LogSoftmaxInputs = {logits: $logits};
-  const attrs: LogSoftmaxAttrs = {axis};
+    const gradFunc = (dy: Tensor, saved: Tensor[]) => {
+      const [value] = saved;
+      const keepDims = true;
+      const softmax = exp(value);
+      return sub(dy, mul(sum(dy, axis, keepDims), softmax));
+    };
+    return {value, gradFunc};
+  });
 
-  return ENGINE.runKernelFunc(
-             forward, inputs as {} as NamedTensorMap, null /* grad */,
-             LogSoftmax, attrs as {} as NamedAttrMap) as T;
+  return customOp($logits) as T;
+
+  // TODO Use Engine.runKernel when CPU/WebGL/WASM backends implement this.
+  // const inputs: LogSoftmaxInputs = {logits: $logits};
+  // const attrs: LogSoftmaxAttrs = {axis};
+  // return ENGINE.runKernel(
+  //            LogSoftmax, inputs as {} as NamedTensorMap,
+  //            attrs as {} as NamedAttrMap);
 }
 
 export const logSoftmax = op({logSoftmax_});

--- a/tfjs-core/src/ops/mean.ts
+++ b/tfjs-core/src/ops/mean.ts
@@ -62,8 +62,7 @@ function mean_<T extends Tensor>(
   const attrs: MeanAttrs = {axis, keepDims};
 
   return ENGINE.runKernel(
-             Mean, inputs as {} as NamedTensorMap,
-             attrs as {} as NamedAttrMap) as T;
+      Mean, inputs as {} as NamedTensorMap, attrs as {} as NamedAttrMap);
 }
 
 export const mean = op({mean_});

--- a/tfjs-core/src/ops/mean.ts
+++ b/tfjs-core/src/ops/mean.ts
@@ -15,21 +15,15 @@
  * =============================================================================
  */
 
-import {ENGINE, ForwardFunc} from '../engine';
+import {ENGINE} from '../engine';
 import {Mean, MeanAttrs, MeanInputs} from '../kernel_names';
 import {NamedAttrMap} from '../kernel_registry';
 import {Tensor} from '../tensor';
 import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
-import {parseAxisParam, sizeFromShape} from '../util';
 
-import {computeOutAndReduceShapes} from './axis_util';
-import {cast} from './cast';
-import {div} from './div';
 import {op} from './operation';
-import {scalar} from './scalar';
-import {sum} from './sum';
 
 /**
  * Computes the mean of elements across dimensions of a `tf.Tensor`.
@@ -66,24 +60,9 @@ function mean_<T extends Tensor>(
 
   const inputs: MeanInputs = {x: $x};
   const attrs: MeanAttrs = {axis, keepDims};
-  const forward: ForwardFunc<Tensor> = (backend, save) => {
-    save([$x]);
-    const axes = parseAxisParam(axis, $x.shape);
-    const shapes = computeOutAndReduceShapes($x.shape, axes);
-    const reduceShape = shapes[1];
-    const reduceSize = sizeFromShape(reduceShape);
 
-    const reduceSizeScalar = scalar(reduceSize);
-    // Cast if needed.
-    const xReduce = reduceSizeScalar.dtype === $x.dtype ?
-        $x :
-        cast($x, reduceSizeScalar.dtype);
-    const res = div(xReduce, reduceSizeScalar);
-    return sum(res, axis, keepDims);
-  };
-
-  return ENGINE.runKernelFunc(
-             forward, inputs as {} as NamedTensorMap, null /* grad */, Mean,
+  return ENGINE.runKernel(
+             Mean, inputs as {} as NamedTensorMap,
              attrs as {} as NamedAttrMap) as T;
 }
 

--- a/tfjs-core/src/ops/sqrt.ts
+++ b/tfjs-core/src/ops/sqrt.ts
@@ -41,10 +41,6 @@ function sqrt_<T extends Tensor>(x: T|TensorLike): T {
 
   const inputs: SqrtInputs = {x: $x};
 
-  return ENGINE.runKernelFunc((backend, save) => {
-    const res = backend.sqrt($x);
-    save([$x]);
-    return res;
-  }, inputs as {} as NamedTensorMap, null /* grad */, Sqrt);
+  return ENGINE.runKernel(Sqrt, inputs as {} as NamedTensorMap);
 }
 export const sqrt = op({sqrt_});

--- a/tfjs-node/src/kernels/Mean.ts
+++ b/tfjs-node/src/kernels/Mean.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {cast, KernelConfig, Mean, MeanAttrs, MeanInputs, Tensor, tensor1d, util} from '@tensorflow/tfjs';
+
+import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+
+export const meanConfig: KernelConfig = {
+  kernelName: Mean,
+  backendName: 'tensorflow',
+  kernelFunc: (args) => {
+    const {x} = args.inputs as MeanInputs;
+    const backend = args.backend as NodeJSKernelBackend;
+    const {axis, keepDims} = args.attrs as {} as MeanAttrs;
+    const axes = util.parseAxisParam(axis, x.shape);
+    const axesTensor = tensor1d(axes, 'int32');
+
+    // Cast to float32 to match existing tfjs implementation/tests.
+    const asFloat32 = cast(x as Tensor, 'float32');
+    const res = backend.executeSingleOutput(
+        Mean, backend.createReductionOpAttrs(x, keepDims),
+        [asFloat32, axesTensor]);
+
+    asFloat32.dispose();
+    axesTensor.dispose();
+    return res;
+  }
+};

--- a/tfjs-node/src/register_all_kernels.ts
+++ b/tfjs-node/src/register_all_kernels.ts
@@ -106,6 +106,7 @@ import {maxPoolConfig} from './kernels/MaxPool';
 import {maxPool3DConfig} from './kernels/MaxPool3D';
 import {maxPool3DGradConfig} from './kernels/MaxPool3DGrad';
 import {maxPoolGradConfig} from './kernels/MaxPoolGrad';
+import {meanConfig} from './kernels/Mean';
 import {minConfig} from './kernels/Min';
 import {minimumConfig} from './kernels/Minimum';
 import {mirrorPadConfig} from './kernels/MirrorPad';
@@ -255,6 +256,7 @@ const kernelConfigs: KernelConfig[] = [
   maxPoolConfig,
   maxPoolGradConfig,
   maximumConfig,
+  meanConfig,
   minConfig,
   minimumConfig,
   mirrorPadConfig,


### PR DESCRIPTION
Change implementation of logSoftmax to use customGrad since no backends implement it directly yet.
Change broadcastTo op to call Tile kernel directly.
Add Mean kernel implementation to node backend.

Also align Div => RealDiv naming across backends.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4381)
<!-- Reviewable:end -->
