### PR TITLE
webgpu: Use uniforms for PadV2 paddings

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/PadV2.ts
+++ b/tfjs-backend-webgpu/src/kernels/PadV2.ts
@@ -15,21 +15,27 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, PadV2, PadV2Attrs, PadV2Inputs, TensorInfo} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, PadV2, PadV2Attrs, PadV2Inputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
+import {identity} from './Identity';
 import {PadProgram} from './pad_webgpu';
 
 export const padV2 =
-    (args: {inputs: PadV2Inputs, backend: WebGPUBackend, attrs: PadV2Attrs}):
-        TensorInfo => {
-          const {inputs, backend, attrs} = args;
-          const {x} = inputs;
-          const {paddings, constantValue} = attrs;
-          const uniformData = [{type: 'float32', data: [constantValue]}];
-          const program = new PadProgram(x.shape, paddings);
-          return backend.runWebGPUProgram(program, [x], x.dtype, uniformData);
-        };
+    (args: {inputs: PadV2Inputs,
+            backend: WebGPUBackend,
+            attrs: PadV2Attrs}): TensorInfo => {
+      const {inputs, backend, attrs} = args;
+      const {x} = inputs;
+      const {paddings, constantValue} = attrs;
+      if (paddings.every(p => util.arraysEqual(p, [0, 0]))) {
+        return identity({inputs: {x}, backend});
+      }
+      const uniformData = [{type: 'float32', data: [constantValue]}];
+      paddings.map(p => uniformData.push({type: 'int32', data: [p[0], p[1]]}));
+      const program = new PadProgram(x.shape, paddings);
+      return backend.runWebGPUProgram(program, [x], x.dtype, uniformData);
+    };
 
 export const padV2Config: KernelConfig = {
   kernelName: PadV2,

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -42,19 +42,21 @@ export class PadProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
-
+    paddings.map((_, i) => this.uniforms += ` ivec2 pad${i};`);
     this.xShape = xShape;
     this.paddings = paddings;
-    // xShape is used by const start and end.
-    this.shaderKey = `pad_${paddings}_${xShape}`;
+    this.shaderKey = 'pad';
     this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const rank = this.xShape.length;
     const type = getCoordsDataType(rank);
-    const start = this.paddings.map(p => p[0]).join(',');
-    const end = this.paddings.map((p, i) => p[0] + this.xShape[i]).join(',');
+    const start = this.paddings.map((_, i) => `pad${i}[0]`).join(',');
+    const end =
+        this.paddings
+            .map((_, i) => `pad${i}[0] + xShape${rank > 1 ? `[${i}]` : ''}`)
+            .join(',');
     const startValue = rank > 1 ? `${type}(${start})` : `${start}`;
     const endValue = rank > 1 ? `${type}(${end})` : `${end}`;
 

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -32,7 +32,6 @@ export class PadProgram implements WebGPUProgram {
   workPerThread = 8;
   workGroupSize: [number, number, number] = [16, 1, 1];
   xShape: number[];
-  paddings: Array<[number, number]>;
   size: number;
 
   constructor(xShape: number[], paddings: Array<[number, number]>) {
@@ -44,7 +43,6 @@ export class PadProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
     paddings.map((_, i) => this.uniforms += ` ivec2 pad${i};`);
     this.xShape = xShape;
-    this.paddings = paddings;
     this.shaderKey = 'pad';
     this.size = util.sizeFromShape(this.outputShape);
   }
@@ -52,9 +50,10 @@ export class PadProgram implements WebGPUProgram {
   getUserCode(): string {
     const rank = this.xShape.length;
     const type = getCoordsDataType(rank);
-    const start = this.paddings.map((_, i) => `pad${i}[0]`).join(',');
+    // The length of paddings are same with the rank of the input tensor.
+    const start = this.xShape.map((_, i) => `pad${i}[0]`).join(',');
     const end =
-        this.paddings
+        this.xShape
             .map((_, i) => `pad${i}[0] + xShape${rank > 1 ? `[${i}]` : ''}`)
             .join(',');
     const startValue = rank > 1 ? `${type}(${start})` : `${start}`;


### PR DESCRIPTION
This PR uses uniforms for PadV2 paddings. Meanwhile, it does a small
optimization to directly return the identity of the input if all
paddings are zero.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4966)
<!-- Reviewable:end -->
