### PR TITLE
[webgl]Remove cpu backend warning.

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -141,7 +141,6 @@ export class MathBackendWebGL extends KernelBackend {
   private gpgpuCreatedLocally: boolean;
   private numMBBeforeWarning: number;
   private warnedAboutMemory = false;
-  private warnedAboutCPUBackend = false;
 
   constructor(gpgpu?: GPGPUContext) {
     super();
@@ -623,18 +622,6 @@ export class MathBackendWebGL extends KernelBackend {
     return this.texData.get(dataId);
   }
 
-  private getCPUBackend(): KernelBackend|null {
-    if (!env().getBool('WEBGL_CPU_FORWARD')) {
-      return null;
-    }
-
-    if (this.cpuBackend == null) {
-      this.cpuBackend = engine().findBackend('cpu');
-    }
-
-    return this.cpuBackend;
-  }
-
   /*
   Tests whether all the inputs to an op are small and on the CPU. This heuristic
   determines when it would be faster to execute a kernel on the CPU. WebGL
@@ -645,19 +632,7 @@ export class MathBackendWebGL extends KernelBackend {
   shouldExecuteOnCPU(
       inputs: TensorInfo[],
       sizeThreshold = CPU_HANDOFF_SIZE_THRESHOLD): boolean {
-    const cpuBackend = this.getCPUBackend();
-    if (!env().getBool('IS_TEST') && !this.warnedAboutCPUBackend &&
-        cpuBackend == null) {
-      console.warn(
-          'Your application contains ops that are small enough to be ' +
-          'executed on the CPU backend, however the CPU backend cannot ' +
-          'be found. Consider importing the CPU backend ' +
-          '(@tensorflow/tfjs-backend-cpu) for better performance.');
-
-      this.warnedAboutCPUBackend = true;
-    }
-
-    return cpuBackend != null &&
+    return env().getBool('WEBGL_CPU_FORWARD') &&
         inputs.every(
             input => this.texData.get(input.dataId).texture == null &&
                 util.sizeFromShape(input.shape) < sizeThreshold);


### PR DESCRIPTION
After modularization, we no longer forward small tensors to cpu backend, instead, we import cpu impls to each backend. This change removes the warning to register cpu backend, and also changes the logic to not checking cpu backend availability. Instead, the logic is only based on cpu_forward flag and tensor states.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4908)
<!-- Reviewable:end -->
