### PR TITLE
Bump jpeg-js

### DIFF
--- a/tfjs-react-native/integration_rn59/package.json
+++ b/tfjs-react-native/integration_rn59/package.json
@@ -29,7 +29,7 @@
     "expo-gl-cpp": "^7.0.0",
     "expo-image-manipulator": "^6.0.0",
     "jasmine-core": "^3.4.0",
-    "jpeg-js": "^0.3.5",
+    "jpeg-js": "^0.4.3",
     "react": "16.8.3",
     "react-native": "0.59.10",
     "react-native-fs": "2.14.1",

--- a/tfjs-react-native/integration_rn59/yarn.lock
+++ b/tfjs-react-native/integration_rn59/yarn.lock
@@ -4364,10 +4364,15 @@ jest@^24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
-jpeg-js@^0.3.5, jpeg-js@^0.3.6:
+jpeg-js@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.6.tgz#c40382aac9506e7d1f2d856eb02f6c7b2a98b37c"
   integrity sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw==
+
+jpeg-js@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
+  integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"

--- a/tfjs-react-native/package.json
+++ b/tfjs-react-native/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "base64-js": "^1.3.0",
     "buffer": "^5.2.1",
-    "jpeg-js": "^0.3.6"
+    "jpeg-js": "^0.4.3"
   },
   "peerDependencies": {
     "@react-native-community/async-storage": "^1.4.2",

--- a/tfjs-react-native/src/decode_image.ts
+++ b/tfjs-react-native/src/decode_image.ts
@@ -38,8 +38,7 @@ export function decodeJpeg(
       () => 'The passed contents are not a valid JPEG image');
   util.assert(
       channels === 3, () => 'Only 3 channels is supported at this time');
-  const TO_UINT8ARRAY = true;
-  const {width, height, data} = jpeg.decode(contents, TO_UINT8ARRAY);
+  const {width, height, data} = jpeg.decode(contents, {useTArray: true});
   // Drop the alpha channel info because jpeg.decode always returns a typedArray
   // with 255
   const buffer = new Uint8Array(width * height * 3);

--- a/tfjs-react-native/yarn.lock
+++ b/tfjs-react-native/yarn.lock
@@ -975,10 +975,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-jpeg-js@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.6.tgz#c40382aac9506e7d1f2d856eb02f6c7b2a98b37c"
-  integrity sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw==
+jpeg-js@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
+  integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
jpeg-js < 0.4.0 is vulnerable to [CVE-2020-8175](https://nvd.nist.gov/vuln/detail/CVE-2020-8175).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4718)
<!-- Reviewable:end -->
