### PR TITLE
[webgpu] Reuse GPUBindGroupLayout and GPUPipelineLayout

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -27,13 +27,17 @@ import {BinaryOpType, getBinaryOpString} from './kernels/binary_ops';
 import {FromPixelsProgram} from './kernels/FromPixels_utils/from_pixels_webgpu';
 import * as unary_op from './kernels/unary_op_webgpu';
 import * as webgpu_program from './kernels/webgpu_program';
-import {WebGPUBinary} from './kernels/webgpu_program';
 import * as webgpu_util from './webgpu_util';
 
 export interface WebGPUMemoryInfo extends backend_util.MemoryInfo {
   numBytesInGPU: number;
   numBytesAllocatedInGPU: number;
   unreliable: boolean;
+}
+
+interface WebGPULayout {
+  bindGroupLayout: GPUBindGroupLayout;
+  pipelineLayout: GPUPipelineLayout;
 }
 
 type BufferInfo = {
@@ -80,6 +84,7 @@ export class WebGPUBackend extends KernelBackend {
   currentCommandEncoder: GPUCommandEncoder;
   tensorMap: DataStorage<TensorBufferInfo>;
   fromPixelProgram: FromPixelsProgram;
+  fromPixelLayout: WebGPULayout;
   supportTimeQuery: boolean;
 
   private static nextDataId = 0;
@@ -87,7 +92,8 @@ export class WebGPUBackend extends KernelBackend {
     return WebGPUBackend.nextDataId++;
   }
   private commandQueueOwnedIds = new WeakSet<DataId>();
-  private binaryCache: {[key: string]: WebGPUBinary};
+  private layoutCache: {[key: number]: WebGPULayout};
+  private pipelineCache: {[key: string]: GPUComputePipeline};
   private bufferManager: BufferManager;
 
   private tensorDisposalQueue: DataId[] = [];
@@ -105,7 +111,8 @@ export class WebGPUBackend extends KernelBackend {
 
   constructor(device: GPUDevice, glslang: Glslang, supportTimeQuery = false) {
     super();
-    this.binaryCache = {};
+    this.layoutCache = {};
+    this.pipelineCache = {};
     this.device = device;
     this.queue = device.queue;
     this.currentCommandEncoder = null;
@@ -120,6 +127,8 @@ export class WebGPUBackend extends KernelBackend {
         count: 2,
       });
     }
+    // FromPixel has only one input texture.
+    this.fromPixelLayout = this.createTextureLayout();
   }
 
   floatPrecision(): 32 {
@@ -415,12 +424,11 @@ export class WebGPUBackend extends KernelBackend {
     return res;
   }
 
-  getAndSavePipeline(
-      key: string, getBinary: () => webgpu_program.WebGPUBinary) {
-    if (!(key in this.binaryCache)) {
-      this.binaryCache[key] = getBinary();
+  getAndSavePipeline(key: string, getPipeline: () => GPUComputePipeline) {
+    if (!(key in this.pipelineCache)) {
+      this.pipelineCache[key] = getPipeline();
     }
-    return this.binaryCache[key];
+    return this.pipelineCache[key];
   }
 
   makeTensorInfo(
@@ -570,6 +578,74 @@ export class WebGPUBackend extends KernelBackend {
     return this.arrayToDataView(dimUniformsData, dataViewIndex);
   }
 
+  // This layout is used by all programs except fromPixel.
+  private createLayout(inputEntrySize: number): WebGPULayout {
+    const bindGroupLayoutEntries: GPUBindGroupLayoutEntry[] = [];
+    // Output buffer binding layout.
+    bindGroupLayoutEntries.push({
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      type: 'storage-buffer'
+    });
+    // Input buffer binding layout. Depends on variableNames length.
+    for (let i = 0; i < inputEntrySize; i++) {
+      bindGroupLayoutEntries.push({
+        binding: i + 1,
+        visibility: GPUShaderStage.COMPUTE,
+        type: 'readonly-storage-buffer'
+      });
+    }
+    bindGroupLayoutEntries.push({
+      binding: inputEntrySize + 1,
+      visibility: GPUShaderStage.COMPUTE,
+      type: 'uniform-buffer'
+    });
+    const bindGroupLayout =
+        this.device.createBindGroupLayout({entries: bindGroupLayoutEntries});
+    const pipelineLayout =
+        this.device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});
+    return {bindGroupLayout, pipelineLayout};
+  }
+
+  // This layout is only used by fromPixel.
+  private createTextureLayout(): WebGPULayout {
+    const bindGroupLayoutEntries: GPUBindGroupLayoutEntry[] = [];
+    // Output buffer binding layout.
+    bindGroupLayoutEntries.push({
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      type: 'storage-buffer'
+    });
+    // Input buffer binding layout.
+    bindGroupLayoutEntries.push({
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE,
+      type: 'readonly-storage-texture',
+      storageTextureFormat: 'rgba8unorm'
+    });
+    // Uniform buffer binding layout.
+    bindGroupLayoutEntries.push({
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE,
+      type: 'uniform-buffer'
+    });
+    const fromPixelBindGroupLayout =
+        this.device.createBindGroupLayout({entries: bindGroupLayoutEntries});
+    const fromPixelPipelineLayout = this.device.createPipelineLayout(
+        {bindGroupLayouts: [fromPixelBindGroupLayout]});
+    return {
+      bindGroupLayout: fromPixelBindGroupLayout,
+      pipelineLayout: fromPixelPipelineLayout
+    };
+  }
+
+  private getCachedOrCreateLayout(inputEntrySize: number): WebGPULayout {
+    if (!(inputEntrySize in this.layoutCache)) {
+      this.layoutCache[inputEntrySize] = this.createLayout(inputEntrySize);
+    }
+    return this.layoutCache[inputEntrySize];
+  }
+
   public runWebGPUProgram(
       program: webgpu_program.WebGPUProgram, inputs: TensorInfo[],
       outputDtype: DataType,
@@ -623,9 +699,14 @@ export class WebGPUBackend extends KernelBackend {
     const broadcastDimsKey = broadcastDims.map(d => d.join('_')).join(';');
     const key = webgpu_program.makeShaderKey(
         program, bufferShapes, bufferTypes, broadcastDimsKey);
-    const {bindGroupLayout, pipeline} = this.getAndSavePipeline(key, () => {
+
+    const {bindGroupLayout, pipelineLayout} =
+        this.getCachedOrCreateLayout(program.variableNames.length);
+
+    const pipeline = this.getAndSavePipeline(key, () => {
       return webgpu_program.compileProgram(
-          this.glslang, this.device, program, inputsData, output);
+          this.glslang, this.device, program, pipelineLayout, inputsData,
+          output);
     });
 
     const shouldTimeProgram = this.activeTimers != null;
@@ -683,7 +764,7 @@ export class WebGPUBackend extends KernelBackend {
 
   recordFromPixelsCommands(output: GPUBuffer) {
     const bindGroup = this.device.createBindGroup({
-      layout: this.fromPixelProgram.bindGroupLayout,
+      layout: this.fromPixelLayout.bindGroupLayout,
       entries: [
         {
           binding: 0,

--- a/tfjs-backend-webgpu/src/kernels/FromPixelsImageBitmap.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixelsImageBitmap.ts
@@ -50,12 +50,13 @@ export function fromPixelsImageBitmap(args: {
   const key = webgpu_program.makeShaderKey(
       backend.fromPixelProgram, outputShapes, outputTypes);
 
-  const {bindGroupLayout, pipeline} = backend.getAndSavePipeline(key, () => {
+  const pipeline = backend.getAndSavePipeline(key, () => {
     return webgpu_program.compileProgram(
-        backend.glslang, backend.device, backend.fromPixelProgram, [], output,
-        true);
+        backend.glslang, backend.device, backend.fromPixelProgram,
+        backend.fromPixelLayout.pipelineLayout, [], output, true);
   });
-  backend.fromPixelProgram.setWebGPUBinary(bindGroupLayout, pipeline);
+
+  backend.fromPixelProgram.setPipeline(pipeline);
 
   backend.queue.copyImageBitmapToTexture(
       {imageBitmap, origin: {x: 0, y: 0}}, {

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -31,8 +31,6 @@ export class FromPixelsProgram implements WebGPUProgram {
       [256, 1, 1];  // The empirical value.
 
   pipeline: GPUComputePipeline;
-  bindGroupLayout: GPUBindGroupLayout;
-
   uniform: GPUBuffer;
   lastUniformData: number[] = [];
 
@@ -92,9 +90,7 @@ export class FromPixelsProgram implements WebGPUProgram {
     return userCode;
   }
 
-  setWebGPUBinary(
-      bindGroupLayout: GPUBindGroupLayout, pipeline: GPUComputePipeline) {
-    this.bindGroupLayout = bindGroupLayout;
+  setPipeline(pipeline: GPUComputePipeline) {
     this.pipeline = pipeline;
   }
 

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -45,11 +45,6 @@ export interface WebGPUProgram {
   getUserCode: () => string;
 }
 
-export interface WebGPUBinary {
-  bindGroupLayout: GPUBindGroupLayout;
-  pipeline: GPUComputePipeline;
-}
-
 export interface TensorData {
   dtype: DataType;
 }
@@ -70,8 +65,9 @@ export const makeBindGroup =
 
 export const compileProgram =
     (glslang: Glslang, device: GPUDevice, program: WebGPUProgram,
+     pipelineLayout: GPUPipelineLayout,
      inputsData: shader_preprocessor.InputInfo[], output: TensorInfo,
-     isFromPixel = false): WebGPUBinary => {
+     isFromPixel = false): GPUComputePipeline => {
       const outputData = {dtype: output.dtype, shape: output.shape};
 
       const source = shader_preprocessor.makeShader(
@@ -83,11 +79,10 @@ export const compileProgram =
 
       const module = device.createShaderModule({code: result.data});
       const pipeline = device.createComputePipeline(
-          {compute: {module, entryPoint: 'main'}});
-      const bindGroupLayout = pipeline.getBindGroupLayout(0);
+          {layout: pipelineLayout, compute: {module, entryPoint: 'main'}});
 
       result.free();
-      return {bindGroupLayout, pipeline};
+      return pipeline;
     };
 
 export function makeShaderKey<R extends Rank>(


### PR DESCRIPTION
Currently, different models create different size of GPUBindGroupLayouts and GPUPipelineLayouts. For example, bodypix(ResNet50) needs about 36 GPUBindGroupLayouts and GPUPipelineLayouts, mobilenet_v2 needs about 14.
With this change, only 7 GPUBindGroupLayouts and GPUPipelineLayouts is created. 


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5001)
<!-- Reviewable:end -->
