### PR TITLE
[core] Fix a bug in einsum kernels

### DIFF
--- a/tfjs-backend-cpu/src/kernels/Einsum.ts
+++ b/tfjs-backend-cpu/src/kernels/Einsum.ts
@@ -70,11 +70,12 @@ export function einsum(
     }
     if (i < nSteps - 1) {
       if (path[i] >= 0) {
+        const sumAxis = path[i] - (allDims.length - numDimsRemaining);
         out = sum({
           inputs: {x: out},
           backend,
           attrs: {
-            axis: path[i] < out.shape.length ? path[i] : undefined,
+            axis: sumAxis,
             keepDims: false
           }
         });

--- a/tfjs-backend-cpu/src/kernels/Einsum.ts
+++ b/tfjs-backend-cpu/src/kernels/Einsum.ts
@@ -70,12 +70,11 @@ export function einsum(
     }
     if (i < nSteps - 1) {
       if (path[i] >= 0) {
-        const sumAxis = path[i] - (allDims.length - numDimsRemaining);
         out = sum({
           inputs: {x: out},
           backend,
           attrs: {
-            axis: sumAxis,
+            axis: path[i] - (allDims.length - numDimsRemaining),
             keepDims: false
           }
         });

--- a/tfjs-backend-webgl/src/kernels/Einsum.ts
+++ b/tfjs-backend-webgl/src/kernels/Einsum.ts
@@ -71,11 +71,12 @@ export function einsum(
     }
     if (i < nSteps - 1) {
       if (path[i] >= 0) {
+        const sumAxis = path[i] - (allDims.length - numDimsRemaining);
         out = sum({
           inputs: {x: out},
           backend,
           attrs: {
-            axis: path[i] < out.shape.length ? path[i] : undefined,
+            axis: sumAxis,
             keepDims: false
           }
         });

--- a/tfjs-backend-webgl/src/kernels/Einsum.ts
+++ b/tfjs-backend-webgl/src/kernels/Einsum.ts
@@ -71,12 +71,11 @@ export function einsum(
     }
     if (i < nSteps - 1) {
       if (path[i] >= 0) {
-        const sumAxis = path[i] - (allDims.length - numDimsRemaining);
         out = sum({
           inputs: {x: out},
           backend,
           attrs: {
-            axis: sumAxis,
+            axis: path[i] - (allDims.length - numDimsRemaining),
             keepDims: false
           }
         });

--- a/tfjs-core/src/backends/einsum_util.ts
+++ b/tfjs-core/src/backends/einsum_util.ts
@@ -108,11 +108,6 @@ export function decodeEinsumEquation(equation: string, numTensors: number): {
   for (let i = numOutDims; i < numDims; ++i) {
     summedDims.push(i);
   }
-  if (numInputs > 1 && summedDims.length > 1) {
-    throw new Error(
-        'Summation over >1 axes is not implemented for ' +
-        '>1 input tensors yet.');
-  }
   return {allDims, summedDims, idDims};
 }
 

--- a/tfjs-core/src/ops/einsum.ts
+++ b/tfjs-core/src/ops/einsum.ts
@@ -90,7 +90,6 @@ import {op} from './operation';
  * - Does not support >2 input tensors.
  * - Does not support duplicate axes for any given input tensor. E.g., equation
  *   'ii->' is not suppoted.
- * - For two or more input tensors, up to only one summation axis is supported.
  * - The `...` notation is not supported.
  *
  * @param equation a string describing the contraction, in the same format as


### PR DESCRIPTION
- Allow summing over more than 1 dimension for two tensors.
  Achieved by using the correct axis for sum().

Fixes #2349 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4915)
<!-- Reviewable:end -->
