### PR TITLE
Support e2e inputType

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -451,7 +451,7 @@ limitations under the License.
           });
         }
       }
-      predict = benchmark.predictFunc(inputSize, state.inputType);
+      predict = benchmark.predictFunc(inputSize);
       const elapsed = performance.now() - start;
 
       await showMsg(null);

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -129,6 +129,7 @@ limitations under the License.
     let backendsController = null;
     let runButton = null;
     let inputSizeController = null;
+    let inputTypeController = null;
     let modelArchitectureController = null;
 
     function updateGUIFromURLState() {
@@ -203,6 +204,7 @@ limitations under the License.
       backend: 'wasm',
       kernelTiming: 'aggregate',
       inputSize: 0,
+      inputType: '',
       architecture: '',
       modelType: '',
       modelUrl: '',
@@ -261,10 +263,15 @@ limitations under the License.
       appendRow(parameterTable, 'numRuns', state.numRuns);
       appendRow(parameterTable, 'backend', state.backend);
       appendRow(parameterTable, 'kernelTiming', state.kernelTiming);
-      if (isParameterDefined('inputSizes'))
+      if (isParameterDefined('inputSizes')) {
         appendRow(parameterTable, 'inputSize', state.inputSize);
-      if (isParameterDefined('architectures'))
+      }
+      if (isParameterDefined('inputTypes')) {
+        appendRow(parameterTable, 'inputType', state.inputType);
+      }
+      if (isParameterDefined('architectures')) {
         appendRow(parameterTable, 'architecture', state.architecture);
+      }
     }
 
     async function setupKernelTable() {
@@ -409,6 +416,8 @@ limitations under the License.
         state.backend = urlState.get('backend');
       if (urlState.has('inputSize'))
         state.inputSize = Number(urlState.get('inputSize'));
+      if (urlState.has('inputType'))
+        state.inputType = urlState.get('inputType');
       if (urlState.has('architecture'))
         state.architecture = urlState.get('architecture');
     }
@@ -426,7 +435,7 @@ limitations under the License.
       await showMsg('Loading the model');
       let start = performance.now();
       const inputSize = parseFloat(state.inputSize);
-      model = await benchmark.load(inputSize, state.architecture);
+      model = await benchmark.load(inputSize, state.architecture, state.inputType);
       state.inputs = [];
       if (model.inputs) {
         // construct the input state for the model
@@ -442,7 +451,7 @@ limitations under the License.
           });
         }
       }
-      predict = benchmark.predictFunc(inputSize);
+      predict = benchmark.predictFunc(inputSize, state.inputType);
       const elapsed = performance.now() - start;
 
       await showMsg(null);
@@ -644,13 +653,17 @@ limitations under the License.
         const benchmark = benchmarks[state.benchmark];
         state.isModelChanged = true;
         state.isModelLoaded = false;
+        if (modelArchitectureController !== null) {
+          modelParameterFolder.remove(modelArchitectureController);
+          modelArchitectureController = null;
+        }
         if (inputSizeController !== null) {
           modelParameterFolder.remove(inputSizeController);
           inputSizeController = null;
         }
-        if (modelArchitectureController !== null) {
-          modelParameterFolder.remove(modelArchitectureController);
-          modelArchitectureController = null;
+        if (inputTypeController !== null) {
+          modelParameterFolder.remove(inputTypeController);
+          inputTypeController = null;
         }
 
         if (isParameterDefined('inputSizes')) {
@@ -660,10 +673,11 @@ limitations under the License.
           });
           // Current use first value as default.
           let defaultInputSize = 0;
-          if (isURLParameterDefined('inputSize'))
+          if (isURLParameterDefined('inputSize')) {
             defaultInputSize = urlState.get('inputSize');
-          else
+          } else {
             defaultInputSize = benchmark['inputSizes'][0];
+          }
           inputSizeController.setValue(defaultInputSize);
           state.inputSize = defaultInputSize;
         } else {
@@ -689,7 +703,26 @@ limitations under the License.
           // Model doesn't support input size.
           state.architecture = '';
         }
-        if (isParameterDefined('inputSizes') || isParameterDefined('architectures')) {
+
+        if (isParameterDefined('inputTypes')) {
+          inputTypeController = modelParameterFolder.add(state, 'inputType', benchmark['inputTypes']).name('inputTypes').onChange(async inputType => {
+            state.inputType = inputType;
+            state.isModelChanged = true;
+          });
+          // Current use first value as default.
+          let defaultInputType = null;
+          if (isURLParameterDefined('inputType')) {
+            defaultInputType = urlState.get('inputType');
+          } else {
+            defaultInputType = benchmark['inputTypes'][0];
+          }
+          inputTypeController.setValue(defaultInputType);
+          state.inputType = defaultInputType;
+        } else {
+          // Model doesn't support input type.
+          state.inputType = '';
+        }
+        if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures')) {
           modelParameterFolder.open();
         }
 
@@ -716,12 +749,16 @@ limitations under the License.
       parameterFolder.open();
 
       modelParameterFolder = gui.addFolder('Model Parameters');
-      if (isParameterDefined('inputSizes')) {
-        inputSizeController = modelParameterFolder.add(state, 'inputSize', []);
-      }
       if (isParameterDefined('architectures')) {
         modelArchitectureController = modelParameterFolder.add(state, 'architecture', []);
       }
