### PR TITLE
Fix python in the CI dockerfile

### DIFF
--- a/dockers/wasm-docker/Dockerfile
+++ b/dockers/wasm-docker/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
         gcc \
         python3 \
         python3-pip \
+        python \
+        python-pip \
         file
 
 # Install absl


### PR DESCRIPTION
Bazel requires both python versions.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4773)
<!-- Reviewable:end -->
