### PR TITLE
docs: remove duplicate documentation line

### DIFF
--- a/tfjs-react-native/README.md
+++ b/tfjs-react-native/README.md
@@ -32,7 +32,6 @@ Note that if you are using in a managed expo app the install instructions may be
 
   - Install and configure [react-native-unimodules](https://github.com/unimodules/react-native-unimodules) (can be skipped if in an expo app)
   - Install and configure [expo-gl-cpp](https://github.com/expo/expo/tree/master/packages/expo-gl-cpp) and [expo-gl](https://github.com/expo/expo/tree/master/packages/expo-gl)
-  - Install and configure [expo-gl](https://github.com/expo/expo/tree/master/packages/expo-gl)
   - Install and configure [expo-camera](https://www.npmjs.com/package/expo-camera)
   - Install and configure [async-storage](https://github.com/react-native-community/async-storage)
   - Install and configure [react-native-fs](https://www.npmjs.com/package/react-native-fs)

--- a/tfjs-react-native/README.md
+++ b/tfjs-react-native/README.md
@@ -33,7 +33,6 @@ Note that if you are using in a managed expo app the install instructions may be
   - Install and configure [react-native-unimodules](https://github.com/unimodules/react-native-unimodules) (can be skipped if in an expo app)
   - Install and configure [expo-gl-cpp](https://github.com/expo/expo/tree/master/packages/expo-gl-cpp) and [expo-gl](https://github.com/expo/expo/tree/master/packages/expo-gl)
   - Install and configure [expo-gl](https://github.com/expo/expo/tree/master/packages/expo-gl)
-  - Install and configure [expo-gl-cpp](https://github.com/expo/expo/tree/master/packages/expo-gl-cpp) and [expo-gl](https://github.com/expo/expo/tree/master/packages/expo-gl)
   - Install and configure [expo-camera](https://www.npmjs.com/package/expo-camera)
   - Install and configure [async-storage](https://github.com/react-native-community/async-storage)
   - Install and configure [react-native-fs](https://www.npmjs.com/package/react-native-fs)


### PR DESCRIPTION
When doing the steps I noticed a duplicate step. This commit removes that duplicate line, preventing the eventual reinstallation of the package from the tutorial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4599)
<!-- Reviewable:end -->
