### PR TITLE
[Converter] removed h5py direct deps to rely on TF

### DIFF
--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow>=2.1.0,<3
-h5py>=2.8.0,<3
+h5py>=2.8.0,<4
 six>=1.12.0,<2
 tensorflow-hub>=0.7.0,<0.10

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,4 +1,3 @@
 tensorflow>=2.1.0,<3
-h5py>=2.8.0,<4
 six>=1.12.0,<2
 tensorflow-hub>=0.7.0,<0.10


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/4997)
<!-- Reviewable:end -->
