### PR TITLE
revert custom bundle tests to be regression tests

### DIFF
--- a/e2e/integration_tests/custom_bundle_test.ts
+++ b/e2e/integration_tests/custom_bundle_test.ts
@@ -17,7 +17,7 @@
 // tslint:disable-next-line: no-imports-from-dist
 import {CHROME_ENVS, Constraints, describeWithFlags, HAS_WORKER} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
-import {SMOKE} from './constants';
+import {REGRESSION} from './constants';
 
 const CHROME_ENVS_WITH_WORKER: Constraints =
     Object.assign({}, CHROME_ENVS, HAS_WORKER);
@@ -32,7 +32,7 @@ function getBundleUrl(folder: string, custom: boolean, bundler: string) {
 
 const DEBUG_WORKER_SCRIPT = true;
 
-describe(`${SMOKE} blazeface`, () => {
+describe(`${REGRESSION} blazeface`, () => {
   describeWithFlags('webpack', CHROME_ENVS_WITH_WORKER, () => {
     let webpackBundle: {full: string, custom: string};
     let originalTimeout: number;
@@ -106,7 +106,7 @@ describe(`${SMOKE} blazeface`, () => {
   });
 });
 
-describe(`${SMOKE} dense model`, () => {
+describe(`${REGRESSION} dense model`, () => {
   describeWithFlags('webpack', CHROME_ENVS_WITH_WORKER, () => {
     let webpackBundle: {full: string, custom: string};
     let originalTimeout: number;
@@ -198,7 +198,7 @@ describe(`${SMOKE} dense model`, () => {
   });
 });
 
-describe(`${SMOKE} universal sentence encoder model`, () => {
+describe(`${REGRESSION} universal sentence encoder model`, () => {
   const expectedKernels = [
     'StridedSlice', 'Less',       'Cast',      'Reshape',       'GatherV2',
     'Max',          'Add',        'Maximum',   'SparseToDense', 'Greater',

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -46,10 +46,10 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
   source ../scripts/cleanup-py-env.sh
 
   cd ..
-fi
 
-# Generate custom bundle files for tests
-./scripts/run-custom-builds.sh
+  # Generate custom bundle files for tests
+  ./scripts/run-custom-builds.sh
+fi
 
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   yarn run-browserstack --browsers=bs_safari_mac --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
@@ -63,9 +63,4 @@ if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js
 else
   yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
-
-  # TODO(yassogba) revisit whether we want to keep this after this
-  # has merged into master.
-  # Test script tag bundles
-  karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js
 fi


### PR DESCRIPTION
This reverts the custom bundling tests be regression tests rather than smoke tests.

They were changed to smoke tests in the 3.x_dev branch as that provided much quicker feedback on if changes were breaking the custom bundling flow.

This just restores the testing strategy to what it was before the 3.x_dev branch.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4613)
<!-- Reviewable:end -->
