### PR TITLE
e2e: add webgpu backend to E2E benchmarks

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -434,7 +434,8 @@ const TUNABLE_FLAG_VALUE_RANGE_MAP = {
   WEBGL_PACK: [true, false],
   WEBGL_FORCE_F16_TEXTURES: [true, false],
   WEBGL_RENDER_FLOAT32_CAPABLE: [true, false],
-  WEBGL_FLUSH_THRESHOLD: [-1, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2]
+  WEBGL_FLUSH_THRESHOLD: [-1, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+  WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE: [1, 5, 10, 15, 20, 25, 30, 35, 40]
 };
 
 /**
@@ -475,9 +476,8 @@ async function setEnvFlags(flagConfig) {
               TUNABLE_FLAG_VALUE_RANGE_MAP[flag]}], while ${flagConfig[flag]}` +
           ' is found.');
     }
+    tf.env().set(flag, flagConfig[flag]);
   }
-
-  tf.env().setFlags(flagConfig);
 
   // `WASM_HAS_SIMD_SUPPORT` and `WEBGL_VERSION` are also evaluated when
   // initializing backends, not only inferring.

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -98,6 +98,7 @@ limitations under the License.
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/posenet@2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/body-pix@2"></script>
 
+  <script src="../../../tfjs-backend-webgpu/dist/tf-backend-webgpu.js"></script>
   <script src="../model_config.js"></script>
   <script src="../benchmark_util.js"></script>
   <script src="./util.js"></script>
@@ -613,6 +614,7 @@ limitations under the License.
     }
 
     async function runBenchmark() {
+      await tf.ready();
       if (state.isFlagChanged) {
         await setEnvFlags(state.flags);
         envDiv.innerHTML = '';
@@ -633,11 +635,8 @@ limitations under the License.
       await showBenchmarkingParameters();
 
       await warmUpAndRecordTime();
-      await showMsg('Waiting for GC');
-      await sleep(1000);
-      await profileMemoryAndKernelTime();
-      await sleep(200);
       await measureAveragePredictTime();
+      await profileMemoryAndKernelTime();
       urlState = null;
     }
 
@@ -781,7 +780,7 @@ limitations under the License.
       modelParameterFolder.open();
 
       const envFolder = gui.addFolder('Environment');
-      backendsController = envFolder.add(state, 'backend', ['wasm', 'webgl', 'cpu']);
+      backendsController = envFolder.add(state, 'backend', ['wasm', 'webgl', 'cpu', 'webgpu']);
       backendsController.onChange(async backend => {
         // TODO: Failed to set backend
         await tf.setBackend(backend);

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -23,7 +23,8 @@ const BACKEND_FLAGS_MAP = {
     'WEBGL_VERSION', 'WEBGL_CPU_FORWARD', 'WEBGL_PACK',
     'WEBGL_FORCE_F16_TEXTURES', 'WEBGL_RENDER_FLOAT32_CAPABLE',
     'WEBGL_FLUSH_THRESHOLD'
-  ]
+  ],
+  webgpu: ['WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE']
 };
 const TUNABLE_FLAG_NAME_MAP = {
   PROD: 'production mode',
@@ -34,7 +35,8 @@ const TUNABLE_FLAG_NAME_MAP = {
   WEBGL_PACK: 'webgl pack',
   WEBGL_FORCE_F16_TEXTURES: 'enforce float16',
   WEBGL_RENDER_FLOAT32_CAPABLE: 'enable float32',
-  WEBGL_FLUSH_THRESHOLD: 'GL flush wait time(ms)'
+  WEBGL_FLUSH_THRESHOLD: 'GL flush wait time(ms)',
+  WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE: 'deferred submit batch size'
 };
 
 /**


### PR DESCRIPTION
Use env().set instead of env().setFlags

Add flag WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE

Adjust the warmup sequence to get more accurate profiling time

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4913)
<!-- Reviewable:end -->
