### PR TITLE
Add support for SparseSegmentMean conversion

### DIFF
--- a/tfjs-converter/metadata/kernel2op.json
+++ b/tfjs-converter/metadata/kernel2op.json
@@ -461,6 +461,9 @@
   "SparseReshape": [
     "sparse.sparseReshape"
   ],
+  "SparseSegmentMean": [
+    "sparse.sparseSegmentMean"
+  ],
   "SparseSegmentSum": [
     "sparse.sparseSegmentSum"
   ],

--- a/tfjs-converter/python/tensorflowjs/op_list/sparse.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/sparse.json
@@ -55,6 +55,27 @@
     ]
   },
   {
+    "tfOpName": "SparseSegmentMean",
+    "category": "sparse",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "data",
+        "type": "tensor"
+      },
+      {
+        "start": 1,
+        "name": "indices",
+        "type": "tensor"
+      },
+      {
+        "start": 2,
+        "name": "segmentIds",
+        "type": "tensor"
+      }
+    ]
+  },
+  {
     "tfOpName": "SparseSegmentSum",
     "category": "sparse",
     "inputs": [

--- a/tfjs-converter/src/operations/executors/sparse_executor.ts
+++ b/tfjs-converter/src/operations/executors/sparse_executor.ts
@@ -56,6 +56,14 @@ export const executeOp: InternalOpExecutor =
               getParamValue('newShape', node, tensorMap, context) as Tensor1D);
           return [outputIndices, outputShape];
         }
+        case 'SparseSegmentMean': {
+          const outputData = tfOps.sparse.sparseSegmentMean(
+              getParamValue('data', node, tensorMap, context) as Tensor,
+              getParamValue('indices', node, tensorMap, context) as Tensor1D,
+              getParamValue('segmentIds', node, tensorMap, context) as
+                  Tensor1D);
+          return [outputData];
+        }
         case 'SparseSegmentSum': {
           const outputData = tfOps.sparse.sparseSegmentSum(
               getParamValue('data', node, tensorMap, context) as Tensor,

--- a/tfjs-converter/src/operations/executors/sparse_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/sparse_executor_test.ts
@@ -124,6 +124,40 @@ describe('sparse', () => {
         expect(validateParam(node, sparse.json)).toBeTruthy();
       });
     });
+    describe('SparseSegmentMean', () => {
+      it('should call tfOps.sparse.sparseSegmentMean', async () => {
+        spyOn(tfOps.sparse, 'sparseSegmentMean').and.callThrough();
+        node.op = 'SparseSegmentMean';
+        node.inputParams = {
+          data: createTensorAttr(0),
+          indices: createTensorAttr(1),
+          segmentIds: createTensorAttr(2)
+        };
+        node.inputNames = ['data', 'indices', 'segmentIds'];
+
+        const data = [tfOps.tensor2d(
+            [1, 2, 3, 4, -1, -2, -3, -4, 6, 7, 8, 9], [3, 4], 'float32')];
+        const indices = [tfOps.tensor1d([0, 1, 2], 'int32')];
+        const segmentIds = [tfOps.tensor1d([0, 1, 1], 'int32')];
+        const result =
+            executeOp(node, {data, indices, segmentIds}, context) as Tensor[];
+
+        expect(tfOps.sparse.sparseSegmentMean)
+            .toHaveBeenCalledWith(data[0], indices[0], segmentIds[0]);
+        test_util.expectArraysClose(
+            await result[0].data(), [1.0, 2.0, 3.0, 4.0, 2.5, 2.5, 2.5, 2.5]);
+      });
+      it('should match json def', () => {
+        node.op = 'SparseSegmentMean';
+        node.inputParams = {
+          data: createTensorAttr(0),
+          indices: createTensorAttr(1),
+          segmentIds: createTensorAttr(2)
+        };
+
+        expect(validateParam(node, sparse.json)).toBeTruthy();
+      });
+    });
     describe('SparseSegmentSum', () => {
       it('should call tfOps.sparse.sparseSegmentSum', async () => {
         spyOn(tfOps.sparse, 'sparseSegmentSum').and.callThrough();

--- a/tfjs-converter/src/operations/op_list/sparse.ts
+++ b/tfjs-converter/src/operations/op_list/sparse.ts
@@ -41,6 +41,15 @@ export const json: OpMapper[] = [
     ]
   },
   {
+    'tfOpName': 'SparseSegmentMean',
+    'category': 'sparse',
+    'inputs': [
+      {'start': 0, 'name': 'data', 'type': 'tensor'},
+      {'start': 1, 'name': 'indices', 'type': 'tensor'},
+      {'start': 2, 'name': 'segmentIds', 'type': 'tensor'},
+    ]
+  },
+  {
     'tfOpName': 'SparseSegmentSum',
     'category': 'sparse',
     'inputs': [


### PR DESCRIPTION
ref #4838

Added SparseSegmentMean op support for the graph model executor.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5037)
<!-- Reviewable:end -->
