### PR TITLE
Use URL parameters to automate e2e test

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -105,34 +105,23 @@ limitations under the License.
   <script>
     'use strict';
 
-    let uriState = null;
+    let urlState = null;
     let runTimes = 50;
     let warmupTimes = 1;
 
-    function getURIState(url) {
-      const params = {};
-      const parser = document.createElement('a');
-      parser.href = url;
-      const query = parser.search.substring(1);
-      const vars = query.split('&');
-
-      for (let i = 0; i < vars.length; i++) {
-        const pair = vars[i].split('=');
-        if (pair[0] == null || pair[1] == null)
-          return null;
-        params[pair[0]] = decodeURIComponent(pair[1]);
+    function getURLState(url) {
+      let params = new URLSearchParams(url);
+      const keys = [...params.keys()];
+      if (keys.length === 0)
+        return null;
+      if (params.has('run')) {
+        runTimes = Number(params.get('run'));
       }
-
-      if (Object.keys(params).includes('run')) {
-        runTimes = Number(params['run']);
-      }
-
-      if (Object.keys(params).includes('warmup')) {
-        warmupTimes = Number(params['warmup']);
+      if (params.has('warmup')) {
+        warmupTimes = Number(params.get('warmup'));
       }
       return params;
-    };
-
+    }
     // Controllers can be updated by URI or clicked by user.
     let modelController = null;
     let numRunsController = null;
@@ -142,16 +131,18 @@ limitations under the License.
     let inputSizeController = null;
     let modelArchitectureController = null;
 
-    function updateGUIFromURIState() {
+    function updateGUIFromURLState() {
+      if (urlState == null)
+        return;
       // The model parameter will be update automically by onChange.
-      if (modelController != null && isURIStateParameterSupported('benchmark'))
-        modelController.setValue(uriState['benchmark']);
-      if (numRunsController != null && isURIStateParameterSupported('run'))
-        numRunsController.setValue(uriState['run']);
-      if (backendsController != null && isURIStateParameterSupported('backend'))
-        backendsController.setValue(uriState['backend']);
+      if (modelController != null && urlState.has('benchmark'))
+        modelController.setValue(urlState.get('benchmark'));
+      if (numRunsController != null && urlState.has('run'))
+        numRunsController.setValue(urlState.get('run'));
+      if (backendsController != null && urlState.has('backend'))
+        backendsController.setValue(urlState.get('backend'));
       // Only auto run when URI component exists.
-      if (uriState != null && runButton != null)
+      if (runButton != null)
         runButton.domElement.click();
     }
 
@@ -222,7 +213,7 @@ limitations under the License.
       inputs: {}
     };
 
-    uriState = getURIState(window.location.href);
+    urlState = getURLState(window.location.search);
 
     const modalDiv = document.getElementById('modal-msg');
     const timeTable = document.querySelector('#timings tbody');
@@ -405,21 +396,23 @@ limitations under the License.
       return input;
     }
 
-    function updateStateFromURIState() {
-      if (isURIStateParameterSupported('run'))
-        state.numRuns = uriState['run'];
-      if (isURIStateParameterSupported('benchmark'))
-        state.benchmark = uriState['benchmark'];
-      if (isURIStateParameterSupported('backend'))
-        state.backend = uriState['backend'];
-      if (isURIStateParameterSupported('inputSize'))
-        state.inputSize = uriState['inputSize'];
-      if (isURIStateParameterSupported('architecture'))
-        state.architecture = uriState['architecture'];
+    function updateStateFromURLState() {
+      if (urlState == null)
+        return;
+      if (urlState.has('run'))
+        state.numRuns = Number(urlState.get('run'));
+      if (urlState.has('benchmark'))
+        state.benchmark = urlState.get('benchmark');
+      if (urlState.has('backend'))
+        state.backend = urlState.get('backend');
+      if (urlState.has('inputSize'))
+        state.inputSize = Number(urlState.get('inputSize'));
+      if (urlState.has('architecture'))
+        state.architecture = urlState.get('architecture');
     }
 
     async function loadModelAndRecordTime() {
-      updateStateFromURIState();
+      updateStateFromURLState();
       const benchmark = benchmarks[state.benchmark];
       state.modelType = benchmark['type'];
       state.isModelChanged = false; // used to clean the performance history
@@ -615,7 +608,7 @@ limitations under the License.
       await profileMemoryAndKernelTime();
       await sleep(200);
       await measureAveragePredictTime();
-      uriState = null;
+      urlState = null;
     }
 
     function isParameterDefined(parameter) {
@@ -627,11 +620,11 @@ limitations under the License.
       return false;
     }
 
-    function isURIStateParameterSupported(parameter) {
-      if (uriState != null && uriState[parameter] != undefined) {
+    function isURLParameterDefined(parameter) {
+      if (urlState != null && urlState.has(parameter)) {
         return true;
       }
-      // URI state doesn't support this parameter.
+      // URL doesn't support this parameter.
       return false;
     }
 
@@ -646,7 +639,6 @@ limitations under the License.
       modelController = modelFolder.add(state, 'benchmark', Object.keys(benchmarks));
       modelController.name('models').onChange(async model => {
         await showMsg(null);
-
         const benchmark = benchmarks[state.benchmark];
         state.isModelChanged = true;
         state.isModelLoaded = false;
@@ -666,8 +658,8 @@ limitations under the License.
           });
           // Current use first value as default.
           let defaultInputSize = 0;
-          if (isURIStateParameterSupported('inputSize'))
-            defaultInputSize = uriState['inputSize'];
+          if (isURLParameterDefined('inputSize'))
+            defaultInputSize = urlState.get('inputSize');
           else
             defaultInputSize = benchmark['inputSizes'][0];
           inputSizeController.setValue(defaultInputSize);
@@ -684,8 +676,8 @@ limitations under the License.
           });
           // Current use first value as default.
           let defaultModelArchitecture = null;
-          if (isURIStateParameterSupported('architecture'))
-            defaultModelArchitecture = uriState['architecture'];
+          if (isURLParameterDefined('architecture'))
+            defaultModelArchitecture = urlState.get('architecture');
           else
             defaultModelArchitecture = benchmark['architectures'][0];
 
@@ -747,7 +739,7 @@ limitations under the License.
       await showFlagSettings(envFolder, state.backend);
       showVersions();
       await showEnvironment();
-      updateGUIFromURIState();
+      updateGUIFromURLState();
     }
 
     onPageLoad();

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -105,8 +105,58 @@ limitations under the License.
   <script>
     'use strict';
 
+    let uriState = null;
+    let runTimes = 50;
+    let warmupTimes = 1;
+
+    function getURIState(url) {
+      const params = {};
+      const parser = document.createElement('a');
+      parser.href = url;
+      const query = parser.search.substring(1);
+      const vars = query.split('&');
+
+      for (let i = 0; i < vars.length; i++) {
+        const pair = vars[i].split('=');
+        if (pair[0] == null || pair[1] == null)
+          return null;
+        params[pair[0]] = decodeURIComponent(pair[1]);
+      }
+
+      if (Object.keys(params).includes('run')) {
+        runTimes = Number(params['run']);
+      }
+
+      if (Object.keys(params).includes('warmup')) {
+        warmupTimes = Number(params['warmup']);
+      }
+      return params;
+    };
+
+    // Controllers can be updated by URI or clicked by user.
+    let modelController = null;
+    let numRunsController = null;
+    let modelParameterFolder = null;
+    let backendsController = null;
+    let runButton = null;
+    let inputSizeController = null;
+    let modelArchitectureController = null;
+
+    function updateGUIFromURIState() {
+      // The model parameter will be update automically by onChange.
+      if (modelController != null && isURIStateParameterSupported('benchmark'))
+        modelController.setValue(uriState['benchmark']);
+      if (numRunsController != null && isURIStateParameterSupported('run'))
+        numRunsController.setValue(uriState['run']);
+      if (backendsController != null && isURIStateParameterSupported('backend'))
+        backendsController.setValue(uriState['backend']);
+      // Only auto run when URI component exists.
+      if (uriState != null && runButton != null)
+        runButton.domElement.click();
+    }
+
     const state = {
-      numRuns: 50,
+      numRuns: runTimes,
       benchmark: 'mobilenet_v2',
       run: (v) => {
         runBenchmark().catch(e => {
@@ -162,15 +212,17 @@ limitations under the License.
       backend: 'wasm',
       kernelTiming: 'aggregate',
       inputSize: 0,
+      architecture: '',
       modelType: '',
       modelUrl: '',
       isModelChanged: false,
-      isInputSizeChanged: false,
       flags: {},
       isFlagChanged: false,
       isModelLoaded: false,
       inputs: {}
     };
+
+    uriState = getURIState(window.location.href);
 
     const modalDiv = document.getElementById('modal-msg');
     const timeTable = document.querySelector('#timings tbody');
@@ -218,8 +270,10 @@ limitations under the License.
       appendRow(parameterTable, 'numRuns', state.numRuns);
       appendRow(parameterTable, 'backend', state.backend);
       appendRow(parameterTable, 'kernelTiming', state.kernelTiming);
-      if (isInputSizeSupported())
+      if (isParameterDefined('inputSizes'))
         appendRow(parameterTable, 'inputSize', state.inputSize);
+      if (isParameterDefined('architectures'))
+        appendRow(parameterTable, 'architecture', state.architecture);
     }
 
     async function setupKernelTable() {
@@ -265,18 +319,23 @@ limitations under the License.
     }
 
     async function warmUpAndRecordTime() {
-      await showMsg('Warming up');
+      if (warmupTimes == 0) {
+        await showMsg('Skip warming up');
+        await sleep(1000);
+        return;
+      }
+      await showMsg(`Warming up for ${warmupTimes} time(s)`);
 
       let timeInfo;
       if (state.benchmark === 'custom') {
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
-          timeInfo = await timeModelInference(model, input, 1);
+          timeInfo = await timeModelInference(model, input, warmupTimes);
         } finally {
           tf.dispose(input);
         }
       } else {
-        timeInfo = await timeInference(() => predict(model), 1);
+        timeInfo = await timeInference(() => predict(model), warmupTimes);
       }
 
       await showMsg(null);
@@ -345,11 +404,25 @@ limitations under the License.
       });
       return input;
     }
