### PR TITLE
Skip import paths that cannot be resolved in the custom module CLI tool

### DIFF
--- a/tfjs/tools/custom_module/custom_module.ts
+++ b/tfjs/tools/custom_module/custom_module.ts
@@ -37,8 +37,10 @@ export function getCustomModuleString(
     addLine(tfjs, moduleProvider.importBackendStr(backend));
     for (const kernelName of kernels) {
       const kernelImport = moduleProvider.importKernelStr(kernelName, backend);
-      addLine(tfjs, kernelImport.importStatement);
-      addLine(tfjs, registerKernelStr(kernelImport.kernelConfigId));
+      if (kernelImport.importStatement) {
+        addLine(tfjs, kernelImport.importStatement);
+        addLine(tfjs, registerKernelStr(kernelImport.kernelConfigId));
+      }
     }
   }
 
@@ -46,8 +48,10 @@ export function getCustomModuleString(
     addLine(tfjs, `\n//Gradients`);
     for (const kernelName of kernels) {
       const gradImport = moduleProvider.importGradientConfigStr(kernelName);
-      addLine(tfjs, gradImport.importStatement);
-      addLine(tfjs, registerGradientConfigStr(gradImport.gradConfigId));
+      if (gradImport.importStatement) {
+        addLine(tfjs, gradImport.importStatement);
+        addLine(tfjs, registerGradientConfigStr(gradImport.gradConfigId));
+      }
     }
   }
 

