### PR TITLE
Address mutability edge case in tf.Tensor docs

### DIFF
--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -236,6 +236,12 @@ export declare namespace Tensor {}
  * A `tf.Tensor` object represents an immutable, multidimensional array of
  * numbers that has a shape and a data type.
  *
+ * For performance reasons, functions that create tensors do not necessarily
+ * perform a copy of the data passed to them (e.g. if the data is passed as a
+ * `Float32Array`), and changes to that data will change the tensor. This is not
+ * a feature and is not supported. To avoid this behavior, use the tensor before
+ * changing the input data or manually copy it with `tf.add(yourTensor, 0)`.
+ *
  * See `tf.tensor` for details on how to create a `tf.Tensor`.
  *
  * @doc {heading: 'Tensors', subheading: 'Classes'}

--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -240,7 +240,7 @@ export declare namespace Tensor {}
  * perform a copy of the data passed to them (e.g. if the data is passed as a
  * `Float32Array`), and changes to that data will change the tensor. This is not
  * a feature and is not supported. To avoid this behavior, use the tensor before
- * changing the input data or manually copy it with `tf.add(yourTensor, 0)`.
+ * changing the input data or create a copy with `copy = tf.add(yourTensor, 0)`.
  *
  * See `tf.tensor` for details on how to create a `tf.Tensor`.
  *

--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -238,7 +238,7 @@ export declare namespace Tensor {}
  *
  * For performance reasons, functions that create tensors do not necessarily
  * perform a copy of the data passed to them (e.g. if the data is passed as a
- * `Float32Array`), and changes to that data will change the tensor. This is not
+ * `Float32Array`), and changes to the data will change the tensor. This is not
  * a feature and is not supported. To avoid this behavior, use the tensor before
  * changing the input data or create a copy with `copy = tf.add(yourTensor, 0)`.
  *


### PR DESCRIPTION
Tensors are meant to be immutable, but for performance reasons, we don't always copy the data used to create them. If that underlying data is changed the tensor will be changed as well. This PR updates the docs to reflect this limitation.

Closes #4905 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4916)
<!-- Reviewable:end -->
