### PR TITLE
"tensorflowjswizard" distribution does not exist

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -49,7 +49,7 @@ __1. Install the TensorFlow.js pip package:__
 
 Install the library with interactive CLI:
 ```bash
- pip install tensorflowjs[wizard]
+ pip install tensorflowjs
 ```
 
 __2. Run the converter script provided by the pip package:__


### PR DESCRIPTION
I'm guessing these instructions are outdated and I should just `pip install tensorflowjs`, because it seems to provide the `tensorflowjs_wizard` executable.

```
$ pip3 install tensorflowjswizard
ERROR: Could not find a version that satisfies the requirement tensorflowjswizard
ERROR: No matching distribution found for tensorflowjswizard
$ pip3 install tensorflowjs_wizard
ERROR: Could not find a version that satisfies the requirement tensorflowjs_wizard
ERROR: No matching distribution found for tensorflowjs_wizard
$ pip3 install tensorflowjs-wizard
ERROR: Could not find a version that satisfies the requirement tensorflowjs-wizard
ERROR: No matching distribution found for tensorflowjs-wizard
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4794)
<!-- Reviewable:end -->
