### PR TITLE
[webgpu] Use uniform instead of constant for shape

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -88,7 +88,7 @@ describeWebGPU('backend webgpu', () => {
 
     expect(endNumBytes - startNumBytes).toEqual(48);
     expect(endNumTensors - startNumTensors).toEqual(2);
-    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(24);
+    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(-8);
 
     tf.test_util.expectArraysClose(
         dData, new Float32Array([9, 12, 15, 19, 26, 33]));
@@ -142,7 +142,8 @@ describeWebGPU('backend webgpu', () => {
     tf.matMul(c, f);
     const freeBuffersAfterFirstMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterFirstMatMul = bufferManager.getNumUsedBuffers();
-    expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul).toEqual(0);
+    expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul)
+        .toEqual(1);  // from released uniform
     expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(2);
 
     const a2 = tf.tensor2d([2, 4, 6, 8], [2, 2]);
@@ -151,7 +152,8 @@ describeWebGPU('backend webgpu', () => {
     const c2 = tf.mul(a2, b2);
     const freeBuffersAfterSecondMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMul = bufferManager.getNumUsedBuffers();
-    expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul).toEqual(0);
+    expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul)
+        .toEqual(0);  // released a uniform buffer and reused a buffer
     expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(3);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
@@ -182,7 +184,7 @@ describeWebGPU('backend webgpu', () => {
     const freeBuffersAfterFirstMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterFirstMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul).toEqual(0);
-    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(2);
+    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(3);
 
     const a2 = tf.tensor2d([2, 4, 6, 8], [2, 2]);
     const b2 = tf.tensor2d([0.5, 0.5, 0.5, 0.5], [2, 2]);
@@ -191,14 +193,14 @@ describeWebGPU('backend webgpu', () => {
     const freeBuffersAfterSecondMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul).toEqual(0);
-    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(3);
+    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(4);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const c3 = tf.matMul(c2, f2);
     const freeBuffersAfterSecondMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMatMul - freeBuffersAfterSecondMul).toEqual(0);
-    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(2);
+    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(3);
 
     // Tests happen within a tidy so we need to read a tensor at the end of a
     // test in delayed mode in order to force flush the disposal queue.

--- a/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
+++ b/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
@@ -15,13 +15,12 @@
  * =============================================================================
  */
 
-import {backend_util, TensorInfo, util, sumOutType, TypedArray} from '@tensorflow/tfjs-core';
+import {backend_util, sumOutType, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {ReduceProgram} from '../kernels/reduce_webgpu';
-
 import {maxImplCPU} from '../kernel_utils/shared';
 import {prodImplCPU} from '../kernel_utils/shared';
+import {ReduceProgram} from '../kernels/reduce_webgpu';
 import {reshape} from '../kernels/Reshape';
 import {transpose} from '../kernels/Transpose';
 
@@ -60,8 +59,8 @@ export function reduce(
     const xVals = backend.tensorMap.get(input.dataId).values as TypedArray;
     switch (reduceType) {
       case 'max':
-        const outValues = maxImplCPU(xVals, util.sizeFromShape(reduceShape),
-            resOutShape, x.dtype);
+        const outValues = maxImplCPU(
+            xVals, util.sizeFromShape(reduceShape), resOutShape, x.dtype);
         res = backend.makeTensorInfo(resOutShape, x.dtype, outValues);
         break;
       case 'prod':
@@ -78,19 +77,18 @@ export function reduce(
     const xSize = util.sizeFromShape(input.shape);
     const batchSize = xSize / inSize;
 
-    const reshapedInput = reshape(
-        {inputs: {x: input}, attrs: {shape: [batchSize, inSize]}, backend});
-    toDispose.push(reshapedInput);
-
     const reduceInfo = {windowSize: inSize, inSize, batchSize, outSize: 1};
-    const program = new ReduceProgram(reduceInfo, reduceType);
     const dtype = reduceType === 'mean' ? 'float32' : sumOutType(x.dtype);
-    const reduced = backend.runWebGPUProgram(program, [input], dtype);
+    const uniformData = [
+      {type: 'int32', data: [batchSize, inSize]},
+    ];
+    const program = new ReduceProgram(reduceInfo, reduceType, dtype);
+    const reduced =
+        backend.runWebGPUProgram(program, [input], dtype, uniformData);
     toDispose.push(reduced);
 
-    res = reshape({inputs: {x: reduced}, attrs: {shape: resOutShape},
-        backend});
-    }
+    res = reshape({inputs: {x: reduced}, attrs: {shape: resOutShape}, backend});
+  }
 
   toDispose.forEach(t => backend.disposeData(t.dataId));
 

--- a/tfjs-backend-webgpu/src/kernels/ArgMax.ts
+++ b/tfjs-backend-webgpu/src/kernels/ArgMax.ts
@@ -18,6 +18,7 @@
 import {ArgMax, ArgMaxAttrs, ArgMaxInputs, backend_util, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
+
 import {ArgMinMaxProgram} from './argminmax_webgpu';
 import {transpose} from './Transpose';
 
@@ -40,7 +41,7 @@ export function argMax(
 
   backend_util.assertAxesAreInnerMostDims('argMax', [axes[0]], $x.shape.length);
   const program = new ArgMinMaxProgram($x.shape, axes[0], 'max');
-  const uniformData = new Int32Array([axes[0]]);
+  const uniformData = [{type: 'int32', data: [axes[0]]}];
   const out = backend.runWebGPUProgram(program, [$x], 'int32', uniformData);
   intermediateTensorInfos.forEach(t => backend.disposeData(t.dataId));
   return out;

--- a/tfjs-backend-webgpu/src/kernels/ArgMin.ts
+++ b/tfjs-backend-webgpu/src/kernels/ArgMin.ts
@@ -40,7 +40,7 @@ export function argMin(
 
   backend_util.assertAxesAreInnerMostDims('argMin', [axes[0]], $x.shape.length);
   const program = new ArgMinMaxProgram($x.shape, axes[0], 'min');
-  const uniformData = new Int32Array([axes[0]]);
+  const uniformData = [{type: 'int32', data: [axes[0]]}];
   const out = backend.runWebGPUProgram(program, [$x], 'int32', uniformData);
   intermediateTensorInfos.forEach(t => backend.disposeData(t.dataId));
   return out;

--- a/tfjs-backend-webgpu/src/kernels/AvgPool.ts
+++ b/tfjs-backend-webgpu/src/kernels/AvgPool.ts
@@ -45,15 +45,16 @@ export function avgPool(
   }
 
   const dimensions = [
-    convInfo.padInfo.top, convInfo.padInfo.left,      // Padding.
-    convInfo.strideHeight, convInfo.strideWidth,      // Stride.
-    convInfo.dilationHeight, convInfo.dilationWidth,  // Dilation.
-    convInfo.inHeight, convInfo.inWidth,              // Conv dims.
-    convInfo.effectiveFilterHeight,
-    convInfo.effectiveFilterWidth  // Filter dims.
+    {type: 'int32', data: [convInfo.padInfo.top, convInfo.padInfo.left]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]},
+    {type: 'int32', data: [convInfo.inHeight, convInfo.inWidth]}, {
+      type: 'int32',
+      data: [convInfo.effectiveFilterHeight, convInfo.effectiveFilterWidth]
+    }
   ];
-  const uniformData = new Int32Array(dimensions);
-  return backend.runWebGPUProgram(program, [x], x.dtype, uniformData);
+
+  return backend.runWebGPUProgram(program, [x], x.dtype, dimensions);
 }
 
 export const avgPoolConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
@@ -95,8 +95,6 @@ export function batchMatMulImpl({
 
   const batchDim = Math.max(batchDimA, batchDimB);
 
-  const hasBias = bias != null;
-  const hasPreluActivationWeights = preluActivationWeights != null;
   const useVec4 = a.shape[2] % 4 === 0 && b.shape[2] % 4 === 0 && !transposeA &&
       !transposeB;
   const fusedActivation = activation ?
@@ -109,13 +107,13 @@ export function batchMatMulImpl({
     // remove this limitation by insert 0 to pack data.
     program = new MatMulPackedVec4Program(
         a3dShape, [batchDim, outerShapeA, outerShapeB],
-        env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, hasBias,
-        fusedActivation, hasPreluActivationWeights);
+        env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, bias,
+        fusedActivation, preluActivationWeights);
   } else {
     program = new MatMulPackedProgram(
         a3dShape, [batchDim, outerShapeA, outerShapeB],
         env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, transposeA,
-        transposeB, hasBias, fusedActivation, hasPreluActivationWeights);
+        transposeB, bias, fusedActivation, preluActivationWeights);
   }
   const inputs: TensorInfo[] = [a3d, b3d];
   if (bias) {

--- a/tfjs-backend-webgpu/src/kernels/Conv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv2D.ts
@@ -66,13 +66,13 @@ export function conv2d(
   const padInfo = [convInfo.padInfo.top, convInfo.padInfo.left];
 
   const dimensions = [
-    convInfo.filterHeight, convInfo.filterWidth, ...padInfo,
-    convInfo.strideHeight, convInfo.strideWidth, convInfo.dilationHeight,
-    convInfo.dilationWidth
+    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
+    {type: 'int32', data: [...padInfo]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]}
   ];
-  const uniformData = new Int32Array(dimensions);
 
-  return backend.runWebGPUProgram(program, [x, filter], x.dtype, uniformData);
+  return backend.runWebGPUProgram(program, [x, filter], x.dtype, dimensions);
 }
 
 export const conv2DConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
+++ b/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
@@ -40,14 +40,16 @@ export function depthwiseConv2dNative(args: {
       pad, dimRoundingMode, true /* depthwise */);
 
   const program = new DepthwiseConv2DProgram(convInfo);
+
   const dimensions = [
-    convInfo.filterHeight, convInfo.filterWidth, convInfo.padInfo.top,
-    convInfo.padInfo.left, convInfo.strideHeight, convInfo.strideWidth,
-    convInfo.dilationHeight, convInfo.dilationWidth, convInfo.inHeight,
-    convInfo.inWidth
+    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
+    {type: 'int32', data: [convInfo.padInfo.top, convInfo.padInfo.left]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]},
+    {type: 'int32', data: [convInfo.inHeight, convInfo.inWidth]}
   ];
-  const uniformData = new Int32Array(dimensions);
-  return backend.runWebGPUProgram(program, [x, filter], x.dtype, uniformData);
+
+  return backend.runWebGPUProgram(program, [x, filter], x.dtype, dimensions);
 }
 
 export const depthwiseConv2dNativeConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/Fill.ts
+++ b/tfjs-backend-webgpu/src/kernels/Fill.ts
@@ -35,7 +35,7 @@ export function fill(args: {backend: WebGPUBackend, attrs: FillAttrs}):
     return backend.makeTensorInfo(shape, dtype, values);
   } else {
     const program = new FillProgram(shape);
-    const uniformData = new Float32Array([value as number]);
+    const uniformData = [{type: 'float32', data: [value as number]}];
     return backend.runWebGPUProgram(program, [], dtype, uniformData);
   }
 }

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -34,7 +34,7 @@ export class FromPixelsProgram implements WebGPUProgram {
   bindGroupLayout: GPUBindGroupLayout;
 
   uniform: GPUBuffer;
-  lastUniformData = [0, 0];
+  lastUniformData: number[] = [];
 
   inputTexture: GPUTexture = null;
   lastPixelSize = {width: 0, height: 0};
@@ -68,19 +68,22 @@ export class FromPixelsProgram implements WebGPUProgram {
     layout(set = 0, binding = 2) uniform Meta {
       int size;
       int numChannels;
-    } outShape;
+      ivec2 shapeStride;
+    };
+
+    ivec3 getCoordsFromFlatIndex(int flatIndexBase);
 
     void main() {
-      int flatIndexBase = int(gl_GlobalInvocationID.x) * outShape.numChannels;
+      int flatIndexBase = int(gl_GlobalInvocationID.x) * numChannels;
       ivec3 coords = getCoordsFromFlatIndex(flatIndexBase);
       int texR = coords[0];
       int texC = coords[1];
       int depth = coords[2];
       vec4 values = imageLoad(srcImage, ivec2(texC, texR));
-      for(int i = 0; i < outShape.numChannels; i++) {
+      for(int i = 0; i < numChannels; i++) {
         float value = values[i];
         int flatIndex = flatIndexBase + i;
-        if (flatIndex < outShape.size) {
+        if (flatIndex < size) {
           result[flatIndex] = int(floor(255.0 * value));
         }
       }
@@ -101,7 +104,8 @@ export class FromPixelsProgram implements WebGPUProgram {
     // and reuse it always.
     if (!this.uniform) {
       const uniformBuffer = device.createBuffer({
-        size: 8,  // The uniform buffer contains two 4 bytes element always.
+        size: uniformData.length *
+            4,  // The uniform buffer contains two 4 bytes element always.
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
       });
 
@@ -109,18 +113,15 @@ export class FromPixelsProgram implements WebGPUProgram {
     }
 
     // No need to update uniform buffer if no changes.
-    // The initial lastUniformData will have value [0, 0],
-    // which is not a valid numChannels or valid size.
     if (!uniformData ||
-        (uniformData[0] === this.lastUniformData[0] &&
-         uniformData[1] === this.lastUniformData[1])) {
+        ((uniformData.length === this.lastUniformData.length) &&
+         uniformData.every((v, i) => v === this.lastUniformData[i]))) {
       return;
     }
 
     device.queue.writeBuffer(this.uniform, 0, new Uint32Array(uniformData));
 
-    this.lastUniformData[0] = uniformData[0];
-    this.lastUniformData[1] = uniformData[1];
+    this.lastUniformData = uniformData;
   }
 
   makeInputTexture(device: GPUDevice, pixelWidth: number, pixelHeight: number):

--- a/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
@@ -60,15 +60,17 @@ export function fusedDepthwiseConv2D(args: {
 
   const program = new DepthwiseConv2DProgram(
       convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+
   const dimensions = [
-    convInfo.filterHeight, convInfo.filterWidth, convInfo.padInfo.top,
-    convInfo.padInfo.left, convInfo.strideHeight, convInfo.strideWidth,
-    convInfo.dilationHeight, convInfo.dilationWidth, convInfo.inHeight,
-    convInfo.inWidth
+    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
+    {type: 'int32', data: [convInfo.padInfo.top, convInfo.padInfo.left]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]},
+    {type: 'int32', data: [convInfo.inHeight, convInfo.inWidth]}
   ];
-  const uniformData = new Int32Array(dimensions);
+
   const result =
-      backend.runWebGPUProgram(program, programInputs, 'float32', uniformData);
+      backend.runWebGPUProgram(program, programInputs, 'float32', dimensions);
 
   return result;
 }

--- a/tfjs-backend-webgpu/src/kernels/MaxPool.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPool.ts
@@ -17,7 +17,6 @@
 import {backend_util, KernelConfig, KernelFunc, MaxPool, MaxPoolAttrs, MaxPoolInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-
 import {identity} from './Identity';
 import {Pool2DProgram} from './pool2d_webgpu';
 import {PoolWithFilterSizeEqualsOneProgram} from './pool_filtersizeone_webgpu';
@@ -43,15 +42,16 @@ export function maxPool(
   }
 
   const dimensions = [
-    convInfo.padInfo.top, convInfo.padInfo.left,      // Padding.
-    convInfo.strideHeight, convInfo.strideWidth,      // Stride.
-    convInfo.dilationHeight, convInfo.dilationWidth,  // Dilation.
-    convInfo.inHeight, convInfo.inWidth,              // Conv dims.
-    convInfo.effectiveFilterHeight,
-    convInfo.effectiveFilterWidth  // Filter dims.
+    {type: 'int32', data: [convInfo.padInfo.top, convInfo.padInfo.left]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]},
+    {type: 'int32', data: [convInfo.inHeight, convInfo.inWidth]}, {
+      type: 'int32',
+      data: [convInfo.effectiveFilterHeight, convInfo.effectiveFilterWidth]
+    }
   ];
-  const uniformData = new Int32Array(dimensions);
-  return backend.runWebGPUProgram(program, [x], x.dtype, uniformData);
+
+  return backend.runWebGPUProgram(program, [x], x.dtype, dimensions);
 }
 
 export const maxPoolConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/PadV2.ts
+++ b/tfjs-backend-webgpu/src/kernels/PadV2.ts
@@ -26,7 +26,7 @@ export const padV2 =
           const {inputs, backend, attrs} = args;
           const {x} = inputs;
           const {paddings, constantValue} = attrs;
-          const uniformData = new Float32Array([constantValue]);
+          const uniformData = [{type: 'float32', data: [constantValue]}];
           const program = new PadProgram(x.shape, paddings);
           return backend.runWebGPUProgram(program, [x], x.dtype, uniformData);
         };

--- a/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
@@ -30,6 +30,7 @@ export class AddNPackedProgram implements WebGPUProgram {
   variableNames: string[];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
+  size: number;
 
   constructor(shapes: number[][]) {
     this.outputShape = shapes[0];
@@ -39,10 +40,10 @@ export class AddNPackedProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
     this.shaderKey = 'addN';
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
-    const size = util.sizeFromShape(this.outputShape);
     const snippets: string[] = [];
     // Get target elements from every input tensor.
     this.variableNames.forEach(variable => {
@@ -61,7 +62,7 @@ export class AddNPackedProgram implements WebGPUProgram {
         int index = int(gl_GlobalInvocationID.x);
         for (int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
-          if (flatIndex < ${size}) {
+          if (flatIndex < size) {
             ${type} coords = getCoordsFromFlatIndex(flatIndex);
             ${snippets.join('\n        ')}
             setOutput(flatIndex, ${operation});

--- a/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -65,7 +65,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.inputShape = inputShape;
-    this.shaderKey = `argMinMax_${this.op}_${reduceSize}`;
+    this.shaderKey = `argMinMax${this.op}`;
   }
 
   getUserCode(): string {
@@ -121,9 +121,9 @@ export class ArgMinMaxProgram implements WebGPUProgram {
 
     const indexInputShape = (index: string) => {
       if (this.inputShape.length === 1) {
-        return `${getShapeCoords(this.inputShape)}`;
+        return 'xShape';
       } else {
-        return `${getShapeCoords(this.inputShape)}[${index}]`;
+        return `xShape[${index}]`;
       }
     };
 

--- a/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -83,7 +83,7 @@ export class BatchNormProgram implements WebGPUProgram {
     }
     const userCode = `
       void writeResult(${coordsDataType} coords,float value) {
-        if (coordsInBounds(coords, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coords, outShape)) {
           ${setOutput}
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
@@ -38,6 +38,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [128, 1, 1];
   op: string;
+  size: number;
 
   constructor(op: string, aShape: number[], bShape: number[]) {
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
@@ -45,12 +46,12 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.shaderKey = `binaryOpComplex${op}`;
+    this.shaderKey = `binaryOpComplex_${op}`;
     this.op = op;
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
-    const size = util.sizeFromShape(this.outputShape);
     const userCode = `
       float binaryOpComplex(
           float areal, float aimag, float breal, float bimag) {
@@ -59,7 +60,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
 
       void main() {
         int index = int(gl_GlobalInvocationID.x);
-        if(index < ${size}) {
+        if(index < size) {
           float areal = getARealAtOutCoords();
           float aimag = getAImagAtOutCoords();
           float breal = getBRealAtOutCoords();

--- a/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 import {getCoordsDataType} from '../shader_preprocessor';
-
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -33,6 +32,7 @@ export class BinaryOpProgram implements WebGPUProgram {
   op: string;
   sizeFit: boolean;
   shapesFit: boolean;
+  size: number;
 
   constructor(op: string, aShape: number[], bShape: number[]) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
@@ -40,15 +40,15 @@ export class BinaryOpProgram implements WebGPUProgram {
     this.workGroupSize = [workGroupSizeX, 1, 1];
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
-    const size = util.sizeFromShape(this.outputShape);
-    this.sizeFit = size % workGroupSizeX === 0;
+    this.size = util.sizeFromShape(this.outputShape);
+    this.sizeFit = this.size % workGroupSizeX === 0;
     this.shapesFit = util.arraysEqual(aShape, bShape) && this.sizeFit;
     this.workPerThread = this.sizeFit || this.shapesFit ? 1 : 2;
 
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
-    this.shaderKey = `binary_${op}`;
+    this.shaderKey = `binary_${op}_${this.sizeFit}_${this.shapesFit}`;
     this.op = op;
   }
 
@@ -87,7 +87,6 @@ export class BinaryOpProgram implements WebGPUProgram {
       `;
     } else {
       const type = getCoordsDataType(this.outputShape.length);
-      const size = util.sizeFromShape(this.outputShape);
       userCode = `
       float binaryOperation(float a, float b) {
         ${this.op}
@@ -99,7 +98,7 @@ export class BinaryOpProgram implements WebGPUProgram {
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
 
-          if(flatIndex < ${size}) {
+          if(flatIndex < size) {
             ${type} coords = getCoordsFromFlatIndex(flatIndex);
 
             float a = getAAtOutCoords(coords);

--- a/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
@@ -31,6 +31,7 @@ export class ClipProgram implements WebGPUProgram {
   workGroupSize: [number, number, number] = [64, 1, 1];
   minVal: number;
   maxVal: number;
+  size: number;
 
   constructor(outputShape: number[], minVal: number, maxVal: number) {
     this.outputShape = outputShape;
@@ -41,18 +42,19 @@ export class ClipProgram implements WebGPUProgram {
 
     this.minVal = minVal;
     this.maxVal = maxVal;
+    // TODO(xing.xu): move min max to uniform.
     this.shaderKey = `clip_${minVal}_${maxVal}`;
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const type = getCoordsDataType(this.outputShape.length);
-    const size = util.sizeFromShape(this.outputShape);
     const userCode = `
       void main() {
         int index = int(gl_GlobalInvocationID.x);
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
-          if(flatIndex < ${size}) {
+          if(flatIndex < size) {
             ${type} coords = getCoordsFromFlatIndex(flatIndex);
 
             float value = getAAtOutCoords(coords);

--- a/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
@@ -29,6 +29,7 @@ export class ConcatProgram implements WebGPUProgram {
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
   shapes: Array<[number, number]>;
+  size: number;
 
   constructor(shapes: Array<[number, number]>) {
     this.outputShape =
@@ -40,7 +41,9 @@ export class ConcatProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
 
     this.shapes = shapes;
-    this.shaderKey = 'concat';
+    // shapes is used by const snippets.
+    this.shaderKey = `concat${shapes}`;
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -67,14 +70,14 @@ export class ConcatProgram implements WebGPUProgram {
     } else {
       snippets.push(`setOutput(coords.x, coords.y, getT0(yR, yC));`);
     }
-    const size = util.sizeFromShape(this.outputShape);
+
     const userCode = `
       void main() {
         int index = int(gl_GlobalInvocationID.x);
 
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
-          if(flatIndex < ${size}) {
+          if(flatIndex < size) {
             ivec2 coords = getCoordsFromFlatIndex(flatIndex);
             int yR = coords.x;
             int yC = coords.y;

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, tilesFitEvenlyIntoShape} from '../webgpu_util';
 
 import {makeMatMulPackedVec4Source} from './matmul_packed_vec4_webgpu';
@@ -37,6 +36,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
   activation: string;
   hasPreluActivationWeights: boolean;
   hasLeakyreluAlpha: boolean;
+  fitA: boolean;
+  fitB: boolean;
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
@@ -58,7 +59,6 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
     this.hasLeakyreluAlpha = hasLeakyreluAlpha;
-    this.shaderKey = `conv2DMMVec4_${this.activation}`;
     if (this.addBias) {
       this.variableNames.push('bias');
     }
@@ -70,12 +70,13 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     if (this.hasLeakyreluAlpha) {
       this.variableNames.push('leakyreluAlpha');
     }
+
+    [this.fitA, this.fitB] = this.getShapeFit(elementsPerThread);
+    this.shaderKey =
+        `conv2DMMVec4_${this.activation}_${this.fitA}_${this.fitB}`;
   }
 
-  getUserCode(): string {
-    const elementsPerThread: [number, number, number] = [4, 4, 1];
-    const matMulSource = makeMatMulPackedVec4Source(elementsPerThread);
-
+  getShapeFit(elementsPerThread: [number, number, number]): boolean[] {
     const tileAOuter = this.workGroupSize[1] * elementsPerThread[1];
     const tileBOuter = this.workGroupSize[0] * elementsPerThread[0];
     const tileInner = tileBOuter;
@@ -86,10 +87,18 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     const dimBOuter = this.outputShape[3];
     const dimInner = this.convInfo.filterHeight * this.convInfo.filterWidth *
         this.convInfo.inChannels;
+    return [
+      tilesFitEvenlyIntoShape(tileSizeA, [dimAOuter, dimInner]),
+      tilesFitEvenlyIntoShape(tileSizeB, [dimInner, dimBOuter])
+    ];
+  }
+
+  getUserCode(): string {
+    const elementsPerThread: [number, number, number] = [4, 4, 1];
+    const matMulSource = makeMatMulPackedVec4Source(elementsPerThread);
 
     // Below code only applys to valid padding type.
-    const sampleAWithRemainder = `int flatIndex = getFlatIndex(coord, ${
-        getShapeCoords(this.convInfo.inShape)});
+    const sampleAWithRemainder = `int flatIndex = getFlatIndex(coord, xShape);
         int divBy4Remainder = flatIndex % 4;
         int divBy4Index = flatIndex / 4;
         vec4 curData = x[divBy4Index];
@@ -114,10 +123,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     const remainderSnippet = remainder === 0 ?
         `// The bounds checking is always needed since we use it to pad zero for
         // the 'same' padding type.
-        resData = coordsInBounds(coord, ${
-            getShapeCoords(this.convInfo.inShape)}) ? x[getFlatIndex(coord, ${
-            getShapeCoords(
-                this.convInfo.inShape)}) / 4] : vec4(0.0, 0.0, 0.0, 0.0);` :
+        resData = coordsInBounds(coord, xShape) ?
+        x[getFlatIndex(coord, xShape) / 4] : vec4(0.0, 0.0, 0.0, 0.0);` :
         `vec4 temp = vec4(0, 0, 0, 0);
         ${sampleAWithRemainder}
         resData = temp;
@@ -135,11 +142,11 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         }
         `;
 
-    const readASnippet = `int outRow = r / ${this.outputShape[2]};
-        int outCol = r % ${this.outputShape[2]};
-        int WRow = c / (filterDims[1] * ${this.convInfo.inShape[3]});
-        int WCol = (c / ${this.convInfo.inShape[3]}) % filterDims[1];
-        int inChCoord = c % ${this.convInfo.inShape[3]};
+    const readASnippet = `int outRow = r / outShape[2];
+        int outCol = r % outShape[2];
+        int WRow = c / (filterDims[1] * xShape[3]);
+        int WCol = (c / xShape[3]) % filterDims[1];
+        int inChCoord = c % xShape[3];
         ivec4 coord = ivec4(
             batch,
             outRow * stride[0] + dilation[0] * WRow - pad[0],
@@ -149,16 +156,14 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         ${remainderSnippet}
         return resData;`;
 
-    const fitA = tilesFitEvenlyIntoShape(tileSizeA, [dimAOuter, dimInner]);
     const sampleA =
-        fitA ? `${readASnippet}` : `if (r < dimAOuter && c < dimInner) {
+        this.fitA ? `${readASnippet}` : `if (r < dimAOuter && c < dimInner) {
           ${readASnippet}
         } else {
           return vec4(0.0, 0.0, 0.0, 0.0);
         }`;
 
-    const fitB = tilesFitEvenlyIntoShape(tileSizeB, [dimInner, dimBOuter]);
-    const sampleB = fitB ?
+    const sampleB = this.fitB ?
         `W[row * dimBOuter / 4 + col]` :
         `coordsInBounds(ivec2(row, col * 4), ivec2(dimInner, dimBOuter)) ?
             W[row * dimBOuter / 4 + col] : vec4(0.0, 0.0, 0.0, 0.0)`;
@@ -195,10 +200,9 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         ${matMulSource}
 
         int batch;
-        int dimAOuter = ${this.outputShape[1]} * ${this.outputShape[2]};
-        int dimBOuter = ${this.outputShape[3]};
-        int dimInner = filterDims[0] * filterDims[1] * ${
-        this.convInfo.inShape[3]};
+        int dimAOuter = outShape[1] * outShape[2];
+        int dimBOuter = outShape[3];
+        int dimInner = filterDims[0] * filterDims[1] * xShape[3];
         vec4 mm_readA(int row, int col) {
           int r = int(row), c = int(col * 4);
           ${sampleA};
@@ -213,8 +217,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
           {
             ivec4 outCoord = ivec4(
               batch,
-              row / ${this.outputShape[2]},
-              row % ${this.outputShape[2]},
+              row / outShape[2],
+              row % outShape[2],
               col * 4);
             ${addBiasSnippet}
             ${applyActivationSnippet}

--- a/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -87,20 +86,19 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
       ${activationSnippet}
       float readInp(int batch, int row, int col, int chan) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        return coordsInBounds(coord, ${getShapeCoords(this.convInfo.inShape)}) ?
+        return coordsInBounds(coord, xShape) ?
           getX(batch, row, col, chan) : 0;
       }
 
       float readFilt(int row, int col, int xChannel, int outChannel) {
         ivec4 coord = ivec4(row, col, xChannel, outChannel);
-        return coordsInBounds(coord, ${
-        getShapeCoords(this.convInfo.filterShape)}) ?
+        return coordsInBounds(coord, wShape) ?
           getW(row, col, xChannel, outChannel) : 0;
       }
 
       void writeResult(int batch, int row, int col, int chan, float value) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        if (coordsInBounds(coord, ${getShapeCoords(this.convInfo.outShape)})) {
+        if (coordsInBounds(coord, outShape)) {
           ${addBiasSnippet}
           ${applyActivationSnippet}
           setOutput(batch, row, col, chan, value);

--- a/tfjs-backend-webgpu/src/kernels/crop_and_resize_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/crop_and_resize_webgpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -42,8 +41,9 @@ export class CropAndResizeProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.shaderKey =
-        `cropAndResize_${method}_${cropSize}_${extrapolationValue}`;
+    // imageShape is used by const imageHeight and imageWidth.
+    this.shaderKey = `cropAndResize_${method}_${cropSize}_${
+        extrapolationValue}_${imageShape}`;
     this.imageShape = imageShape;
     this.cropSize = cropSize;
     this.methodId = method === 'bilinear' ? 1 : 0;
@@ -86,7 +86,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
       const float height_ratio = float(${heightRatio});
       const float width_ratio = float(${widthRatio});
       void writeResult(ivec4 coords,float value) {
-        if (coordsInBounds(coords, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coords, outShape)) {
           setOutput(coords[0], coords[1], coords[2], coords[3], value);
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
@@ -16,7 +16,6 @@
  */
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 import {WebGPUProgram} from './webgpu_program';
 
@@ -58,7 +57,8 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
     this.activation = activation;
     this.hasPreluActivation = hasPreluActivation;
 
-    this.shaderKey = `depthwise_${activation}`;
+    this.shaderKey = `depthwise_${activation}_${
+        this.convInfo.outChannels / this.convInfo.inChannels}`;
   }
 
   getUserCode(): string {
@@ -89,7 +89,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
 
       void writeResult(int batch, int row, int col, int chan, float value) {
         ivec4 coord = ivec4(batch, row, col, chan);
-        if (coordsInBounds(coord, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coord, outShape)) {
           setOutput(batch, row, col, chan, value);
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -27,6 +27,7 @@ export class FillProgram implements WebGPUProgram {
   uniforms = 'float value;';
   workPerThread = 4;
   workGroupSize: [number, number, number] = [16, 1, 1];
+  size: number;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
@@ -36,17 +37,17 @@ export class FillProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
 
     this.shaderKey = 'fill';
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
-    const size = util.sizeFromShape(this.outputShape);
     const userCode = `
     void main() {
       int index = int(gl_GlobalInvocationID.x);
       for (int i = 0; i < ${this.workPerThread}; i++) {
         int flatIndex = index * ${this.workPerThread} + i;
-        if (flatIndex < ${size}) {
-          setOutput(flatIndex, value);
+        if (flatIndex < size) {
+          setOutput(flatIndex, float(value));
         }
       }
     }

--- a/tfjs-backend-webgpu/src/kernels/gather_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/gather_webgpu.ts
@@ -28,6 +28,7 @@ export class GatherProgram implements WebGPUProgram {
   variableNames: string[] = ['A', 'indices'];
   workGroupSize: [number, number, number] = [64, 1, 1];
   aShape: number[];
+  size: number;
 
   constructor(aShape: number[], outputShape: number[]) {
     this.outputShape = aShape.slice();
@@ -37,15 +38,15 @@ export class GatherProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
     this.shaderKey = `gather`;
+    this.size = util.sizeFromShape(this.outputShape);
   }
   getUserCode(): string {
     const sourceCoords = getSourceCoords(this.aShape);
-    const size = util.sizeFromShape(this.outputShape);
     const userCode = `
       void main() {
         int index = int(gl_GlobalInvocationID.x);
         ivec4 resRC = getOutputCoords();
-        if (index < ${size}) {
+        if (index < size) {
           setOutput(index, getA(${sourceCoords}));
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
@@ -33,6 +33,7 @@ export class MirrorPadProgram implements WebGPUProgram {
   xShape: number[];
   paddings: Array<[number, number]>;
   offset: number;
+  size: number;
 
   constructor(
       xShape: number[], paddings: Array<[number, number]>,
@@ -48,11 +49,11 @@ export class MirrorPadProgram implements WebGPUProgram {
     this.paddings = paddings;
     this.offset = mode === 'reflect' ? 0 : 1;
     this.shaderKey = `mirrorPad_${mode}_${paddings}`;
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const rank = this.xShape.length;
-    const size = util.sizeFromShape(this.outputShape);
     const type = getCoordsDataType(rank);
     const start = this.paddings.map(p => p[0]).join(',');
     const end = this.paddings.map((p, i) => p[0] + this.xShape[i]).join(',');
@@ -78,7 +79,7 @@ export class MirrorPadProgram implements WebGPUProgram {
         for (int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
 
-          if (flatIndex < ${size}) {
+          if (flatIndex < size) {
             ${type} outC = getCoordsFromFlatIndex(flatIndex);
             ${rank === 1 ? '' : coordsLoop}
             if (${shaderOutC} < ${shaderStart}) {

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -33,6 +33,7 @@ export class PadProgram implements WebGPUProgram {
   workGroupSize: [number, number, number] = [16, 1, 1];
   xShape: number[];
   paddings: Array<[number, number]>;
+  size: number;
 
   constructor(xShape: number[], paddings: Array<[number, number]>) {
     this.outputShape = paddings.map(
@@ -44,12 +45,13 @@ export class PadProgram implements WebGPUProgram {
 
     this.xShape = xShape;
     this.paddings = paddings;
-    this.shaderKey = `pad_${paddings}`;
+    // xShape is used by const start and end.
+    this.shaderKey = `pad_${paddings}_${xShape}`;
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const rank = this.xShape.length;
-    const size = util.sizeFromShape(this.outputShape);
     const type = getCoordsDataType(rank);
     const start = this.paddings.map(p => p[0]).join(',');
     const end = this.paddings.map((p, i) => p[0] + this.xShape[i]).join(',');
@@ -75,7 +77,7 @@ export class PadProgram implements WebGPUProgram {
         for (int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
 
-          if (flatIndex < ${size}) {
+          if (flatIndex < size) {
             ${type} outC = getCoordsFromFlatIndex(flatIndex);
 
             if (${leftPadCondition} || ${rightPadCondition}) {

--- a/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -60,7 +59,7 @@ export class Pool2DProgram implements WebGPUProgram {
     const userCode = `
       void main() {
         ivec4 coords = getOutputCoords();
-        if (coordsInBounds(coords, ${getShapeCoords(this.outputShape)})) {
+        if (coordsInBounds(coords, outShape)) {
           int batch = coords[0];
           ivec2 xRCCorner = coords.yz * stride - pad;
           int xRCorner = xRCCorner.x;

--- a/tfjs-backend-webgpu/src/kernels/pool_filtersizeone_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool_filtersizeone_webgpu.ts
@@ -17,7 +17,6 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -48,7 +47,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
         int batch = coords[0];
         int d = coords[3];
 
-        if (all(lessThan(coords, ${getShapeCoords(this.outputShape)}))) {
+        if (all(lessThan(coords, outShape))) {
           ivec2 xRCCorner = coords.yz * stride;
           int xRCorner = xRCCorner.x;
           int xCCorner = xRCCorner.y;

--- a/tfjs-backend-webgpu/src/kernels/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/reduce_webgpu.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {backend_util, util} from '@tensorflow/tfjs-core';
-import {getCoordsDataType, getShapeCoords} from '../shader_preprocessor';
+import {backend_util, DataType, util} from '@tensorflow/tfjs-core';
+import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
+
 import {WebGPUProgram} from './webgpu_program';
 
 export class ReduceProgram implements WebGPUProgram {
@@ -27,6 +28,7 @@ export class ReduceProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workGroupSize: [number, number, number];
   variableNames = ['x'];
+  uniforms = 'ivec2 reduceShape;';
   reduceType: 'max'|'mean'|'min'|'prod'|'sum';
   inputShape: number[];
   reduceSize: number;
@@ -34,7 +36,7 @@ export class ReduceProgram implements WebGPUProgram {
 
   constructor(
       reduceInfo: backend_util.ReduceInfo,
-      reduceType: 'max'|'mean'|'min'|'prod'|'sum') {
+      reduceType: 'max'|'mean'|'min'|'prod'|'sum', outputDtype: DataType) {
     this.inputShape = [reduceInfo.batchSize, reduceInfo.inSize];
     const [outputShape, reduceShape] =
         backend_util.computeOutAndReduceShapes(this.inputShape, [1]);
@@ -52,7 +54,7 @@ export class ReduceProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.reduceType = reduceType;
-    this.shaderKey = `reduce_${reduceType}`;
+    this.shaderKey = `reduce_${reduceType}_${outputDtype}`;
   }
 
   getUserCode(): string {
@@ -62,8 +64,8 @@ export class ReduceProgram implements WebGPUProgram {
     let initValue = '0.0';
     if (this.reduceType === 'min' || this.reduceType === 'max') {
       reduceOp = ` if (candidate ${this.reduceType === 'min' ? '<' : '>'}
-          bestValue && !isnan(candidate))
-          {  bestValue = candidate; }`;
+           bestValue && !isnan(candidate))
+           {  bestValue = candidate; }`;
       initValue = 'x[offset]';
     } else if (this.reduceType === 'sum' || this.reduceType === 'mean') {
       reduceOp = ' bestValue += candidate; ';
@@ -77,66 +79,68 @@ export class ReduceProgram implements WebGPUProgram {
         `setOutput(flatOutputIndex, bestValue);`;
 
     const sharedMemorySnippet = `
-        shared float xBestValues[WorkGroupSize];
-      `;
+         shared float xBestValues[WorkGroupSize];
+       `;
     const sharedMemoryReduceSnippet = `
-      xBestValues[gl_LocalInvocationID.x] = bestValue;
-      ${this.reduceType === 'sum' || this.reduceType === 'mean' ||
-          this.reduceType === 'prod' ? `bestValue=${initValue};` : ' '}
-      int currentSize = WorkGroupSize;
-      while (currentSize > 1) {
-        barrier();
-        for (int w = 0; w < ${this.reductionFactor}; ++w) {
-          int i = int(gl_LocalInvocationID.x) * ${this.reductionFactor} + w;
-          if (i < currentSize) {
-            float candidate = xBestValues[i];
-            ${reduceOp}
-          }
-        }
-        barrier();
-        xBestValues[gl_LocalInvocationID.x] = bestValue;
-        currentSize = DIV_CEIL(currentSize, ${this.reductionFactor});
-        ${this.reduceType === 'sum' || this.reduceType === 'mean' ||
-            this.reduceType === 'prod' ?
-            `if(currentSize > 1) bestValue=${initValue};` : ''}
-      }
-      if (gl_LocalInvocationID.x == 0) {
-        ${outputSnippet}
-      }
-    `;
+       xBestValues[gl_LocalInvocationID.x] = bestValue;
+       ${
+        this.reduceType === 'sum' || this.reduceType === 'mean' ||
+                this.reduceType === 'prod' ?
+            `bestValue=${initValue};` :
+            ' '}
+       int currentSize = WorkGroupSize;
+       while (currentSize > 1) {
+         barrier();
+         for (int w = 0; w < ${this.reductionFactor}; ++w) {
+           int i = int(gl_LocalInvocationID.x) * ${this.reductionFactor} + w;
+           if (i < currentSize) {
+             float candidate = xBestValues[i];
+             ${reduceOp}
+           }
+         }
+         barrier();
+         xBestValues[gl_LocalInvocationID.x] = bestValue;
+         currentSize = DIV_CEIL(currentSize, ${this.reductionFactor});
+         ${
+        this.reduceType === 'sum' || this.reduceType === 'mean' ||
+                this.reduceType === 'prod' ?
+            `if(currentSize > 1) bestValue=${initValue};` :
+            ''}
+       }
+       if (gl_LocalInvocationID.x == 0) {
+         ${outputSnippet}
+       }
+     `;
 
     const outputCoordsType = getCoordsDataType(this.outputShape.length);
 
     const userCode = `
-      #define DIV_CEIL(x, y) (((x) - 1) / (y) + 1)
-      const int WorkGroupSize = int(gl_WorkGroupSize.x);
-      ${reduceInSharedMemory ? sharedMemorySnippet : ''}
-      int getOffset() {
-        const ${outputCoordsType} outputCoords = getOutputCoords();
-        int offset = ${
-        this.outputShape.length === 1 ?
-            'outputCoords' :
-            'outputCoords[0]'} * ${getShapeCoords(this.inputShape)}[1];
-        return offset;
-      }
-      void main() {
-        const int offset= getOffset();
-        float bestValue = ${initValue};
-        const int Length = ${
-        this.inputShape.length === 1 ? `${getShapeCoords(this.inputShape)}` :
-                                       `${getShapeCoords(this.inputShape)}[1]`};
-        const int WorkPerThread = DIV_CEIL(Length, WorkGroupSize);
-        for (int w = 0; w < WorkPerThread; ++w) {
-          int i = int(gl_GlobalInvocationID.x) * WorkPerThread + w;
-          if (i < Length) {
-            float candidate = x[offset + i];
-            ${reduceOp}
-          }
-        }
-        const int flatOutputIndex = int(gl_GlobalInvocationID.y);
-        ${reduceInSharedMemory ? sharedMemoryReduceSnippet :outputSnippet}
-      }
-    `;
+       #define DIV_CEIL(x, y) (((x) - 1) / (y) + 1)
+       const int WorkGroupSize = int(gl_WorkGroupSize.x);
+       ${reduceInSharedMemory ? sharedMemorySnippet : ''}
+       int getOffset() {
+         const ${outputCoordsType} outputCoords = getOutputCoords();
+         int offset = ${
+        this.outputShape.length === 1 ? 'outputCoords' :
+                                        'outputCoords[0]'} * reduceShape[1];
+         return offset;
+       }
+       void main() {
+         const int offset= getOffset();
+         float bestValue = ${initValue};
+         const int Length = reduceShape[1];
+         const int WorkPerThread = DIV_CEIL(Length, WorkGroupSize);
+         for (int w = 0; w < WorkPerThread; ++w) {
+           int i = int(gl_GlobalInvocationID.x) * WorkPerThread + w;
+           if (i < Length) {
+             float candidate = x[offset + i];
+             ${reduceOp}
+           }
+         }
+         const int flatOutputIndex = int(gl_GlobalInvocationID.y);
+         ${reduceInSharedMemory ? sharedMemoryReduceSnippet : outputSnippet}
+       }
+     `;
     return userCode;
   }
 }

--- a/tfjs-backend-webgpu/src/kernels/resize_bilinear_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/resize_bilinear_webgpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {getShapeCoords} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -27,7 +26,6 @@ export class ResizeBilinearProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   workGroupSize: [number, number, number] = [64, 1, 1];
-  inputShape: [number, number, number, number];
   alignCorners: boolean;
 
   constructor(
@@ -40,9 +38,9 @@ export class ResizeBilinearProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
-    this.inputShape = inputShape;
     this.alignCorners = alignCorners;
-    this.shaderKey = `resizeBilinear_${alignCorners}`;
+    this.shaderKey = `resizeBilinear_${alignCorners}_${
+        this.outputShape[1] > 1}_${this.outputShape[2] > 1}`;
   }
 
   getUserCode(): string {
@@ -52,24 +50,18 @@ export class ResizeBilinearProgram implements WebGPUProgram {
     const userCode = `
       void main() {
         ivec4 coords = getOutputCoords();
-        if (all(lessThan(coords, ${getShapeCoords(this.outputShape)}))) {
+        if (all(lessThan(coords, outShape))) {
           int b = coords[0];
           int d = coords[3];
           ivec2 rc = coords.yz;
 
           vec2 effectiveInSize = vec2(
-            ${
-        adjustHeight ? `${this.inputShape[1]} - 1.0` : `${this.inputShape[1]}`},
-            ${
-        adjustWidth ? `${this.inputShape[2]} - 1.0` : `${this.inputShape[2]}`});
+            ${adjustHeight ? `xShape.y - 1.0` : `xShape.y`},
+            ${adjustWidth ? `xShape.z - 1.0` : `xShape.z`});
 
           vec2 effectiveOutSize = vec2(
-            ${
-        adjustHeight ? `${this.outputShape[1]} - 1.0` :
-                       `${this.outputShape[1]}`},
-            ${
-        adjustWidth ? `${this.outputShape[2]} - 1.0` :
-                      `${this.outputShape[2]}`});
+            ${adjustHeight ? `outShape.y - 1.0` : `outShape.y`},
+            ${adjustWidth ? `outShape.z - 1.0` : `outShape.z`});
 
           vec2 effectiveInputOverOutputRatioRC =
               effectiveInSize / effectiveOutSize;
@@ -80,8 +72,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
           // Compute the four integer indices.
           ivec2 sourceFloorRC = ivec2(sourceFracIndexRC);
           ivec2 sourceCeilRC = ivec2(
-            min(vec2(${this.inputShape[1]}, ${
-        this.inputShape[2]}) - 1.0, ceil(sourceFracIndexRC)));
+            min(xShape.yz - 1.0, ceil(sourceFracIndexRC)));
 
           float topLeft = getX(b, sourceFloorRC.x, sourceFloorRC.y, d);
           float bottomLeft = getX(b, sourceCeilRC.x, sourceFloorRC.y, d);

--- a/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
@@ -31,6 +31,7 @@ export class SelectProgram implements WebGPUProgram {
   workGroupSize: [number, number, number] = [16, 1, 1];
   cRank: number;
   rank: number;
+  size: number;
 
   constructor(cRank: number, shape: number[], rank: number) {
     this.outputShape = shape;
@@ -42,6 +43,7 @@ export class SelectProgram implements WebGPUProgram {
     this.cRank = cRank;
     this.rank = rank;
     this.shaderKey = 'select';
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -69,7 +71,6 @@ export class SelectProgram implements WebGPUProgram {
     }
 
     const dtype = getCoordsDataType(this.rank);
-    const size = util.sizeFromShape(this.outputShape);
     const userCode = `
       void main() {
         int index = int(gl_GlobalInvocationID.x);
@@ -77,7 +78,7 @@ export class SelectProgram implements WebGPUProgram {
         for (int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
 
-          if (flatIndex < ${size}) {
+          if (flatIndex < size) {
             ${dtype} resRC = getOutputCoords();
             float cVal = getC(${cCoords});
             if (cVal >= 1.0) {

--- a/tfjs-backend-webgpu/src/kernels/slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/slice_webgpu.ts
@@ -42,7 +42,7 @@ export class SliceProgram implements WebGPUProgram {
 
     this.start = start;
     this.destSize = destSize;
-    this.shaderKey = `slice_${start}_${destSize}`;
+    this.shaderKey = `slice_${start}_${destSize.length}`;
   }
 
   getUserCode(): string {

--- a/tfjs-backend-webgpu/src/kernels/transpose_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transpose_shared_webgpu.ts
@@ -47,8 +47,8 @@ export class TransposeSharedProgram implements WebGPUProgram {
         int index = int(gl_GlobalInvocationID.x);
         int x = int(gl_WorkGroupID.x) * TILE_DIM + int(gl_LocalInvocationID.x);
         int y = int(gl_WorkGroupID.y) * TILE_DIM + int(gl_LocalInvocationID.y);
-        int width = ${this.outputShape[0]};
-        int height = ${this.outputShape[1]};
+        int width = outShape[0];
+        int height = outShape[1];
         if (x < width && y < height) {
           tile[gl_LocalInvocationID.y][gl_LocalInvocationID.x] =
               A[y * width + x];

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -72,6 +72,7 @@ export class UnaryOpProgram implements WebGPUProgram {
   workPerThread: number;
   workGroupSize: [number, number, number];
   op: string;
+  size: number;
 
   constructor(outputShape: number[], op: string) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
@@ -86,12 +87,12 @@ export class UnaryOpProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
     this.op = op;
-    this.shaderKey = `unary_${op}`;
+    this.shaderKey = `unary_${op}_${fit}`;
+    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
-    const size = util.sizeFromShape(this.outputShape);
-    const fit = size % this.workGroupSize[0] === 0;
+    const fit = this.size % this.workGroupSize[0] === 0;
     let userCode: string;
     if (fit) {
       userCode = `
@@ -118,7 +119,7 @@ export class UnaryOpProgram implements WebGPUProgram {
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
 
-          if(flatIndex < ${size}) {
+          if(flatIndex < size) {
             ${type} coords = getCoordsFromFlatIndex(flatIndex);
 
             float a = getAAtOutCoords(coords);

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -40,6 +40,8 @@ export interface WebGPUProgram {
   // the group.
   workGroupSize?: [number, number, number];
   isVec4?: boolean;
+  // size is used for bounds checking.
+  size?: number;
   getUserCode: () => string;
 }
 
@@ -69,11 +71,11 @@ export const makeBindGroup =
 export const compileProgram =
     (glslang: Glslang, device: GPUDevice, program: WebGPUProgram,
      inputsData: shader_preprocessor.InputInfo[], output: TensorInfo,
-     uniforms?: GPUBindingResource): WebGPUBinary => {
+     isFromPixel = false): WebGPUBinary => {
       const outputData = {dtype: output.dtype, shape: output.shape};
 
-      const source =
-          shader_preprocessor.makeShader(inputsData, outputData, program);
+      const source = shader_preprocessor.makeShader(
+          inputsData, outputData, program, isFromPixel);
       const result = glslang.compileGLSLZeroCopy(source, 'compute', false);
       if (result.data.length === 0) {
         throw new Error('Shader compilation failed');
@@ -89,10 +91,10 @@ export const compileProgram =
     };
 
 export function makeShaderKey<R extends Rank>(
-    program: WebGPUProgram, shapes: Array<ShapeMap[R]>,
-    types: string[]): string {
+    program: WebGPUProgram, shapes: Array<ShapeMap[R]>, types: string[],
+    broadcastDimsKey = ''): string {
   const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
-      shapes.join(',') + types.join(',') + program.variableNames.join(',') +
-      program.shaderKey;
+      shapes.map(shape => shape.length).join(',') + types.join(',') +
+      program.variableNames.join(',') + broadcastDimsKey + program.shaderKey;
   return key;
 }

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -33,22 +33,6 @@ export function getCoordsDataType(rank: number): string {
   }
 }
 
-export function getShapeCoords(dataShape: number[]): string {
-  const rank = dataShape.length;
-  if (rank <= 1) {
-    return `int(${dataShape[0]})`;
-  } else if (rank === 2) {
-    return `ivec2(${dataShape[0]}, ${dataShape[1]})`;
-  } else if (rank === 3) {
-    return `ivec3(${dataShape[0]}, ${dataShape[1]}, ${dataShape[2]})`;
-  } else if (rank === 4) {
-    return `ivec4(${dataShape[0]}, ${dataShape[1]}, ${dataShape[2]}, ${
-        dataShape[3]})`;
-  } else {
-    throw Error(`GPU for rank ${rank} is not yet supported`);
-  }
-}
-
 type GLSLDataType = 'float'|'int'|'vec4'|'ivec4'|'bvec4';
 function mapToGlslTypes(type: DataType, isVec4: boolean): GLSLDataType|
     DataType {
@@ -69,6 +53,7 @@ interface ProgramParams {
   variableNames: string[];
   uniforms?: string;
   isVec4?: boolean;
+  size?: number;
   getUserCode: () => string;
 }
 
@@ -80,7 +65,17 @@ export interface InputInfo {
 
 export function makeShader(
     inputInfo: InputInfo[], outputData: {dtype: DataType, shape: number[]},
-    program: ProgramParams): string {
+    program: ProgramParams, isFromPixel = false): string {
+  const outputBufferStr =
+      `    layout(std430, set = 0, binding = 0) writeonly buffer ssbOut {
+      ${mapToGlslTypes(outputData.dtype, program.isVec4)} result[];
+    };`;
+  if (isFromPixel === true) {
+    const getCoords = generateGetCoordsFromFlatIndex(outputData.shape);
+    return [
+      SHADER_PREFIX, outputBufferStr, program.getUserCode(), getCoords
+    ].join('\n');
+  }
   const prefixSnippets: string[] = [];
 
   if (program.workGroupSize != null) {
@@ -107,17 +102,32 @@ export function makeShader(
   });
 
   let uniformDeclaration = '';
+  program.variableNames.forEach((x, i) => {
+    uniformDeclaration += `${getCoordsDataType(inputInfo[i].shape.length)} ${
+        x.charAt(0).toLowerCase() + x.slice(1)}Shape; `;
+  });
+  uniformDeclaration +=
+      `${getCoordsDataType(outputData.shape.length)} outShape; `;
+  const stridesLength = outputData.shape.length - 1;
+  uniformDeclaration += `${getCoordsDataType(stridesLength)} shapeStride; `;
+
+  if (program.size != null) {
+    uniformDeclaration += 'int size; ';
+  }
 
   if (program.uniforms) {
     uniformDeclaration += program.uniforms;
-
-    prefixSnippets.push(`
-    layout(std140, set = 0, binding = ${
-        1 + program.variableNames.length}) uniform Uniforms {
-      ${uniformDeclaration}
-    };
-  `);
   }
+
+  if (uniformDeclaration !== '') {
+    prefixSnippets.push(`
+        layout(std140, set = 0, binding = ${
+        1 + program.variableNames.length}) uniform Uniforms {
+            ${uniformDeclaration}
+        };
+    `);
+  }
+
   const [getOutputCoords, dispatchLayoutRank] =
       generateGetOutputCoords(outputData.shape, program.dispatchLayout);
   const getCoords = generateGetCoordsFromFlatIndex(outputData.shape);
@@ -229,26 +239,22 @@ function getSetOutputSnippet(
     if (isVec4) {
       snippet += `
       void setOutput(${dims.map(d => `int ${d}`).join(', ')}, vec4 value) {
-        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), ${
-          getShapeCoords(outShape)});
+        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), outShape);
         setOutput(flatIndex / 4, value);
       }
       void setOutput(${dims.map(d => `int ${d}`).join(', ')}, ivec4 value) {
-        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), ${
-          getShapeCoords(outShape)});
+        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), outShape);
         setOutput(flatIndex / 4, value);
       }
     `;
     } else {
       snippet += `
       void setOutput(${dims.map(d => `int ${d}`).join(', ')}, float value) {
-        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), ${
-          getShapeCoords(outShape)});
+        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), outShape);
         setOutput(flatIndex, value);
       }
       void setOutput(${dims.map(d => `int ${d}`).join(', ')}, int value) {
-        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), ${
-          getShapeCoords(outShape)});
+        int flatIndex = getFlatIndex(${type}(${dims.join(', ')}), outShape);
         setOutput(flatIndex, value);
       }
     `;
@@ -294,21 +300,23 @@ function getSamplerFromInInfo(inInfo: InputInfo, isVec4: boolean): string {
     `;
   }
 
+  const shapeStr = `${texName.charAt(0).toLowerCase() + texName.slice(1)}Shape`;
+
   if (isVec4) {
     return `
-    vec4 ${funcName}(${inputs}) {
-      return ${texName}[getFlatIndex(${type}(${dims.join(',')}),
-        ${getShapeCoords(inInfo.shape)}) / 4];
-    }
-  `;
+      vec4 ${funcName}(${inputs}) {
+        return ${texName}[getFlatIndex(${type}(${dims.join(',')}),
+          ${shapeStr}) / 4];
+      }
+      `;
   }
 
   return `
     float ${funcName}(${inputs}) {
       return float(${texName}[getFlatIndex(${type}(${dims.join(',')}),
-        ${getShapeCoords(inInfo.shape)})]);
+        ${shapeStr})]);
     }
-  `;
+   `;
 }
 
 function getSamplerAtOutputCoords(
@@ -371,19 +379,21 @@ function getSamplerAtOutputCoords(
     }
   }
 
+  const shapeStr = `${texName.charAt(0).toLowerCase() + texName.slice(1)}Shape`;
+
   if (isVec4) {
     return `
       vec4 ${funcName}() {
         ${type} coords = getOutputCoords();
         ${coordsSnippet}
         return ${texName}[getFlatIndex(${unpackedCoordsSnippet}, ${
-        getShapeCoords(inInfo.shape)}) / 4];
+        shapeStr}) / 4];
       }
 
       vec4 ${funcName}(${type} coords) {
         ${coordsSnippet}
         return ${texName}[getFlatIndex(${unpackedCoordsSnippet}, ${
-        getShapeCoords(inInfo.shape)}) / 4];
+        shapeStr}) / 4];
       }
     `;
   }
@@ -393,13 +403,13 @@ function getSamplerAtOutputCoords(
       ${type} coords = getOutputCoords();
       ${coordsSnippet}
       return float(${texName}[getFlatIndex(${unpackedCoordsSnippet}, ${
-      getShapeCoords(inInfo.shape)})]);
+      shapeStr})]);
     }
 
     float ${funcName}(${type} coords) {
       ${coordsSnippet}
       return float(${texName}[getFlatIndex(${unpackedCoordsSnippet}, ${
-      getShapeCoords(inInfo.shape)})]);
+      shapeStr})]);
     }
   `;
 }
@@ -431,10 +441,9 @@ function generateGetOutputCoords(
       gatherDimensionsStr += `int d${arr[0]} =
         int(gl_GlobalInvocationID[${i}]);`;
     } else {
-      const strides =
-          symbolicallyComputeStrides(arr, `${getShapeCoords(outShape)}`);
+      const strides = symbolicallyComputeStrides(arr, 'outShape');
       gatherDimensionsStr += `int index${i} =
-        int(gl_GlobalInvocationID[${i}]);`;
+          int(gl_GlobalInvocationID[${i}]);`;
       for (let j = 0; j < strides.length; j++) {
         gatherDimensionsStr += `int d${arr[j]} = index${i} / ${strides[j]};`;
 
@@ -467,8 +476,8 @@ function generateGetOutputCoords(
 }
 
 /**
- * Derives logical coordinates from a flat index. Performs integer division with
- * each stride and decrements the index until the index equals the final
+ * Derives logical coordinates from a flat index. Performs integer division
+ * with each stride and decrements the index until the index equals the final
  * dimension coordinate.
  */
 function generateGetCoordsFromFlatIndex(shape: number[]): string {
@@ -485,16 +494,23 @@ function generateGetCoordsFromFlatIndex(shape: number[]): string {
     coords.push(`d${i}`);
   }
 
-  const snippet =
-      strides
-          .map((stride, i) => {
-            const line1 = `int ${coords[i]} = index / ${stride}`;
-            const line2 = i === strides.length - 1 ?
-                `int ${coords[i + 1]} = index - ${coords[i]} * ${stride}` :
-                `index -= ${coords[i]} * ${stride}`;
-            return `${line1}; ${line2};`;
-          })
-          .join('');
+  if (strides.length === 1) {
+    return `    ivec2 getCoordsFromFlatIndex(int index) {
+      int d0 = index / shapeStride; int d1 = index - d0 * shapeStride;
+      return ivec2(d0,d1);
+    }`;
+  }
+  const snippet = strides
+                      .map((_, i) => {
+                        const line1 =
+                            `int ${coords[i]} = index / shapeStride[${i}]`;
+                        const line2 = i === strides.length - 1 ?
+                            `int ${coords[i + 1]} = index - ${
+                                coords[i]} * shapeStride[${i}]` :
+                            `index -= ${coords[i]} * shapeStride[${i}]`;
+                        return `${line1}; ${line2};`;
+                      })
+                      .join('');
 
   return `
     ${dtype} getCoordsFromFlatIndex(int index) {


### PR DESCRIPTION
This reverts https://github.com/tensorflow/tfjs/pull/3647 and adds:
1. support float/int uniform buffers, merge all uniforms into one uniform buffer.
2. store shape strides and shape size in uniform buffer.
3. turn shapes to shape lengths to save shader in makeShaderKey.

These changes will save warmup time. For all e2e related model, this saves wamup time from 60% ~ 90%. And no obvious performance regression is found.

TODO: 
remove all shapes from all shader key, such as ConcatProgram,  CropAndResizeProgram, PadProgram.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4819)
<!-- Reviewable:end -->
