### PR TITLE
Update FromPixelsImageBitmap Pipeline Cache Strategy

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -355,7 +355,7 @@ export class WebGPUBackend extends KernelBackend {
     return res;
   }
 
-  private getAndSavePipeline(
+  getAndSavePipeline(
       key: string, getBinary: () => webgpu_program.WebGPUBinary) {
     if (!(key in this.binaryCache)) {
       this.binaryCache[key] = getBinary();

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -92,8 +92,8 @@ export class FromPixelsProgram implements WebGPUProgram {
   }
 
   setUniform(device: GPUDevice, uniformData: number[]) {
-    // Create the uniform buffer if it is not exists.
-    // The uniform buffer size is stick so we can hold
+    // Create the uniform buffer if it does not exist.
+    // The uniform buffer size is fixed so we can hold
     // and reuse it always.
     if (!this.uniform) {
       const uniformBuffer = device.createBuffer({

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -306,5 +306,39 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
           .toEqual(imageDataHeight * imageDataWidth * numChannel);
       expectArraysEqual(await res.data(), [0, 1, 2, 4, 5, 6]);
     });
+
+    it('fromPixels for ImageBitmap outShape changes', async() => {
+      const imageDataWidth = 2;
+      const imageDataHeight = 2;
+      let numChannel = 3;
+      const pixels = new ImageData(imageDataWidth, imageDataHeight);
+      for (let i = 0; i < imageDataWidth * imageDataHeight * 4; ++i) {
+        if (i % 4 === 3) {
+          pixels.data[i] = 255;
+        } else {
+          pixels.data[i] = i;
+        }
+      }
+
+      const imageBitmap = await createImageBitmap(pixels);
+      const res = tf.browser.fromPixels(imageBitmap, numChannel);
+      expect(res.shape).toEqual([imageDataHeight, imageDataWidth, numChannel]);
+      const data = await res.data();
+      expect(data.length)
+          .toEqual(imageDataHeight * imageDataWidth * numChannel);
+      expectArraysEqual(await res.data(),
+          [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]);
+
+      // Change output shapes
+      numChannel = 4;
+      const resShapeChange = tf.browser.fromPixels(imageBitmap, numChannel);
+      expect(resShapeChange.shape)
+          .toEqual([imageDataHeight, imageDataWidth, numChannel]);
+      const data2 = await resShapeChange.data();
+      expect(data2.length)
+          .toEqual(imageDataHeight * imageDataWidth * numChannel);
+      expectArraysEqual(await resShapeChange.data(),
+          [0, 1, 2, 255, 4, 5, 6, 255, 8, 9, 10, 255, 12, 13, 14, 255]);
+    });
   }
 });


### PR DESCRIPTION
In previous code, FromPixelsImageBitmap will cache the whole program
when it has been created first time and keep it unchanged.

But preprocessor will change the shader code based on output shape. So
the cache strategy of FromPixelsImageBitmap is not correct.

This CL updated the strategy to use WebGPU pipeline cache system and
check out shape for every invocation.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4499)
<!-- Reviewable:end -->
