### PR TITLE
Add 'tfjs-core' as a dependency to the NODE release phase

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -86,7 +86,7 @@ export const UNION_PHASE: Phase = {
 // the test to tf.layers.
 export const NODE_PHASE: Phase = {
   packages: ['tfjs-node', 'tfjs-node-gpu'],
-  deps: ['tfjs'],
+  deps: ['tfjs', 'tfjs-core'],
   scripts: {'tfjs-node-gpu': {'before-yarn': ['yarn prep-gpu']}}
 };
 


### PR DESCRIPTION
tfjs-node and tfjs-node-gpu need access to tfjs-core to compile during release (and verdaccio tests). Otherwise, they throw the following error:
```
src/index.ts:59:14 - error TS2742: The inferred type of 'io' cannot be named without a reference to '@tensorflow/tfjs/node_modules/@tensorflow/tfjs-core/dist/io/browser_files'. This is likely not portable. A type annotation is necessary.

59 export const io = {
                ~~
```

[Full logs of the above verdaccio test](https://console.cloud.google.com/cloud-build/builds;region=global/8267b451-6b36-44f1-9940-4d411aab862e?project=learnjs-174218)

[Logs of a verdaccio test after the change](https://console.cloud.google.com/cloud-build/builds/529fd4a6-2b27-485a-a71b-4c348f554089?project=834911136599) (Still running at the time of writing)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4678)
<!-- Reviewable:end -->
