### PR TITLE
Use same GUI layout when warmup is 0

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -333,7 +333,7 @@ limitations under the License.
 
       await showMsg(null);
       appendRow(timeTable, 'backend', state.backend);
-      appendRow(timeTable, '1st inference', printTime(timeInfo.times[0]));
+      appendRow(timeTable, 'Warmup time', printTime(timeInfo.times[0]));
     }
 
     async function showInputs() {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -312,6 +312,8 @@ limitations under the License.
     async function warmUpAndRecordTime() {
       if (warmupTimes == 0) {
         await showMsg('Skip warming up');
+        appendRow(timeTable, 'backend', state.backend);
+        appendRow(timeTable, 'Warmup time', '0 ms');
         await sleep(1000);
         return;
       }
@@ -513,7 +515,7 @@ limitations under the License.
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(profileInfo.peakBytes));
       appendRow(timeTable, 'Leaked tensors', profileInfo.newTensors);
-      appendRow(timeTable, '2nd inference', printTime(elapsed));
+      appendRow(timeTable, 'Profile time', printTime(elapsed));
 
       if (state.backend != 'webgl' || queryTimerIsEnabled()) {
         await showMsg('Profiling kernels');


### PR DESCRIPTION
Add backend and 1st inference info at the results GUI when warmup is 0, so the result GUI will be the same for all warmups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4635)
<!-- Reviewable:end -->
