### PR TITLE
Enable flaky tests for 2.8.x

### DIFF
--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -49,15 +49,17 @@ if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
 fi
 
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
-  yarn run-browserstack --browsers=bs_safari_mac --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
-  yarn run-browserstack --browsers=bs_ios_11 --tags $TAGS --testEnv webgl --flags '{"WEBGL_VERSION": 1, "WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
 
-  yarn run-browserstack --browsers=bs_firefox_mac --tags $TAGS
-  yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
-  yarn run-browserstack --browsers=win_10_chrome --tags $TAGS
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_11 --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
+
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac --tags '$TAGS'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=win_10_chrome --tags '$TAGS'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_android_9 --tags '$TAGS'"
 
   # Test script tag bundles
-  karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js
+  node ../scripts/run_flaky.js "karma start ./script_tag_tests/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js"
 else
-  yarn run-browserstack --browsers=bs_chrome_mac --tags $TAGS
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS'"
 fi

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-packages-ci": "yarn generate-cloudbuild-for-packages && ./scripts/run-build.sh",
     "generate-cloudbuild-for-packages": "./scripts/generate_cloudbuild_for_packages.js",
     "test-generate-cloudbuild": "jasmine run scripts/generate_cloudbuild_test.js",
+    "test-run-flaky": "jasmine run scripts/run_flaky_test.js",
     "release": "ts-node -s ./scripts/release.ts",
     "release-tfjs": "ts-node -s ./scripts/release-tfjs.ts",
     "publish-npm": "ts-node -s ./scripts/publish-npm.ts",

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -14,6 +14,15 @@ steps:
   args: ['test-generate-cloudbuild']
   waitFor: ['yarn-common']
 
+# Test run_flaky.js
+# The flaky test runner is important enough to test every time and takes less
+# than 5 seconds.
+- name: 'node:10'
+  id: 'test-run-flaky'
+  entrypoint: 'yarn'
+  args: ['test-run-flaky']
+  waitFor: ['yarn-common']
+
 # General configuration
 secrets:
 - kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -13,6 +13,13 @@ steps:
     waitFor:
       - yarn-common
   - name: 'node:10'
+    id: test-run-flaky
+    entrypoint: yarn
+    args:
+      - test-run-flaky
+    waitFor:
+      - yarn-common
+  - name: 'node:10'
     dir: tfjs-core
     id: yarn-tfjs-core
     entrypoint: yarn

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -13,6 +13,13 @@ steps:
     waitFor:
       - yarn-common
   - name: 'node:10'
+    id: test-run-flaky
+    entrypoint: yarn
+    args:
+      - test-run-flaky
+    waitFor:
+      - yarn-common
+  - name: 'node:10'
     dir: tfjs-core
     id: yarn-tfjs-core
     entrypoint: yarn

--- a/scripts/run_flaky.js
+++ b/scripts/run_flaky.js
@@ -1,0 +1,69 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+const {ArgumentParser} = require('argparse');
+const {exec} = require('shelljs');
+
+
+function main(args) {
+  const command = args['command'];
+  const times = parseInt(args['times']);
+
+  if (times === 0) {
+    throw new Error(`Flaky test asked to run zero times: '${command}'`);
+  }
+
+  console.log(`Running flaky test at most ${times} times`);
+  console.log(`Command: '${command}'`);
+  const exitCodes = [];
+  for (let i = 0; i < times; i++) {
+    console.log(`Flaky run ${i + 1} of a potential ${times} for '${command}'`);
+    const exitCode = exec(command).code;
+    exitCodes.push(exitCode);
+    if (exitCode === 0) {
+      break;
+    }
+  }
+
+  const success = exitCodes[exitCodes.length - 1] === 0;
+  if (!success) {
+    console.error(`Flaky test failed ${times} times`);
+  } else if (exitCodes.length > 1) {
+    console.warn(
+        `Flaky test failed ${exitCodes.length - 1} times before passing.`);
+  } else {
+    // Test passed with no fails
+    console.log('Flaky test passed on the first run');
+  }
+  console.error(`Command: '${command}'`);
+  console.error(`Exit codes: ${exitCodes}`);
+
+  if (!success) {
+    process.exit(1);
+  }
+}
+
+const parser = new ArgumentParser(
+    {description: 'Run a flaky test a number of times or until it passes'});
+
+parser.addArgument('command', {help: 'Flaky command to run'})
+parser.addArgument('--times', {
+  help: 'Maximum number of times to run the command',
+  defaultValue: 3,
+  nargs: '?',
+  type: 'int',
+});
+
+main(parser.parseArgs());

