### PR TITLE
Fix WASM JS script not working after minification

### DIFF
--- a/rollup.config.helpers.js
+++ b/rollup.config.helpers.js
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {terser} from 'rollup-plugin-terser';
+
+/**
+ * Returns a standardized list of browser package configuration options
+ * that we want to use in all our rollup files and ship to NPM.
+ *
+ * @param {string} fileName
+ * @param {string} preamble
+ * @param {boolean} visualize - produce bundle visualizations for certain
+ *     bundles
+ * @param {boolean} ci is this a CI build
+ * @param {object} terserExtraOptions is any extra options passed to terser
+ */
+export function getBrowserBundleConfigOptions(
+    config, name, fileName, preamble, visualize, ci, terserExtraOptions = {}) {
+  const bundles = [];
+
+  const terserPlugin =
+      terser({output: {preamble, comments: false}, ...terserExtraOptions});
+  const extend = true;
+  const umdFormat = 'umd';
+  const fesmFormat = 'es';
+
+  // UMD ES5 minified
+  bundles.push(config({
+    plugins: [terserPlugin],
+    output: {
+      format: umdFormat,
+      name,
+      extend,
+      file: `dist/${fileName}.min.js`,
+      freeze: false
+    },
+    tsCompilerOptions: {target: 'es5'},
+    visualize
+  }));
+
+  if (ci) {
+    // In CI we do not build all the possible bundles.
+    return bundles;
+  }
+
+  // UMD ES5 unminified
+  bundles.push(config({
+    output: {
+      format: umdFormat,
+      name,
+      extend,
+      file: `dist/${fileName}.js`,
+      freeze: false
+    },
+    tsCompilerOptions: {target: 'es5'}
+  }));
+
+  // UMD ES2017
+  bundles.push(config({
+    output:
+        {format: umdFormat, name, extend, file: `dist/${fileName}.es2017.js`},
+    tsCompilerOptions: {target: 'es2017'}
+  }));
+
+  // UMD ES2017 minified
+  bundles.push(config({
+    plugins: [terserPlugin],
+    output: {
+      format: umdFormat,
+      name,
+      extend,
+      file: `dist/${fileName}.es2017.min.js`
+    },
+    tsCompilerOptions: {target: 'es2017'},
+    visualize
+  }));
+
+  // FESM ES2017
+  bundles.push(config({
+    output:
+        {format: fesmFormat, name, extend, file: `dist/${fileName}.fesm.js`},
+    tsCompilerOptions: {target: 'es2017'}
+  }));
+
+  // FESM ES2017 minified
+  bundles.push(config({
+    plugins: [terserPlugin],
+    output: {
+      format: fesmFormat,
+      name,
+      extend,
+      file: `dist/${fileName}.fesm.min.js`
+    },
+    tsCompilerOptions: {target: 'es2017'},
+    visualize
+  }));
+
+
+  return bundles;
+}

--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -116,7 +116,7 @@ tf.setBackend('wasm').then(() => {...});
 ## JS Minification
 
 If your bundler is capable of minifying JS code, please turn off the option
