### PR TITLE
Fix SparseFillEmptyRows output shape bug

### DIFF
--- a/tfjs-backend-cpu/src/kernels/SparseFillEmptyRows_impl.ts
+++ b/tfjs-backend-cpu/src/kernels/SparseFillEmptyRows_impl.ts
@@ -130,7 +130,7 @@ export function sparseFillEmptyRowsImpl(
       }
     }
     return [
-      outputIndices, [indicesCount, rank], outputValues, emptyRowIndicator,
+      outputIndices, [fullIndicesCount, rank], outputValues, emptyRowIndicator,
       reverseIndexMap
     ];
   }

--- a/tfjs-core/src/ops/sparse/sparse_fill_empty_rows.ts
+++ b/tfjs-core/src/ops/sparse/sparse_fill_empty_rows.ts
@@ -62,7 +62,7 @@ import {op} from '../operation';
  * result['outputIndices'].print(); // [[0, 0], [1, 0], [1, 3], [1, 4],
  *                                  //  [2, 0], [3, 2], [3, 3], [4, 0]]
  * result['outputValues'].print(); // [0, 10, 13, 14,-1, 32, 33, -1]
- * result['emptyRowIndicator'].print(); // [0, 0, 1, 0, 1]
+ * result['emptyRowIndicator'].print(); // [false, false, true, false, true]
  * result['reverseIndexMap'].print(); // [0, 1, 2, 3, 5, 6]
  * ```
  * @param indices: 2-D. the indices of the sparse tensor.


### PR DESCRIPTION
The outputIndices tensor returned by SparseFillEmptyRows has the correct data but the shape was incorrect so it is not enough to check that the data is correct in the tests. The PR fixes this issue and adds a test to ensure that it the shape is now correct. 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5020)
<!-- Reviewable:end -->