--- a/scripts/run_flaky_test.js
+++ b/scripts/run_flaky_test.js
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+const {exec} = require('shelljs');
+
+describe('run_flaky', () => {
+  it('exits with zero if the command succeeds', () => {
+    expect(exec('node ./scripts/run_flaky.js "echo success"').code).toEqual(0);
+  });
+
+  it('exits with one if the command fails', () => {
+    expect(exec('node ./scripts/run_flaky.js "exit 1"').code).toEqual(1);
+  });
+
+  it('exits with zero if the command eventually succeeds', () => {
+    // Try a command that exits with a random number in [0...4] 100 times.
+    // Bash's "$RANDOM" does not work in CI tests, so use "node -e" instead.
+    // P(this test failing | run_flaky and this test are correct) = (4/5)**100
+    expect(exec(
+               'node ./scripts/run_flaky.js --times 100 \'node -e "' +
+               'process.exit(Math.floor(Math.random() * 5))' +
+               '"\'')
+               .code)
+        .toEqual(0);
+  });
+});

--- a/scripts/run_flaky_test_helper.js
+++ b/scripts/run_flaky_test_helper.js
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+const fs = require('fs');
+const FILE_NAME = './flaky_test_has_run';
+module.exports.FILE_NAME = FILE_NAME;
+
+function main() {
+  if (!fs.existsSync(FILE_NAME)) {
+    fs.writeFileSync(
+        FILE_NAME,
+        'This temp file is used for testing' +
+            ' scripts/flaky_test.js and can be safely removed.');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -13,11 +13,11 @@ set -e
 yarn test-node
 
 if [ "$NIGHTLY" = true ]; then
-  yarn run-browserstack --browsers=bs_safari_mac
-  yarn run-browserstack --browsers=bs_firefox_mac
-  yarn run-browserstack --browsers=bs_chrome_mac
-  yarn run-browserstack --browsers=win_10_chrome
-  yarn run-browserstack --browsers=bs_ios_11
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=win_10_chrome"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_11"
 else
-  yarn run-browserstack --browsers=bs_chrome_mac
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
 fi

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -22,6 +22,7 @@ if [ "$NIGHTLY" = true ]; then
   yarn run-browserstack --browsers=bs_firefox_mac
   yarn run-browserstack --browsers=bs_chrome_mac
   yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2
+  yarn run-browserstack --browsers=bs_android_9 --testEnv webgl2
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
   yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
 else

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -17,14 +17,14 @@
 set -e
 
 if [ "$NIGHTLY" = true ]; then
-  yarn run-browserstack --browsers=bs_safari_mac --testEnv webgl1
-  yarn run-browserstack --browsers=bs_ios_11 --testEnv webgl1
-  yarn run-browserstack --browsers=bs_firefox_mac
-  yarn run-browserstack --browsers=bs_chrome_mac
-  yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2
-  yarn run-browserstack --browsers=bs_android_9 --testEnv webgl2
-  yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_PACK": false}'
-  yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"WEBGL_CPU_FORWARD": true}'
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac --testEnv webgl1"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_11 --testEnv webgl1"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=win_10_chrome --testEnv webgl2"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_android_9 --testEnv webgl2"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"\""WEBGL_PACK"\"": false}'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"\""WEBGL_CPU_FORWARD"\"": true}'"
 else
-  yarn run-browserstack --browsers=bs_chrome_mac
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
 fi

