### PR TITLE
add WEBGL_FLUSH_THRESHOLD flag

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -897,13 +897,6 @@ export class MathBackendWebGL extends KernelBackend {
           {name: program.constructor.name, query: this.getQueryTime(query)});
     }
 
-    if (!env().getBool('WEBGL_LAZILY_UNPACK') && outData.isPacked &&
-        preventEagerUnpackingOfOutput === false) {
-      const unpacked = this.unpackTensor(output);
-      this.disposeIntermediateTensorInfo(output);
-      return unpacked;
-    }
-
     const glFlushThreshold = env().get('WEBGL_FLUSH_THRESHOLD');
     // Manually GL flush requested
     if (glFlushThreshold > 0) {
@@ -912,6 +905,13 @@ export class MathBackendWebGL extends KernelBackend {
         this.gpgpu.gl.flush();
         this.lastGlFlushTime = time;
       }
+    }
+
+    if (!env().getBool('WEBGL_LAZILY_UNPACK') && outData.isPacked &&
+        preventEagerUnpackingOfOutput === false) {
+      const unpacked = this.unpackTensor(output);
+      this.disposeIntermediateTensorInfo(output);
+      return unpacked;
     }
     return output;
   }

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -564,9 +564,9 @@ describeWithFlags('manual gl flush', WEBGL_ENVS, () => {
     const savedGlThreshold = tf.env().get('WEBGL_FLUSH_THRESHOLD') as number;
     tf.env().set('WEBGL_FLUSH_THRESHOLD', 0);
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
-    const b = tf.tensor2d([1, 1, -3, 2, 2, 1], [3, 2]);
+    const b = tf.tensor2d([1, 1, -3, 2, 2, 1], [2, 3]);
 
-    const result = tf.div(tf.div(tf.matMul(a, b), a), b);
+    const result = tf.div(tf.div(tf.mul(a, b), a), b);
     expectArraysClose(await result.data(), [1, 1, 1, 1, 1, 1]);
     tf.env().set('WEBGL_FLUSH_THRESHOLD', savedGlThreshold);
   });

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -562,7 +562,7 @@ describeWithFlags('memory webgl', WEBGL_ENVS, () => {
 describeWithFlags('manual gl flush', WEBGL_ENVS, () => {
   it('works when manual gl flush is enabled', async () => {
     const savedGlThreshold = tf.env().get('WEBGL_FLUSH_THRESHOLD') as number;
-    tf.env().set('WEBGL_FLUSH_THRESHOLD', 0);
+    tf.env().set('WEBGL_FLUSH_THRESHOLD', 1);
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([1, 1, -3, 2, 2, 1], [2, 3]);
 

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -559,6 +559,18 @@ describeWithFlags('memory webgl', WEBGL_ENVS, () => {
   });
 });
 
+describeWithFlags('manual gl flush', WEBGL_ENVS, () => {
+  it('works when manual gl flush is enabled', async () => {
+    const savedGlThreshold = tf.env().get('WEBGL_FLUSH_THRESHOLD') as number;
+    tf.env().set('WEBGL_FLUSH_THRESHOLD', 0);
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([1, 1, -3, 2, 2, 1], [3, 2]);
+
+    const result = tf.div(tf.div(tf.matMul(a, b), a), b);
+    expectArraysClose(await result.data(), [1, 1, 1, 1, 1, 1]);
+    tf.env().set('WEBGL_FLUSH_THRESHOLD', savedGlThreshold);
+  });
+});
 // We do not yet fully support half float backends. These tests are a starting
 // point.
 describeWithFlags('backend without render float32 support', WEBGL_ENVS, () => {

--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -189,13 +189,13 @@ ENV.registerFlag(
     });
 
 /**
- * Trigger a manul GL command flush if the threshold of time has passed since
+ * Trigger a manual GL command flush if the threshold of time has passed since
  * previous Kernel execution. This can be useful for Andorid device where GL
- * command flush are delayed til the end of javascript task. This value is
+ * command flush are delayed un til the end of javascript task. This value is
  * measured in millisecond. Typically you want to set this value to close to 1.
  *
- * Default value -1 indicates that we will enforce manual flush and depends on
- * system default flush schedule.
+ * Default value -1 indicates that we will not enforce manual flush and depend
+ * on system default flush schedule.
  */
 ENV.registerFlag(
     'WEBGL_FLUSH_THRESHOLD',

--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -187,3 +187,25 @@ ENV.registerFlag(
             `delete) or at least 0, but got ${threshold}.`);
       }
     });
+
+/**
+ * Trigger a manul GL command flush if the threshold of time has passed since
+ * previous Kernel execution. This can be useful for Andorid device where GL
+ * command flush are delayed til the end of javascript task. This value is
+ * measured in millisecond. Typically you want to set this value to close to 1.
+ *
+ * Default value -1 indicates that we will enforce manual flush and depends on
+ * system default flush schedule.
+ */
+ENV.registerFlag(
+    'WEBGL_FLUSH_THRESHOLD',
+    () => {
+      return -1;
+    },
+    threshold => {
+      if (threshold < 0 && threshold !== -1) {
+        throw new Error(
+            `WEBGL_FLUSH_THRESHOLD must be -1 (indicating never ` +
+            `manual flush) or at least 0, but got ${threshold}.`);
+      }
+    });

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -362,3 +362,9 @@ describeWithFlags('WEBGL_DELETE_TEXTURE_THRESHOLD', WEBGL_ENVS, () => {
     expect(() => tf.env().set('WEBGL_DELETE_TEXTURE_THRESHOLD', -2)).toThrow();
   });
 });
+
+describeWithFlags('WEBGL_FLUSH_THRESHOLD', WEBGL_ENVS, () => {
+  it('should throw an error if given a negative value', () => {
+    expect(() => tf.env().set('WEBGL_FLUSH_THRESHOLD', -2)).toThrow();
+  });
+});


### PR DESCRIPTION
We have notice that in Android, GL commands are not flushed periodically as desktop chrome (every 1ms), it is set to be flushed at the end of the javascript task, this means no GL execution until the end of the model execution is done is javascript.

Created a flag for trigger manual gl flush, I have observed significant performance gain on mobilenet with Andorid devices (flush every 0.8ms):
One+ 8 phone:  48ms -> 20ms
Pixel 5: 64 -> 40ms
pixel 4: 54ms -> 24ms


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4737)
<!-- Reviewable:end -->
