### PR TITLE
fixed wasm conv2d backprop error when strides is greater than 1

### DIFF
--- a/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <iostream>
 #include <vector>
 #include "tfjs-backend-wasm/src/cc/backend.h"
 
@@ -52,31 +53,33 @@ void Conv2DBackpropInput(
   for (size_t b = 0; b < batch_size; ++b) {
     for (size_t d1 = 0; d1 < in_channels; ++d1) {
       for (size_t xr = 0; xr < in_height; ++xr) {
-        size_t xr_corner = xr - top_pad;
-        int stride_height_multiples = ceil(xr_corner / stride_height);
-        size_t xr_min = std::max(0, stride_height_multiples);
-        size_t yr_max =
-            std::min(out_height, (filter_height + xr_corner) / stride_height);
-
+        int xr_corner = xr - top_pad;
+        float stride_height_multiples =
+            ceil(xr_corner / static_cast<int>(stride_height));
+        float xr_min = std::max(0.0f, stride_height_multiples);
+        float yr_max = std::min(static_cast<float>(out_height),
+                                static_cast<float>(filter_height + xr_corner) /
+                                    static_cast<float>(stride_height));
         for (size_t xc = 0; xc < in_width; ++xc) {
-          size_t xc_corner = xc - left_pad;
-          int stride_width_multiples = ceil(xc_corner / stride_width);
-          size_t xC_min = std::max(0, stride_width_multiples);
-          size_t yC_max =
-              std::min(out_width, (filter_width + xc_corner) / stride_width);
+          int xc_corner = xc - left_pad;
+          float stride_width_multiples = ceil(static_cast<float>(xc_corner) /
+                                              static_cast<float>(stride_width));
+          float xc_min = std::max(0.0f, stride_width_multiples);
+          float yc_max = std::min(static_cast<float>(out_width),
+                                  static_cast<float>(filter_width + xc_corner) /
+                                      static_cast<float>(stride_width));
 
           float dot_prod = 0.0;
           for (size_t yr = xr_min; yr < yr_max; ++yr) {
-            size_t wr = yr * stride_height - xr_corner;
+            int wr = yr * stride_height - xr_corner;
 
-            for (size_t yc = xC_min; yc < yC_max; ++yc) {
-              size_t wc = yc * stride_width - xc_corner;
+            for (size_t yc = xc_min; yc < yc_max; ++yc) {
+              int wc = yc * stride_width - xc_corner;
               size_t dy_offset =
                   y_batch_stride * b + y_row_stride * yr + y_col_stride * yc;
               size_t flt_offset = flt_s0 * (filter_height - 1 - wr) +
                                   flt_s1 * (filter_width - 1 - wc) +
                                   flt_s2 * d1;
-
               for (size_t d2 = 0; d2 < out_channels; ++d2) {
                 float pixel = dy_buf[dy_offset + y_channel_stride * d2];
                 float weight = filter_buf[flt_offset + d2];

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
@@ -52,15 +52,15 @@ void Conv2DBackpropInput(
   for (size_t b = 0; b < batch_size; ++b) {
     for (size_t d1 = 0; d1 < in_channels; ++d1) {
       for (size_t xr = 0; xr < in_height; ++xr) {
-        int xr_corner = xr - top_pad;
-        float stride_height_multiples =
-            ceil(xr_corner / static_cast<int>(stride_height));
+        int32_t xr_corner = xr - top_pad;
+        float stride_height_multiples = ceil(static_cast<float>(xr_corner) /
+                                             static_cast<float>(stride_height));
         float xr_min = std::max(0.0f, stride_height_multiples);
         float yr_max = std::min(static_cast<float>(out_height),
                                 static_cast<float>(filter_height + xr_corner) /
                                     static_cast<float>(stride_height));
         for (size_t xc = 0; xc < in_width; ++xc) {
-          int xc_corner = xc - left_pad;
+          int32_t xc_corner = xc - left_pad;
           float stride_width_multiples = ceil(static_cast<float>(xc_corner) /
                                               static_cast<float>(stride_width));
           float xc_min = std::max(0.0f, stride_width_multiples);

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
@@ -18,7 +18,6 @@
 
 #include <cmath>
 #include <cstddef>
-#include <iostream>
 #include <vector>
 #include "tfjs-backend-wasm/src/cc/backend.h"
 

--- a/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
@@ -70,10 +70,10 @@ void Conv2DBackpropInput(
 
           float dot_prod = 0.0;
           for (size_t yr = xr_min; yr < yr_max; ++yr) {
-            int wr = yr * stride_height - xr_corner;
+            int32_t wr = yr * stride_height - xr_corner;
 
             for (size_t yc = xc_min; yc < yc_max; ++yc) {
-              int wc = yc * stride_width - xc_corner;
+              int32_t wc = yc * stride_width - xc_corner;
               size_t dy_offset =
                   y_batch_stride * b + y_row_stride * yr + y_col_stride * yc;
               size_t flt_offset = flt_s0 * (filter_height - 1 - wr) +

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -133,6 +133,7 @@ const TEST_FILTERS: TestFilter[] = [
       'prelu bias stride 2 x=[1,8,8,16] f=[3,3,16,1] s=[2,2] d=8 p=same',
     ]
   },
+  {include: 'conv2dTranspose ', excludes: ['gradient']},
   {
     include: 'prelu ',
     excludes: [

--- a/tfjs-core/src/ops/conv2d_transpose_test.ts
+++ b/tfjs-core/src/ops/conv2d_transpose_test.ts
@@ -40,6 +40,32 @@ describeWithFlags('conv2dTranspose', ALL_ENVS, () => {
     expectArraysClose(await result.data(), expected);
   });
 
+  it('input=3x3x1,d2=1,f=3,s=2,p=0', async () => {
+    const origInputDepth = 1;
+    const origOutputDepth = 4;
+    const inputShape: [number, number, number, number] =
+        [1, 2, 2, origOutputDepth];
+    const fSize = 2;
+    const origPad = 'same';
+    const origStride = 2;
+
+    const x = tf.tensor4d(
+        [
+          124., 166., 90., 139., 16., 27., 42., 61., 4., 17., 34., 28., 0., 6.,
+          14., 24.
+        ],
+        inputShape);
+    const w = tf.tensor4d(
+        [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.],
+        [fSize, fSize, origInputDepth, origOutputDepth]);
+
+    const result = tf.conv2dTranspose(x, w, [1, 3, 3, 1], origStride, origPad);
+    const expected = [763., 2839., 294., 4915., 6991., 1462., 169., 501., 106.];
+
+    expect(result.shape).toEqual([1, 3, 3, 1]);
+    expectArraysClose(await result.data(), expected);
+  });
+
   it('input=2x2x1,d2=1,f=2,s=1,p=0, batch=2', async () => {
     const origInputDepth = 1;
     const origOutputDepth = 1;


### PR DESCRIPTION
Fixed https://github.com/tensorflow/tfjs/issues/4892

The problem is related size_t can hold negative number and the convolution range needs to be float point when stride is not 1.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4981)
<!-- Reviewable:end -->
