### PR TITLE
Update README.md

### DIFF
--- a/tfjs-node/README.md
+++ b/tfjs-node/README.md
@@ -58,13 +58,14 @@ After that operation completes, re-run `yarn add` or `npm install` for the `@ten
 
 You only need to include `@tensorflow/tfjs-node` or `@tensorflow/tfjs-node-gpu` in the package.json file, since those packages ship with `@tensorflow/tfjs` already.
 
-#### Rebuild the package on Raspberry Pi
+#### Raspberry Pi package rebuilding is no longer necessary
+~~#### Rebuild the package on Raspberry Pi
 
-To use this package on Raspberry Pi, you need to rebuild the node native addon with the following command after you installed the package:
+~~To use this package on Raspberry Pi, you need to rebuild the node native addon with the following command after you installed the package:
 
-```sh
+~~```sh
 $ npm rebuild @tensorflow/tfjs-node --build-from-source
-```
+```~~
 
 ## Using the binding
 


### PR DESCRIPTION
Rebuilding is not necessary on newer versions 3.0.0, 2.8.5, 2.8.4, 2.8.3, etc.  The specific older version(s) of @tensorflow/tfjs-node which requires rebuilding on Raspberry Pi should be indicated with this comment or it should be removed.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4611)
<!-- Reviewable:end -->
