### PR TITLE
Avoid building tfjs-core twice in CI

### DIFF
--- a/tfjs-core/cloudbuild.yml
+++ b/tfjs-core/cloudbuild.yml
@@ -13,25 +13,26 @@ steps:
   args: ['install']
   waitFor: ['yarn-common']
 
-# Build deps.
-# Named 'build-deps-always' since it must be run in CI,
-# and 'build-deps' would get automatically removed.
-# This is a hack around the limitation that there can not
-# be cycles in the continuous integration dependency tree.
-- name: 'node:10'
-  dir: 'tfjs-core'
-  id: 'build-deps-always'
-  entrypoint: 'yarn'
-  args: ['build-deps-ci']
-  waitFor: ['yarn']
-
 # Build.
 - name: 'node:10'
   dir: 'tfjs-core'
   id: 'build'
   entrypoint: 'yarn'
   args: ['build-ci']
-  waitFor: ['yarn', 'build-deps-always']
+  waitFor: ['yarn']
+
+# Build cpu backend. The cpu backend is included into tfjs-core with 'require()'
+# syntax to avoid circular 'import' statements between packages and is only used
+# for running tests. It is built after tfjs-core because it imports from
+# tfjs-core. In CI runs of generated cloudbuild files, tfjs-backend-cpu may be
+# built twice (here and in its own cloudbuild rules), but the second build only
+# takes about 20 seconds due to incremental tsc.
+- name: 'node:10'
+  dir: 'tfjs-core'
+  id: 'build-cpu-backend'
+  entrypoint: 'yarn'
+  args: ['build-cpu-backend']
+  waitFor: ['build']
 
 # Lint.
 - name: 'node:10'
@@ -39,7 +40,7 @@ steps:
   id: 'lint'
   entrypoint: 'yarn'
   args: ['lint']
-  waitFor: ['yarn', 'build-deps-always']
+  waitFor: ['yarn', 'build-cpu-backend']
 
 # Run unit tests.
 - name: 'node:10'
@@ -47,7 +48,7 @@ steps:
   id: 'test'
   entrypoint: 'yarn'
   args: ['test-ci']
-  waitFor: ['yarn', 'build-deps-always', 'lint']
+  waitFor: ['yarn', 'build-cpu-backend', 'lint']
   env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
   secretEnv: ['BROWSERSTACK_KEY']
 
@@ -65,7 +66,7 @@ steps:
   id: 'test-snippets'
   entrypoint: 'yarn'
   args: ['test-snippets-ci']
-  waitFor: ['yarn', 'build']
+  waitFor: ['yarn', 'build-cpu-backend']
 
 # test Async backends
 - name: 'node:10'
@@ -73,7 +74,7 @@ steps:
   id: 'test-async-backends'
   entrypoint: 'yarn'
   args: ['test-async-backends-ci']
-  waitFor: ['build']
+  waitFor: ['build-cpu-backend']
 
 # General configuration
 secrets:

--- a/tfjs-core/cloudbuild.yml
+++ b/tfjs-core/cloudbuild.yml
@@ -31,7 +31,7 @@ steps:
   dir: 'tfjs-core'
   id: 'build-cpu-backend'
   entrypoint: 'yarn'
-  args: ['build-cpu-backend']
+  args: ['build-cpu-backend-ci']
   waitFor: ['build']
 
 # Lint.

--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -57,7 +57,6 @@
     "bundle-ci": "rollup -c --ci",
     "build-npm": "./scripts/build-npm.sh",
     "build-deps": "yarn build && yarn build-cpu-backend",
-    "build-deps-ci": "yarn build-ci && yarn build-cpu-backend-ci",
     "build-cpu-backend": "cd ../tfjs-backend-cpu && yarn && yarn build",
     "build-cpu-backend-ci": "cd ../tfjs-backend-cpu && yarn && yarn build-ci",
     "build:bazel": "bazelisk build //...",


### PR DESCRIPTION
tfjs-core's 'build-deps-always' cloudbuild rule runs 'yarn build-deps-ci', which, due to a circular dependency with tfjs-backend-cpu, first builds tfjs-core before building its dependencies. The 'build' cloudbuild rule then builds tfjs-core again right after tfjs-backend-cpu is built. Since tfjs-core imports tfjs-backend-cpu for testing only, and uses `require()` notation to do so, this rebuild is unnecessary. This commit removes the extra rebuild of tfjs-core.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4518)
<!-- Reviewable:end -->