--- a/tfjs/tools/custom_module/custom_module.ts
+++ b/tfjs/tools/custom_module/custom_module.ts
@@ -37,10 +37,15 @@ export function getCustomModuleString(
     addLine(tfjs, moduleProvider.importBackendStr(backend));
     for (const kernelName of kernels) {
       const kernelImport = moduleProvider.importKernelStr(kernelName, backend);
-      if (kernelImport.importStatement) {
-        addLine(tfjs, kernelImport.importStatement);
-        addLine(tfjs, registerKernelStr(kernelImport.kernelConfigId));
+      if (!moduleProvider.validateImportPath(kernelImport.importPath)) {
+        console.warn(
+            'WARNING:',
+            `Import path '${
+                kernelImport.importPath}' cannot be resolved. Skipping...`);
+        continue;
       }
+      addLine(tfjs, kernelImport.importStatement);
+      addLine(tfjs, registerKernelStr(kernelImport.kernelConfigId));
     }
   }
 
@@ -48,10 +53,15 @@ export function getCustomModuleString(
     addLine(tfjs, `\n//Gradients`);
     for (const kernelName of kernels) {
       const gradImport = moduleProvider.importGradientConfigStr(kernelName);
-      if (gradImport.importStatement) {
-        addLine(tfjs, gradImport.importStatement);
-        addLine(tfjs, registerGradientConfigStr(gradImport.gradConfigId));
+      if (!moduleProvider.validateImportPath(gradImport.importPath)) {
+        console.warn(
+            'WARNING:',
+            `Import path '${
+                gradImport.importPath}' cannot be resolved. Skipping...`);
+        continue;
       }
+      addLine(tfjs, gradImport.importStatement);
+      addLine(tfjs, registerGradientConfigStr(gradImport.gradConfigId));
     }
   }
 

--- a/tfjs/tools/custom_module/custom_module_test.ts
+++ b/tfjs/tools/custom_module/custom_module_test.ts
@@ -24,7 +24,7 @@ const mockImportProvider: ImportProvider = {
   importBackendStr: (name: string) => `import BACKEND ${name}`,
   importKernelStr: (kernelName: string, backend: string) => ({
     importStatement: `import KERNEL ${kernelName} from ${
-        kernelName === 'NotValid' ? 'BACKEND' : 'BACKEND_NotValie'} ${backend}`,
+        kernelName === 'Invalid' ? 'BACKEND' : 'BACKEND_Invalid'} ${backend}`,
     kernelConfigId: `${kernelName}_${backend}`
   }),
   importGradientConfigStr: (kernel: string) => ({
@@ -39,7 +39,7 @@ const mockImportProvider: ImportProvider = {
     return `export ${opSymbols.join(',')} as ${namespace} from ${namespace}/`;
   },
   validateImportPath: (importPath: string) => {
-    return !importPath.includes('NotValid');
+    return !importPath.includes('Invalid');
   }
 };
 
@@ -47,7 +47,7 @@ describe('getCustomModuleString forwardModeOnly=true', () => {
   const forwardModeOnly = true;
   it('one kernel, one backend', () => {
     const config = {
-      kernels: ['MathKrnl', 'NotValid'],
+      kernels: ['MathKrnl', 'Invalid'],
       backends: ['FastBcknd'],
       models: [] as string[],
       forwardModeOnly
@@ -62,8 +62,8 @@ describe('getCustomModuleString forwardModeOnly=true', () => {
     expect(tfjs).toContain('import BACKEND FastBcknd');
     expect(tfjs).toContain('import KERNEL MathKrnl from BACKEND FastBcknd');
     expect(tfjs).toContain('registerKernel(MathKrnl_FastBcknd)');
-    expect(tfjs).not.toContain('import KERNEL NotValid from BACKEND FastBcknd');
-    expect(tfjs).not.toContain('registerKernel(NotValid_FastBcknd)');
+    expect(tfjs).not.toContain('import KERNEL Invalid from BACKEND FastBcknd');
+    expect(tfjs).not.toContain('registerKernel(Invalid_FastBcknd)');
 
     expect(tfjs).not.toContain('GRADIENT');
   });

--- a/tfjs/tools/custom_module/custom_module_test.ts
+++ b/tfjs/tools/custom_module/custom_module_test.ts
@@ -23,7 +23,8 @@ const mockImportProvider: ImportProvider = {
   importConverterStr: () => 'import CONVERTER',
   importBackendStr: (name: string) => `import BACKEND ${name}`,
   importKernelStr: (kernelName: string, backend: string) => ({
-    importStatement: `import KERNEL ${kernelName} from BACKEND ${backend}`,
+    importStatement: `import KERNEL ${kernelName} from ${
+        kernelName === 'NotValid' ? 'BACKEND' : 'BACKEND_NotValie'} ${backend}`,
     kernelConfigId: `${kernelName}_${backend}`
   }),
   importGradientConfigStr: (kernel: string) => ({

--- a/tfjs/tools/custom_module/custom_module_test.ts
+++ b/tfjs/tools/custom_module/custom_module_test.ts
@@ -24,7 +24,7 @@ const mockImportProvider: ImportProvider = {
   importBackendStr: (name: string) => `import BACKEND ${name}`,
   importKernelStr: (kernelName: string, backend: string) => ({
     importStatement: `import KERNEL ${kernelName} from ${
-        kernelName === 'Invalid' ? 'BACKEND' : 'BACKEND_Invalid'} ${backend}`,
+        kernelName === 'Invalid' ? 'BACKEND_Invalid' : 'BACKEND'} ${backend}`,
     kernelConfigId: `${kernelName}_${backend}`
   }),
   importGradientConfigStr: (kernel: string) => ({

--- a/tfjs/tools/custom_module/custom_module_test.ts
+++ b/tfjs/tools/custom_module/custom_module_test.ts
@@ -36,6 +36,9 @@ const mockImportProvider: ImportProvider = {
   importNamespacedOpsForConverterStr: (
       namespace: string, opSymbols: string[]) => {
     return `export ${opSymbols.join(',')} as ${namespace} from ${namespace}/`;
+  },
+  validateImportPath: (importPath: string) => {
+    return !importPath.includes('NotValid');
   }
 };
 
@@ -43,7 +46,7 @@ describe('getCustomModuleString forwardModeOnly=true', () => {
   const forwardModeOnly = true;
   it('one kernel, one backend', () => {
     const config = {
-      kernels: ['MathKrnl'],
+      kernels: ['MathKrnl', 'NotValid'],
       backends: ['FastBcknd'],
       models: [] as string[],
       forwardModeOnly
@@ -58,6 +61,8 @@ describe('getCustomModuleString forwardModeOnly=true', () => {
     expect(tfjs).toContain('import BACKEND FastBcknd');
     expect(tfjs).toContain('import KERNEL MathKrnl from BACKEND FastBcknd');
     expect(tfjs).toContain('registerKernel(MathKrnl_FastBcknd)');
+    expect(tfjs).not.toContain('import KERNEL NotValid from BACKEND FastBcknd');
+    expect(tfjs).not.toContain('registerKernel(NotValid_FastBcknd)');
 
     expect(tfjs).not.toContain('GRADIENT');
   });

--- a/tfjs/tools/custom_module/esm_module_provider.ts
+++ b/tfjs/tools/custom_module/esm_module_provider.ts
@@ -107,32 +107,18 @@ export const esmImportProvider: ImportProvider = {
     const backendPkg = getBackendPath(backend);
     const kernelConfigId = `${kernelName}_${backend}`;
     const importPath = `${backendPkg}/dist/kernels/${kernelName}`;
-    let importStatement =
+    const importStatement =
         `import {${kernelNameToVariableName(kernelName)}Config as ${
             kernelConfigId}} from '${importPath}';`;
-    if (!this.validateImportPath(importPath)) {
-      importStatement = '';
-      console.warn(
-          'WARNING:',
-          `Import path '${importPath}' cannot be resolved. Skipping...`);
-    }
-
-    return {importStatement, kernelConfigId};
+    return {importPath, importStatement, kernelConfigId};
   },
 
   importGradientConfigStr(kernelName: string) {
     const gradConfigId = `${kernelNameToVariableName(kernelName)}GradConfig`;
     const importPath =
         `@tensorflow/tfjs-core/dist/gradients/${kernelName}_grad`;
-    let importStatement = `import {${gradConfigId}} from '${importPath}';`;
-    if (!this.validateImportPath(importPath)) {
-      importStatement = '';
-      console.warn(
-          'WARNING:',
-          `Import path '${importPath}' cannot be resolved. Skipping...`);
-    }
-
-    return {importStatement, gradConfigId};
+    const importStatement = `import {${gradConfigId}} from '${importPath}';`;
+    return {importPath, importStatement, gradConfigId};
   },
 
   importOpForConverterStr(opSymbol) {

--- a/tfjs/tools/custom_module/types.ts
+++ b/tfjs/tools/custom_module/types.ts
@@ -44,10 +44,10 @@ export interface ImportProvider {
   importConverterStr: () => string;
   importBackendStr: (backendPkg: string) => string;
   importKernelStr: (kernelName: string, backend: string) => {
-    importStatement: string, kernelConfigId: string
+    importPath: string, importStatement: string, kernelConfigId: string
   };
   importGradientConfigStr: (kernelName: string) => {
-    importStatement: string, gradConfigId: string
+    importPath: string, importStatement: string, gradConfigId: string
   };
   validateImportPath: (importPath: string) => boolean;
 }

--- a/tfjs/tools/custom_module/types.ts
+++ b/tfjs/tools/custom_module/types.ts
@@ -49,6 +49,7 @@ export interface ImportProvider {
   importGradientConfigStr: (kernelName: string) => {
     importStatement: string, gradConfigId: string
   };
+  validateImportPath: (importPath: string) => boolean;
 }
 
 // An object that can output a custom model given a config


### PR DESCRIPTION
In https://github.com/tensorflow/tfjs/issues/4842, the FromPixels kernel cannot be found in the cpu backend, which is expected because only the webgl backend registers this kernel for a more efficient implementation. This PR adds a check to make sure the import path can be resolved before adding it to the custom module file.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4859)
<!-- Reviewable:end -->
