### PR TITLE
Fix for Failed Symlink on NPM Installation of 'tfjs-node'

### DIFF
--- a/tfjs-node/scripts/install.js
+++ b/tfjs-node/scripts/install.js
@@ -179,8 +179,10 @@ async function build() {
     if (platform === 'win32') {
       // Move libtensorflow to module path, where tfjs_binding.node locates.
       cp.exec('node scripts/deps-stage.js symlink ' + modulePath, (error) => {
-        console.error('symlink ' + modulePath + ' failed: ', error);
-        process.exit(1);
+        if (error) {
+          console.error('symlink ' + modulePath + ' failed: ', error);
+          process.exit(1);
+        }
       });
     }
     revertAddonName(origBinary);


### PR DESCRIPTION
Attempting to install `tfjs-node` or `tfjs-node-gpu` on the Windows platform would always result in the following error:

```
> node scripts/install.js

CPU-windows-3.2.0.zip
* Downloading libtensorflow

* Building TensorFlow Node.js bindings
symlink ./lib/napi-v7 failed:  null
```
This is due to the original code not checking the error value on the result of the symlink call. A simple conditional on whether `error`  is null or not fixes the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4754)
<!-- Reviewable:end -->
