### PR TITLE
add prioritizeBackend, expose getSortedBackends

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -168,7 +168,7 @@ export class Engine implements TensorTracker, DataMover {
     const sortedBackends = this.getSortedBackends();
 
     for (let i = 0; i < sortedBackends.length; i++) {
-      const backendName = sortedBackends[i];
+      const backendName = sortedBackends[i].name;
       const success = await this.initializeBackend(backendName).success;
       if (success) {
         await this.setBackend(backendName);
@@ -368,7 +368,17 @@ export class Engine implements TensorTracker, DataMover {
     }
   }
 
-  private getSortedBackends(): string[] {
+  prioritizeBackend(name: string, priority: number): void {
+    const registryFactoryEntry = this.registryFactory[name];
+    if (registryFactoryEntry == null) {
+      throw new Error(
+        `Cannot prioritize backend ${name}, no registration found.`);
+    }
+
+    registryFactoryEntry.priority = priority;
+  }
+
+  getSortedBackends(): Array<{name: string, priority: number}> {
     if (Object.keys(this.registryFactory).length === 0) {
       throw new Error('No backend found in registry.');
     }
@@ -376,7 +386,10 @@ export class Engine implements TensorTracker, DataMover {
       // Highest priority comes first.
       return this.registryFactory[b].priority -
           this.registryFactory[a].priority;
-    });
+    }).map(name => ({
+      name,
+      priority: this.registryFactory[name].priority
+    }));
   }
 
   private initializeBackendsAndReturnBest():
@@ -384,7 +397,7 @@ export class Engine implements TensorTracker, DataMover {
     const sortedBackends = this.getSortedBackends();
 
     for (let i = 0; i < sortedBackends.length; i++) {
-      const backendName = sortedBackends[i];
+      const backendName = sortedBackends[i].name;
       const {success, asyncInit} = this.initializeBackend(backendName);
       if (asyncInit || success) {
         return {name: backendName, asyncInit};

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -314,6 +314,28 @@ export function getBackend(): string {
 }
 
 /**
+ * Returns all backends sorted by priority order.
+ *
+ * @doc {heading: 'Backends'}
+ */
+export function getSortedBackends(): Array<{name: string, priority: number}> {
+  return ENGINE.getSortedBackends();
+}
+
+/**
+ * Re-prioritize a backend.
+ * Should be called prior awaiting ready() or backend().
+ *
+ * @param name The backend to prioritize
+ * @param priority The new priority. Defaults to 1.
+ *
+ * @doc {heading: 'Backends'}
+ */
+export function prioritizeBackend(name: string, priority = 1): void {
+  ENGINE.prioritizeBackend(name, priority);
+}
+
+/**
  * Removes a backend and the registered factory.
  *
  * @doc {heading: 'Backends'}


### PR DESCRIPTION
I observed some backends are registered with the same priority, like [webgl](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-webgl/src/base.ts#L25) and [wasm](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-wasm/src/base.ts#L27), both with priority `2`. In this case, it is not trivial to predict which backend will be sorted with the highest priority, as per the [getSortedBackends](https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/engine.ts#L375) implementation.
More generally, a consumer may wish to manage backend priorities on its own.

This change proposes to include priorities in the array returned by `getSortedBackends`, and expose a new `prioritizeBackend`.

Usage example:
```js
const backends = tf.getSortedBackends();
// [{name: 'wasm', priority: 2}, {name: 'webgl', priority: 2}, {name: 'cpu', priority: 1}]

// favor webgl over wasm
tf.prioritizeBackend('webgl', 3);
// [{name: 'webgl', priority: 3}, {name: 'wasm', priority: 2}, {name: 'cpu', priority: 1}]

await tf.ready();
```