+
+    function updateStateFromURIState() {
+      if (isURIStateParameterSupported('run'))
+        state.numRuns = uriState['run'];
+      if (isURIStateParameterSupported('benchmark'))
+        state.benchmark = uriState['benchmark'];
+      if (isURIStateParameterSupported('backend'))
+        state.backend = uriState['backend'];
+      if (isURIStateParameterSupported('inputSize'))
+        state.inputSize = uriState['inputSize'];
+      if (isURIStateParameterSupported('architecture'))
+        state.architecture = uriState['architecture'];
+    }
+
     async function loadModelAndRecordTime() {
+      updateStateFromURIState();
       const benchmark = benchmarks[state.benchmark];
       state.modelType = benchmark['type'];
       state.isModelChanged = false; // used to clean the performance history
-      state.isInputSizeChanged = false;
 
       if (benchmark['load'] == null) {
         throw new Error(`Please provide a load method for '${state.benchmark}' model.`);
@@ -358,7 +431,7 @@ limitations under the License.
       await showMsg('Loading the model');
       let start = performance.now();
       const inputSize = parseFloat(state.inputSize);
-      model = await benchmark.load(inputSize);
+      model = await benchmark.load(inputSize, state.architecture);
       state.inputs = [];
       if (model.inputs) {
         // construct the input state for the model
@@ -504,7 +577,7 @@ limitations under the License.
     }
 
     async function loadModel() {
-      if (state.isModelChanged || !state.isModelLoaded || state.isFlagChanged || state.isInputSizeChanged) {
+      if (state.isModelChanged || !state.isModelLoaded || state.isFlagChanged) {
         await loadModelAndRecordTime();
         state.isModelLoaded = true;
         const needInputShape = await showInputs();
@@ -542,14 +615,23 @@ limitations under the License.
       await profileMemoryAndKernelTime();
       await sleep(200);
       await measureAveragePredictTime();
+      uriState = null;
     }
 
-    function isInputSizeSupported() {
+    function isParameterDefined(parameter) {
       const benchmark = benchmarks[state.benchmark];
-      if (benchmark['supportedInput'] != null) {
+      if (benchmark[parameter] != null) {
         return true;
       }
-      // Model doesn't support input size.
+      // Model doesn't support this parameter.
+      return false;
+    }
+
+    function isURIStateParameterSupported(parameter) {
+      if (uriState != null && uriState[parameter] != undefined) {
+        return true;
+      }
+      // URI state doesn't support this parameter.
       return false;
     }
 
@@ -561,30 +643,61 @@ limitations under the License.
 
       const modelFolder = gui.addFolder('Benchmark');
       let modelUrlController = null;
-      let modelParameterFolder = null;
-      let inputSizeController = null;
-      modelFolder.add(state, 'benchmark', Object.keys(benchmarks)).name('models').onChange(async model => {
+      modelController = modelFolder.add(state, 'benchmark', Object.keys(benchmarks));
+      modelController.name('models').onChange(async model => {
         await showMsg(null);
+
+        const benchmark = benchmarks[state.benchmark];
         state.isModelChanged = true;
         state.isModelLoaded = false;
         if (inputSizeController !== null) {
           modelParameterFolder.remove(inputSizeController);
           inputSizeController = null;
         }
-        const benchmark = benchmarks[state.benchmark];
-        if (isInputSizeSupported()) {
-          inputSizeController = modelParameterFolder.add(state, 'inputSize', benchmark['supportedInput']).name('inputSizes').onChange(async inputSize => {
+        if (modelArchitectureController !== null) {
+          modelParameterFolder.remove(modelArchitectureController);
+          modelArchitectureController = null;
+        }
+
+        if (isParameterDefined('inputSizes')) {
+          inputSizeController = modelParameterFolder.add(state, 'inputSize', benchmark['inputSizes']).name('inputSizes').onChange(async inputSize => {
             state.inputSize = inputSize;
-            state.isInputSizeChanged = true;
+            state.isModelChanged = true;
           });
           // Current use first value as default.
-          const defaultInputSize = benchmark['supportedInput'][0];
+          let defaultInputSize = 0;
+          if (isURIStateParameterSupported('inputSize'))
+            defaultInputSize = uriState['inputSize'];
+          else
+            defaultInputSize = benchmark['inputSizes'][0];
           inputSizeController.setValue(defaultInputSize);
           state.inputSize = defaultInputSize;
-          modelParameterFolder.open();
         } else {
           // Model doesn't support input size.
           state.inputSize = 0;
+        }
+
+        if (isParameterDefined('architectures')) {
+          modelArchitectureController = modelParameterFolder.add(state, 'architecture', benchmark['architectures']).name('architectures').onChange(async architecture => {
+            state.architecture = architecture;
+            state.isModelChanged = true;
+          });
+          // Current use first value as default.
+          let defaultModelArchitecture = null;
+          if (isURIStateParameterSupported('architecture'))
+            defaultModelArchitecture = uriState['architecture'];
+          else
+            defaultModelArchitecture = benchmark['architectures'][0];
+
+          modelArchitectureController.setValue(defaultModelArchitecture);
+          state.architecture = defaultModelArchitecture;
+          modelParameterFolder.open();
+        } else {
+          // Model doesn't support input size.
+          state.architecture = '';
+        }
+        if (isParameterDefined('inputSizes') || isParameterDefined('architectures')) {
+          modelParameterFolder.open();
         }
 
         if (model === 'custom') {
@@ -605,30 +718,36 @@ limitations under the License.
       modelFolder.open();
 
       const parameterFolder = gui.addFolder('Parameters');
-      parameterFolder.add(state, 'numRuns');
+      numRunsController = parameterFolder.add(state, 'numRuns');
       parameterFolder.add(state, 'kernelTiming', ['aggregate', 'individual']);
       parameterFolder.open();
 
       modelParameterFolder = gui.addFolder('Model Parameters');
-      if (isInputSizeSupported()) {
+      if (isParameterDefined('inputSizes')) {
         inputSizeController = modelParameterFolder.add(state, 'inputSize', []);
+      }
+      if (isParameterDefined('architectures')) {
+        modelArchitectureController = modelParameterFolder.add(state, 'architecture', []);
       }
       modelParameterFolder.open();
 
       const envFolder = gui.addFolder('Environment');
-      envFolder.add(state, 'backend', ['wasm', 'webgl', 'cpu']).onChange(async backend => {
+      backendsController = envFolder.add(state, 'backend', ['wasm', 'webgl', 'cpu']);
+      backendsController.onChange(async backend => {
         // TODO: Failed to set backend
         await tf.setBackend(backend);
         await showFlagSettings(envFolder, state.backend);
       });
       envFolder.open();
 
-      gui.add(state, 'run').name('Run benchmark');
+      runButton = gui.add(state, 'run');
+      runButton.name('Run benchmark');
       gui.add(state, 'testCorrectness').name('Test correctness');
 
       await showFlagSettings(envFolder, state.backend);
       showVersions();
       await showEnvironment();
+      updateGUIFromURIState();
     }
 
     onPageLoad();

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -683,7 +683,6 @@ limitations under the License.
 
           modelArchitectureController.setValue(defaultModelArchitecture);
           state.architecture = defaultModelArchitecture;
-          modelParameterFolder.open();
         } else {
           // Model doesn't support input size.
           state.architecture = '';

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -198,7 +198,7 @@ const benchmarks = {
     type: 'GraphModel',
     inputSizes: [128, 257, 512, 1024],
     architectures: ['MobileNetV1', 'ResNet50'],
-    load: async (inputResolution = 257, modelArchitecture = 'MobileNetV1') => {
+    load: async (inputResolution = 128, modelArchitecture = 'MobileNetV1') => {
       let config = null;
       if (modelArchitecture === 'MobileNetV1') {
         config = {

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -196,12 +196,26 @@ const benchmarks = {
   },
   'posenet': {
     type: 'GraphModel',
-    supportedInput: [257, 512, 1024],
-    load: async (inputResolution = 257) => {
-      const mobileNetConfig = {
-        inputResolution: inputResolution,
-      };
-      const model = await posenet.load(mobileNetConfig);
+    inputSizes: [128, 257, 512, 1024],
+    architectures: ['MobileNetV1', 'ResNet50'],
+    load: async (inputResolution = 257, modelArchitecture = 'MobileNetV1') => {
+      let config = null;
+      if (modelArchitecture === 'MobileNetV1') {
+        config = {
+          architecture: modelArchitecture,
+          outputStride: 16,
+          multiplier: 0.75,
+          inputResolution: inputResolution,
+        };
+      } else if (modelArchitecture === 'ResNet50') {
+        config = {
+          architecture: modelArchitecture,
+          outputStride: 32,
+          quantBytes: 2,
+          inputResolution: inputResolution,
+        };
+      }
+      const model = await posenet.load(config);
       model.image = await loadImage('tennis_standing.jpg');
       return model;
     },
@@ -214,9 +228,26 @@ const benchmarks = {
   'bodypix': {
     type: 'GraphModel',
     // The ratio to the default camera size [640, 480].
-    supportedInput: [0.5, 0.75, 1.0, 2.0],
-    load: async () => {
-      const model = await bodyPix.load();
+    inputSizes: [0.25, 0.5, 0.75, 1.0],
+    architectures: ['MobileNetV1', 'ResNet50'],
+    // bodypix doesn't support inputResolution when loading.
+    load: async (inputResolution, modelArchitecture = 'MobileNetV1') => {
+      let config = null;
+      if (modelArchitecture === 'MobileNetV1') {
+        config = {
+          architecture: 'MobileNetV1',
+          outputStride: 16,
+          quantBytes: 4,
+          multiplier: 0.75,
+        };
+      } else if (modelArchitecture === 'ResNet50') {
+        config = {
+          architecture: 'ResNet50',
+          outputStride: 32,
+          quantBytes: 4,
+        };
+      }
+      const model = await bodyPix.load(config);
       model.image = await loadImage('tennis_standing.jpg');
       return model;
     },
@@ -231,7 +262,7 @@ const benchmarks = {
   },
   'blazeface': {
     type: 'GraphModel',
-    supportedInput: [128],
+    inputSizes: [128],
     load: async () => {
       const url =
           'https://tfhub.dev/tensorflow/tfjs-model/blazeface/1/default/1';


### PR DESCRIPTION
The idea is to enable an automatic mode e2e. When an URL with required
parameter is given, e2e will run the test automatically, no need to
click any GUI menu or run button.

Example URL:
local-benchmark/?benchmark=bodypix&inputSize=0.5&architecture=MobileNetV1&backend=webgl&warmup=1&run=10

Parameters:
benchmark: mobilenet_v2, bodypix, etc. For full list, check model_config.js.
backend: wasm, webgl, webgpu.
warmup: number.
run: number > 0.
architecture: depends on benchamrk, check architectures in model_config.js.
inputSize: depends on benchmark, check inputSizes in model_config.js.

The original manual mode works as before. Also add model architecture supports.

Example URL 1: http://localhost:8080/local-benchmark/?backend=webgl&warmup=3&run=2&benchmark=posenet&inputSize=128&architecture=MobileNetV1
![config1](https://user-images.githubusercontent.com/10395334/106553025-76843980-6553-11eb-8ce8-f2816112e1a3.jpg)

Example URL 2: http://localhost:8080/local-benchmark/?backend=wasm&warmup=5&run=10&benchmark=posenet&inputSize=257&architecture=ResNet50
![config2](https://user-images.githubusercontent.com/10395334/106553032-7a17c080-6553-11eb-8072-16eae94da5a6.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4615)
<!-- Reviewable:end -->
