### PR TITLE
Fix benchmark data range.

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -90,8 +90,23 @@ function generateInputFromDef(inputDefs, isForGraphModel = false) {
       // Construct the input tensor.
       let inputTensor;
       if (inputDef.dtype === 'float32' || inputDef.dtype === 'int32') {
-        inputTensor = tf.randomNormal(
-            inputShape, inputDef.range[0], inputDef.range[1], inputDef.dtype);
+        // We assume a bell curve normal distribution. In this case,
+        // we use below approximation:
+        // mean ~= (min + max) / 2
+        // std ~= (max - min) / 4
+        // Note: for std, our approximation is based on the fact that
+        // 95% of the data is within the range of 2 stds above and
+        // below the mean. So 95% of the data falls in the range of
+        // 4 stds.
+        const min = inputDef.range[0];
+        const max = inputDef.range[1];
+        const mean = (min + max) / 2;
+        const std = (max - min) / 4;
+        generatedRaw = tf.randomNormal(inputShape, mean, std, inputDef.dtype);
+        // We clip the value to be within [min, max], because 5% of
+        // the data generated maybe outside of [min, max].
+        inputTensor = tf.clipByValue(generatedRaw, min, max);
+        generatedRaw.dispose();
       } else {
         throw new Error(
             `The ${inputDef.dtype} dtype of '${inputDef.name}' input ` +


### PR DESCRIPTION
Fix a bug in the benchmark tool's data generation. User input specifies min and max. However, data generation uses mean and standard deviation. We can assume a bell curve normal distribution to get an approximate mean and std from min and max. If in the future, user needs to specify distribution of data, we should allow them to just upload testing data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4728)
<!-- Reviewable:end -->
