### PR TITLE
Enable CPU kernel profiling for browser does not support timer query

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -86,8 +86,7 @@ limitations under the License.
       <tbody></tbody>
     </table>
   </div>
-  <script src="../tf-core.js"></script>
-  <!-- <script src="https://unpkg.com/@tensorflow/tfjs-core@latest/dist/tf-core.js"></script> -->
+  <script src="https://unpkg.com/@tensorflow/tfjs-core@latest/dist/tf-core.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-cpu@latest/dist/tf-backend-cpu.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-webgl@latest/dist/tf-backend-webgl.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-layers@latest/dist/tf-layers.js"></script>
@@ -518,13 +517,14 @@ limitations under the License.
       appendRow(timeTable, 'Leaked tensors', profileInfo.newTensors);
       appendRow(timeTable, 'Profile time', printTime(elapsed));
 
-      if (state.backend == 'webgl' && queryTimerIsEnabled()) {
-        await showMsg('browser does not support the EXT_disjoint_timer_query,' +
-            ' the kernel time contains GPU texture download time.');
-      }
-      await showMsg('Profiling kernels');
-      appendRow(timeTable, 'Number of kernels', profileInfo.kernels.length);
-      showKernelTime(profileInfo);
+      if (state.backend != 'webgl' || queryTimerIsEnabled()) {
+        await showMsg('Profiling kernels');
+        appendRow(timeTable, 'Number of kernels', profileInfo.kernels.length);
+        showKernelTime(profileInfo);
+      } else {
+        await showMsg('Skipping kernel times since query timer extension is not ' +
+          'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
+      };
     }
 
     function showKernelTime(profileInfo) {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -86,7 +86,8 @@ limitations under the License.
       <tbody></tbody>
     </table>
   </div>
-  <script src="https://unpkg.com/@tensorflow/tfjs-core@latest/dist/tf-core.js"></script>
+  <script src="../tf-core.js"></script>
+  <!-- <script src="https://unpkg.com/@tensorflow/tfjs-core@latest/dist/tf-core.js"></script> -->
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-cpu@latest/dist/tf-backend-cpu.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-webgl@latest/dist/tf-backend-webgl.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-layers@latest/dist/tf-layers.js"></script>
@@ -517,14 +518,13 @@ limitations under the License.
       appendRow(timeTable, 'Leaked tensors', profileInfo.newTensors);
       appendRow(timeTable, 'Profile time', printTime(elapsed));
 
-      if (state.backend != 'webgl' || queryTimerIsEnabled()) {
-        await showMsg('Profiling kernels');
-        appendRow(timeTable, 'Number of kernels', profileInfo.kernels.length);
-        showKernelTime(profileInfo);
-      } else {
-        await showMsg('Skipping kernel times since query timer extension is not ' +
-          'available. <br/> Please use a browser supporting the EXT_disjoint_timer_query WebGL API.');
-      };
+      if (state.backend == 'webgl' && queryTimerIsEnabled()) {
+        await showMsg('browser does not support the EXT_disjoint_timer_query,' +
+            ' the kernel time contains GPU texture download time.');
+      }
+      await showMsg('Profiling kernels');
+      appendRow(timeTable, 'Number of kernels', profileInfo.kernels.length);
+      showKernelTime(profileInfo);
     }
 
     function showKernelTime(profileInfo) {

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -440,6 +440,10 @@ export class MathBackendWebGL extends KernelBackend {
     return vals;
   }
 
+  timerAvailable(): boolean {
+    return env().getNumber('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE') > 0;
+  }
+
   async time(f: () => void): Promise<WebGLTimingInfo> {
     const oldActiveTimers = this.activeTimers;
     const newActiveTimers: TimerNode[] = [];

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -85,6 +85,8 @@ export interface DataMover {
 }
 
 export interface BackendTimer {
+  // check if backend timer is available
+  timerAvailable(): boolean;
   time(f: () => void): Promise<BackendTimingInfo>;
 }
 
@@ -100,6 +102,9 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   }
   incRef(dataId: DataId): void {
     return notYetImplemented('incRef');
+  }
+  timerAvailable(): boolean {
+    return true;
   }
   time(f: () => void): Promise<BackendTimingInfo> {
     return notYetImplemented('time');

--- a/tfjs-core/src/profiler.ts
+++ b/tfjs-core/src/profiler.ts
@@ -49,11 +49,14 @@ export class Profiler {
 
     if (env().getBool('CHECK_COMPUTATION_FOR_ERRORS')) {
       for (let i = 0; i < outputs.length; i++) {
-        kernelTime = util.now() - start;
         const output = outputs[i];
         // Dangling promise here because we don't want to propagate up
         // asynchronicity.
         output.data().then(tensorVals => {
+          // Update the kernel time only after the first output is downloaded.
+          if (kernelTime === 0) {
+            kernelTime = util.now() - start;
+          }
           checkComputationForErrors(tensorVals, output.dtype, kernelName);
         });
       }

--- a/tfjs-core/src/profiler.ts
+++ b/tfjs-core/src/profiler.ts
@@ -43,13 +43,13 @@ export class Profiler {
     const holdResultWrapperFn = () => {
       outputs = f();
     };
-    const start = performance.now();
+    const start = util.now();
     let kernelTime = 0;
     const timer = this.backendTimer.time(holdResultWrapperFn);
 
     if (env().getBool('CHECK_COMPUTATION_FOR_ERRORS')) {
       for (let i = 0; i < outputs.length; i++) {
-        kernelTime = performance.now() - start;
+        kernelTime = util.now() - start;
         const output = outputs[i];
         // Dangling promise here because we don't want to propagate up
         // asynchronicity.

--- a/tfjs-core/src/profiler_test.ts
+++ b/tfjs-core/src/profiler_test.ts
@@ -29,6 +29,10 @@ class TestBackendTimer implements BackendTimer {
       private delayMs: number, private queryTimeMs: number,
       private extraInfo: string) {}
 
+  timerAvailable() {
+    return true;
+  }
+
   async time(query: () => void): Promise<BackendTimingInfo> {
     query();
     const kernelMs = await new Promise<number>(


### PR DESCRIPTION
Most mobile browsers do not support timer query, enable CPU based kernel profiling as fallback mechanism.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4640)
<!-- Reviewable:end -->
