### PR TITLE
Revert "[webgl] Texture to tensor API. (#4376)"

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -170,26 +170,6 @@ export class MathBackendWebGL extends KernelBackend {
         this.pendingDeletes;
   }
 
-  // Writes a new entry to the data store with a WebGL texture, and registers it
-  // to the texture manager.
-  writeTexture(
-      texture: WebGLTexture, shape: number[], dtype: DataType,
-      texShape: [number, number]): DataId {
-    const dataId = {};
-    this.texData.set(dataId, {
-      shape,
-      dtype,
-      usage: TextureUsage.RENDER,
-      texture,
-      texShape,
-      isPacked: false,
-      refCount: 1
-    });
-
-    this.textureManager.registerRenderTexture(texture, texShape);
-    return dataId;
-  }
-
   write(values: BackendValues, shape: number[], dtype: DataType): DataId {
     if (env().getBool('WEBGL_CHECK_NUMERICAL_PROBLEMS') ||
         env().getBool('DEBUG')) {

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -21,7 +21,6 @@ import {engine, test_util, util} from '@tensorflow/tfjs-core';
 import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 const {expectArraysClose, expectArraysEqual} = test_util;
 const {decodeString} = util;
-import {createTensorFromTexture} from './base';
 
 import {getBinaryCache, MathBackendWebGL, WebGLMemoryInfo, WebGLTimingInfo} from './backend_webgl';
 import {computeBytes} from './texture_manager';
@@ -33,308 +32,10 @@ function decodeStrings(bytes: Uint8Array[]): string[] {
   return bytes.map(b => decodeString(b));
 }
 
-const WEBGL1_ENVS = {
-  flags: {'WEBGL_VERSION': 1},
-  predicate: WEBGL_ENVS.predicate
-};
-
-const WEBGL2_ENVS = {
-  flags: {'WEBGL_VERSION': 2},
-  predicate: WEBGL_ENVS.predicate
-};
-
 const RENDER_FLOAT32_ENVS = {
   flags: {'WEBGL_RENDER_FLOAT32_ENABLED': true},
   predicate: WEBGL_ENVS.predicate
 };
-
-describeWithFlags('create tensor from texture', WEBGL2_ENVS, () => {
-  it('basic usage', async () => {
-    // In this test we create a WebGL texture using the GL context from the
-    // WebGL backend. Then we create a tensor from that texture, and ensure that
-    // we can perform a TF operation on that tensor and get the expected result.
-
-    const gpgpu = new GPGPUContext();
-    const width = 3;
-    const height = 4;
-
-    const gl = gpgpu.gl;
-    const texture = gl.createTexture();
-    const tex2d = gl.TEXTURE_2D;
-    // tslint:disable-next-line:no-any
-    const glany = gl as any;
-    const internalFormat = glany.R32F;
-    const textureFormat = glany.RED;
-    const textureType = glany.FLOAT;
-    const dataForUpload =
-        new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-
-    gl.bindTexture(tex2d, texture);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(tex2d, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texImage2D(
-        tex2d, 0, internalFormat, width, height, 0, textureFormat, textureType,
-        dataForUpload);
-
-    const logicalShape = [height, width];
-    const physicalShape: [number, number] = [height, width];
-    const a = createTensorFromTexture({
-      texture,
-      shape: logicalShape,
-      dtype: 'float32',
-      texShapeRC: physicalShape,
-      internalFormat,
-      textureFormat,
-      textureType
-    });
-    const b = tf.mul(a, 2);
-
-    expect(b.shape).toEqual(logicalShape);
-    expectArraysClose(
-        await b.data(), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
-
-    gpgpu.dispose();
-  });
-
-  it('logical and physical shapes do not match', async () => {
-    // In this test we create a WebGL texture using the GL context from the
-    // WebGL backend. Then we create a tensor from that texture, and ensure that
-    // we can perform a TF operation on that tensor and get the expected result.
-
-    const gpgpu = new GPGPUContext();
-    const width = 3;
-    const height = 4;
-
-    const gl = gpgpu.gl;
-    const texture = gl.createTexture();
-    const tex2d = gl.TEXTURE_2D;
-    // tslint:disable-next-line:no-any
-    const glany = gl as any;
-    const internalFormat = glany.R32F;
-    const textureFormat = glany.RED;
-    const textureType = glany.FLOAT;
-    const dataForUpload =
-        new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-
-    gl.bindTexture(tex2d, texture);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(tex2d, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texImage2D(
-        tex2d, 0, internalFormat, width, height, 0, textureFormat, textureType,
-        dataForUpload);
-
-    const logicalShape = [2, 6];
-    const physicalShape: [number, number] = [height, width];
-    const a = createTensorFromTexture({
-      texture,
-      shape: logicalShape,
-      dtype: 'float32',
-      texShapeRC: physicalShape,
-      internalFormat,
-      textureFormat,
-      textureType
-    });
-    const b = tf.mul(a, 2);
-
-    expect(b.shape).toEqual(logicalShape);
-    expectArraysClose(
-        await b.data(), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
-
-    gpgpu.dispose();
-  });
-
-  it('physical texture has empty entries', async () => {
-    // In this test we create a WebGL texture using the GL context from the
-    // WebGL backend. Then we create a tensor from that texture, and ensure that
-    // we can perform a TF operation on that tensor and get the expected result.
-
-    const gpgpu = new GPGPUContext();
-    const width = 3;
-    const height = 5;
-
-    const gl = gpgpu.gl;
-    const texture = gl.createTexture();
-    const tex2d = gl.TEXTURE_2D;
-    // tslint:disable-next-line:no-any
-    const glany = gl as any;
-    const internalFormat = glany.R32F;
-    const textureFormat = glany.RED;
-    const textureType = glany.FLOAT;
-
-    const dataForUpload = new Float32Array(width * height);
-    const data = new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-    dataForUpload.set(data);
-
-    gl.bindTexture(tex2d, texture);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(tex2d, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texImage2D(
-        tex2d, 0, internalFormat, width, height, 0, textureFormat, textureType,
-        dataForUpload);
-
-    const logicalShape = [1, 13];
-    const physicalShape: [number, number] = [height, width];
-    const a = createTensorFromTexture({
-      texture,
-      shape: logicalShape,
-      dtype: 'float32',
-      texShapeRC: physicalShape,
-      internalFormat,
-      textureFormat,
-      textureType
-    });
-    const b = tf.mul(a, 2);
-
-    expect(b.shape).toEqual(logicalShape);
-    expectArraysClose(
-        await b.data(), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24]);
-
-    gpgpu.dispose();
-  });
-
-  it('force f16', async () => {
-    // Unlike in the basic usage test, rather than creating a texture from
-    // scratch, we must extract the output texture from an operation because we
-    // cannot upload Float16 data directly to the GPU.
-
-    // We clean up explicitly so that we have full control over the environment
-    // flags during texture initialization / disposal.
-    tf.engine().startScope();
-
-    const webglRenderF32EnabledFlagSaved =
-        tf.env().getBool('WEBGL_RENDER_FLOAT32_ENABLED');
-    const webglPackedFlagSaved = tf.env().getBool('WEBGL_PACK');
-    tf.env().set('WEBGL_RENDER_FLOAT32_ENABLED', false);
-
-    // We must set `WEBGL_PACK` to false because createTensorFromTexture only
-    // accepts unpacked textures so this ensures the output texture (`bTexture`
-    // below) is unpacked.
-    tf.env().set('WEBGL_PACK', false);
-
-    const gpgpu = new GPGPUContext();
-    const gl = gpgpu.gl;
-    // tslint:disable-next-line:no-any
-    const glany = gl as any;
-
-    const width = 3;
-    const height = 4;
-
-    const logicalShape: [number, number] = [height, width];
-    const physicalShape: [number, number] = [height, width];
-    const a = tf.tensor2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], logicalShape);
-    const b = tf.relu(a);
-    const bTexture = (tf.backend() as MathBackendWebGL).getTexture(b.dataId);
-    const c = createTensorFromTexture({
-      texture: bTexture,
-      shape: logicalShape,
-      dtype: 'float32',
-      texShapeRC: physicalShape,
-      internalFormat: glany.R16F,
-      textureFormat: glany.RED,
-      textureType: glany.HALF_FLOAT
-    });
-    const d = tf.mul(c, 2);
-
-    expect(d.shape).toEqual(logicalShape);
-    expectArraysClose(
-        await d.data(), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
-
-    gpgpu.dispose();
-
-    tf.engine().endScope();
-    tf.env().set(
-        'WEBGL_RENDER_FLOAT32_ENABLED', webglRenderF32EnabledFlagSaved);
-    tf.env().set('WEBGL_PACK', webglPackedFlagSaved);
-  });
-});
-
-describeWithFlags('create tensor from texture', WEBGL1_ENVS, () => {
-  it('basic usage', async () => {
-    const gpgpu = new GPGPUContext();
-    const width = 3;
-    const height = 4;
-
-    const logicalShape: [number, number] = [height, width];
-    const physicalShape: [number, number] = [height, width];
-
-    const gl = gpgpu.gl;
-    const texture = gl.createTexture();
-    const tex2d = gl.TEXTURE_2D;
-    const internalFormat = gl.RGBA;
-    const textureFormat = gl.RGBA;
-    const textureType = gl.FLOAT;
-    // WebGL 1 does not accept gl.RED as an internalFormat, so we have to
-    // upload values for the unused channels as well.
-    const dataForUpload = new Float32Array([
-      0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4,  0, 0, 0, 5,  0, 0, 0,
-      6, 0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 9, 0, 0, 0, 10, 0, 0, 0, 11, 0, 0, 0,
-    ]);
-
-    gl.bindTexture(tex2d, texture);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(tex2d, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(tex2d, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texImage2D(
-        tex2d, 0, internalFormat, width, height, 0, textureFormat, textureType,
-        dataForUpload);
-
-    const a = createTensorFromTexture({
-      texture,
-      shape: logicalShape,
-      texShapeRC: physicalShape,
-      dtype: 'float32',
-      internalFormat,
-      textureFormat,
-      textureType
-    });
-    const b = tf.mul(a, 2);
-
-    expect(b.shape).toEqual(logicalShape);
-    expectArraysClose(
-        await b.data(), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
-    gpgpu.dispose();
-  });
-
-  it('chained', async () => {
-    const gpgpu = new GPGPUContext();
-    const gl = gpgpu.gl;
-
-    const webglPackedFlagSaved = tf.env().getBool('WEBGL_PACK');
-    tf.env().set('WEBGL_PACK', false);
-
-    const width = 3;
-    const height = 4;
-
-    const logicalShape: [number, number] = [height, width];
-    const physicalShape: [number, number] = [height, width];
-    const a = tf.tensor2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], logicalShape);
-    const b = tf.relu(a);
-    const bTexture = (tf.backend() as MathBackendWebGL).getTexture(b.dataId);
-    const c = createTensorFromTexture({
-      texture: bTexture,
-      shape: logicalShape,
-      texShapeRC: physicalShape,
-      dtype: 'float32',
-      internalFormat: gl.RGBA,
-      textureFormat: gl.RGBA,
-      textureType: gl.FLOAT
-    });
-    const d = tf.mul(c, 2);
-
-    expect(d.shape).toEqual(logicalShape);
-    expectArraysClose(
-        await d.data(), [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
-
-    tf.env().set('WEBGL_PACK', webglPackedFlagSaved);
-  });
-});
 
 describeWithFlags('forced f16 render', RENDER_FLOAT32_ENVS, () => {
   beforeAll(() => {
@@ -740,6 +441,16 @@ describeWithFlags('debug on webgl', WEBGL_ENVS, () => {
     tf.env().set('WEBGL_RENDER_FLOAT32_ENABLED', savedRenderFloat32Flag);
   });
 });
+
+const WEBGL1_ENVS = {
+  flags: {'WEBGL_VERSION': 1},
+  predicate: WEBGL_ENVS.predicate
+};
+
+const WEBGL2_ENVS = {
+  flags: {'WEBGL_VERSION': 2},
+  predicate: WEBGL_ENVS.predicate
+};
 
 describeWithFlags('computeBytes counts bytes correctly', WEBGL1_ENVS, () => {
   it('for all physical texture types', () => {

--- a/tfjs-backend-webgl/src/base.ts
+++ b/tfjs-backend-webgl/src/base.ts
@@ -28,10 +28,6 @@ if (device_util.isBrowser()) {
 // Export webgl utilities
 export * from './webgl';
 
-// Export forceHalfFloat and createTensorFromTexture under webgl namespace for
-// the union bundle.
-import {forceHalfFloat, createTensorFromTexture} from './webgl';
-export const webgl = {
-  forceHalfFloat,
-  createTensorFromTexture
-};
+// Export forceHalfFlost under webgl namespace for the union bundle.
+import {forceHalfFloat} from './webgl';
+export const webgl = {forceHalfFloat};

--- a/tfjs-backend-webgl/src/gpgpu_util.ts
+++ b/tfjs-backend-webgl/src/gpgpu_util.ts
@@ -81,25 +81,15 @@ export function getInternalFormatForFloat32MatrixTexture(
   return textureConfig.internalFormatFloat;
 }
 
-export function getTextureParamsForFloat32MatrixTexture(
-    gl: WebGLRenderingContext,
-    textureConfig: TextureConfig): TextureCreationParams {
-  return {
-    internalFormat: getInternalFormatForFloat32MatrixTexture(textureConfig),
-    textureFormat: textureConfig.textureFormatFloat,
-    textureType: gl.FLOAT
-  };
-}
-
 export function createFloat32MatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
     textureConfig: TextureConfig): WebGLTexture {
   const [width, height] =
       tex_util.getUnpackedMatrixTextureShapeWidthHeight(rows, columns);
-  const {internalFormat, textureFormat, textureType} =
-      getTextureParamsForFloat32MatrixTexture(gl, textureConfig);
   return createAndConfigureTexture(
-      gl, width, height, internalFormat, textureFormat, textureType);
+      gl, width, height,
+      getInternalFormatForFloat32MatrixTexture(textureConfig),
+      textureConfig.textureFormatFloat, gl.FLOAT);
 }
 
 export function getInternalFormatForFloat16MatrixTexture(
@@ -107,25 +97,15 @@ export function getInternalFormatForFloat16MatrixTexture(
   return textureConfig.internalFormatHalfFloat;
 }
 
-export function getTextureParamsForFloat16MatrixTexture(
-    gl: WebGLRenderingContext,
-    textureConfig: TextureConfig): TextureCreationParams {
-  return {
-    internalFormat: getInternalFormatForFloat16MatrixTexture(textureConfig),
-    textureFormat: textureConfig.textureFormatFloat,
-    textureType: textureConfig.textureTypeHalfFloat
-  };
-}
-
 export function createFloat16MatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
     textureConfig: TextureConfig): WebGLTexture {
   const [width, height] =
       tex_util.getUnpackedMatrixTextureShapeWidthHeight(rows, columns);
-  const {internalFormat, textureFormat, textureType} =
-      getTextureParamsForFloat16PackedMatrixTexture(gl, textureConfig);
   return createAndConfigureTexture(
-      gl, width, height, internalFormat, textureFormat, textureType);
+      gl, width, height,
+      getInternalFormatForFloat16MatrixTexture(textureConfig),
+      textureConfig.textureFormatFloat, textureConfig.textureTypeHalfFloat);
 }
 
 export function getInternalFormatForUnsignedBytesMatrixTexture(
@@ -149,25 +129,14 @@ export function getInternalFormatForPackedMatrixTexture(
   return textureConfig.internalFormatPackedFloat;
 }
 
-export function getTextureParamsForPackedMatrixTexture(
-    gl: WebGLRenderingContext,
-    textureConfig: TextureConfig): TextureCreationParams {
-  return {
-    internalFormat: getInternalFormatForPackedMatrixTexture(textureConfig),
-    textureFormat: gl.RGBA,
-    textureType: gl.FLOAT
-  };
-}
-
 export function createPackedMatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
     textureConfig: TextureConfig): WebGLTexture {
   const [width, height] =
       tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
-  const {internalFormat, textureFormat, textureType} =
-      getTextureParamsForPackedMatrixTexture(gl, textureConfig);
   return createAndConfigureTexture(
-      gl, width, height, internalFormat, textureFormat, textureType);
+      gl, width, height, getInternalFormatForPackedMatrixTexture(textureConfig),
+      gl.RGBA, gl.FLOAT);
 }
 
 export function getInternalFormatForFloat16PackedMatrixTexture(
@@ -175,32 +144,15 @@ export function getInternalFormatForFloat16PackedMatrixTexture(
   return textureConfig.internalFormatPackedHalfFloat;
 }
 
-export type TextureCreationParams = {
-  internalFormat: number,
-  textureFormat: number,
-  textureType: number
-};
-
-export function getTextureParamsForFloat16PackedMatrixTexture(
-    gl: WebGLRenderingContext,
-    textureConfig: TextureConfig): TextureCreationParams {
-  return {
-    internalFormat:
-        getInternalFormatForFloat16PackedMatrixTexture(textureConfig),
-    textureFormat: gl.RGBA,
-    textureType: textureConfig.textureTypeHalfFloat
-  };
-}
-
 export function createFloat16PackedMatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
     textureConfig: TextureConfig): WebGLTexture {
   const [width, height] =
       tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
-  const {internalFormat, textureFormat, textureType} =
-      getTextureParamsForFloat16PackedMatrixTexture(gl, textureConfig);
   return createAndConfigureTexture(
-      gl, width, height, internalFormat, textureFormat, textureType);
+      gl, width, height,
+      getInternalFormatForFloat16PackedMatrixTexture(textureConfig), gl.RGBA,
+      textureConfig.textureTypeHalfFloat);
 }
 
 export function bindVertexProgramAttributeStreams(

--- a/tfjs-backend-webgl/src/tex_util.ts
+++ b/tfjs-backend-webgl/src/tex_util.ts
@@ -176,33 +176,24 @@ export interface TextureConfig {
   textureTypeFloat: number;
 }
 
-export type WebGLTextureInternalFormat = WebGL2RenderingContext['R32F']|
-    WebGL2RenderingContext['R16F']|WebGL2RenderingContext['RGBA16F']|
-    WebGL2RenderingContext['RGBA32F']|WebGLRenderingContext['RGBA'];
-export type WebGLTextureFormat =
-    WebGL2RenderingContext['RED']|WebGLRenderingContext['RGBA'];
-export type WebGLTextureType =
-    WebGL2RenderingContext['HALF_FLOAT']|WebGL2RenderingContext['FLOAT']|
-    WebGLRenderingContext['FLOAT']|OES_texture_half_float['HALF_FLOAT_OES'];
-
 export function getTextureConfig(
     // tslint:disable-next-line:no-any
     gl: WebGLRenderingContext, textureHalfFloatExtension?: any): TextureConfig {
   // tslint:disable-next-line:no-any
   const glany = gl as any;
 
-  let internalFormatFloat: WebGLTextureInternalFormat;
-  let internalFormatHalfFloat: WebGLTextureInternalFormat;
-  let internalFormatPackedHalfFloat: WebGLTextureInternalFormat;
-  let internalFormatPackedFloat: WebGLTextureInternalFormat;
-  let textureFormatFloat: WebGLTextureFormat;
+  let internalFormatFloat: number;
+  let internalFormatHalfFloat: number;
+  let internalFormatPackedHalfFloat: number;
+  let internalFormatPackedFloat: number;
+  let textureFormatFloat: number;
 
-  let downloadTextureFormat: WebGLTextureFormat;
+  let downloadTextureFormat: number;
   let downloadUnpackNumChannels: number;
 
   let defaultNumChannels: number;
-  let textureTypeHalfFloat: WebGLTextureType;
-  let textureTypeFloat: WebGLTextureType;
+  let textureTypeHalfFloat: number;
+  let textureTypeFloat: number;
 
   if (env().getNumber('WEBGL_VERSION') === 2) {
     internalFormatFloat = glany.R32F;

--- a/tfjs-backend-webgl/src/texture_manager.ts
+++ b/tfjs-backend-webgl/src/texture_manager.ts
@@ -33,30 +33,6 @@ export class TextureManager {
 
   constructor(private gpgpu: GPGPUContext) {}
 
-  registerRenderTexture(texture: WebGLTexture, shapeRC: [number, number]) {
-    const usage = TextureUsage.RENDER;
-    const isPacked = false;
-    const physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
-
-    const shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
-    if (!(shapeKey in this.freeTextures)) {
-      this.freeTextures[shapeKey] = [];
-    }
-    if (!(shapeKey in this.usedTextures)) {
-      this.usedTextures[shapeKey] = [];
-    }
-
-    const texBytes = computeBytes(
-        shapeRC, physicalTexType, this.gpgpu.gl, this.gpgpu.textureConfig,
-        isPacked);
-
-    this.usedTextures[shapeKey].push(texture);
-
-    this.numUsedTextures++;
-    this._numBytesAllocated += texBytes;
-    this.log();
-  }
-
   acquireTexture(
       shapeRC: [number, number], usage: TextureUsage,
       isPacked: boolean): WebGLTexture {

--- a/tfjs-backend-webgl/src/webgl.ts
+++ b/tfjs-backend-webgl/src/webgl.ts
@@ -15,11 +15,9 @@
  * =============================================================================
  */
 
-import {DataType, engine, env, Tensor, util} from '@tensorflow/tfjs-core';
+import {env} from '@tensorflow/tfjs-core';
 
-import {MathBackendWebGL} from './backend_webgl';
 import * as gpgpu_util from './gpgpu_util';
-import {WebGLTextureFormat, WebGLTextureInternalFormat, WebGLTextureType} from './tex_util';
 import * as webgl_util from './webgl_util';
 
 export {MathBackendWebGL, WebGLMemoryInfo, WebGLTimingInfo} from './backend_webgl';
@@ -36,121 +34,4 @@ export {gpgpu_util, webgl_util};
  */
 export function forceHalfFloat(): void {
   env().set('WEBGL_FORCE_F16_TEXTURES', true);
-}
-
-type TensorFromTextureConfig = {
-  texture: WebGLTexture,
-  shape: number[],
-  dtype: DataType,
-  texShapeRC: [number, number],
-  internalFormat: WebGLTextureInternalFormat,
-  textureFormat: WebGLTextureFormat,
-  textureType: WebGLTextureType
-};
-
-/**
- * Create a TF.js tensor out of an existing WebGL texture. The texture is added
- * to the WebGL texture registry.
- *
- * This makes it possible for TF.js applications to avoid GPU / CPU sync. For
- * example, if your application includes a preprocessing step on the GPU, you
- * could upload the GPU output directly to TF.js, rather than first downloading
- * the values.
- *
- * ```js
- * // Example for WebGL2:
- * const gl = tf.backend().gpgpu.gl;
- * const texture = gl.createTexture();
- * const tex2d = gl.TEXTURE_2D;
- * const width = 3;
- * const height = 4;
- *
- * gl.bindTexture(tex2d, texture);
- * gl.texParameteri(tex2d, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
- * gl.texParameteri(tex2d, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
- * gl.texParameteri(tex2d, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
- * gl.texParameteri(tex2d, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
- * gl.texImage2D(
- *   tex2d, 0, gl.R32F, // internalFormat
- *   width, height, 0,
- *   gl.RED, // textureFormat
- *   gl.FLOAT, // textureType
- *   new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) // data
- * );
- *
- * const logicalShape = [height, width];
- * const physicalShape = [height, width];
- * const a = tf.webgl.createTensorFromTexture(texture, logicalShape,
- *   physicalShape);
- *
- * ```
- *
- * For postprocessing on the GPU, it's possible to retrieve the texture backing
- * any tensor by calling the WebGL backend's `getTexture` method like so:
- *
- * ```js
- * const a = tf.tensor1d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
- * const tex = tf.backend().getTexture(a.dataId);
- * ```
- *
- * @param obj An object with the following properties:
- *  @param texture The WebGL texture to create a tensor from. The texture must
- * be unpacked - each texel should only store a single value. The flattened
- * values of the tensor will be read from left to right, and top to bottom. The
- * texture can have empty texels at the end, but the values must be written
- * densely - in other words, all empty texels must be contiguous.
- *  @param shape The logical shape of the texture.
- *  @param dtype The dtype of the tensor to be created.
- *  @param texShapeRC The physical dimensions of the texture expressed as [rows,
- * columns].
- *  @param internalFormat The internalFormat of the texture provided to
- * gl.texImage2D during texture creation.
- *  @param textureFormat The textureFormat of the texture provided to
- * gl.texImage2D during texture creation.
- *  @param textureType The textureType of the texture provided to gl.texImage2D
- * during texture creation.
- * @doc {heading: 'Environment', namespace: 'webgl'}
- */
-export function createTensorFromTexture({
-  texture,
-  shape,
-  dtype,
-  texShapeRC,
-  internalFormat,
-  textureFormat,
-  textureType
-}: TensorFromTextureConfig): Tensor {
-  // OpenGL / WebGL do not make it possible to query textures for their
-  // properties (physical dimensions, internalFormat, etc.), therefore we ask
-  // the user to provide this information in order to validate their texture.
-  // References:
-  // https://stackoverflow.com/questions/30140178/opengl-es-2-0-get-texture-size-and-other-info
-  // https://stackoverflow.com/questions/26315021/is-there-a-way-to-retrieve-the-dimensions-of-a-texture-after-binding-with-gl-bin
-  // https://stackoverflow.com/questions/46387922/how-to-check-a-texture-is-2d-texture-or-cube-texture-in-webgl
-
-  const backend = engine().backend as MathBackendWebGL;
-  const gl = backend.gpgpu.gl;
-  const texConfig = backend.gpgpu.textureConfig;
-  let params: gpgpu_util.TextureCreationParams;
-
-  if (env().getBool('WEBGL_RENDER_FLOAT32_ENABLED') === true) {
-    params = gpgpu_util.getTextureParamsForFloat32MatrixTexture(gl, texConfig);
-  } else {
-    params = gpgpu_util.getTextureParamsForFloat16MatrixTexture(gl, texConfig);
-  }
-
-  // Ensure that the properties of the texture match the expectations of the
-  // WebGL backend.
-  util.assert(
-      internalFormat === params.internalFormat,
-      () => `The internalFormat must be ${params.internalFormat}.`);
-  util.assert(
-      textureFormat === params.textureFormat,
-      () => `The textureFormat must be ${params.textureFormat}.`);
-  util.assert(
-      textureType === params.textureType,
-      () => `The textureType must be ${params.textureType}.`);
-
-  const dataId = backend.writeTexture(texture, shape, dtype, texShapeRC);
-  return engine().makeTensorFromDataId(dataId, shape, dtype, backend);
 }


### PR DESCRIPTION
This reverts commit 65dcfcceb78d26923c946e60db0e02e155ce6d88, which is failing on Mobile Safari in [nightly tests](https://console.cloud.google.com/cloud-build/builds/f4a9c31e-7f5f-43d6-ba7a-8dc14448c37c?project=834911136599).

```
Mobile Safari 11.0.0 (iOS 11.2.0) create tensor from texture webgl1 {"WEBGL_VERSION":1,"WEBGL_CPU_FORWARD":false,"WEBGL_SIZE_UPLOAD_UNIFORM":0} basic usage FAILED
	Error: The textureType must be 36193. in /tmp/karma-typescript-bundle--163-OZsx3WJLYu4d-.js (line 166939)
	assert@/tmp/karma-typescript-bundle--163-OZsx3WJLYu4d-.js:166939:24
	createTensorFromTexture@src/webgl.ts:150:14 <- src/webgl.js:125:28
	src/backend_webgl_test.ts:288:38 <- src/backend_webgl_test.js:296:55
	step@src/backend_webgl_test.js:48:27
	src/backend_webgl_test.js:23:75
	<Jasmine>
	src/backend_webgl_test.js:19:36
	<Jasmine>
```



To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4675)
<!-- Reviewable:end -->
