### PR TITLE
Allow undefined element shape for TensorList

### DIFF
--- a/tfjs-converter/src/executor/tensor_list.ts
+++ b/tfjs-converter/src/executor/tensor_list.ts
@@ -116,7 +116,8 @@ export class TensorList {
     }
     assertShapesMatchAllowUndefinedSize(
         elementShape, this.elementShape, 'TensorList shape mismatch: ');
-    const outputElementShape = findElementShape(this, elementShape);
+    const outputElementShape =
+        findElementShape(this.elementShape, this.tensors, elementShape);
     return tidy(() => {
       const reshapedTensors =
           this.tensors.map(tensor => reshape(tensor, outputElementShape));
@@ -138,7 +139,8 @@ export class TensorList {
     if (this.size() === 0) {
       throw new Error('Trying to pop from an empty list.');
     }
-    const outputElementShape = findElementShape(this, elementShape);
+    const outputElementShape =
+        findElementShape(this.elementShape, this.tensors, elementShape);
     const tensor = this.tensors.pop();
 
     assertShapesMatchAllowUndefinedSize(
@@ -208,7 +210,8 @@ export class TensorList {
     assertShapesMatchAllowUndefinedSize(
         this.tensors[elementIndex].shape, elementShape,
         'TensorList shape mismatch: ');
-    const outputElementShape = findElementShape(this, elementShape);
+    const outputElementShape =
+        findElementShape(this.elementShape, this.tensors, elementShape);
     return reshape(this.tensors[elementIndex], outputElementShape);
   }
 
@@ -255,7 +258,8 @@ export class TensorList {
     // When indices is greater than the size of the list, indices beyond the
     // size of the list are ignored.
     indices = indices.slice(0, this.size());
-    const outputElementShape = findElementShape(this, elementShape);
+    const outputElementShape =
+        findElementShape(this.elementShape, this.tensors, elementShape);
     if (indices.length === 0) {
       return tensor([], [0].concat(outputElementShape));
     }
@@ -280,7 +284,8 @@ export class TensorList {
 
     assertShapesMatchAllowUndefinedSize(
         this.elementShape, elementShape, 'TensorList shape mismatch: ');
-    const outputElementShape = findElementShape(this, elementShape);
+    const outputElementShape =
+        findElementShape(this.elementShape, this.tensors, elementShape);
 
     if (this.size() === 0) {
       return tensor([], [0].concat(outputElementShape));

--- a/tfjs-converter/src/executor/tensor_list.ts
+++ b/tfjs-converter/src/executor/tensor_list.ts
@@ -50,7 +50,7 @@ export class TensorList {
    *   meaning that the size of `tensors` is unbounded.
    */
   constructor(
-      readonly tensors: Tensor[], readonly elementShape: number[],
+      readonly tensors: Tensor[], readonly elementShape: number|number[],
       readonly elementDtype: DataType, maxNumElements = -1) {
     if (tensors != null) {
       tensors.forEach(tensor => {
@@ -141,7 +141,7 @@ export class TensorList {
     const tensor = this.tensors.pop();
     assertShapesMatchAllowUndefinedSize(
         tensor.shape, elementShape, 'TensorList shape mismatch: ');
-    return reshape(tensor, elementShape);
+    return tensor;
   }
 
   /**
@@ -258,7 +258,7 @@ export class TensorList {
     }
 
     return tidy(() => {
-      const tensors = indices.map(i => reshape(this.tensors[i], elementShape));
+      const tensors = indices.map(i => this.tensors[i]);
       return stack(tensors, 0);
     });
   }
@@ -281,10 +281,7 @@ export class TensorList {
       return tensor([], [0].concat(this.elementShape));
     }
 
-    return tidy(() => {
-      const tensors = this.tensors.map(t => reshape(t, elementShape));
-      return concat(tensors, 0);
-    });
+    return concat(this.tensors, 0);
   }
 }
 

--- a/tfjs-converter/src/executor/tensor_list_test.ts
+++ b/tfjs-converter/src/executor/tensor_list_test.ts
@@ -123,7 +123,8 @@ describe('TensorList', () => {
       tensorList.pushBack(tensor);
       const numTensors = memory().numTensors;
       tensorList.popBack(SHAPE, DTYPE);
-      expect(memory().numTensors).toEqual(numTensors);
+      // a new reshaped tensor
+      expect(memory().numTensors).toEqual(numTensors + 1);
     });
     it('should not fail for wildcard shape', () => {
       tensorList = new TensorList([], [-1, 1], DTYPE, SIZE);
@@ -171,9 +172,13 @@ describe('TensorList', () => {
       tensorList.setItem(1, tensor2);
     });
 
-    it('should read the correct index', () => {
-      expect(tensorList.getItem(0, SHAPE, DTYPE)).toBe(tensor);
-      expect(tensorList.getItem(1, SHAPE, DTYPE)).toBe(tensor2);
+    it('should read the correct index', async () => {
+      test_util.expectArraysEqual(
+          await tensorList.getItem(0, SHAPE, DTYPE).data(),
+          await tensor.data());
+      test_util.expectArraysEqual(
+          await tensorList.getItem(1, SHAPE, DTYPE).data(),
+          await tensor2.data());
     });
 
     it('should failed if index is out of bound', () => {
@@ -184,11 +189,12 @@ describe('TensorList', () => {
       const numTensors = memory().numTensors;
       tensorList.getItem(0, SHAPE, DTYPE);
       tensorList.getItem(1, SHAPE, DTYPE);
-      expect(memory().numTensors).toEqual(numTensors);
+      // 2 reshape tensors
+      expect(memory().numTensors).toEqual(numTensors + 2);
     });
-    it('should not fail for wildcard shape', () => {
+    it('should not fail for wildcard shape', async () => {
       const tensor3 = tensorList.getItem(0, [-1, 1], DTYPE);
-      expect(tensor3).toBe(tensor);
+      test_util.expectArraysEqual(await tensor3.data(), await tensor.data());
     });
   });
 

--- a/tfjs-converter/src/executor/tensor_list_test.ts
+++ b/tfjs-converter/src/executor/tensor_list_test.ts
@@ -224,7 +224,7 @@ describe('TensorList', () => {
       expect(concat.shape).toEqual([2, 1]);
       test_util.expectArraysClose(await concat.data(), [1, 2]);
     });
-    it('should fail for wildcard shape', async () => {
+    it('should not fail for wildcard shape', async () => {
       const concat = tensorList.concat(DTYPE, [-1, 1]);
       expect(concat.shape).toEqual([2, 1]);
       test_util.expectArraysClose(await concat.data(), [1, 2]);
@@ -264,7 +264,7 @@ describe('TensorList', () => {
       tensorList.gather([0, 1], DTYPE, SHAPE);
       expect(memory().numTensors).toEqual(numTensors + 1);
     });
-    it('should fail for wildcard shape', async () => {
+    it('should not fail for wildcard shape', async () => {
       const numTensors: number = memory().numTensors;
       tensorList.gather([0, 1], DTYPE, [-1, 1]);
       expect(memory().numTensors).toEqual(numTensors + 1);

--- a/tfjs-converter/src/executor/tensor_list_test.ts
+++ b/tfjs-converter/src/executor/tensor_list_test.ts
@@ -187,10 +187,13 @@ describe('TensorList', () => {
     });
     it('should create no new tensors', () => {
       const numTensors = memory().numTensors;
-      tensorList.getItem(0, SHAPE, DTYPE);
-      tensorList.getItem(1, SHAPE, DTYPE);
+      const tensor1 = tensorList.getItem(0, SHAPE, DTYPE);
+      const tensor2 = tensorList.getItem(1, SHAPE, DTYPE);
+
+      tensor1.dispose();
+      tensor2.dispose();
       // 2 reshape tensors
-      expect(memory().numTensors).toEqual(numTensors + 2);
+      expect(memory().numTensors).toEqual(numTensors);
     });
     it('should not fail for wildcard shape', async () => {
       const tensor3 = tensorList.getItem(0, [-1, 1], DTYPE);

--- a/tfjs-converter/src/executor/tensor_utils.ts
+++ b/tfjs-converter/src/executor/tensor_utils.ts
@@ -24,20 +24,21 @@
 import {util} from '@tensorflow/tfjs-core';
 
 export function assertShapesMatchAllowUndefinedSize(
-    shapeA: number[], shapeB: number[], errorMessagePrefix = ''): void {
+    shapeA: number|number[], shapeB: number|number[],
+    errorMessagePrefix = ''): void {
+  // constant shape means unknown rank
+  if (typeof shapeA === 'number' || typeof shapeB === 'number') {
+    return;
+  }
   util.assert(
-      shapesEqualAllowUndefinedSize(shapeA, shapeB),
+      shapeA.length === shapeB.length,
       () => errorMessagePrefix + ` Shapes ${shapeA} and ${shapeB} must match`);
-}
-
-export function shapesEqualAllowUndefinedSize(n1: number[], n2: number[]) {
-  if (n1.length !== n2.length) {
-    return false;
+  for (let i = 0; i < shapeA.length; i++) {
+    const dim0 = shapeA[i];
+    const dim1 = shapeB[i];
+    util.assert(
+        dim0 < 0 || dim1 < 0 || dim0 === dim1,
+        () =>
+            errorMessagePrefix + ` Shapes ${shapeA} and ${shapeB} must match`);
   }
-  for (let i = 0; i < n1.length; i++) {
-    if (n1[i] !== -1 && n2[i] !== -1 && n1[i] !== n2[i]) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/tfjs-converter/src/executor/tensor_utils.ts
+++ b/tfjs-converter/src/executor/tensor_utils.ts
@@ -57,11 +57,13 @@ export function fullDefinedShape(elementShape: number|number[]): boolean {
   return true;
 }
 /**
- * Generate the output element shape from the list and input param.
- * @param list
+ * Generate the output element shape from the list elementShape, list tensors
+ * and input param.
+ * @param listElementShape
+ * @param tensors
  * @param elementShape
  */
-export function findElementShape(
+export function inferElementShape(
     listElementShape: number|number[], tensors: Tensor[],
     elementShape: number|number[]): number[] {
   let partialShape = mergeElementShape(listElementShape, elementShape);

--- a/tfjs-converter/src/executor/tensor_utils.ts
+++ b/tfjs-converter/src/executor/tensor_utils.ts
@@ -21,8 +21,7 @@
  * anything.
  */
 
-import {util} from '@tensorflow/tfjs-core';
-import {TensorList} from './tensor_list';
+import {Tensor, util} from '@tensorflow/tfjs-core';
 
 /**
  * Used by TensorList and TensorArray to verify if elementShape matches, support
@@ -63,16 +62,17 @@ export function fullDefinedShape(elementShape: number|number[]): boolean {
  * @param elementShape
  */
 export function findElementShape(
-    list: TensorList, elementShape: number|number[]): number[] {
-  let partialShape = mergeElementShape(list.elementShape, elementShape);
+    listElementShape: number|number[], tensors: Tensor[],
+    elementShape: number|number[]): number[] {
+  let partialShape = mergeElementShape(listElementShape, elementShape);
   const notfullDefinedShape = !fullDefinedShape(partialShape);
-  if (notfullDefinedShape && list.size() === 0) {
+  if (notfullDefinedShape && tensors.length === 0) {
     throw new Error(
         `Tried to calculate elements of an empty list` +
         ` with non-fully-defined elementShape: ${partialShape}`);
   }
   if (notfullDefinedShape) {
-    list.tensors.forEach(tensor => {
+    tensors.forEach(tensor => {
       partialShape = mergeElementShape(tensor.shape, partialShape);
     });
   }
@@ -101,7 +101,7 @@ export function mergeElementShape(
   for (let i = 0; i < elementShapeA.length; ++i) {
     const dim0 = elementShapeA[i];
     const dim1 = elementShapeB[i];
-    if (dim0 >= 0 && dim1 >= 0 && dim0 != dim1) {
+    if (dim0 >= 0 && dim1 >= 0 && dim0 !== dim1) {
       throw new Error(`Incompatible shape during merge: ${elementShapeA} vs. ${
           elementShapeB}`);
     }


### PR DESCRIPTION
fix https://github.com/tensorflow/tfjs/issues/4641

TensorList can have element_shape defined as following [-1, -1, 1], which is not supported by our reshape.
This would auto calculate the output element shape from the ArrayList and input elementShape param, as well as the tensors within the list.

 
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4657)
<!-- Reviewable:end -->
