### PR TITLE
Add kernel SparseSegmentMean for CPU and WebGL backend

### DIFF
--- a/tfjs-backend-cpu/src/kernels/SparseSegmentMean.ts
+++ b/tfjs-backend-cpu/src/kernels/SparseSegmentMean.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, SparseSegmentMean, SparseSegmentMeanInputs, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
+
+import {MathBackendCPU} from '../backend_cpu';
+
+import {sparseSegmentReductionImpl} from './SparseSegmentReduction_impl';
+
+export function sparseSegmentMean(
+    args: {inputs: SparseSegmentMeanInputs, backend: MathBackendCPU}):
+    TensorInfo {
+  const {inputs, backend} = args;
+  const {data, indices, segmentIds} = inputs;
+  if (data.shape.length < 1) {
+    throw new Error(
+        `Data should be at least 1 dimensional but received scalar`);
+  }
+  if (indices.shape.length !== 1) {
+    throw new Error(`Indices should be a vector but received shape
+          ${indices.shape}`);
+  }
+  if (segmentIds.shape.length !== 1) {
+    throw new Error(`Segment ids should be a vector but received shape
+          ${segmentIds.shape}`);
+  }
+
+  const $data = backend.data.get(data.dataId).values as TypedArray;
+  const $indices = backend.data.get(indices.dataId).values as TypedArray;
+  const $segmentIds = backend.data.get(segmentIds.dataId).values as TypedArray;
+
+  const [outputData, outputDataShape] = sparseSegmentReductionImpl(
+      $data, data.shape, data.dtype, $indices, $segmentIds, true);
+  return backend.makeTensorInfo(outputDataShape, data.dtype, outputData);
+}
+
+export const sparseSegmentMeanConfig: KernelConfig = {
+  kernelName: SparseSegmentMean,
+  backendName: 'cpu',
+  kernelFunc: sparseSegmentMean,
+};

--- a/tfjs-backend-cpu/src/kernels/SparseSegmentReduction_impl.ts
+++ b/tfjs-backend-cpu/src/kernels/SparseSegmentReduction_impl.ts
@@ -116,8 +116,10 @@ export function sparseSegmentReductionImpl(
       }
     }
 
