### PR TITLE
[wasm] Workaround sin/cos bug with ios11/12, and use tensor4d as image related test source to reduce flakyness

### DIFF
--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -443,8 +443,8 @@ tfjs_cc_library(
     srcs = ["kernels/Cos.cc"],
     deps = [
         ":backend",
-        ":unary",
         ":sin_cos_workaround",
+        ":unary",
     ],
 )
 
@@ -931,8 +931,8 @@ tfjs_cc_library(
     srcs = ["kernels/Sin.cc"],
     deps = [
         ":backend",
-        ":unary",
         ":sin_cos_workaround",
+        ":unary",
     ],
 )
 

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -131,6 +131,15 @@ tfjs_cc_library(
 )
 
 tfjs_cc_library(
+    name = "sin_cos_workaround",
+    srcs = ["sin_cos_workaround.cc"],
+    hdrs = ["sin_cos_workaround.h"],
+    deps = [
+        ":util",
+    ],
+)
+
+tfjs_cc_library(
     name = "clamp_impl",
     srcs = ["clamp_impl.cc"],
     hdrs = ["clamp_impl.h"],
@@ -241,6 +250,7 @@ tfjs_cc_library(
         ":ClipByValue",
         ":Conv2D",
         ":Conv2DBackpropInput",
+        ":Cos",
         ":CropAndResize",
         ":Cumsum",
         ":DepthToSpace",
@@ -283,6 +293,7 @@ tfjs_cc_library(
         ":ScatterNd",
         ":SelectV2",
         ":Sigmoid",
+        ":Sin",
         ":Softmax",
         ":Square",
         ":SquaredDifference",
@@ -427,6 +438,16 @@ tfjs_cc_library(
     srcs = ["kernels/Conv2DBackpropInput.cc"],
     deps = [
         ":backend",
+    ],
+)
+
+tfjs_cc_library(
+    name = "Cos",
+    srcs = ["kernels/Cos.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+        ":sin_cos_workaround",
     ],
 )
 
@@ -905,6 +926,16 @@ tfjs_cc_library(
     deps = [
         ":backend",
         ":unary",
+    ],
+)
+
+tfjs_cc_library(
+    name = "Sin",
+    srcs = ["kernels/Sin.cc"],
+    deps = [
+        ":backend",
+        ":unary",
+        ":sin_cos_workaround",
     ],
 )
 

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -134,9 +134,6 @@ tfjs_cc_library(
     name = "sin_cos_workaround",
     srcs = ["sin_cos_workaround.cc"],
     hdrs = ["sin_cos_workaround.h"],
-    deps = [
-        ":util",
-    ],
 )
 
 tfjs_cc_library(

--- a/tfjs-backend-wasm/src/cc/kernels/Cos.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Cos.cc
@@ -19,6 +19,7 @@
 #include <math.h>
 
 #include "tfjs-backend-wasm/src/cc/backend.h"
+#include "tfjs-backend-wasm/src/cc/sin_cos_workaround.h"
 #include "tfjs-backend-wasm/src/cc/unary.h"
 
 namespace tfjs {
@@ -29,7 +30,9 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void Cos(const int x_id, const int out_id) { unary(x_id, out_id, cos); }
+void Cos(const int x_id, const int out_id) {
+  unary(x_id, out_id, tfjs::sin_cos_workaround::cos_fixed);
+}
 
 }  // extern "C"
 }  // namespace wasm

--- a/tfjs-backend-wasm/src/cc/sin_cos_workaround.cc
+++ b/tfjs-backend-wasm/src/cc/sin_cos_workaround.cc
@@ -23,10 +23,10 @@ float sin_fixed(float x) {
   auto zero_to_2pi = fmod(fmod(x, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
 
   if (zero_to_2pi < M_PI_4) {
-    return sin_broken(zero_to_2pi);
+    return sin(zero_to_2pi);
   } else if (zero_to_2pi < M_PI_2) {
     auto past_pi_4 = zero_to_2pi - M_PI_4;
-    return cos_broken(M_PI_4 - past_pi_4);
+    return cos(M_PI_4 - past_pi_4);
   } else if (zero_to_2pi < M_PI) {
     auto past_pi_2 = zero_to_2pi - M_PI_2;
     return sin_fixed(M_PI_2 - past_pi_2);

--- a/tfjs-backend-wasm/src/cc/sin_cos_workaround.h
+++ b/tfjs-backend-wasm/src/cc/sin_cos_workaround.h
@@ -15,30 +15,10 @@
 #ifndef SIN_COS_WORKAROUND_H_
 #define SIN_COS_WORKAROUND_H_
 
-#include <math.h>
-
-#include "tfjs-backend-wasm/src/cc/util.h"
-
 // Workaround a bug related to sin/cos with emscripten/webkit on iOS 11/12:
 // https://github.com/emscripten-core/emscripten/issues/13130
 namespace tfjs {
 namespace sin_cos_workaround {
-
-inline float sin_broken(float x) {
-  if (x < 0 || x >= M_PI_4) {
-    tfjs::util::warn("broken sin given %f", x);
-    exit(1);
-  }
-  return sin(x);
-}
-
-inline float cos_broken(float x) {
-  if (x < 0 || x >= M_PI_4) {
-    tfjs::util::warn("broken cos given %f", x);
-    exit(1);
-  }
-  return cos(x);
-}
 
 float sin_fixed(float x);
 

--- a/tfjs-backend-wasm/src/cc/sin_cos_workaround.h
+++ b/tfjs-backend-wasm/src/cc/sin_cos_workaround.h
@@ -1,0 +1,49 @@
+/* Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================*/
+
+#ifndef SIN_COS_WORKAROUND_H_
+#define SIN_COS_WORKAROUND_H_
+
+#include <math.h>
+
+#include "tfjs-backend-wasm/src/cc/util.h"
+
+// Workaround a bug related to sin/cos with emscripten/webkit on iOS 11/12:
+// https://github.com/emscripten-core/emscripten/issues/13130
+namespace tfjs {
+namespace sin_cos_workaround {
+
+inline float sin_broken(float x) {
+  if (x < 0 || x >= M_PI_4) {
+    tfjs::util::warn("broken sin given %f", x);
+    exit(1);
+  }
+  return sin(x);
+}
+
+inline float cos_broken(float x) {
+  if (x < 0 || x >= M_PI_4) {
+    tfjs::util::warn("broken cos given %f", x);
+    exit(1);
+  }
+  return cos(x);
+}
+
+float sin_fixed(float x);
+
+float cos_fixed(float x);
+
+}  // namespace sin_cos_workaround
+}  // namespace tfjs
+#endif  // SIN_COS_WORKAROUND_H_

--- a/tfjs-core/src/image_test_util.ts
+++ b/tfjs-core/src/image_test_util.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from './index';
+
+/**
+ * Returns an image used in various image related tests as a 4d tensor.
+ *
+ * The image is 8x8 and looks like this:
+ * https://drive.google.com/file/d/1Y0AsFZ2w9HsWgJfm8f2uDOGY7A4IHjcK/view?usp=sharing
+ *
+ */
+export function getTestImageAsTensor4d() {
+  return tf.tensor4d(
+      [
+        156, 100, 111, 255, 171, 120, 117, 255, 183, 138, 109, 255, 200, 155,
+        98,  255, 212, 157, 75,  255, 224, 156, 55,  255, 241, 153, 43,  255,
+        230, 133, 18,  255, 168, 129, 130, 255, 186, 152, 140, 255, 202, 174,
+        137, 255, 220, 190, 128, 255, 230, 193, 104, 255, 241, 188, 82,  255,
+        250, 177, 64,  255, 233, 148, 31,  255, 179, 176, 159, 255, 199, 198,
+        168, 255, 211, 216, 162, 255, 225, 228, 151, 255, 235, 227, 128, 255,
+        243, 220, 106, 255, 247, 201, 81,  255, 222, 164, 41,  255, 163, 208,
+        187, 255, 179, 226, 194, 255, 184, 234, 181, 255, 191, 239, 165, 255,
+        201, 236, 142, 255, 213, 230, 126, 255, 218, 210, 103, 255, 191, 170,
+        61,  255, 108, 214, 202, 255, 119, 226, 206, 255, 121, 231, 192, 255,
+        130, 235, 179, 255, 141, 232, 162, 255, 155, 226, 146, 255, 162, 206,
+        127, 255, 135, 166, 86,  255, 55,  207, 212, 255, 62,  217, 213, 255,
+        64,  219, 201, 255, 76,  225, 193, 255, 87,  220, 175, 255, 94,  206,
+        156, 255, 98,  181, 135, 255, 71,  143, 97,  255, 18,  200, 224, 255,
+        19,  204, 222, 255, 19,  203, 211, 255, 30,  209, 205, 255, 35,  200,
+        186, 255, 37,  177, 164, 255, 39,  150, 141, 255, 15,  115, 105, 255,
+        0,   193, 228, 255, 0,   192, 221, 255, 0,   189, 209, 255, 0,   194,
+        204, 255, 4,   182, 186, 255, 3,   158, 162, 255, 6,   133, 140, 255,
+        0,   102, 113, 255
+      ],
+      [1, 8, 8, 4]);
+}

--- a/tfjs-core/src/ops/cos_test.ts
+++ b/tfjs-core/src/ops/cos_test.ts
@@ -21,7 +21,8 @@ import {expectArraysClose} from '../test_util';
 
 describeWithFlags('cos', ALL_ENVS, () => {
   it('basic', async () => {
-    const values = [1, -3, 2, 7, -4];
+    // Covers every 1/4pi range from -4pi to 4pi.
+    const values = [1, 3, 4, 6, 7, 9, 10, 12, -1, -3, -4, -6, -7, -9, -10, -12];
     const a = tf.tensor1d(values);
     const result = tf.cos(a);
 

--- a/tfjs-core/src/ops/image/flip_left_right_test.ts
+++ b/tfjs-core/src/ops/image/flip_left_right_test.ts
@@ -46,6 +46,6 @@ describeWithFlags('flipLeftRight', BROWSER_ENVS, () => {
       255
     ];
 
-    expectArraysClose(expected, flippedPixelsData, 10);
+    expectArraysClose(expected, flippedPixelsData);
   });
 });

--- a/tfjs-core/src/ops/image/flip_left_right_test.ts
+++ b/tfjs-core/src/ops/image/flip_left_right_test.ts
@@ -14,31 +14,15 @@
  * limitations under the License.
  * =============================================================================
  */
+import {getTestImageAsTensor4d} from '../../image_test_util';
 import * as tf from '../../index';
 import {BROWSER_ENVS, describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose} from '../../test_util';
 
 describeWithFlags('flipLeftRight', BROWSER_ENVS, () => {
-  // tslint:disable:max-line-length
-  const imageBase64String =
-      'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCMRXhpZgAATU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAAigAwAEAAAAAQAAAAgAAAAA/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ1B2M2Y8AsgTpgAmY7PhCfv/AABEIAAgACAMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgv/xAC1EAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp6vHy8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAAAAQIDBAUGBwgJCgv/xAC1EQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2wBDAAkGBw0HCA0HBw0HBwcHBw0HBwcHDQ8IDQcNFREWFhURExMYHSggGBolGxUTITEhMSk3Ojo6Fx8zODMtNygtLiv/2wBDAQoKCg0NDRUNDRUrGRUZKysrKy0rKy0rKysrKy0rKysrKystKzctKysrKy0rKysrLSsrKysrKzcrLSsrKy0rKyv/3QAEAAH/2gAMAwEAAhEDEQA/AOin1Kxs7JgEVSsZAPU5xWF/wkdp6L+QqlrX/Hm/0P8AKuSqsRk+FlUcmnd+Z4WBzzGulrO+vY//2Q==';
-  const size = 8;
-
   it('should flip', async () => {
-    const img = new Image();
-    img.src = imageBase64String;
-
-    await new Promise(resolve => {
-      img.onload = () => resolve(img);
-    });
-
-    img.width = size;
-    img.height = size;
-
-    const pixels = await tf.browser.fromPixels(img, 4);
-    const pixels4D: tf.Tensor4D = pixels.toFloat().expandDims(0);
-
-    const flippedPixels = tf.image.flipLeftRight(pixels4D).toInt();
+    const flippedPixels =
+        tf.image.flipLeftRight(getTestImageAsTensor4d()).toInt();
     const flippedPixelsData = await flippedPixels.data();
 
     const expected = [

--- a/tfjs-core/src/ops/image/rotate_with_offset_test.ts
+++ b/tfjs-core/src/ops/image/rotate_with_offset_test.ts
@@ -14,32 +14,16 @@
  * limitations under the License.
  * =============================================================================
  */
+import {getTestImageAsTensor4d} from '../../image_test_util';
 import * as tf from '../../index';
 import {BROWSER_ENVS, describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose} from '../../test_util';
 
 describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
-  // tslint:disable:max-line-length
-  const imageBase64String =
-      'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCMRXhpZgAATU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAAigAwAEAAAAAQAAAAgAAAAA/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ1B2M2Y8AsgTpgAmY7PhCfv/AABEIAAgACAMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgv/xAC1EAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp6vHy8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAAAAQIDBAUGBwgJCgv/xAC1EQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2wBDAAkGBw0HCA0HBw0HBwcHBw0HBwcHDQ8IDQcNFREWFhURExMYHSggGBolGxUTITEhMSk3Ojo6Fx8zODMtNygtLiv/2wBDAQoKCg0NDRUNDRUrGRUZKysrKy0rKy0rKysrKy0rKysrKystKzctKysrKy0rKysrLSsrKysrKzcrLSsrKy0rKyv/3QAEAAH/2gAMAwEAAhEDEQA/AOin1Kxs7JgEVSsZAPU5xWF/wkdp6L+QqlrX/Hm/0P8AKuSqsRk+FlUcmnd+Z4WBzzGulrO+vY//2Q==';
-  const size = 8;
-
   it('should rotate counterclockwise 90 degrees', async () => {
-    const img = new Image();
-    img.src = imageBase64String;
-
-    await new Promise(resolve => {
-      img.onload = () => resolve(img);
-    });
-
-    img.width = size;
-    img.height = size;
-
-    const pixels = await tf.browser.fromPixels(img, 4);
-    const pixels4D: tf.Tensor4D = pixels.toFloat().expandDims(0);
-
     const rotatedPixels =
-        tf.image.rotateWithOffset(pixels4D, 90 * Math.PI / 180).toInt();
+        tf.image.rotateWithOffset(getTestImageAsTensor4d(), 90 * Math.PI / 180)
+            .toInt();
     const rotatedPixelsData = await rotatedPixels.data();
 
     const expected = [
@@ -67,21 +51,9 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
   });
 
   it('should rotate clockwise 90 degrees', async () => {
-    const img = new Image();
-    img.src = imageBase64String;
-
-    await new Promise(resolve => {
-      img.onload = () => resolve(img);
-    });
-
-    img.width = size;
-    img.height = size;
-
-    const pixels = await tf.browser.fromPixels(img, 4);
-    const pixels4D: tf.Tensor4D = pixels.toFloat().expandDims(0);
-
     const rotatedPixels =
-        tf.image.rotateWithOffset(pixels4D, -90 * Math.PI / 180).toInt();
+        tf.image.rotateWithOffset(getTestImageAsTensor4d(), -90 * Math.PI / 180)
+            .toInt();
     const rotatedPixelsData = await rotatedPixels.data();
 
     const expected = [
@@ -109,21 +81,10 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
   });
 
   it('offset center of rotation', async () => {
-    const img = new Image();
-    img.src = imageBase64String;
-
-    await new Promise(resolve => {
-      img.onload = () => resolve(img);
-    });
-
-    img.width = size;
-    img.height = size;
-
-    const pixels = await tf.browser.fromPixels(img, 4);
-    const pixels4D: tf.Tensor4D = pixels.toFloat().expandDims(0);
-
     const rotatedPixels =
-        tf.image.rotateWithOffset(pixels4D, 45 * Math.PI / 180, 0, [0.25, 0.75])
+        tf.image
+            .rotateWithOffset(
+                getTestImageAsTensor4d(), 45 * Math.PI / 180, 0, [0.25, 0.75])
             .toInt();
     const rotatedPixelsData = await rotatedPixels.data();
 
@@ -152,22 +113,10 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
   });
 
   it('offset center of rotation with white fill', async () => {
-    const img = new Image();
-    img.src = imageBase64String;
-
-    await new Promise(resolve => {
-      img.onload = () => resolve(img);
-    });
-
-    img.width = size;
-    img.height = size;
-
-    const pixels = await tf.browser.fromPixels(img, 4);
-    const pixels4D: tf.Tensor4D = pixels.toFloat().expandDims(0);
-
     const rotatedPixels =
         tf.image
-            .rotateWithOffset(pixels4D, 45 * Math.PI / 180, 255, [0.25, 0.75])
+            .rotateWithOffset(
+                getTestImageAsTensor4d(), 45 * Math.PI / 180, 255, [0.25, 0.75])
             .toInt();
     const rotatedPixelsData = await rotatedPixels.data();
 

--- a/tfjs-core/src/ops/image/rotate_with_offset_test.ts
+++ b/tfjs-core/src/ops/image/rotate_with_offset_test.ts
@@ -47,7 +47,7 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
       255
     ];
 
-    expectArraysClose(expected, rotatedPixelsData, 10);
+    expectArraysClose(expected, rotatedPixelsData);
   });
 
   it('should rotate clockwise 90 degrees', async () => {
@@ -77,7 +77,7 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
       255
     ];
 
-    expectArraysClose(expected, rotatedPixelsData, 10);
+    expectArraysClose(expected, rotatedPixelsData);
   });
 
   it('offset center of rotation', async () => {
@@ -109,7 +109,7 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
       0
     ];
 
-    expectArraysClose(expected, rotatedPixelsData, 10);
+    expectArraysClose(expected, rotatedPixelsData);
   });
 
   it('offset center of rotation with white fill', async () => {
@@ -141,6 +141,6 @@ describeWithFlags('rotateWithOffset', BROWSER_ENVS, () => {
       255
     ];
 
-    expectArraysClose(expected, rotatedPixelsData, 10);
+    expectArraysClose(expected, rotatedPixelsData);
   });
 });

--- a/tfjs-core/src/ops/sin_test.ts
+++ b/tfjs-core/src/ops/sin_test.ts
@@ -21,7 +21,8 @@ import {expectArraysClose} from '../test_util';
 
 describeWithFlags('sin', ALL_ENVS, () => {
   it('basic', async () => {
-    const values = [1, -3, 2, 7, -4];
+    // Covers every 1/4pi range from -4pi to 4pi.
+    const values = [1, 3, 4, 6, 7, 9, 10, 12, -1, -3, -4, -6, -7, -9, -10, -12];
     const a = tf.tensor1d(values);
     const result = tf.sin(a);
 


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4738)
<!-- Reviewable:end -->
