### PR TITLE
[e2e] Fix e2e virtualenv in nightly CI

### DIFF
--- a/e2e/scripts/setup-py-env.sh
+++ b/e2e/scripts/setup-py-env.sh
@@ -38,12 +38,13 @@ fi
 
 VENV_DIR="$(mktemp -d)_venv"
 echo "Creating virtualenv at ${VENV_DIR} ..."
-python -m virtualenv -p python3 "${VENV_DIR}"
 PLATFORM="$(python -m platform)"
 if [[ $PLATFORM =~ "Windows" ]]
 then
+  python -m virtualenv -p python3 "${VENV_DIR}"
   source "${VENV_DIR}/Scripts/activate"
 else
+  virtualenv -p python3 "${VENV_DIR}"
   source "${VENV_DIR}/bin/activate"
 fi
 


### PR DESCRIPTION
Fix a bug where nightly e2e tests are unable to create a virtualenv. 

[Here's a nightly run (of just e2e and its dependencies) with the change](https://console.cloud.google.com/cloud-build/builds/cb8768c0-0e67-4196-b3ba-204fd0d73f7c?project=834911136599).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4857)
<!-- Reviewable:end -->
