### PR TITLE
Reintegrate webgpu with CI

### DIFF
--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -567,6 +567,72 @@ steps:
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
   - name: 'node:10'
+    dir: tfjs-backend-webgpu
+    id: yarn-tfjs-backend-webgpu
+    entrypoint: yarn
+    args:
+      - install
+    waitFor:
+      - yarn-common
+      - yarn-tfjs-core
+      - build-tfjs-core
+      - build-cpu-backend-tfjs-core
+      - lint-tfjs-core
+      - yarn-tfjs-converter
+      - build-tfjs-converter
+      - lint-tfjs-converter
+      - yarn-tfjs-backend-cpu
+      - build-tfjs-backend-cpu
+      - lint-tfjs-backend-cpu
+      - yarn-tfjs-backend-webgl
+      - build-tfjs-backend-webgl
+      - lint-tfjs-backend-webgl
+  - name: 'node:10'
+    dir: tfjs-backend-webgpu
+    id: lint-tfjs-backend-webgpu
+    entrypoint: yarn
+    args:
+      - lint
+    waitFor:
+      - yarn-tfjs-backend-webgpu
+      - yarn-common
+      - yarn-tfjs-core
+      - build-tfjs-core
+      - build-cpu-backend-tfjs-core
+      - lint-tfjs-core
+      - yarn-tfjs-converter
+      - build-tfjs-converter
+      - lint-tfjs-converter
+      - yarn-tfjs-backend-cpu
+      - build-tfjs-backend-cpu
+      - lint-tfjs-backend-cpu
+      - yarn-tfjs-backend-webgl
+      - build-tfjs-backend-webgl
+      - lint-tfjs-backend-webgl
+  - name: 'node:10'
+    dir: tfjs-backend-webgpu
+    entrypoint: yarn
+    id: test-webgpu-tfjs-backend-webgpu
+    args:
+      - test-ci
+    waitFor:
+      - yarn-tfjs-backend-webgpu
+      - lint-tfjs-backend-webgpu
+      - yarn-common
+      - yarn-tfjs-core
+      - build-tfjs-core
+      - build-cpu-backend-tfjs-core
+      - lint-tfjs-core
+      - yarn-tfjs-converter
+      - build-tfjs-converter
+      - lint-tfjs-converter
+      - yarn-tfjs-backend-cpu
+      - build-tfjs-backend-cpu
+      - lint-tfjs-backend-cpu
+      - yarn-tfjs-backend-webgl
+      - build-tfjs-backend-webgl
+      - lint-tfjs-backend-webgl
+  - name: 'node:10'
     dir: tfjs-data
     entrypoint: yarn
     id: yarn-tfjs-data

--- a/scripts/package_dependencies.json
+++ b/scripts/package_dependencies.json
@@ -10,7 +10,7 @@
   "tfjs-backend-wasm": ["tfjs-core", "tfjs-backend-cpu"],
   "tfjs-backend-cpu": ["tfjs-core"],
   "tfjs-backend-webgl": ["tfjs-core", "tfjs-backend-cpu"],
-  "tfjs-backend-webgpu": [],
+  "tfjs-backend-webgpu": ["tfjs-core", "tfjs-converter", "tfjs-backend-cpu", "tfjs-backend-webgl"],
   "tfjs-inference": [],
   "tfjs-react-native": [],
   "tfjs-vis": [],

--- a/tfjs-backend-webgpu/cloudbuild.yml
+++ b/tfjs-backend-webgpu/cloudbuild.yml
@@ -14,11 +14,9 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-# TODO(Yunfei): Change id to 'build-deps' after webgpu dependencies write into
-# packange_dependencies.json
 - name: 'node:10'
   dir: 'tfjs-backend-webgpu'
-  id: 'build-deps-for-webgpu'
+  id: 'build-deps'
   entrypoint: 'yarn'
   args: ['build-deps-ci']
   waitFor: ['yarn-common']
@@ -29,7 +27,7 @@ steps:
   id: 'lint'
   entrypoint: 'yarn'
   args: ['lint']
-  waitFor: ['yarn', 'build-deps-for-webgpu']
+  waitFor: ['yarn', 'build-deps']
 
 # Run tests.
 - name: 'node:10'
@@ -37,7 +35,7 @@ steps:
   entrypoint: 'yarn'
   id: 'test-webgpu'
   args: ['test-ci']
-  waitFor: ['yarn', 'build-deps-for-webgpu', 'lint']
+  waitFor: ['yarn', 'build-deps', 'lint']
 
 # General configuration
 timeout: 1800s


### PR DESCRIPTION
During nightly, webgpu was concurrently rebuilding packages that were already being built. This PR makes webgpu wait for its dependencies to be built in nightly and CI instead of trying to build them itself.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4643)
<!-- Reviewable:end -->