-    for (let j = 0; j < numCol; j++) {
-      output[outIndex * numCol + j] /= end - start;
+    if (isMean) {
+      for (let j = 0; j < numCol; j++) {
+        output[outIndex * numCol + j] /= end - start;
+      }
     }
 
     start = end;

--- a/tfjs-backend-cpu/src/kernels/SparseSegmentReduction_impl.ts
+++ b/tfjs-backend-cpu/src/kernels/SparseSegmentReduction_impl.ts
@@ -19,8 +19,8 @@ import {DataType, TypedArray, util} from '@tensorflow/tfjs-core';
 
 export function sparseSegmentReductionImpl(
     input: TypedArray, inputShape: number[], inputDType: DataType,
-    indices: TypedArray, segmentIds: TypedArray, defaultValue = 0,
-    numSegments?: number): [TypedArray, number[]] {
+    indices: TypedArray, segmentIds: TypedArray, isMean = false,
+    defaultValue = 0, numSegments?: number): [TypedArray, number[]] {
   let outputRows = -1;
 
   if (numSegments !== undefined) {
@@ -114,6 +114,10 @@ export function sparseSegmentReductionImpl(
       for (let j = 0; j < numCol; j++) {
         output[outIndex * numCol + j] += input[index * numCol + j];
       }
+    }
+
+    for (let j = 0; j < numCol; j++) {
+      output[outIndex * numCol + j] /= end - start;
     }
 
     start = end;

--- a/tfjs-backend-cpu/src/kernels/SparseSegmentReduction_impl.ts
+++ b/tfjs-backend-cpu/src/kernels/SparseSegmentReduction_impl.ts
@@ -20,16 +20,7 @@ import {DataType, TypedArray, util} from '@tensorflow/tfjs-core';
 export function sparseSegmentReductionImpl(
     input: TypedArray, inputShape: number[], inputDType: DataType,
     indices: TypedArray, segmentIds: TypedArray, isMean = false,
-    defaultValue = 0, numSegments?: number): [TypedArray, number[]] {
-  let outputRows = -1;
-
-  if (numSegments !== undefined) {
-    outputRows = numSegments;
-    if (outputRows < 0) {
-      throw new Error(`segment ids must be >= 0`);
-    }
-  }
-
+    defaultValue = 0): [TypedArray, number[]] {
   const numIndices = indices.length;
   if (numIndices !== segmentIds.length) {
     throw new Error(`segmentIds and indices should have same size.`);
@@ -42,13 +33,8 @@ export function sparseSegmentReductionImpl(
   // sorted.
   const lastSegmentIdPlusOne =
       numIndices > 0 ? segmentIds[numIndices - 1] + 1 : 0;
-  if (numSegments !== undefined) {
-    if (outputRows < lastSegmentIdPlusOne) {
-      throw new Error(`segment ids must be < numSegments`);
-    }
-  } else {
-    outputRows = lastSegmentIdPlusOne;
-  }
+  const outputRows = lastSegmentIdPlusOne;
+
   if (outputRows < 0) {
     throw new Error(`segment ids must be >= 0`);
   }

--- a/tfjs-backend-cpu/src/register_all_kernels.ts
+++ b/tfjs-backend-cpu/src/register_all_kernels.ts
@@ -157,6 +157,7 @@ import {softplusConfig} from './kernels/Softplus';
 import {spaceToBatchNDConfig} from './kernels/SpaceToBatchND';
 import {sparseFillEmptyRowsConfig} from './kernels/SparseFillEmptyRows';
 import {sparseReshapeConfig} from './kernels/SparseReshape';
+import {sparseSegmentMeanConfig} from './kernels/SparseSegmentMean';
 import {sparseSegmentSumConfig} from './kernels/SparseSegmentSum';
 import {sparseToDenseConfig} from './kernels/SparseToDense';
 import {splitVConfig} from './kernels/SplitV';
@@ -318,6 +319,7 @@ const kernelConfigs: KernelConfig[] = [
   spaceToBatchNDConfig,
   sparseFillEmptyRowsConfig,
   sparseReshapeConfig,
+  sparseSegmentMeanConfig,
   sparseSegmentSumConfig,
   sparseToDenseConfig,
   splitVConfig,

--- a/tfjs-backend-webgl/src/kernels/SparseSegmentMean.ts
+++ b/tfjs-backend-webgl/src/kernels/SparseSegmentMean.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, KernelFunc, SparseSegmentMean, SparseSegmentMeanInputs, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
+
+import {MathBackendWebGL} from '../backend_webgl';
+import {sparseSegmentReductionImplCPU} from '../kernel_utils/shared';
+
+export function sparseSegmentMean(
+    args: {inputs: SparseSegmentMeanInputs, backend: MathBackendWebGL}):
+    TensorInfo {
+  const {inputs, backend} = args;
+  const {data, indices, segmentIds} = inputs;
+  if (data.shape.length < 1) {
+    throw new Error(
+        `Data should be at least 1 dimensional but received scalar`);
+  }
+  if (indices.shape.length !== 1) {
+    throw new Error(`Indices should be a vector but received shape
+              ${indices.shape}`);
+  }
+  if (segmentIds.shape.length !== 1) {
+    throw new Error(`Segment ids should be a vector but received shape
+              ${segmentIds.shape}`);
+  }
+
+  const $data = backend.readSync(data.dataId) as TypedArray;
+  const $indices = backend.readSync(indices.dataId) as TypedArray;
+  const $segmentIds = backend.readSync(segmentIds.dataId) as TypedArray;
+
+  const [outputData, outputDataShape] = sparseSegmentReductionImplCPU(
+      $data, data.shape, data.dtype, $indices, $segmentIds, true);
+  return backend.makeTensorInfo(outputDataShape, data.dtype, outputData);
+}
+
+export const sparseSegmentMeanConfig: KernelConfig = {
+  kernelName: SparseSegmentMean,
+  backendName: 'webgl',
+  kernelFunc: sparseSegmentMean as {} as KernelFunc,
+};

--- a/tfjs-backend-webgl/src/register_all_kernels.ts
+++ b/tfjs-backend-webgl/src/register_all_kernels.ts
@@ -153,6 +153,7 @@ import {softplusConfig} from './kernels/Softplus';
 import {spaceToBatchNDConfig} from './kernels/SpaceToBatchND';
 import {sparseFillEmptyRowsConfig} from './kernels/SparseFillEmptyRows';
 import {sparseReshapeConfig} from './kernels/SparseReshape';
+import {sparseSegmentMeanConfig} from './kernels/SparseSegmentMean';
 import {sparseSegmentSumConfig} from './kernels/SparseSegmentSum';
 import {sparseToDenseConfig} from './kernels/SparseToDense';
 import {splitVConfig} from './kernels/SplitV';
@@ -313,6 +314,7 @@ const kernelConfigs: KernelConfig[] = [
   spaceToBatchNDConfig,
   sparseFillEmptyRowsConfig,
   sparseReshapeConfig,
+  sparseSegmentMeanConfig,
   sparseSegmentSumConfig,
   sparseToDenseConfig,
   splitVConfig,

--- a/tfjs-core/src/kernel_names.ts
+++ b/tfjs-core/src/kernel_names.ts
@@ -774,6 +774,10 @@ export const SparseReshape = 'SparseReshape';
 export type SparseReshapeInputs =
     Pick<NamedTensorInfoMap, 'inputIndices'|'inputShape'|'newShape'>;
 
+export const SparseSegmentMean = 'SparseSegmentMean';
+export type SparseSegmentMeanInputs =
+    Pick<NamedTensorInfoMap, 'data'|'indices'|'segmentIds'>;
+
 export const SparseSegmentSum = 'SparseSegmentSum';
 export type SparseSegmentSumInputs =
     Pick<NamedTensorInfoMap, 'data'|'indices'|'segmentIds'>;

--- a/tfjs-core/src/ops/ops.ts
+++ b/tfjs-core/src/ops/ops.ts
@@ -300,10 +300,12 @@ const losses = {
 
 import {sparseFillEmptyRows} from './sparse/sparse_fill_empty_rows';
 import {sparseReshape} from './sparse/sparse_reshape';
+import {sparseSegmentMean} from './sparse/sparse_segment_mean';
 import {sparseSegmentSum} from './sparse/sparse_segment_sum';
 const sparse = {
   sparseFillEmptyRows,
   sparseReshape,
+  sparseSegmentMean,
   sparseSegmentSum
 };
 

--- a/tfjs-core/src/ops/sparse/sparse_segment_mean.ts
+++ b/tfjs-core/src/ops/sparse/sparse_segment_mean.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENGINE} from '../../engine';
+import {SparseSegmentMean, SparseSegmentMeanInputs} from '../../kernel_names';
+import {Tensor, Tensor1D} from '../../tensor';
+import {convertToTensor} from '../../tensor_util_env';
+import {TensorLike} from '../../types';
+import {op} from '../operation';
+
+/**
+ * Computes the mean along sparse segments of a tensor.
+ *
+ * ```js
+ * const c = tf.tensor2d([[1,2,3,4], [-1,-2,-3,-4], [6,7,8,9]]);
+ * // Select two rows, one segment.
+ * const result1 = tf.sparse.sparseSegmentMean(c,
+ *                                           tf.tensor1d([0, 1], 'int32'),
+ *                                           tf.tensor1d([0, 0], 'int32'));
+ * result1.print(); // [[0, 0, 0, 0]]
+ *
+ * // Select two rows, two segments.
+ * const result2 = tf.sparse.sparseSegmentMean(c,
+ *                                             tf.tensor1d([0, 1], 'int32'),
+ *                                             tf.tensor1d([0, 1], 'int32'));
+ * result2.print(); // [[1, 2, 3, 4], [-1, -2, -3, -4]]
+ *
+ * // Select all rows, two segments.
+ * const result3 = tf.sparse.sparseSegmentMean(c,
+ *                                             tf.tensor1d([0, 1, 2], 'int32'),
+ *                                             tf.tensor1d([0, 1, 1], 'int32'));
+ * result3.print(); // [[1.0, 2.0, 3.0, 4.0], [2.5, 2.5, 2.5, 2.5]]
+ * ```
+ * @param data: A Tensor of at least one dimension with data that will be
+ *     assembled in the output.
+ * @param indices: A 1-D Tensor with indices into data. Has same rank as
+ *     segmentIds.
+ * @param segmentIds: A 1-D Tensor with indices into the output Tensor. Values
+ *     should be sorted and can be repeated.
+ * @return Has same shape as data, except for dimension 0 which has equal to
+ *         the number of segments.
+ *
+ * @doc {heading: 'Operations', subheading: 'Sparse'}
+ */
+function sparseSegmentMean_(
+    data: Tensor|TensorLike, indices: Tensor1D|TensorLike,
+    segmentIds: Tensor1D|TensorLike): Tensor {
+  const $data = convertToTensor(data, 'data', 'sparseSegmentMean');
+  const $indices = convertToTensor(indices, 'indices', 'sparseSegmentMean');
+  const $segmentIds =
+      convertToTensor(segmentIds, 'segmentIds', 'sparseSegmentMean');
+
+  if ($data.rank < 1) {
+    throw new Error(
+        `Data should be at least 1 dimensional but received scalar`);
+  }
+  if ($indices.rank !== 1) {
+    throw new Error(`Indices should be Tensor1D but received shape
+          ${$indices.shape}`);
+  }
+  if ($segmentIds.rank !== 1) {
+    throw new Error(`Segment ids should be Tensor1D but received shape
+          ${$segmentIds.shape}`);
+  }
+
+  const inputs: SparseSegmentMeanInputs = {
+    data: $data,
+    indices: $indices,
+    segmentIds: $segmentIds
+  };
+
+  return ENGINE.runKernel(SparseSegmentMean, inputs as {});
+}
+
+export const sparseSegmentMean = op({sparseSegmentMean_});

--- a/tfjs-core/src/ops/sparse/sparse_segment_mean_test.ts
+++ b/tfjs-core/src/ops/sparse/sparse_segment_mean_test.ts
@@ -111,25 +111,25 @@ describeWithFlags('sparseSegmentMean', ALL_ENVS, () => {
         [[33, 34, 35, 36], [13, 14, 15, 16], [19, 20, 21, 22]]);
   });
 
-  it('indices invalid 1', async () => {
+  it('throw error if indices < 0', async () => {
     expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, -1, 0, 9], [
       0, 1, 2, 2
     ])).toThrowError(/indices\[1\] == -1 out of range \[0, 10\)/);
   });
 
-  it('indices invalid 2', async () => {
+  it('throw error if indices >= max rows', async () => {
     expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 10], [
       0, 1, 2, 2
     ])).toThrowError(/indices\[3\] == 10 out of range \[0, 10\)/);
   });
 
-  it('segments invalid 2', async () => {
+  it('throw error if segment ids are not increasing', async () => {
     expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
       0, 1, 0, 1
     ])).toThrowError('segment ids are not increasing');
   });
 
-  it('segments invalid 3', async () => {
+  it('throw error if segment id is out of range', async () => {
     expect(
         () => tf.sparse.sparseSegmentMean(
             TensorValue10x4(), [8, 3, 0, 9], [0, 1, 2, 0]))
@@ -138,7 +138,7 @@ describeWithFlags('sparseSegmentMean', ALL_ENVS, () => {
             'input is not sorted.');
   });
 
-  it('segments invalid 4', async () => {
+  it('throw error if segment id is out of range and negative', async () => {
     expect(
         () => tf.sparse.sparseSegmentMean(
             TensorValue10x4(), [8, 3, 0, 9], [-1, 0, 1, 1]))
@@ -147,26 +147,26 @@ describeWithFlags('sparseSegmentMean', ALL_ENVS, () => {
             'input is not sorted.');
   });
 
-  it('segments invalid 6', async () => {
+  it('throw error if segment id is negative', async () => {
     expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
       0, 0, 0, -1
     ])).toThrowError('segment ids must be >= 0');
   });
 
-  it('segments invalid 7', async () => {
+  it('throw error if segment id is negative and there is a hole', async () => {
     expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
       0, 0, 0, -2
     ])).toThrowError('segment ids must be >= 0');
   });
 
-  it('indices invalid rank', async () => {
+  it('throw error if indices has invalid rank', async () => {
     expect(
         () => tf.sparse.sparseSegmentMean(
             TensorValue10x4(), [[8, 3, 0, 9]], [0, 0, 0, -2]))
         .toThrowError(/should be Tensor1D/);
   });
 
-  it('segments invalid rank', async () => {
+  it('throw error if segments has invalid rank', async () => {
     expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
       [0, 0, 0, -2]
     ])).toThrowError(/should be Tensor1D/);

--- a/tfjs-core/src/ops/sparse/sparse_segment_mean_test.ts
+++ b/tfjs-core/src/ops/sparse/sparse_segment_mean_test.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../../index';
+import {ALL_ENVS, describeWithFlags} from '../../jasmine_util';
+import {expectArraysClose} from '../../test_util';
+
+function TensorValue3x4Float() {
+  return tf.tensor2d([[1, 2, 3, 4], [-1, -2, -3, -4], [6, 7, 8, 9]]);
+}
+
+function TensorValue3x4Integer() {
+  return tf.tensor2d(
+      [[1, 2, 3, 4], [-1, -2, -3, -4], [6, 7, 8, 9]], [3, 4], 'int32');
+}
+
+function TensorValue10() {
+  return tf.tensor1d(Array.from(Array(10), (_, i) => i + 1));
+}
+
+function TensorValue10x4() {
+  return tf.tensor2d(Array.from(Array(40), (_, i) => i + 1), [10, 4]);
+}
+
+function TensorValue10x2x4() {
+  return tf.tensor3d(Array.from(Array(80), (_, i) => i + 1), [10, 2, 4]);
+}
+
+describeWithFlags('sparseSegmentMean', ALL_ENVS, () => {
+  it('two rows one segment', async () => {
+    const result =
+        tf.sparse.sparseSegmentMean(TensorValue3x4Float(), [0, 1], [0, 0]);
+    expectArraysClose(await result.data(), [[0, 0, 0, 0]]);
+  });
+
+  it('two rows two segments', async () => {
+    const result =
+        tf.sparse.sparseSegmentMean(TensorValue3x4Float(), [0, 1], [0, 1]);
+    expectArraysClose(await result.data(), [[1, 2, 3, 4], [-1, -2, -3, -4]]);
+  });
+
+  it('all rows two segments', async () => {
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue3x4Float(), [0, 1, 2], [0, 1, 1]);
+    expectArraysClose(
+        await result.data(), [[1.0, 2.0, 3.0, 4.0], [2.5, 2.5, 2.5, 2.5]]);
+  });
+
+  it('integer data', async () => {
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue3x4Integer(), [0, 1, 2], [0, 1, 1]);
+    expectArraysClose(await result.data(), [[1, 2, 3, 4], [2, 2, 2, 2]]);
+  });
+
+  it('0 dimensional input invalid', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(tf.scalar(1), [], []))
+        .toThrowError(/should be at least 1 dimensional/);
+  });
+
+  it('1 dimensional input', async () => {
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue10(), [8, 3, 0, 9], [0, 1, 2, 2]);
+    expectArraysClose(await result.data(), [9, 4, 5.5]);
+  });
+
+  it('3 dimensional input', async () => {
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue10x2x4(), [8, 3, 0, 9], [0, 1, 2, 2]);
+    expectArraysClose(await result.data(), [
+      [[65, 66, 67, 68], [69, 70, 71, 72]],
+      [[25, 26, 27, 28], [29, 30, 31, 32]], [[37, 38, 39, 40], [41, 42, 43, 44]]
+    ]);
+  });
+
+  it('segment ids hole', async () => {
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue10x4(), [8, 3, 0, 9], [0, 3, 3, 3]);
+    expectArraysClose(
+        await result.data(),
+        [[33, 34, 35, 36], [0, 0, 0, 0], [0, 0, 0, 0], [17, 18, 19, 20]]);
+  });
+
+  it('segment ids > zero', async () => {
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue10x4(), [8, 3, 0, 9], [2, 3, 3, 3]);
+    expectArraysClose(
+        await result.data(),
+        [[0, 0, 0, 0], [0, 0, 0, 0], [33, 34, 35, 36], [17, 18, 19, 20]]);
+  });
+
+  it('baseline valid', async () => {
+    // Baseline for the *invalid* tests below.
+    const result = tf.sparse.sparseSegmentMean(
+        TensorValue10x4(), [8, 3, 0, 9], [0, 1, 2, 2]);
+    expectArraysClose(
+        await result.data(),
+        [[33, 34, 35, 36], [13, 14, 15, 16], [19, 20, 21, 22]]);
+  });
+
+  it('indices invalid 1', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, -1, 0, 9], [
+      0, 1, 2, 2
+    ])).toThrowError(/indices\[1\] == -1 out of range \[0, 10\)/);
+  });
+
+  it('indices invalid 2', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 10], [
+      0, 1, 2, 2
+    ])).toThrowError(/indices\[3\] == 10 out of range \[0, 10\)/);
+  });
+
+  it('segments invalid 2', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
+      0, 1, 0, 1
+    ])).toThrowError('segment ids are not increasing');
+  });
+
+  it('segments invalid 3', async () => {
+    expect(
+        () => tf.sparse.sparseSegmentMean(
+            TensorValue10x4(), [8, 3, 0, 9], [0, 1, 2, 0]))
+        .toThrowError(
+            'Segment id 1 out of range [0, 1), possibly because segmentIds ' +
+            'input is not sorted.');
+  });
+
+  it('segments invalid 4', async () => {
+    expect(
+        () => tf.sparse.sparseSegmentMean(
+            TensorValue10x4(), [8, 3, 0, 9], [-1, 0, 1, 1]))
+        .toThrowError(
+            'Segment id -1 out of range [0, 2), possibly because segmentIds ' +
+            'input is not sorted.');
+  });
+
+  it('segments invalid 6', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
+      0, 0, 0, -1
+    ])).toThrowError('segment ids must be >= 0');
+  });
+
+  it('segments invalid 7', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
+      0, 0, 0, -2
+    ])).toThrowError('segment ids must be >= 0');
+  });
+
+  it('indices invalid rank', async () => {
+    expect(
+        () => tf.sparse.sparseSegmentMean(
+            TensorValue10x4(), [[8, 3, 0, 9]], [0, 0, 0, -2]))
+        .toThrowError(/should be Tensor1D/);
+  });
+
+  it('segments invalid rank', async () => {
+    expect(() => tf.sparse.sparseSegmentMean(TensorValue10x4(), [8, 3, 0, 9], [
+      [0, 0, 0, -2]
+    ])).toThrowError(/should be Tensor1D/);
+  });
+});

