### PR TITLE
[webgpu] Use uniform instead of constant for shape

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -92,7 +92,7 @@ describeWebGPU('backend webgpu', () => {
 
     expect(endNumBytes - startNumBytes).toEqual(48);
     expect(endNumTensors - startNumTensors).toEqual(2);
-    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(24);
+    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(0);
 
     tf.test_util.expectArraysClose(
         dData, new Float32Array([9, 12, 15, 19, 26, 33]));
@@ -146,7 +146,8 @@ describeWebGPU('backend webgpu', () => {
     tf.matMul(c, f);
     const freeBuffersAfterFirstMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterFirstMatMul = bufferManager.getNumUsedBuffers();
-    expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul).toEqual(0);
+    expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul)
+        .toEqual(1);  // from released uniform
     expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(2);
 
     const a2 = tf.tensor2d([2, 4, 6, 8], [2, 2]);
@@ -155,7 +156,8 @@ describeWebGPU('backend webgpu', () => {
     const c2 = tf.mul(a2, b2);
     const freeBuffersAfterSecondMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMul = bufferManager.getNumUsedBuffers();
-    expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul).toEqual(0);
+    expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul)
+        .toEqual(0);  // released a uniform buffer and reused a buffer
     expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(3);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
@@ -186,7 +188,7 @@ describeWebGPU('backend webgpu', () => {
     const freeBuffersAfterFirstMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterFirstMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul).toEqual(0);
-    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(2);
+    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(3);
 
     const a2 = tf.tensor2d([2, 4, 6, 8], [2, 2]);
     const b2 = tf.tensor2d([0.5, 0.5, 0.5, 0.5], [2, 2]);
@@ -195,14 +197,14 @@ describeWebGPU('backend webgpu', () => {
     const freeBuffersAfterSecondMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul).toEqual(0);
-    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(3);
+    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(4);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const c3 = tf.matMul(c2, f2);
     const freeBuffersAfterSecondMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMatMul - freeBuffersAfterSecondMul).toEqual(0);
-    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(2);
+    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(3);
 
     // Tests happen within a tidy so we need to read a tensor at the end of a
     // test in delayed mode in order to force flush the disposal queue.

--- a/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
+++ b/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
@@ -15,13 +15,12 @@
  * =============================================================================
  */
 
-import {backend_util, TensorInfo, util, sumOutType, TypedArray} from '@tensorflow/tfjs-core';
+import {backend_util, sumOutType, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {ReduceProgram} from '../kernels/reduce_webgpu';
-
 import {maxImplCPU} from '../kernel_utils/shared';
 import {prodImplCPU} from '../kernel_utils/shared';
+import {ReduceProgram} from '../kernels/reduce_webgpu';
 import {reshape} from '../kernels/Reshape';
 import {transpose} from '../kernels/Transpose';
 
@@ -60,8 +59,8 @@ export function reduce(
     const xVals = backend.tensorMap.get(input.dataId).values as TypedArray;
     switch (reduceType) {
       case 'max':
-        const outValues = maxImplCPU(xVals, util.sizeFromShape(reduceShape),
-            resOutShape, x.dtype);
+        const outValues = maxImplCPU(
+            xVals, util.sizeFromShape(reduceShape), resOutShape, x.dtype);
         res = backend.makeTensorInfo(resOutShape, x.dtype, outValues);
         break;
       case 'prod':
@@ -83,14 +82,13 @@ export function reduce(
     toDispose.push(reshapedInput);
 
     const reduceInfo = {windowSize: inSize, inSize, batchSize, outSize: 1};
-    const program = new ReduceProgram(reduceInfo, reduceType);
     const dtype = reduceType === 'mean' ? 'float32' : sumOutType(x.dtype);
+    const program = new ReduceProgram(reduceInfo, reduceType, dtype);
     const reduced = backend.runWebGPUProgram(program, [input], dtype);
     toDispose.push(reduced);
 
-    res = reshape({inputs: {x: reduced}, attrs: {shape: resOutShape},
-        backend});
-    }
+    res = reshape({inputs: {x: reduced}, attrs: {shape: resOutShape}, backend});
+  }
 
   toDispose.forEach(t => backend.disposeData(t.dataId));
 

--- a/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
@@ -95,8 +95,6 @@ export function batchMatMulImpl({
 
   const batchDim = Math.max(batchDimA, batchDimB);
 
-  const hasBias = bias != null;
-  const hasPreluActivationWeights = preluActivationWeights != null;
   const useVec4 = a.shape[2] % 4 === 0 && b.shape[2] % 4 === 0 && !transposeA &&
       !transposeB;
   const fusedActivation = activation ?
@@ -109,13 +107,13 @@ export function batchMatMulImpl({
     // remove this limitation by insert 0 to pack data.
     program = new MatMulPackedVec4Program(
         a3dShape, [batchDim, outerShapeA, outerShapeB],
-        env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, hasBias,
-        fusedActivation, hasPreluActivationWeights);
+        env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, bias,
+        fusedActivation, preluActivationWeights);
   } else {
     program = new MatMulPackedProgram(
         a3dShape, [batchDim, outerShapeA, outerShapeB],
         env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, transposeA,
-        transposeB, hasBias, fusedActivation, hasPreluActivationWeights);
+        transposeB, bias, fusedActivation, preluActivationWeights);
   }
   const inputs: TensorInfo[] = [a3d, b3d];
   if (bias) {

--- a/tfjs-backend-webgpu/src/kernels/FromPixelsImageBitmap.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixelsImageBitmap.ts
@@ -44,8 +44,11 @@ export function fromPixelsImageBitmap(args: {
   // cache system to avoid useless recompile.
   const outputShapes = [output.shape];
   const outputTypes = [output.dtype];
-  const key = webgpu_program.makeShaderKey(
-      backend.fromPixelProgram, outputShapes, outputTypes);
+  // Add outputShapes in key to fix case "fromPixels for ImageBitmap outShape
+  // changes'.
+  const key =
+      `${webgpu_program.makeShaderKey(backend.fromPixelProgram, outputTypes)}` +
+      `${outputShapes}`;
 
   const {bindGroupLayout, pipeline} = backend.getAndSavePipeline(key, () => {
     return webgpu_program.compileProgram(

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -29,6 +29,7 @@ export class FromPixelsProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] =
       [256, 1, 1];  // The empirical value.
+  needsShapesUniforms = false;
 
   pipeline: GPUComputePipeline;
   bindGroupLayout: GPUBindGroupLayout;
@@ -56,7 +57,7 @@ export class FromPixelsProgram implements WebGPUProgram {
 
   constructor(outputShape: number[]) {
     this.updateOutputShape(outputShape);
-    this.shaderKey = 'fromPixels';
+    this.shaderKey = `fromPixels${outputShape}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
@@ -30,6 +30,7 @@ export class AddNPackedProgram implements WebGPUProgram {
   variableNames: string[];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
+  needsShapesUniforms = true;
 
   constructor(shapes: number[][]) {
     this.outputShape = shapes[0];
@@ -38,7 +39,7 @@ export class AddNPackedProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
-    this.shaderKey = 'addN';
+    this.shaderKey = `addN${shapes}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -33,6 +33,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
   inputShape: number[];
   reductionFactor: number;
   op: string;
+  needsShapesUniforms = true;
 
   constructor(inputShape: number[], axis: number, reduceType: 'min'|'max') {
     const axes = [axis];
@@ -65,7 +66,8 @@ export class ArgMinMaxProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.inputShape = inputShape;
-    this.shaderKey = `argMinMax_${this.op}_${reduceSize}`;
+    this.shaderKey =
+        `argMinMax${this.op}${reduceSize}${inputShape}${outputShape}`;
   }
 
   getUserCode(): string {
@@ -121,9 +123,9 @@ export class ArgMinMaxProgram implements WebGPUProgram {
 
     const indexInputShape = (index: string) => {
       if (this.inputShape.length === 1) {
-        return `${getShapeCoords(this.inputShape)}`;
+        return 'xShape';
       } else {
-        return `${getShapeCoords(this.inputShape)}[${index}]`;
+        return `xShape[${index}]`;
       }
     };
 

--- a/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,6 +30,7 @@ export class BatchNormProgram implements WebGPUProgram {
   variableNames: string[];
   // This is an experimental value.
   workGroupSize: [number, number, number] = [128, 1, 1];
+  needsShapesUniforms = true;
   offsetShape: number[]|null;
   scaleShape: number[]|null;
   varianceEpsilon: number;
@@ -57,7 +58,8 @@ export class BatchNormProgram implements WebGPUProgram {
     this.offsetShape = offsetShape;
     this.scaleShape = scaleShape;
     this.varianceEpsilon = varianceEpsilon;
-    this.shaderKey = `batchNorm_${varianceEpsilon}`;
+    this.shaderKey =
+        `batchNorm${varianceEpsilon}${xShape}${meanShape}${varianceShape}`;
   }
 
   getUserCode(): string {
@@ -83,7 +85,7 @@ export class BatchNormProgram implements WebGPUProgram {
     }
     const userCode = `
       void writeResult(${coordsDataType} coords,float value) {
-        if (coordsInBounds(coords, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coords, outShape)) {
           ${setOutput}
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
@@ -37,6 +37,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [128, 1, 1];
+  needsShapesUniforms = true;
   op: string;
 
   constructor(op: string, aShape: number[], bShape: number[]) {
@@ -45,7 +46,12 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.shaderKey = `binaryOpComplex${op}`;
+    this.shaderKey = `binaryOpComplex${op}` +
+        `${aShape}` +
+        `${bShape}` +
+        `${aShape.length}` +
+        `${bShape.length}` +
+        `${this.outputShape}`;
     this.op = op;
   }
 

--- a/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
@@ -16,8 +16,8 @@
  */
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
-import {getCoordsDataType} from '../shader_preprocessor';
 
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,6 +30,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
   variableNames = ['A', 'B'];
   workPerThread: number;
   workGroupSize: [number, number, number];
+  needsShapesUniforms = true;
   useSharedMemoryWithB: boolean;
   lastDimensionSize: number;
   op: string;
@@ -53,7 +54,12 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
-    this.shaderKey = `binaryShared_${op}`;
+    this.shaderKey = `binaryShared_${op}` +
+        `${aShape}` +
+        `${bShape}` +
+        `${aShape.length}` +
+        `${bShape.length}` +
+        `${this.outputShape}`;
     this.useSharedMemoryWithB = useSharedMemoryWithB;
     this.op = op;
   }

--- a/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
@@ -29,6 +29,7 @@ export class BinaryOpVec4Program implements WebGPUProgram {
   variableNames = ['A', 'B'];
   workPerThread = 4;
   workGroupSize: [number, number, number];
+  needsShapesUniforms = true;
   isVec4 = true;
   op: string;
 
@@ -42,7 +43,12 @@ export class BinaryOpVec4Program implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
     this.op = op;
-    this.shaderKey = `binaryVec4_${op}`;
+    this.shaderKey = `binaryVec4_${op}` +
+        `${aShape}` +
+        `${bShape}` +
+        `${aShape.length}` +
+        `${bShape.length}` +
+        `${this.outputShape}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 import {getCoordsDataType} from '../shader_preprocessor';
-
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,6 +29,7 @@ export class BinaryOpProgram implements WebGPUProgram {
   variableNames = ['A', 'B'];
   workPerThread: number;
   workGroupSize: [number, number, number];
+  needsShapesUniforms = true;
   op: string;
   sizeFit: boolean;
   shapesFit: boolean;
@@ -48,7 +48,12 @@ export class BinaryOpProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
-    this.shaderKey = `binary_${op}`;
+    this.shaderKey = `binary_${op}` +
+        `${aShape}` +
+        `${bShape}` +
+        `${aShape.length}` +
+        `${bShape.length}` +
+        `${this.outputShape}`;
     this.op = op;
   }
 

--- a/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
@@ -29,6 +29,7 @@ export class ClipProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workPerThread = 1;
   workGroupSize: [number, number, number] = [64, 1, 1];
+  needsShapesUniforms = true;
   minVal: number;
   maxVal: number;
 

--- a/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
@@ -28,6 +28,7 @@ export class ConcatProgram implements WebGPUProgram {
   variableNames: string[];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
+  needsShapesUniforms = true;
   shapes: Array<[number, number]>;
 
   constructor(shapes: Array<[number, number]>) {
@@ -40,7 +41,7 @@ export class ConcatProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
 
     this.shapes = shapes;
-    this.shaderKey = 'concat';
+    this.shaderKey = `concat${shapes}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
@@ -31,6 +31,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 filterDims, pad, stride, dilation;';
   workGroupSize: [number, number, number];
+  needsShapesUniforms = true;
   isVec4 = true;
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
@@ -58,7 +59,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
     this.hasLeakyreluAlpha = hasLeakyreluAlpha;
-    this.shaderKey = `conv2DMMVec4_${this.activation}`;
+    this.shaderKey = `conv2DMMVec4${this.activation}${convInfo.inShape}${
+        convInfo.filterShape}${convInfo.outShape}`;
     if (this.addBias) {
       this.variableNames.push('bias');
     }

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d, tilesFitEvenlyIntoShape} from '../webgpu_util';
 
 import {makeMatMulPackedSource} from './matmul_packed_webgpu';
@@ -31,6 +30,7 @@ export class Conv2DMMProgram implements WebGPUProgram {
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 filterDims, pad, stride, dilation;';
   workGroupSize: [number, number, number];
+  needsShapesUniforms = true;
   elementsPerThread: [number, number, number];
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
@@ -66,7 +66,8 @@ export class Conv2DMMProgram implements WebGPUProgram {
     this.addBias = addBias;
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
-    this.shaderKey = `conv2DMM_${this.elementsPerThread}_${this.activation}`;
+    this.shaderKey = `conv2DMM${this.elementsPerThread}${this.activation}${
+        convInfo.inShape}`;
   }
 
   getUserCode(): string {
@@ -89,11 +90,11 @@ export class Conv2DMMProgram implements WebGPUProgram {
         this.convInfo.inChannels;
 
     const readASnippet = `
-    int outRow = row / ${this.outputShape[2]};
-    int outCol = row % ${this.outputShape[2]};
+    int outRow = row / outShape[2];
+    int outCol = row % outShape[2];
 
-    int WRow = col / (filterDims[1] * ${this.convInfo.inShape[3]});
-    int WCol = (col / ${this.convInfo.inShape[3]}) % filterDims[1];
+    int WRow = col / (filterDims[1] * xShape[3]);
+    int WCol = (col / xShape[3]) % filterDims[1];
 
     ivec4 coord = ivec4(
         batch,
@@ -102,9 +103,7 @@ export class Conv2DMMProgram implements WebGPUProgram {
         col % ${this.convInfo.inShape[3]});
     // The bounds checking is always needed since we use it to pad zero for the
     // 'same' padding type.
-    return coordsInBounds(coord, ${
-        getShapeCoords(this.convInfo.inShape)}) ? x[getFlatIndex(coord, ${
-        getShapeCoords(this.convInfo.inShape)})] : 0;`;
+    return coordsInBounds(coord, xShape) ? x[getFlatIndex(coord, xShape)] : 0;`;
 
     const fitA = tilesFitEvenlyIntoShape(tileSizeA, [dimAOuter, dimInner]);
     const sampleA =
@@ -146,9 +145,9 @@ export class Conv2DMMProgram implements WebGPUProgram {
     ${matMulSource}
 
     int batch;
-    int dimAOuter = ${this.outputShape[1]} * ${this.outputShape[2]};
-    int dimBOuter = ${this.outputShape[3]};
-    int dimInner = filterDims[0] * filterDims[1] * ${this.convInfo.inShape[3]};
+    int dimAOuter = outShape[1] * outShape[2];
+    int dimBOuter = outShape[3];
+    int dimInner = filterDims[0] * filterDims[1] * xShape[3];
     float mm_readA(int row, int col) {
       ${sampleA}
     }
@@ -160,13 +159,12 @@ export class Conv2DMMProgram implements WebGPUProgram {
     void mm_write(int row, int col, float value) {
       ivec4 outCoord = ivec4(
           batch,
-          row / ${this.outputShape[2]},
-          row % ${this.outputShape[2]},
+          row / outShape[2],
+          row % outShape[2],
           col);
       ${addBiasSnippet}
       ${applyActivationSnippet}
-      result[getFlatIndex(outCoord, ${
-        getShapeCoords(this.outputShape)})] = value;
+      result[getFlatIndex(outCoord, outShape)] = value;
     }
 
     void main() {

--- a/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,6 +29,7 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 filterDims, pad, stride, dilation;';
   workGroupSize: [number, number, number] = [128, 1, 1];
+  needsShapesUniforms = true;
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
   activation: string;
@@ -59,7 +59,7 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 
-    this.shaderKey = `conv2DNaive_${activation}`;
+    this.shaderKey = `conv2DNaive${activation}`;
   }
 
   getUserCode(): string {
@@ -87,20 +87,19 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
       ${activationSnippet}
       float readInp(int batch, int row, int col, int chan) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        return coordsInBounds(coord, ${getShapeCoords(this.convInfo.inShape)}) ?
+        return coordsInBounds(coord, xShape) ?
           getX(batch, row, col, chan) : 0;
       }
 
       float readFilt(int row, int col, int xChannel, int outChannel) {
         ivec4 coord = ivec4(row, col, xChannel, outChannel);
-        return coordsInBounds(coord, ${
-        getShapeCoords(this.convInfo.filterShape)}) ?
+        return coordsInBounds(coord, wShape) ?
           getW(row, col, xChannel, outChannel) : 0;
       }
 
       void writeResult(int batch, int row, int col, int chan, float value) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        if (coordsInBounds(coord, ${getShapeCoords(this.convInfo.outShape)})) {
+        if (coordsInBounds(coord, outShape)) {
           ${addBiasSnippet}
           ${applyActivationSnippet}
           setOutput(batch, row, col, chan, value);

--- a/tfjs-backend-webgpu/src/kernels/crop_and_resize_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/crop_and_resize_webgpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -27,6 +26,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['Image', 'Boxes', 'BoxInd'];
   workGroupSize: [number, number, number] = [4, 4, 4];
+  needsShapesUniforms = true;
   imageShape: [number, number, number, number];
   cropSize: [number, number];
   methodId: number;
@@ -42,8 +42,8 @@ export class CropAndResizeProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.shaderKey =
-        `cropAndResize_${method}_${cropSize}_${extrapolationValue}`;
+    this.shaderKey = `cropAndResize${method}${cropSize}${extrapolationValue}${
+        imageShape}${boxShape}${this.outputShape}`;
     this.imageShape = imageShape;
     this.cropSize = cropSize;
     this.methodId = method === 'bilinear' ? 1 : 0;
@@ -86,7 +86,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
       const float height_ratio = float(${heightRatio});
       const float width_ratio = float(${widthRatio});
       void writeResult(ivec4 coords,float value) {
-        if (coordsInBounds(coords, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coords, outShape)) {
           setOutput(coords[0], coords[1], coords[2], coords[3], value);
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
@@ -16,7 +16,6 @@
  */
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 import {WebGPUProgram} from './webgpu_program';
 
@@ -29,6 +28,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
   uniforms = 'ivec2 filterDims, pad, stride, dilation, inDims;';
   // This is an experimental value.
   workGroupSize: [number, number, number] = [256, 1, 1];
+  needsShapesUniforms = true;
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
   activation: string;
@@ -58,7 +58,9 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
     this.activation = activation;
     this.hasPreluActivation = hasPreluActivation;
 
-    this.shaderKey = `depthwise_${activation}`;
+    this.shaderKey = `depthwise${activation}${
+        this.convInfo.outChannels / this.convInfo.inChannels}${
+        convInfo.inShape}${convInfo.filterShape}${convInfo.outShape}`;
   }
 
   getUserCode(): string {
@@ -89,7 +91,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
 
       void writeResult(int batch, int row, int col, int chan, float value) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        if (coordsInBounds(coord, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coord, outShape)) {
           setOutput(batch, row, col, chan, value);
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -27,6 +27,7 @@ export class FillProgram implements WebGPUProgram {
   uniforms = 'float value;';
   workPerThread = 4;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  needsShapesUniforms = true;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
@@ -35,7 +36,7 @@ export class FillProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
 
-    this.shaderKey = 'fill';
+    this.shaderKey = `fill${this.outputShape}`;
   }
 
   getUserCode(): string {
@@ -46,7 +47,7 @@ export class FillProgram implements WebGPUProgram {
       for (int i = 0; i < ${this.workPerThread}; i++) {
         int flatIndex = index * ${this.workPerThread} + i;
         if (flatIndex < ${size}) {
-          setOutput(flatIndex, value);
+          setOutput(flatIndex, float(value));
         }
       }
     }

--- a/tfjs-backend-webgpu/src/kernels/gather_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/gather_webgpu.ts
@@ -36,7 +36,7 @@ export class GatherProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
-    this.shaderKey = `gather`;
+    this.shaderKey = `gather${aShape}${outputShape}`;
   }
   getUserCode(): string {
     const sourceCoords = getSourceCoords(this.aShape);

--- a/tfjs-backend-webgpu/src/kernels/im2col_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/im2col_webgpu.ts
@@ -29,6 +29,7 @@ export class Im2ColProgram implements WebGPUProgram {
   rank: number;
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
+  needsShapesUniforms = true;
   inputShape: number[];
   convInfo: backend_util.Conv2DInfo;
 
@@ -44,7 +45,8 @@ export class Im2ColProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
     this.inputShape = inputShape;
     this.convInfo = convInfo;
-    this.shaderKey = `im2col_${convInfo}`;
+    this.shaderKey =
+        `im2col${convInfo.inShape}${convInfo.filterShape}${convInfo.outShape}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
+import {TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from '../webgpu_util';
 
@@ -129,6 +129,7 @@ export class MatMulPackedProgram implements WebGPUProgram {
   workPerThread: number;
   variableNames = ['A', 'B'];
   workGroupSize: [number, number, number] = [16, 16, 1];
+  needsShapesUniforms = true;
   aShape: [number, number, number];
   transposeA: boolean;
   transposeB: boolean;
@@ -139,8 +140,8 @@ export class MatMulPackedProgram implements WebGPUProgram {
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
       workPerThread: number, transposeA = false, transposeB = false,
-      addBias = false, activation: string = null,
-      hasPreluActivationWeights = false) {
+      bias: TensorInfo = null, activation: string = null,
+      preluActivationWeights: TensorInfo = null) {
     this.outputShape = outputShape;
     this.dispatchLayout = {x: [2], y: [1], z: [0]};
     const dimInner = transposeA ? aShape[1] : aShape[2];
@@ -165,13 +166,17 @@ export class MatMulPackedProgram implements WebGPUProgram {
           this.dispatchLayout, this.outputShape, this.workGroupSize,
           [workPerThread, workPerThread, 1]);
     }
-
+    const addBias = bias != null;
+    const hasPreluActivationWeights = preluActivationWeights != null;
+    let shapeKey = '';
     if (addBias) {
       this.variableNames.push('bias');
+      shapeKey += bias.shape;
     }
 
     if (hasPreluActivationWeights) {
       this.variableNames.push('preluActivationWeights');
+      shapeKey += preluActivationWeights.shape;
     }
 
     this.workPerThread = workPerThread;
@@ -181,8 +186,8 @@ export class MatMulPackedProgram implements WebGPUProgram {
     this.addBias = addBias;
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
-    this.shaderKey = `matMulPacked_${this.workPerThread}_${transposeA}_${
-        transposeB}_${activation}`;
+    this.shaderKey = `matMulPacked${this.workPerThread}${transposeA}${
+        transposeB}${activation}${aShape}${outputShape}${shapeKey}`;
   }
 
   getUserCode(): string {
@@ -257,12 +262,9 @@ export class MatMulPackedProgram implements WebGPUProgram {
     const userCode = `
       ${activationSnippet}
 
-      int dimAOuter = ${
-        this.transposeA === true ? `${this.aShape[2]}` : `${this.aShape[1]}`};
-      int dimInner = ${
-        this.transposeA === true ? `${this.aShape[1]}` : `${this.aShape[2]}`};
-      int dimBOuter = ${
-        this.transposeB === true ? `${bShape[1]}` : `${bShape[2]}`};
+      int dimAOuter = ${this.transposeA === true ? `aShape[2]` : `aShape[1]`};
+      int dimInner = ${this.transposeA === true ? `aShape[1]` : `aShape[2]`};
+      int dimBOuter = ${this.transposeB === true ? `bShape[1]` : `bShape[2]`};
 
       int batch;
 

--- a/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
@@ -30,6 +30,7 @@ export class MirrorPadProgram implements WebGPUProgram {
   variableNames = ['x'];
   workPerThread = 8;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  needsShapesUniforms = true;
   xShape: number[];
   paddings: Array<[number, number]>;
   offset: number;

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -31,6 +31,7 @@ export class PadProgram implements WebGPUProgram {
   uniforms = 'float constantValue;';
   workPerThread = 8;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  needsShapesUniforms = true;
   xShape: number[];
   paddings: Array<[number, number]>;
 
@@ -44,7 +45,7 @@ export class PadProgram implements WebGPUProgram {
 
     this.xShape = xShape;
     this.paddings = paddings;
-    this.shaderKey = `pad_${paddings}`;
+    this.shaderKey = `pad${paddings}${xShape}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -33,6 +32,7 @@ export class Pool2DProgram implements WebGPUProgram {
   // workPerThead for different output shapes.
   workGroupSize: [number, number, number] = [16, 16, 1];
   workPerThread = 4;
+  needsShapesUniforms = true;
   poolType: 'max'|'avg';
 
   constructor(convInfo: backend_util.Conv2DInfo, poolType: 'max'|'avg') {
@@ -44,7 +44,7 @@ export class Pool2DProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [1, this.workPerThread, 1]);
 
-    this.shaderKey = `pool2D_${poolType}`;
+    this.shaderKey = `pool2D${poolType}${convInfo.inShape}${convInfo.outShape}`;
     this.poolType = poolType;
   }
 
@@ -62,7 +62,7 @@ export class Pool2DProgram implements WebGPUProgram {
     const userCode = `
       void main() {
         ivec4 coords = getOutputCoords();
-        if (all(lessThan(coords, ${getShapeCoords(this.outputShape)}))) {
+        if (all(lessThan(coords, outShape))) {
           int batch = coords[0];
           ivec2 xRCCorner = coords.yz * stride - pad;
           int xRCorner = xRCCorner.x;
@@ -91,7 +91,7 @@ export class Pool2DProgram implements WebGPUProgram {
               for (int i = 0; i < ${this.workPerThread}; i++)
               {
                 int d = coords[3] * ${this.workPerThread} + i;
-                if (d < ${this.outputShape[3]})
+                if (d < outShape[3])
                 {
                   float value = getX(batch, xR, xC, d);
                   ${updateSnippet}
@@ -106,7 +106,7 @@ export class Pool2DProgram implements WebGPUProgram {
           for (int i = 0; i < ${this.workPerThread}; i++)
           {
             int d = coords[3] * ${this.workPerThread} + i;
-            if (d < ${this.outputShape[3]})
+            if (d < outShape[3])
             {
               setOutput(batch, coords[1], coords[2], d, ${returnValue});
             }

--- a/tfjs-backend-webgpu/src/kernels/pool_filtersizeone_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool_filtersizeone_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,6 +29,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
   variableNames = ['x'];
   uniforms = 'ivec2 pad, stride, dilation, convDims, filterDims;';
   workGroupSize: [number, number, number] = [256, 1, 1];
+  needsShapesUniforms = true;
 
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;
@@ -38,7 +38,8 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.shaderKey = 'poolWithFilterSizeEqualsOne';
+    this.shaderKey =
+        `poolWithFilterSizeEqualsOne${convInfo.inShape}${convInfo.outShape}`;
   }
 
   getUserCode(): string {
@@ -48,7 +49,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
         int batch = coords[0];
         int d = coords[3];
 
-        if (all(lessThan(coords, ${getShapeCoords(this.outputShape)}))) {
+        if (all(lessThan(coords, outShape))) {
           ivec2 xRCCorner = coords.yz * stride;
           int xRCorner = xRCCorner.x;
           int xCCorner = xRCCorner.y;

--- a/tfjs-backend-webgpu/src/kernels/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/reduce_webgpu.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {backend_util, util} from '@tensorflow/tfjs-core';
+import {backend_util, DataType, util} from '@tensorflow/tfjs-core';
 import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
+
 import {WebGPUProgram} from './webgpu_program';
 
 export class ReduceProgram implements WebGPUProgram {
@@ -26,6 +27,7 @@ export class ReduceProgram implements WebGPUProgram {
   dispatchLayout: {x: number[], y: number[]};
   dispatch: [number, number, number];
   workGroupSize: [number, number, number];
+  needsShapesUniforms = false;
   variableNames = ['x'];
   reduceType: 'max'|'mean'|'min'|'prod'|'sum';
   inputShape: number[];
@@ -34,7 +36,7 @@ export class ReduceProgram implements WebGPUProgram {
 
   constructor(
       reduceInfo: backend_util.ReduceInfo,
-      reduceType: 'max'|'mean'|'min'|'prod'|'sum') {
+      reduceType: 'max'|'mean'|'min'|'prod'|'sum', outputDtype: DataType) {
     this.inputShape = [reduceInfo.batchSize, reduceInfo.inSize];
     const [outputShape, reduceShape] =
         backend_util.computeOutAndReduceShapes(this.inputShape, [1]);
@@ -52,7 +54,8 @@ export class ReduceProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.reduceType = reduceType;
-    this.shaderKey = `reduce_${reduceType}`;
+    this.shaderKey = `reduce${reduceType}${outputDtype}${this.inputShape}${
+        this.outputShape}`;
   }
 
   getUserCode(): string {
@@ -62,8 +65,8 @@ export class ReduceProgram implements WebGPUProgram {
     let initValue = '0.0';
     if (this.reduceType === 'min' || this.reduceType === 'max') {
       reduceOp = ` if (candidate ${this.reduceType === 'min' ? '<' : '>'}
-          bestValue && !isnan(candidate))
-          {  bestValue = candidate; }`;
+           bestValue && !isnan(candidate))
+           {  bestValue = candidate; }`;
       initValue = 'x[offset]';
     } else if (this.reduceType === 'sum' || this.reduceType === 'mean') {
       reduceOp = ' bestValue += candidate; ';
@@ -77,66 +80,71 @@ export class ReduceProgram implements WebGPUProgram {
         `setOutput(flatOutputIndex, bestValue);`;
 
     const sharedMemorySnippet = `
-        shared float xBestValues[WorkGroupSize];
-      `;
+         shared float xBestValues[WorkGroupSize];
+       `;
     const sharedMemoryReduceSnippet = `
-      xBestValues[gl_LocalInvocationID.x] = bestValue;
-      ${this.reduceType === 'sum' || this.reduceType === 'mean' ||
-          this.reduceType === 'prod' ? `bestValue=${initValue};` : ' '}
-      int currentSize = WorkGroupSize;
-      while (currentSize > 1) {
-        barrier();
-        for (int w = 0; w < ${this.reductionFactor}; ++w) {
-          int i = int(gl_LocalInvocationID.x) * ${this.reductionFactor} + w;
-          if (i < currentSize) {
-            float candidate = xBestValues[i];
-            ${reduceOp}
-          }
-        }
-        barrier();
-        xBestValues[gl_LocalInvocationID.x] = bestValue;
-        currentSize = DIV_CEIL(currentSize, ${this.reductionFactor});
-        ${this.reduceType === 'sum' || this.reduceType === 'mean' ||
-            this.reduceType === 'prod' ?
-            `if(currentSize > 1) bestValue=${initValue};` : ''}
-      }
-      if (gl_LocalInvocationID.x == 0) {
-        ${outputSnippet}
-      }
-    `;
+       xBestValues[gl_LocalInvocationID.x] = bestValue;
+       ${
+        this.reduceType === 'sum' || this.reduceType === 'mean' ||
+                this.reduceType === 'prod' ?
+            `bestValue=${initValue};` :
+            ' '}
+       int currentSize = WorkGroupSize;
+       while (currentSize > 1) {
+         barrier();
+         for (int w = 0; w < ${this.reductionFactor}; ++w) {
+           int i = int(gl_LocalInvocationID.x) * ${this.reductionFactor} + w;
+           if (i < currentSize) {
+             float candidate = xBestValues[i];
+             ${reduceOp}
+           }
+         }
+         barrier();
+         xBestValues[gl_LocalInvocationID.x] = bestValue;
+         currentSize = DIV_CEIL(currentSize, ${this.reductionFactor});
+         ${
+        this.reduceType === 'sum' || this.reduceType === 'mean' ||
+                this.reduceType === 'prod' ?
+            `if(currentSize > 1) bestValue=${initValue};` :
+            ''}
+       }
+       if (gl_LocalInvocationID.x == 0) {
+         ${outputSnippet}
+       }
+     `;
 
     const outputCoordsType = getCoordsDataType(this.outputShape.length);
 
     const userCode = `
-      #define DIV_CEIL(x, y) (((x) - 1) / (y) + 1)
-      const int WorkGroupSize = int(gl_WorkGroupSize.x);
-      ${reduceInSharedMemory ? sharedMemorySnippet : ''}
-      int getOffset() {
-        const ${outputCoordsType} outputCoords = getOutputCoords();
-        int offset = ${
+       #define DIV_CEIL(x, y) (((x) - 1) / (y) + 1)
+       const int WorkGroupSize = int(gl_WorkGroupSize.x);
+       ${reduceInSharedMemory ? sharedMemorySnippet : ''}
+       int getOffset() {
+         const ${outputCoordsType} outputCoords = getOutputCoords();
+         int offset = ${
         this.outputShape.length === 1 ?
             'outputCoords' :
             'outputCoords[0]'} * ${getShapeCoords(this.inputShape)}[1];
-        return offset;
-      }
-      void main() {
-        const int offset= getOffset();
-        float bestValue = ${initValue};
-        const int Length = ${
+         return offset;
+       }
+       void main() {
+         const int offset= getOffset();
+         float bestValue = ${initValue};
+         const int Length = ${
         this.inputShape.length === 1 ? `${getShapeCoords(this.inputShape)}` :
                                        `${getShapeCoords(this.inputShape)}[1]`};
-        const int WorkPerThread = DIV_CEIL(Length, WorkGroupSize);
-        for (int w = 0; w < WorkPerThread; ++w) {
-          int i = int(gl_GlobalInvocationID.x) * WorkPerThread + w;
-          if (i < Length) {
-            float candidate = x[offset + i];
-            ${reduceOp}
-          }
-        }
-        const int flatOutputIndex = int(gl_GlobalInvocationID.y);
-        ${reduceInSharedMemory ? sharedMemoryReduceSnippet :outputSnippet}
-      }
-    `;
+         const int WorkPerThread = DIV_CEIL(Length, WorkGroupSize);
+         for (int w = 0; w < WorkPerThread; ++w) {
+           int i = int(gl_GlobalInvocationID.x) * WorkPerThread + w;
+           if (i < Length) {
+             float candidate = x[offset + i];
+             ${reduceOp}
+           }
+         }
+         const int flatOutputIndex = int(gl_GlobalInvocationID.y);
+         ${reduceInSharedMemory ? sharedMemoryReduceSnippet : outputSnippet}
+       }
+     `;
     return userCode;
   }
 }

--- a/tfjs-backend-webgpu/src/kernels/resize_bilinear_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/resize_bilinear_webgpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -27,7 +26,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   workGroupSize: [number, number, number] = [4, 4, 4];
-  inputShape: [number, number, number, number];
+  needsShapesUniforms = true;
   alignCorners: boolean;
 
   constructor(
@@ -40,9 +39,9 @@ export class ResizeBilinearProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.inputShape = inputShape;
     this.alignCorners = alignCorners;
-    this.shaderKey = `resizeBilinear_${alignCorners}`;
+    this.shaderKey =
+        `resizeBilinear${alignCorners}${inputShape}${this.outputShape}`;
   }
 
   getUserCode(): string {
@@ -52,24 +51,18 @@ export class ResizeBilinearProgram implements WebGPUProgram {
     const userCode = `
       void main() {
         ivec4 coords = getOutputCoords();
-        if (all(lessThan(coords, ${getShapeCoords(this.outputShape)}))) {
+        if (all(lessThan(coords, outShape))) {
           int b = coords[0];
           int d = coords[3];
           ivec2 rc = coords.yz;
 
           vec2 effectiveInSize = vec2(
-            ${
-        adjustHeight ? `${this.inputShape[1]} - 1.0` : `${this.inputShape[1]}`},
-            ${
-        adjustWidth ? `${this.inputShape[2]} - 1.0` : `${this.inputShape[2]}`});
+            ${adjustHeight ? `xShape.y - 1.0` : `xShape.y`},
+            ${adjustWidth ? `xShape.z - 1.0` : `xShape.z`});
 
           vec2 effectiveOutSize = vec2(
-            ${
-        adjustHeight ? `${this.outputShape[1]} - 1.0` :
-                       `${this.outputShape[1]}`},
-            ${
-        adjustWidth ? `${this.outputShape[2]} - 1.0` :
-                      `${this.outputShape[2]}`});
+            ${adjustHeight ? `outShape.y - 1.0` : `outShape.y`},
+            ${adjustWidth ? `outShape.z - 1.0` : `outShape.z`});
 
           vec2 effectiveInputOverOutputRatioRC =
               effectiveInSize / effectiveOutSize;
@@ -80,8 +73,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
           // Compute the four integer indices.
           ivec2 sourceFloorRC = ivec2(sourceFracIndexRC);
           ivec2 sourceCeilRC = ivec2(
-            min(vec2(${this.inputShape[1]}, ${
-        this.inputShape[2]}) - 1.0, ceil(sourceFracIndexRC)));
+            min(xShape.yz - 1.0, ceil(sourceFracIndexRC)));
 
           float topLeft = getX(b, sourceFloorRC.x, sourceFloorRC.y, d);
           float bottomLeft = getX(b, sourceCeilRC.x, sourceFloorRC.y, d);

--- a/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
@@ -29,6 +29,7 @@ export class SelectProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  needsShapesUniforms = true;
   cRank: number;
   rank: number;
 

--- a/tfjs-backend-webgpu/src/kernels/slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/slice_webgpu.ts
@@ -29,6 +29,7 @@ export class SliceProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workPerThread = 1;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  needsShapesUniforms = true;
   start: number[];
   destSize: number[];
 

--- a/tfjs-backend-webgpu/src/kernels/strided_slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/strided_slice_webgpu.ts
@@ -29,6 +29,7 @@ export class StridedSliceProgram implements WebGPUProgram {
   // TODO(xing.xu): Increase the workPerThread.
   workPerThread = 1;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  needsShapesUniforms = true;
   begin: number[];
   strides: number[];
 
@@ -41,7 +42,7 @@ export class StridedSliceProgram implements WebGPUProgram {
 
     this.begin = begin;
     this.strides = strides;
-    this.shaderKey = `stridedSlice_${begin}_${strides}`;
+    this.shaderKey = `stridedSlice${begin}${strides}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/transpose_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transpose_shared_webgpu.ts
@@ -25,6 +25,7 @@ export class TransposeSharedProgram implements WebGPUProgram {
   dispatchLayout: {x: number[], y: number[]};
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [32, 32, 1];
+  needsShapesUniforms = true;
 
   constructor(aShape: number[], newDim: number[]) {
     const outputShape: number[] = new Array(aShape.length);

--- a/tfjs-backend-webgpu/src/kernels/transpose_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transpose_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {util} from '@tensorflow/tfjs-core';
-import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -29,7 +29,7 @@ export class TransposeProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
-  aShape: number[];
+  needsShapesUniforms = true;
   newDim: number[];
 
   constructor(aShape: number[], newDim: number[]) {
@@ -43,9 +43,8 @@ export class TransposeProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
 
-    this.aShape = aShape;
     this.newDim = newDim;
-    this.shaderKey = `transpose_${newDim}`;
+    this.shaderKey = `transpose${newDim}`;
   }
 
   getUserCode(): string {
@@ -62,7 +61,7 @@ export class TransposeProgram implements WebGPUProgram {
           if(flatIndex < ${size}) {
             ${dtype} resRC = getCoordsFromFlatIndex(flatIndex);
             setOutput(flatIndex, A[getFlatIndex(
-              ${dtype}(${switched}), ${getShapeCoords(this.aShape)})]);
+              ${dtype}(${switched}), aShape)]);
           }
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -71,6 +71,7 @@ export class UnaryOpProgram implements WebGPUProgram {
   variableNames = ['A'];
   workPerThread: number;
   workGroupSize: [number, number, number];
+  needsShapesUniforms = true;
   op: string;
 
   constructor(outputShape: number[], op: string) {
@@ -86,7 +87,8 @@ export class UnaryOpProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
     this.op = op;
-    this.shaderKey = `unary_${op}`;
+    this.shaderKey = `unary${op}` +
+        `${outputShape}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {DataType, Rank, ShapeMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {DataType, Rank, TensorInfo} from '@tensorflow/tfjs-core';
 import {Glslang} from '@webgpu/glslang/dist/web-devel/glslang.onefile';
 
 import * as shader_preprocessor from '../shader_preprocessor';
@@ -31,6 +31,8 @@ export interface WebGPUProgram {
   dispatch: [number, number, number];
   variableNames: string[];
   uniforms?: string;
+  // Indicate whether shapes data are needed.
+  needsShapesUniforms?: boolean;
   // Size of register cache in one dimension (assumes square cache).
   // Each thread writes to workPerThread * workPerThread locations in the output
   // buffer.
@@ -55,10 +57,12 @@ export interface TensorData {
 export const makeBindGroup =
     (device: GPUDevice, bindGroupLayout: GPUBindGroupLayout,
      inputs: GPUBindingResource[], output: GPUBindingResource,
-     uniforms?: GPUBindingResource) => {
+     uniforms?: GPUBindingResource[]) => {
       const bindings = [output, ...inputs];
       if (uniforms) {
-        bindings.push(uniforms);
+        uniforms.forEach(uniform => {
+          bindings.push(uniform);
+        });
       }
       return device.createBindGroup({
         layout: bindGroupLayout,
@@ -69,11 +73,11 @@ export const makeBindGroup =
 export const compileProgram =
     (glslang: Glslang, device: GPUDevice, program: WebGPUProgram,
      inputsData: shader_preprocessor.InputInfo[], output: TensorInfo,
-     uniforms?: GPUBindingResource): WebGPUBinary => {
+     uniforms?: GPUBindingResource[]): WebGPUBinary => {
       const outputData = {dtype: output.dtype, shape: output.shape};
 
-      const source =
-          shader_preprocessor.makeShader(inputsData, outputData, program);
+      const source = shader_preprocessor.makeShader(
+          inputsData, outputData, program, uniforms);
       const result = glslang.compileGLSLZeroCopy(source, 'compute', false);
       if (result.data.length === 0) {
         throw new Error('Shader compilation failed');
@@ -89,10 +93,8 @@ export const compileProgram =
     };
 
 export function makeShaderKey<R extends Rank>(
-    program: WebGPUProgram, shapes: Array<ShapeMap[R]>,
-    types: string[]): string {
+    program: WebGPUProgram, types: string[]): string {
   const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
-      shapes.join(',') + types.join(',') + program.variableNames.join(',') +
-      program.shaderKey;
+      types.join(',') + program.variableNames.join(',') + program.shaderKey;
   return key;
 }


### PR DESCRIPTION
This reverts https://github.com/tensorflow/tfjs/pull/3647 and adds:
1. support float/int uniform buffers, merge shape uniform integer program uniform.
2. move shapes from makeShaderKey to program.
3. remove dash from shader key.

FEATURE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4818)
<!-- Reviewable:end -->