-that transforms ```typeof foo == "undefined"``` into ```foo === void ```. For
+that transforms ```typeof foo == "undefined"``` into ```foo === void 0```. For
 example, in [terser](https://github.com/terser/terser), the option is called
 "typeofs" (located under the
 [Compress options](https://github.com/terser/terser#compress-options) section).

--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -113,6 +113,17 @@ setWasmPaths(yourCustomPathPrefix, usePlatformFetch);
 tf.setBackend('wasm').then(() => {...});
 ```
 
+## JS Minification
+
+If your bundler is capable of minifying JS code, please turn off the option
+that transforms ```typeof foo == "undefined"``` into ```foo === void ```. For
+example, in [terser](https://github.com/terser/terser), the option is called
+"typeofs" (located under the
+[Compress options](https://github.com/terser/terser#compress-options) section).
+Without this feature turned off, the minified code will throw "_scriptDir is not
+defined" error from web workers when running in browsers with
+SIMD+multi-threading support.
+
 ## Benchmarks
 
 The benchmarks below show inference times (ms) for two different edge-friendly

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -73,6 +73,7 @@
     "rimraf": "~2.6.2",
     "rollup": "~1.26.3",
     "rollup-plugin-terser": "~5.3.0",
+    "rollup-plugin-visualizer": "~3.3.2",
     "ts-node": "~8.8.2",
     "tslint": "~5.20.0",
     "tslint-no-circular-imports": "~0.7.0",

--- a/tfjs-backend-wasm/rollup.config.js
+++ b/tfjs-backend-wasm/rollup.config.js
@@ -17,9 +17,10 @@
 
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
 import node from '@rollup/plugin-node-resolve';
-import {terser} from 'rollup-plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import visualizer from 'rollup-plugin-visualizer';
+import {getBrowserBundleConfigOptions} from '../rollup.config.helpers';
 
 const PREAMBLE = `/**
  * @license
@@ -38,7 +39,20 @@ const PREAMBLE = `/**
  * =============================================================================
  */`;
 
-function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
+function config({
+  plugins = [],
+  output = {},
+  external = [],
+  visualize = false,
+  tsCompilerOptions = {}
+}) {
+  if (visualize) {
+    const filename = output.file + '.html';
+    plugins.push(visualizer(
+        {sourcemap: true, filename, template: 'sunburst', gzipSize: true}));
+    console.log(`Will output a bundle visualization in ${filename}`);
+  }
+
   const defaultTsOptions = {
     include: ['src/**/*.ts'],
     module: 'ES2015',
@@ -48,8 +62,7 @@ function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
   return {
     input: 'src/index.ts',
     plugins: [
-      typescript(tsoptions), resolve(),
-      node({preferBuiltins: true}),
+      typescript(tsoptions), resolve(), node({preferBuiltins: true}),
       // Polyfill require() from dependencies.
       commonjs({
         ignore: ['crypto', 'node-fetch', 'util'],
@@ -60,10 +73,24 @@ function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
     output: {
       banner: PREAMBLE,
       sourcemap: true,
-      globals: {'@tensorflow/tfjs-core': 'tf', 'fs': 'fs', 'path': 'path', 'worker_threads': 'worker_threads', 'perf_hooks': 'perf_hooks'},
+      globals: {
+        '@tensorflow/tfjs-core': 'tf',
+        'fs': 'fs',
+        'path': 'path',
+        'worker_threads': 'worker_threads',
+        'perf_hooks': 'perf_hooks'
+      },
       ...output,
     },
-    external: ['crypto', '@tensorflow/tfjs-core', 'fs', 'path', 'worker_threads', 'perf_hooks'],
+    external: [
+      'crypto',
+      '@tensorflow/tfjs-core',
+      'fs',
+      'path',
+      'worker_threads',
+      'perf_hooks',
+      ...external,
+    ],
     onwarn: warning => {
       let {code} = warning;
       if (code === 'CIRCULAR_DEPENDENCY' || code === 'CIRCULAR' ||
@@ -78,10 +105,8 @@ function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
 module.exports = cmdOptions => {
   const bundles = [];
 
-  const terserPlugin = terser({output: {preamble: PREAMBLE, comments: false}});
   const name = 'tf.wasm';
   const extend = true;
-  const browserFormat = 'umd';
   const fileName = 'tf-backend-wasm';
 
   // Node

--- a/tfjs-backend-wasm/scripts/build-wasm.sh
+++ b/tfjs-backend-wasm/scripts/build-wasm.sh
@@ -38,6 +38,7 @@ if [[ "$1" != "--dev" ]]; then
         wasm-out/
 
   node ./scripts/create-worker-module.js
+  node ./scripts/patch-threaded-simd-module.js
 fi
 
 mkdir -p dist

--- a/tfjs-backend-wasm/scripts/patch-threaded-simd-module.js
+++ b/tfjs-backend-wasm/scripts/patch-threaded-simd-module.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * This file patches the Emscripten-generated WASM JS script so that it can be
+ * properly loaded in web worker.
+ *
+ * We need to pass the content of this script to WASM module's
+ * mainScriptUrlOrBlob field so that the web worker can correctly load the
+ * script "inline". The returned content of the script (after it self-executes)
+ * is a anonymous function object in which we have the following if block:
+ *
+ * if (_scriptDir) {
+ *   scriptDirectory = _scriptDir;
+ * }
+ *
+ * It works great if the script runs in the main page, where _scriptDir is
+ * initialized to the path of the tf-backend-wasm.js file, outside of the
+ * function object. However, when the script runs in a web worker, the
+ * code that initializes _scriptDir won't be present since it is outside
+ * of the scope of the function object. As a result, a "Uncaught
+ * ReferenceError: _scriptDir is not defined" error will be thrown fron
+ * the web worker.
+ *
+ * To fix this, we will replace all the occurences of "if(_scriptDir)"
+ * with a better version that first checks whether _scriptDir is defined
+ * or not
+ *
+ * For more context, see:
+ * https://github.com/emscripten-core/emscripten/pull/12832
+ */
+const fs = require('fs');
+
+const BASE_PATH = './wasm-out/';
+const JS_PATH = `${BASE_PATH}tfjs-backend-wasm-threaded-simd.js`;
+
+let content = fs.readFileSync(JS_PATH, 'utf8');
+content = content.replace(
+    /if\s*\(\s*_scriptDir\s*\)/g,
+    'if(typeof _scriptDir !== "undefined" && _scriptDir)');
+fs.chmodSync(JS_PATH, 0o644);
+fs.writeFileSync(JS_PATH, content);


### PR DESCRIPTION
In my previous PR, I replaced ```if(_scriptDir)``` with ```if(typeof _scriptDir !== "undefined" && _scriptDir)``` in the emscripten-generated JS script. I did it in backend_wasm.ts where the script content is imported. But it doesn't really work when end users minify the code through a bundler, because "if(_scriptDir)" cannot be found anymore in the minified code.

To make this work, the code replacement has to happen right after the code is generated, which is in build-wasm.sh. I added a node.js script to do the code replacement there.

Another thing I had to do is that by default, terser (the plugin we use to minify code in rollup) will transform ```typeof _scriptDir == "undefined"``` into ```_scriptDir === void 0```, which will break our code (it will throw "_scriptDir is not defined" error). To prevent this, I need to turn off that option in terser in WASM's rollup.config.js. I also updated the README.md file to let users know they need to turn this option off if they want to minified the code by themselves. 

I tested this in various situations:
- Use full script through script tag
- Use our own minified script through script tag
- Use bundler with minification (esbuild, the one used in https://github.com/tensorflow/tfjs/issues/4539)

Because I based this fix on top of the version after Yannick's merge, so please ignore rollup.config.helpers.js (which was added in Yannick's PR). For the tfjs-backend-wasm/rollup.config.js file, please only look at line 124-129. The rest of the changes in that file came from Yannick's PR that makes rollup.config.helper.js work.

Thanks!

Fixed https://github.com/tensorflow/tfjs/issues/4539

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4562)
<!-- Reviewable:end -->
