### PR TITLE
Remove Emscripten toolchain setup from release script

### DIFF
--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -88,27 +88,13 @@ async function main() {
       $('yarn prep-gpu');
     }
 
-    // tfjs-backend-wasm needs emsdk to build.
-    if (pkg === 'tfjs-backend-wasm') {
-      shell.cd('..');
-      $('git clone https://github.com/emscripten-core/emsdk.git');
-      shell.cd('./emsdk');
-      $('./emsdk install 2.0.14');
-      $('./emsdk activate 2.0.14');
-      shell.cd('..');
-      shell.cd(pkg);
-    }
-
     // Yarn above the other checks to make sure yarn doesn't change the lock
     // file.
     $('yarn');
 
     console.log(chalk.magenta('~~~ Build npm ~~~'));
 
-    if (pkg === 'tfjs-backend-wasm') {
-      // tfjs-backend-wasm needs emsdk env variables to build.
-      $('source ../emsdk/emsdk_env.sh && yarn build-npm for-publish');
-    } else if (pkg === 'tfjs-react-native') {
+    if (pkg === 'tfjs-react-native') {
       $('yarn build-npm');
     } else {
       $('yarn build-npm for-publish');


### PR DESCRIPTION
The Emscripten toolchain is now managed by Bazel, so it doesn't need to be manually installed for a release.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4969)
<!-- Reviewable:end -->
