### PR TITLE
enable createImageBitmap test only for chrome

### DIFF
--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -283,25 +283,28 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     expectArraysClose(pixelsData, actualInt32, 10);
   });
 
-  it('fromPixels for ImageBitmap', async () => {
-    const imageDataWidth = 1;
-    const imageDataHeight = 2;
-    const numChannel = 3;
-    const pixels = new ImageData(imageDataWidth,imageDataHeight);
-    for (let i = 0; i < imageDataWidth * imageDataHeight * 4; ++i) {
-      if (i % 4 === 3) {
-        pixels.data[i] = 255;
-      } else {
-        pixels.data[i] = i;
+  if (tf.env().getBool('IS_CHROME')) {
+    it('fromPixels for ImageBitmap', async () => {
+      const imageDataWidth = 1;
+      const imageDataHeight = 2;
+      const numChannel = 3;
+      const pixels = new ImageData(imageDataWidth, imageDataHeight);
+      for (let i = 0; i < imageDataWidth * imageDataHeight * 4; ++i) {
+        if (i % 4 === 3) {
+          pixels.data[i] = 255;
+        } else {
+          pixels.data[i] = i;
+        }
       }
-    }
 
-    const imageBitmap = await createImageBitmap(pixels);
-    const res = tf.browser.fromPixels(imageBitmap, numChannel);
-    imageBitmap.close();
-    expect(res.shape).toEqual([imageDataHeight, imageDataWidth, numChannel]);
-    const data = await res.data();
-    expect(data.length).toEqual(imageDataHeight * imageDataWidth * numChannel);
-    expectArraysEqual(await res.data(), [0, 1, 2, 4, 5, 6]);
-  });
+      const imageBitmap = await createImageBitmap(pixels);
+      const res = tf.browser.fromPixels(imageBitmap, numChannel);
+      imageBitmap.close();
+      expect(res.shape).toEqual([imageDataHeight, imageDataWidth, numChannel]);
+      const data = await res.data();
+      expect(data.length)
+          .toEqual(imageDataHeight * imageDataWidth * numChannel);
+      expectArraysEqual(await res.data(), [0, 1, 2, 4, 5, 6]);
+    });
+  }
 });


### PR DESCRIPTION
This will fix the nightly build failure that is caused by https://github.com/tensorflow/tfjs/pull/4374
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4496)
<!-- Reviewable:end -->
