### PR TITLE
Run a single browser per Karma server

### DIFF
--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -53,7 +53,7 @@ fi
 
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac,win_10_chrome --tags $TAGS
+  yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac,win_10_chrome,bs_android_9 --tags $TAGS
 
   # Test script tag bundles
   karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -52,8 +52,13 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
 fi
 
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
-  yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac,win_10_chrome,bs_android_9 --tags $TAGS
+  yarn run-browserstack --browsers=bs_safari_mac --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  yarn run-browserstack --browsers=bs_ios_11 --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+
+  yarn run-browserstack --browsers=bs_firefox_mac --tags $TAGS
+  yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
+  yarn run-browserstack --browsers=win_10_chrome --tags $TAGS
+  yarn run-browserstack --browsers=bs_android_9 --tags $TAGS
 
   # Test script tag bundles
   karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -14,8 +14,10 @@ yarn test-node
 
 if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_safari_mac
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac
-  yarn run-browserstack --browsers=win_10_chrome,bs_android_9
+  yarn run-browserstack --browsers=bs_firefox_mac
+  yarn run-browserstack --browsers=bs_chrome_mac
+  yarn run-browserstack --browsers=win_10_chrome
+  yarn run-browserstack --browsers=bs_android_9
   yarn run-browserstack --browsers=bs_ios_11
 else
   yarn run-browserstack --browsers=bs_chrome_mac

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -19,7 +19,7 @@ set -e
 if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1
   yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac
-  yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2
+  yarn run-browserstack --browsers=win_10_chrome,bs_android_9 --testEnv webgl2
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
 else

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -17,9 +17,12 @@
 set -e
 
 if [ "$NIGHTLY" = true ]; then
-  yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac
-  yarn run-browserstack --browsers=win_10_chrome,bs_android_9 --testEnv webgl2
+  yarn run-browserstack --browsers=bs_safari_mac --testEnv webgl1
+  yarn run-browserstack --browsers=bs_ios_11 --testEnv webgl1
+  yarn run-browserstack --browsers=bs_firefox_mac
+  yarn run-browserstack --browsers=bs_chrome_mac
+  yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2
+  yarn run-browserstack --browsers=bs_android_9 --testEnv webgl2
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
 else

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -21,11 +21,17 @@ yarn test-node-ci
 
 if [ "$NIGHTLY" = true ]
 then
+  # TODO(mattsoulanille): Is the following comment still relevant now that we're
+  # runing each browser separately?
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
   yarn run-browserstack --browsers=bs_chrome_mac
 
-  yarn run-browserstack --browsers=bs_firefox_mac,bs_safari_mac,bs_ios_11,bs_android_9 --flags '{"HAS_WEBGL": false}' --testEnv cpu
+  yarn run-browserstack --browsers=bs_firefox_mac --flags '{"HAS_WEBGL": false}' --testEnv cpu
+  yarn run-browserstack --browsers=bs_safari_mac --flags '{"HAS_WEBGL": false}' --testEnv cpu
+  yarn run-browserstack --browsers=bs_ios_11 --flags '{"HAS_WEBGL": false}' --testEnv cpu
+  yarn run-browserstack --browsers=bs_android_9 --flags '{"HAS_WEBGL": false}' --testEnv cpu
+
 
   ### The next section tests TF.js in a webworker using the CPU backend.
   echo "Start webworker test."
@@ -33,7 +39,8 @@ then
   yarn rollup -c --ci
   # copy the cpu backend bundle somewhere the test can access it
   cp -v ../tfjs-backend-cpu/dist/tf-backend-cpu.min.js dist/
-  yarn test-webworker --browsers=bs_safari_mac,bs_chrome_mac
+  yarn test-webworker --browsers=bs_safari_mac
+  yarn test-webworker --browsers=bs_chrome_mac
 else
   yarn run-browserstack --browsers=bs_chrome_mac
 fi

--- a/tfjs/scripts/test-ci.sh
+++ b/tfjs/scripts/test-ci.sh
@@ -17,8 +17,12 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-yarn karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun
+yarn karma start --browsers='bs_firefox_mac' --singleRun
+yarn karma start --browsers='bs_chrome_mac' --singleRun
 yarn test-tools
+
+# If these are re-enabled, note that they may run multiple browsers per karma
+# instance.
 # cd integration_tests
 # yarn benchmark-cloud
 # Reinstall the following line once https://github.com/tensorflow/tfjs/pull/1663


### PR DESCRIPTION
Running multiple browsers off of the same Karma server causes tests to sporadically fail. Until we figure out the cause (and to unblock the 2.8.0 release), we should run only one browser per Karma server.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4389)
<!-- Reviewable:end -->