--- a/tfjs-core/scripts/test-ci.sh
+++ b/tfjs-core/scripts/test-ci.sh
@@ -25,11 +25,11 @@ then
   # runing each browser separately?
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-  yarn run-browserstack --browsers=bs_chrome_mac
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
 
-  yarn run-browserstack --browsers=bs_firefox_mac --flags '{"HAS_WEBGL": false}' --testEnv cpu
-  yarn run-browserstack --browsers=bs_safari_mac --flags '{"HAS_WEBGL": false}' --testEnv cpu
-  yarn run-browserstack --browsers=bs_ios_11 --flags '{"HAS_WEBGL": false}' --testEnv cpu
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac --flags '{"\""HAS_WEBGL"\"": false}' --testEnv cpu"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac --flags '{"\""HAS_WEBGL"\"": false}' --testEnv cpu"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_11 --flags '{"\""HAS_WEBGL"\"": false}' --testEnv cpu"
 
 
   ### The next section tests TF.js in a webworker using the CPU backend.
@@ -38,8 +38,8 @@ then
   yarn rollup -c --ci
   # copy the cpu backend bundle somewhere the test can access it
   cp -v ../tfjs-backend-cpu/dist/tf-backend-cpu.min.js dist/
-  yarn test-webworker --browsers=bs_safari_mac
-  yarn test-webworker --browsers=bs_chrome_mac
+  node ../scripts/run_flaky.js "yarn test-webworker --browsers=bs_safari_mac"
+  node ../scripts/run_flaky.js "yarn test-webworker --browsers=bs_chrome_mac"
 else
-  yarn run-browserstack --browsers=bs_chrome_mac
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
 fi

--- a/tfjs-layers/scripts/test-ci.sh
+++ b/tfjs-layers/scripts/test-ci.sh
@@ -10,4 +10,4 @@
 set -e
 
 # Regular testing.
-yarn run-browserstack
+node ../scripts/run_flaky.js "yarn run-browserstack"

--- a/tfjs-react-native/integration_rn59/scripts/test-ci.sh
+++ b/tfjs-react-native/integration_rn59/scripts/test-ci.sh
@@ -40,7 +40,7 @@ echo "Started metro. PID=$metro_pid"
 sleep 2s
 
 # Start the test suite.
-yarn test-integration
+node ../../scripts/run_flaky.js "yarn test-integration"
 test_result=$?
 
 # Kill the child process explicitly so that the exit code of the script

--- a/tfjs-vis/package.json
+++ b/tfjs-vis/package.json
@@ -14,6 +14,7 @@
     "lint": "tslint -p . -t verbose",
     "test": "yarn && yarn build && karma start",
     "test-dev": "karma start",
+    "run-flaky": "node ../scripts/run_flaky.js",
     "run-browserstack": "karma start --singleRun --reporters='dots,karma-typescript,BrowserStack' --hostname='bs-local.com'",
     "test-ci": "./scripts/test-ci.sh",
     "build-npm": "./scripts/build-npm.sh",

--- a/tfjs-vis/scripts/test-ci.sh
+++ b/tfjs-vis/scripts/test-ci.sh
@@ -22,10 +22,10 @@ yarn build
 
 # Run the first karma separately so it can download the BrowserStack binary
 # without conflicting with others.
-yarn run-browserstack --browsers=bs_chrome_mac
+yarn run-flaky "yarn run-browserstack --browsers=bs_chrome_mac"
 
 # Run the rest of the karma tests in parallel. These runs will reuse the
 # already downloaded binary.
 npm-run-all -p -c --aggregate-output \
-  "run-browserstack --browsers=bs_firefox_mac" \
-  "run-browserstack --browsers=bs_safari_mac"
+  "run-flaky \"yarn run-browserstack --browsers=bs_firefox_mac\"" \
+  "run-flaky \"yarn run-browserstack --browsers=bs_safari_mac\""


### PR DESCRIPTION
Cherry-pick #4655, #4664, and #4691 to enable flaky test running for 2.8.x

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4697)
<!-- Reviewable:end -->
