### PR TITLE
Re-enable Android nightly tests

### DIFF
--- a/scripts/run_flaky_test.js
+++ b/scripts/run_flaky_test.js
@@ -16,6 +16,8 @@
 const {exec} = require('shelljs');
 const fs = require('fs');
 
+const {FILE_NAME} = require('./run_flaky_test_helper.js');
+
 describe('run_flaky', () => {
   it('exits with zero if the command succeeds', () => {
     expect(exec('node ./scripts/run_flaky.js "echo success"').code).toEqual(0);
@@ -27,8 +29,8 @@ describe('run_flaky', () => {
 
   it('exits with zero if the command eventually succeeds', () => {
     // Remove test file that was not cleaned up from a prior run.
-    if (fs.existsSync('./flaky_test_has_run')) {
-      fs.unlinkSync('./flaky_test_has_run');
+    if (fs.existsSync(FILE_NAME)) {
+      fs.unlinkSync(FILE_NAME);
     }
 
     // This command should fail once and then succeed the next run.
@@ -39,6 +41,6 @@ describe('run_flaky', () => {
         .toEqual(0);
 
     // Clean up test file
-    fs.unlinkSync('./flaky_test_has_run');
+    fs.unlinkSync(FILE_NAME);
   });
 });

--- a/scripts/run_flaky_test.js
+++ b/scripts/run_flaky_test.js
@@ -14,6 +14,7 @@
 // =============================================================================
 
 const {exec} = require('shelljs');
+const fs = require('fs');
 
 describe('run_flaky', () => {
   it('exits with zero if the command succeeds', () => {
@@ -25,14 +26,19 @@ describe('run_flaky', () => {
   });
 
   it('exits with zero if the command eventually succeeds', () => {
-    // Try a command that exits with a random number in [0...4] 100 times.
-    // Bash's "$RANDOM" does not work in CI tests, so use "node -e" instead.
-    // P(this test failing | run_flaky and this test are correct) = (4/5)**100
+    // Remove test file that was not cleaned up from a prior run.
+    if (fs.existsSync('./flaky_test_has_run')) {
+      fs.unlinkSync('./flaky_test_has_run');
+    }
+
+    // This command should fail once and then succeed the next run.
     expect(exec(
-               'node ./scripts/run_flaky.js --times 100 \'node -e "' +
-               'process.exit(Math.floor(Math.random() * 5))' +
-               '"\'')
+               'node ./scripts/run_flaky.js --times 2' +
+               ' \'node ./scripts/run_flaky_test_helper.js\'')
                .code)
         .toEqual(0);
+
+    // Clean up test file
+    fs.unlinkSync('./flaky_test_has_run');
   });
 });

--- a/scripts/run_flaky_test_helper.js
+++ b/scripts/run_flaky_test_helper.js
@@ -14,11 +14,19 @@
 // =============================================================================
 
 const fs = require('fs');
+const FILE_NAME = './flaky_test_has_run';
+module.exports.FILE_NAME = FILE_NAME;
 
-if (!fs.existsSync('./flaky_test_has_run')) {
-  fs.writeFileSync(
-      './flaky_test_has_run',
-      'This temp file is used for testing' +
-          ' scripts/flaky_test.js and can be safely removed.');
-  process.exit(1);
+function main() {
+  if (!fs.existsSync(FILE_NAME)) {
+    fs.writeFileSync(
+        FILE_NAME,
+        'This temp file is used for testing' +
+            ' scripts/flaky_test.js and can be safely removed.');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
 }

--- a/scripts/run_flaky_test_helper.js
+++ b/scripts/run_flaky_test_helper.js
@@ -1,0 +1,24 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+const fs = require('fs');
+
+if (!fs.existsSync('./flaky_test_has_run')) {
+  fs.writeFileSync(
+      './flaky_test_has_run',
+      'This temp file is used for testing' +
+          ' scripts/flaky_test.js and can be safely removed.');
+  process.exit(1);
+}

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -22,6 +22,7 @@ if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_firefox_mac
   yarn run-browserstack --browsers=bs_chrome_mac
   yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2
+  yarn run-browserstack --browsers=bs_android_9 --testEnv webgl2
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
 else


### PR DESCRIPTION
Also make `run_flaky` tests (the tests for testing the `run_flaky.js` test runner script) deterministic. Flaky test running is currently only enabled for e2e tests. We'll see if there's an improvement in e2e test reliability vs other tests and then perhaps expand flaky testing to all BrowserStack tests.

Closes #4353.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4664)
<!-- Reviewable:end -->
