### PR TITLE
Add missing headings to core operations docs

### DIFF
--- a/tfjs-core/src/ops/diag.ts
+++ b/tfjs-core/src/ops/diag.ts
@@ -43,6 +43,8 @@ import {op} from './operation';
  * tf.diag(x).print()
  * ```
  * @param x The input tensor.
+ *
+ * @doc {heading: 'Tensors', subheading: 'Creation'}
  */
 function diag_(x: Tensor): Tensor {
   const $x = convertToTensor(x, 'x', 'diag');

--- a/tfjs-core/src/ops/rand.ts
+++ b/tfjs-core/src/ops/rand.ts
@@ -30,6 +30,8 @@ import {op} from './operation';
  * @param randFunction A random number generator function which is called
  * for each element in the output tensor.
  * @param dtype The data type of the output tensor. Defaults to 'float32'.
+ *
+ * @doc {heading: 'Tensors', subheading: 'Random'}
  */
 function rand_<R extends Rank>(
     shape: ShapeMap[R], randFunction: () => number,


### PR DESCRIPTION
These two operations were missing from the [latest API docs](https://js.tensorflow.org/api/latest/) because they were missing an `@doc` annotation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4938)
<!-- Reviewable:end -->
