### PR TITLE
Remove browserstack android tests

### DIFF
--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -58,7 +58,6 @@ if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   yarn run-browserstack --browsers=bs_firefox_mac --tags $TAGS
   yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
   yarn run-browserstack --browsers=win_10_chrome --tags $TAGS
-  yarn run-browserstack --browsers=bs_android_9 --tags $TAGS
 
   # Test script tag bundles
   karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -17,7 +17,6 @@ if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_firefox_mac
   yarn run-browserstack --browsers=bs_chrome_mac
   yarn run-browserstack --browsers=win_10_chrome
-  yarn run-browserstack --browsers=bs_android_9
   yarn run-browserstack --browsers=bs_ios_11
 else
   yarn run-browserstack --browsers=bs_chrome_mac

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -22,7 +22,6 @@ if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_firefox_mac
   yarn run-browserstack --browsers=bs_chrome_mac
   yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2
-  yarn run-browserstack --browsers=bs_android_9 --testEnv webgl2
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
 else

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -30,7 +30,6 @@ then
   yarn run-browserstack --browsers=bs_firefox_mac --flags '{"HAS_WEBGL": false}' --testEnv cpu
   yarn run-browserstack --browsers=bs_safari_mac --flags '{"HAS_WEBGL": false}' --testEnv cpu
   yarn run-browserstack --browsers=bs_ios_11 --flags '{"HAS_WEBGL": false}' --testEnv cpu
-  yarn run-browserstack --browsers=bs_android_9 --flags '{"HAS_WEBGL": false}' --testEnv cpu
 
 
   ### The next section tests TF.js in a webworker using the CPU backend.


### PR DESCRIPTION
Automated android tests are blocking the 2.8.1 release, so we're testing them manually.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4423)
<!-- Reviewable:end -->
