### PR TITLE
Add a local test config for the wasm threaded-simd binary

### DIFF
--- a/tfjs-backend-wasm/karma.conf.js
+++ b/tfjs-backend-wasm/karma.conf.js
@@ -95,6 +95,10 @@ module.exports = function(config) {
     proxies: {
       '/base/node_modules/karma-typescript/dist/client/tfjs-backend-wasm.wasm':
           '/base/wasm-out/tfjs-backend-wasm.wasm',
+      '/base/node_modules/karma-typescript/dist/client/tfjs-backend-wasm-simd.wasm':
+          '/base/wasm-out/tfjs-backend-wasm-simd.wasm',
+      '/base/node_modules/karma-typescript/dist/client/tfjs-backend-wasm-threaded-simd.wasm':
+          '/base/wasm-out/tfjs-backend-wasm-threaded-simd.wasm',
     },
     browsers: ['Chrome'],
     browserStack: {
@@ -156,7 +160,11 @@ module.exports = function(config) {
         browser_version: '77.0',
         os: 'Windows',
         os_version: '10'
-      }
+      },
+      chrome_simd_threaded: {
+        base: 'Chrome',
+        flags: ['--enable-experimental-webassembly-features']
+      },
     },
     client: {jasmine: {random: false}, args: args},
   })

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -32,6 +32,7 @@
     "lint": "tslint -p . -t verbose && yarn cpplint",
     "test": "yarn && yarn build-deps && yarn build && karma start",
     "test-dev": "yarn && yarn build-deps && yarn build-dev && karma start",
+    "test-simd-threaded": "yarn karma start --browsers=chrome_simd_threaded",
     "test-ci": "./scripts/test-ci.sh",
     "test-node": "tsc && ts-node --transpile-only --skip-ignore -P tsconfig.test.json src/test_node.ts",
     "test-bundle-size": "./scripts/test-bundle-size.js",

--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -32,7 +32,7 @@
     "lint": "tslint -p . -t verbose && yarn cpplint",
     "test": "yarn && yarn build-deps && yarn build && karma start",
     "test-dev": "yarn && yarn build-deps && yarn build-dev && karma start",
-    "test-simd-threaded": "yarn karma start --browsers=chrome_simd_threaded",
+    "test-threaded-simd": "yarn karma start --browsers=chrome_simd_threaded",
     "test-ci": "./scripts/test-ci.sh",
     "test-node": "tsc && ts-node --transpile-only --skip-ignore -P tsconfig.test.json src/test_node.ts",
     "test-bundle-size": "./scripts/test-bundle-size.js",


### PR DESCRIPTION
This PR enables locally testing the threaded simd wasm bundle with `yarn test-threaded-simd`.

It appears as though we may have a broken test on threaded-simd. Using the [spec reporter](https://www.npmjs.com/package/karma-spec-reporter), tests stop running after `pad 2d test-wasm`. It seems like the `pad 3d` tests may be causing this.

I have not yet found out how to test just simd without threaded. I haven't found a chrome flag to disable threaded wasm yet. 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.