### PR TITLE
initialize/set backend in runKernelFunc

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -585,7 +585,8 @@ export class Engine implements TensorTracker, DataMover {
     if (this.backendName == null) {
       // backend has not been initialized yet. Fetch it to trigger
       // initialization.
-      this.backend;
+      // tslint:disable-next-line: no-unused-expression
+      this.backend;  // this getter has side effects
     }
     const kernel = getKernel(kernelName, this.backendName);
     let out: TensorInfo|TensorInfo[];

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -583,10 +583,12 @@ export class Engine implements TensorTracker, DataMover {
 
     let kernelFunc: () => Tensor[];
     if (this.backendName == null) {
-      // backend has not been initialized yet. Fetch it to trigger
-      // initialization.
+      // backend has not been initialized yet (backend initialization is lazy
+      // can be deferred until an op/ kernel is run).
+      // The below getter has side effects that will try to initialize the
+      // backend and set properties like this.backendName
       // tslint:disable-next-line: no-unused-expression
-      this.backend;  // this getter has side effects
+      this.backend;
     }
     const kernel = getKernel(kernelName, this.backendName);
     let out: TensorInfo|TensorInfo[];

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -582,6 +582,11 @@ export class Engine implements TensorTracker, DataMover {
     }
 
     let kernelFunc: () => Tensor[];
+    if (this.backendName == null) {
+      // backend has not been initialized yet. Fetch it to trigger
+      // initialization.
+      this.backend;
+    }
     const kernel = getKernel(kernelName, this.backendName);
     let out: TensorInfo|TensorInfo[];
     if (kernel != null) {


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/4480

Initialize backend in runKernelFunc if its not already initialized/set.

It manifests in the bug above because linspace no longer calls other ops which would initialize the backend (usually by creating some tensor). It also affects op like range which call runKernel before doing any tensor creation or anything else. The bug will _only appear if linspace or range is the first op_ called, and no any other action that would cause the lazy setting of a backend to have completed (like tensor creation).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4485)
<!-- Reviewable:end -->
