### PR TITLE
Mark imports as ignored in the browser

### DIFF
--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -90,7 +90,8 @@
   "browser": {
     "node-fetch": false,
     "util": false,
-    "crypto": false
+    "crypto": false,
+    "worker_threads": false
   },
   "sideEffects": [
     "./dist/index.js",

--- a/tfjs/package.json
+++ b/tfjs/package.json
@@ -96,5 +96,10 @@
     "core-js": "3",
     "regenerator-runtime": "^0.13.5",
     "yargs": "^16.0.3"
+  },
+  "browser": {
+    "node-fetch": false,
+    "util": false,
+    "crypto": false
   }
 }


### PR DESCRIPTION
This change marks several node-specific imports as ignored in the browser. It's necessary for tfjs-react-native to build on 3.0.x. Otherwise, Metro tries to include them in a react-native build, which breaks the build as they're not available outside of node. 

Since tfjs-react-native is not a part of the monorepo and pulls `@tensorflow/...` dependencies from npm (instead of using `link:...`), this change has to be _released_ before tfjs-react-native can be updated to 3.0.x and pass its CI tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4614)
<!-- Reviewable:end -->
