### PR TITLE
[tfjs-converter] heuristically determine the signature name 

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -34,6 +34,7 @@ from tensorflow.python.grappler import tf_optimizer
 from tensorflow.python.saved_model.load import load
 from tensorflow.python.saved_model import loader
 from tensorflow.python.training.saver import export_meta_graph
+from tensorflow.python.tools.saved_model_cli import get_signature_def_map
 from google.protobuf.json_format import MessageToDict
 import tensorflow_hub as hub
 
@@ -424,8 +425,25 @@ def _freeze_saved_model_v2(concrete_func, control_flow_v2=False):
       concrete_func, lower_control_flow=not control_flow_v2,
       aggressive_inlining=True).graph
 
+def _find_signature_def_name(tensor, signature_map):
+  if not signature_map:
+    return tensor.name
 
-def _build_signature_def(frozen_graph, input_nodes, output_nodes):
+  tensor_shape_str = tensor.shape.as_proto().SerializeToString()
+  names = []
+  for key in signature_map:
+    tensor_info = signature_map[key]
+    signature_shape_str = tensor_info.tensor_shape.SerializeToString()
+    if tensor_info.dtype == tensor.dtype and tensor_shape_str == signature_shape_str:
+      names.append(key)
+
+  if len(names) == 0 or len(names) > 1:
+    return tensor.name
+  else:
+    return names[0]
+
+def _build_signature_def(frozen_graph, input_nodes, output_nodes,
+                         signature_def):
   signature = meta_graph_pb2.SignatureDef()
   for input_tensor in input_nodes:
     op_name = input_tensor.name.split(':')[0]
@@ -434,20 +452,20 @@ def _build_signature_def(frozen_graph, input_nodes, output_nodes):
     try:
       op = frozen_graph.get_operation_by_name(op_name)
       if op.type != 'Const':
-        signature.inputs[input_tensor.name].name = input_tensor.name
-        signature.inputs[
-            input_tensor.name].dtype = input_tensor.dtype.as_datatype_enum
-        signature.inputs[input_tensor.name].tensor_shape.CopyFrom(
+        name = _find_signature_def_name(input_tensor, signature_def.inputs)
+        signature.inputs[name].name = input_tensor.name
+        signature.inputs[name].dtype = input_tensor.dtype.as_datatype_enum
+        signature.inputs[name].tensor_shape.CopyFrom(
             input_tensor.shape.as_proto())
     except KeyError:
       # The original input was removed when the graph was frozen.
       continue
   for output_tensor in output_nodes:
     if hasattr(output_tensor, 'name'):
-      signature.outputs[output_tensor.name].name = output_tensor.name
-      signature.outputs[
-          output_tensor.name].dtype = output_tensor.dtype.as_datatype_enum
-      signature.outputs[output_tensor.name].tensor_shape.CopyFrom(
+      name = _find_signature_def_name(output_tensor, signature_def.outputs)
+      signature.outputs[name].name = output_tensor.name
+      signature.outputs[name].dtype = output_tensor.dtype.as_datatype_enum
+      signature.outputs[name].tensor_shape.CopyFrom(
           output_tensor.shape.as_proto())
     else: #just the tensor name string array
       signature.outputs[output_tensor].name = output_tensor
@@ -554,6 +572,14 @@ def convert_tf_saved_model(saved_model_dir,
   output_graph = os.path.join(
       output_dir, common.ARTIFACT_MODEL_JSON_FILE_NAME)
 
+  signature_def_map = get_signature_def_map(saved_model_dir, saved_model_tags)
+  if signature_def not in signature_def_map.keys():
+      raise ValueError(
+          'Signature "%s" does on existing in the saved model, available '
+          'signatures are: %s' % (signature_def, signature_def_map.keys()))
+
+  saved_model_sigature = signature_def_map[signature_def]
+
   if saved_model_tags:
     saved_model_tags = saved_model_tags.split(',')
 
@@ -581,7 +607,7 @@ def convert_tf_saved_model(saved_model_dir,
 
   inputs = [x for x in concrete_func.inputs if not x.dtype == 'resource']
   signature = _build_signature_def(
-      frozen_graph, inputs, concrete_func.outputs)
+      frozen_graph, inputs, concrete_func.outputs, saved_model_sigature)
 
   # Check if the TransformGraph is available to be imported, this package is
   # available in g3 but not in oss version of TensorFlow.

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -438,7 +438,7 @@ def _find_signature_def_name(tensor, signature_map):
         tensor_shape_str == signature_shape_str):
       names.append(key)
 
-  if not len(names) or len(names) > 1:
+  if not names or len(names) > 1:
     return tensor.name
   else:
     return names[0]

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -438,7 +438,7 @@ def _find_signature_def_name(tensor, signature_map):
         tensor_shape_str == signature_shape_str):
       names.append(key)
 
-  if len(names) == 0 or len(names) > 1:
+  if not len(names) or len(names) > 1:
     return tensor.name
   else:
     return names[0]


### PR DESCRIPTION
After tensorflow loads the saved model, it will convert the tf_function to concrete_func, but the signature name will not be perserved.
During tfjs conversion, we will heuristically determine the input/output signature names based on the dtype and shape matching between the saved model signature def and concrete function.

fix https://github.com/tensorflow/tfjs/issues/3942

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5043)
<!-- Reviewable:end -->
