### PR TITLE
[wasm] Implement the Round kernel

### DIFF
--- a/tfjs-backend-wasm/src/cc/kernels/Round.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Round.cc
@@ -1,0 +1,38 @@
+/* Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+#include <xnnpack.h>
+
+#include "src/cc/backend.h"
+#include "src/cc/unary.h"
+
+namespace tfjs {
+namespace wasm {
+// We use C-style API to interface with Javascript.
+extern "C" {
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+void Round(const size_t x_id, const size_t out_id) {
+  unary_xnn_f32(x_id, out_id, xnn_create_bankers_rounding_nc_f32,
+                xnn_setup_bankers_rounding_nc_f32);
+}
+
+}  // extern "C"
+}  // namespace wasm
+}  // namespace tfjs

--- a/tfjs-backend-wasm/src/kernels/Round.ts
+++ b/tfjs-backend-wasm/src/kernels/Round.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {KernelConfig, Round} from '@tensorflow/tfjs-core';
+
+import {createUnaryKernelConfig} from './unary_kernel';
+
+export const roundConfig: KernelConfig = createUnaryKernelConfig(Round);

--- a/tfjs-backend-wasm/src/register_all_kernels.ts
+++ b/tfjs-backend-wasm/src/register_all_kernels.ts
@@ -83,6 +83,7 @@ import {reshapeConfig} from './kernels/Reshape';
 import {resizeBilinearConfig} from './kernels/ResizeBilinear';
 import {reverseConfig} from './kernels/Reverse';
 import {rotateWithOffsetConfig} from './kernels/RotateWithOffset';
+import {roundConfig} from './kernels/Round';
 import {rsqrtConfig} from './kernels/Rsqrt';
 import {scatterNdConfig} from './kernels/ScatterNd';
 import {selectConfig} from './kernels/Select';
@@ -171,6 +172,7 @@ const kernelConfigs: KernelConfig[] = [
   reverseConfig,
   rotateWithOffsetConfig,
   rsqrtConfig,
+  roundConfig,
   scatterNdConfig,
   selectConfig,
   sigmoidConfig,

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -381,7 +381,12 @@ const TEST_FILTERS: TestFilter[] = [
   {include: 'floor'},
   {include: 'topk'},
   {include: 'expandDims'},
-  {include: 'stack'}
+  {include: 'stack'},
+  {
+    include: 'round',
+    // Pool is not supported yet.
+    excludes: ['pool'],
+  },
 ];
 
 const customInclude = (testName: string) => {


### PR DESCRIPTION
Implement the Round kernel using XNNPACK's banker's rounding. Banker's rounding rounds to the nearest integer, but breaks ties in the direction of the nearest even integer. It passes our tests, but might not be desirable. XNNPACK doesn't seem to expose a 'normal' rounding operator that always rounds up in the case of a tie.

Closes #4434 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4486)
<!-- Reviewable:end -->
