### PR TITLE
e2e: Use env().set instead of env().setFlags

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -475,9 +475,8 @@ async function setEnvFlags(flagConfig) {
               TUNABLE_FLAG_VALUE_RANGE_MAP[flag]}], while ${flagConfig[flag]}` +
           ' is found.');
     }
+    tf.env().set(flag, flagConfig[flag]);
   }
-
-  tf.env().setFlags(flagConfig);
 
   // `WASM_HAS_SIMD_SUPPORT` and `WEBGL_VERSION` are also evaluated when
   // initializing backends, not only inferring.


### PR DESCRIPTION
setFlags will reset all flags with the given list and override other flags values.
So we should use set instead of setFlags function.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4831)
<!-- Reviewable:end -->