--- a/tfjs-core/src/tests.ts
+++ b/tfjs-core/src/tests.ts
@@ -206,6 +206,7 @@ import './ops/softplus_test';
 import './ops/space_to_batch_nd_test';
 import './ops/sparse/sparse_fill_empty_rows_test';
 import './ops/sparse/sparse_reshape_test';
+import './ops/sparse/sparse_segment_mean_test';
 import './ops/sparse/sparse_segment_sum_test';
 import './ops/sparse_to_dense_test';
 import './ops/spectral/fft_test';

--- a/tfjs-node/src/run_tests.ts
+++ b/tfjs-node/src/run_tests.ts
@@ -102,7 +102,8 @@ const IGNORE_LIST: string[] = [
   'sign test-tensorflow {} accepts a tensor-like object',
   // Node kernel for einsum is yet to be implemented.
   // See: ttps://github.com/tensorflow/tfjs/issues/2349
-  'einsum', 'sparseFillEmptyRows', 'sparseReshape', 'sparseSegmentSum'
+  'einsum', 'sparseFillEmptyRows', 'sparseReshape', 'sparseSegmentMean',
+  'sparseSegmentSum'
 ];
 
 if (process.platform === 'win32') {


### PR DESCRIPTION
ref #4838
TensorFlow python version is defined  [here](https://www.tensorflow.org/api_docs/python/tf/sparse/segment_mean)
c++ kernel definition (SparseSegmentReductionMeanOp) is  [here](https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/core/kernels/segment_reduction_ops_impl.h)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5025)
<!-- Reviewable:end -->
