### PR TITLE
use template literals to support multi-line string

### DIFF
--- a/tfjs-backend-wasm/scripts/create-worker-module.js
+++ b/tfjs-backend-wasm/scripts/create-worker-module.js
@@ -27,4 +27,4 @@ const WORKER_PATH = `${BASE_PATH}tfjs-backend-wasm-threaded-simd.worker.js`;
 
 const workerContents = fs.readFileSync(WORKER_PATH, "utf8");
 fs.writeFileSync(`${WORKER_PATH}`,
-  `export const wasmWorkerContents = '${workerContents.trim()}';`);
+  `export const wasmWorkerContents = \`${workerContents.trim()}\`;`);


### PR DESCRIPTION
The workerContents maybe a multi-line string, which will cause build error, we can use template literals to fix this issue