### PR TITLE
tfjs-vis heatmap: disable vega-lite sorting of ticklabels

### DIFF
--- a/tfjs-vis/demos/api/index.html
+++ b/tfjs-vis/demos/api/index.html
@@ -770,6 +770,36 @@
         }
       </script>
 
+
+      <p>
+        Heatmap displays labels in order provided
+      </p>
+      <div id='heatmap-sort-order'></div>
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: [
+              [5, 4, 3, 2, 1],
+              [10, 9, 8, 7, 6],
+              [15, 14, 13, 12, 11],
+              [20, 19, 18, 17, 16],
+              [24, 24, 23, 22, 21]
+            ],
+            xTickLabels: [0, 1, 10, 50, 100],
+            yTickLabels: [0, 1, 10, 50, 100],
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({ name: 'Heatmap w Custom Colormap', tab: 'Charts' });
+          tfvis.render.heatmap(surface, data);
+
+          // Render to page
+          const container = document.getElementById('heatmap-sort-order');
+          tfvis.render.heatmap(container, data);
+        }
+      </script>
+
       <p>
         Tensor2D's are also supported
       </p>

--- a/tfjs-vis/src/render/heatmap.ts
+++ b/tfjs-vis/src/render/heatmap.ts
@@ -170,13 +170,13 @@ export async function heatmap(
         'field': 'x',
         'type': options.xType,
         'title': options.xLabel,
-        'sort': 'x',
+        'sort': false,
       },
       'y': {
         'field': 'y',
         'type': options.yType,
         'title': options.yLabel,
-        'sort': 'y',
+        'sort': false,
       },
       'fill': {
         'field': 'value',


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/3555

Numerical labels were being sorted lexicographically rather than numerically. This disables any extra sorting by vegalite after the labels have been created. 

![Screen Shot 2021-01-27 at 11 13 34 AM](https://user-images.githubusercontent.com/26408/106019785-08420180-6091-11eb-9609-3bbe88c1a243.png)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4607)
<!-- Reviewable:end -->