+      if (isParameterDefined('inputSizes')) {
+        inputSizeController = modelParameterFolder.add(state, 'inputSize', []);
+      }
+      if (isParameterDefined('inputTypes')) {
+        inputTypeController = modelParameterFolder.add(state, 'inputType', []);
+      }
+
       modelParameterFolder.open();
 
       const envFolder = gui.addFolder('Environment');

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -198,7 +198,10 @@ const benchmarks = {
     type: 'GraphModel',
     inputSizes: [128, 257, 512, 1024],
     architectures: ['MobileNetV1', 'ResNet50'],
-    load: async (inputResolution = 128, modelArchitecture = 'MobileNetV1') => {
+    inputTypes: ['image', 'tensor'],
+    load: async (
+        inputResolution = 128, modelArchitecture = 'MobileNetV1',
+        inputType = 'image') => {
       let config = null;
       if (modelArchitecture === 'MobileNetV1') {
         config = {
@@ -216,7 +219,11 @@ const benchmarks = {
         };
       }
       const model = await posenet.load(config);
-      model.image = await loadImage('tennis_standing.jpg');
+      if (inputType === 'tensor') {
+        model.image = tf.zeros([inputResolution, inputResolution, 3]);
+      } else {
+        model.image = await loadImage('tennis_standing.jpg');
+      }
       return model;
     },
     predictFunc: () => {
@@ -227,11 +234,13 @@ const benchmarks = {
   },
   'bodypix': {
     type: 'GraphModel',
-    // The ratio to the default camera size [640, 480].
+    // The ratio to the default camera size [480, 640].
     inputSizes: [0.25, 0.5, 0.75, 1.0],
     architectures: ['MobileNetV1', 'ResNet50'],
-    // bodypix doesn't support inputResolution when loading.
-    load: async (inputResolution, modelArchitecture = 'MobileNetV1') => {
+    inputTypes: ['image', 'tensor'],
+    load: async (
+        internalResolution, modelArchitecture = 'MobileNetV1',
+        inputType = 'image') => {
       let config = null;
       if (modelArchitecture === 'MobileNetV1') {
         config = {
@@ -248,10 +257,15 @@ const benchmarks = {
         };
       }
       const model = await bodyPix.load(config);
-      model.image = await loadImage('tennis_standing.jpg');
+      if (inputType === 'tensor') {
+        model.image =
+            tf.zeros([480 * internalResolution, 640 * internalResolution, 3]);
+      } else {
+        model.image = await loadImage('tennis_standing.jpg');
+      }
       return model;
     },
-    predictFunc: (internalResolution = 0.5) => {
+    predictFunc: (internalResolution = 0.5, inputType = 'image') => {
       return async model => {
         const PERSON_INFERENCE_CONFIG = {
           internalResolution: internalResolution,

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -220,15 +220,15 @@ const benchmarks = {
       }
       const model = await posenet.load(config);
       if (inputType === 'tensor') {
-        model.image = tf.zeros([inputResolution, inputResolution, 3]);
+        model.input = tf.zeros([inputResolution, inputResolution, 3]);
       } else {
-        model.image = await loadImage('tennis_standing.jpg');
+        model.input = await loadImage('tennis_standing.jpg');
       }
       return model;
     },
     predictFunc: () => {
       return async model => {
-        return model.estimateSinglePose(model.image);
+        return model.estimateSinglePose(model.input);
       };
     }
   },
@@ -258,10 +258,10 @@ const benchmarks = {
       }
       const model = await bodyPix.load(config);
       if (inputType === 'tensor') {
-        model.image =
+        model.input =
             tf.zeros([480 * internalResolution, 640 * internalResolution, 3]);
       } else {
-        model.image = await loadImage('tennis_standing.jpg');
+        model.input = await loadImage('tennis_standing.jpg');
       }
       return model;
     },
@@ -270,7 +270,7 @@ const benchmarks = {
         const PERSON_INFERENCE_CONFIG = {
           internalResolution: internalResolution,
         };
-        return model.segmentPerson(model.image, PERSON_INFERENCE_CONFIG);
+        return model.segmentPerson(model.input, PERSON_INFERENCE_CONFIG);
       };
     }
   },

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -265,7 +265,7 @@ const benchmarks = {
       }
       return model;
     },
-    predictFunc: (internalResolution = 0.5, inputType = 'image') => {
+    predictFunc: (internalResolution = 0.5) => {
       return async model => {
         const PERSON_INFERENCE_CONFIG = {
           internalResolution: internalResolution,


### PR DESCRIPTION
Currently most benchamrks use image as input. When tuning performance,
it's hard to tell the bottleneck lies in the image (such as memory copy from CPU
to GPU, memory copy from GPU to GPU) or the GPU/CPU computing.

With inputType, we can easily understand the total performance (use
image) and the computing performance (use tensor) difference.

Example usage:
http://localhost:8080/local-benchmark/?backend=webgl&warmup=0&run=2&benchmark=bodypix&inputsize=0.25&architecture=MobileNetV1&inputType=image
![inputType](https://user-images.githubusercontent.com/10395334/107132849-b7969800-691d-11eb-89d8-55d3339686b0.jpg)


inputType: image, tensor. This depends on model, check model_config.js.

FEATURE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4651)
<!-- Reviewable:end -->
