### PR TITLE
make mobile chrome flush threshold default as 1ms

### DIFF
--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -194,13 +194,13 @@ ENV.registerFlag(
  * command flush are delayed un til the end of javascript task. This value is
  * measured in millisecond. Typically you want to set this value to close to 1.
  *
- * Default value -1 indicates that we will not enforce manual flush and depend
- * on system default flush schedule.
+ * Default value 1 for mobile chrome, and -1 for rest cases. -1 indicates that
+ * we will not enforce manual flush and depend on system default flush schedule.
  */
 ENV.registerFlag(
     'WEBGL_FLUSH_THRESHOLD',
     () => {
-      return -1;
+      return device_util.isMobile() && ENV.getBool('IS_CHROME') ? 1 : -1;
     },
     threshold => {
       if (threshold < 0 && threshold !== -1) {

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -364,7 +364,7 @@ describeWithFlags('WEBGL_DELETE_TEXTURE_THRESHOLD', WEBGL_ENVS, () => {
 });
 
 describeWithFlags('WEBGL_FLUSH_THRESHOLD', WEBGL_ENVS, () => {
-  it('should return the correct default for mobile', () => {
+  it('should return the correct default value', () => {
     if (device_util.isMobile() && tf.env().getBool('IS_CHROME')) {
       expect(tf.env().getNumber('WEBGL_FLUSH_THRESHOLD')).toEqual(1);
     } else {

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -364,6 +364,13 @@ describeWithFlags('WEBGL_DELETE_TEXTURE_THRESHOLD', WEBGL_ENVS, () => {
 });
 
 describeWithFlags('WEBGL_FLUSH_THRESHOLD', WEBGL_ENVS, () => {
+  it('should return the correct default for mobile', () => {
+    if (device_util.isMobile() && tf.env().getBool('IS_CHROME')) {
+      expect(tf.env().getNumber('WEBGL_FLUSH_THRESHOLD')).toEqual(1);
+    } else {
+      expect(tf.env().getNumber('WEBGL_FLUSH_THRESHOLD')).toEqual(-1);
+    }
+  });
   it('should throw an error if given a negative value', () => {
     expect(() => tf.env().set('WEBGL_FLUSH_THRESHOLD', -2)).toThrow();
   });


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4756)
<!-- Reviewable:end -->
