### PR TITLE
Add safeguard to initializer field.

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -330,7 +330,7 @@ def write_artifacts(topology,
   if metadata:
     model_json[common.USER_DEFINED_METADATA_KEY] = metadata
 
-  if initializer_graph_def:
+  if initializer_graph_def and initializer_graph_def.node:
     model_json[common.ARTIFACT_MODEL_INITIALIZER] = MessageToDict(
         initializer_graph_def)
 


### PR DESCRIPTION
TFX has some logic in exporter to remove some preprocessing nodes that are not included in the final graph, but collection_def still has table_initializer with an empty node list. Ideally, this should be fixed in the exporter code. Adding safeguard code on our side to only set modelInitializer field if node list is not empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4513)
<!-- Reviewable:end -->
