### PR TITLE
[DRAFT] Add flag WASM_THREAD_POOL_SIZE get/set

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -430,6 +430,7 @@ const TUNABLE_FLAG_VALUE_RANGE_MAP = {
   WEBGL_VERSION: [1, 2],
   WASM_HAS_SIMD_SUPPORT: [true, false],
   WASM_HAS_MULTITHREAD_SUPPORT: [true, false],
+  WASM_THREAD_POOL_SIZE: [1, 2, 3, 4],
   WEBGL_CPU_FORWARD: [true, false],
   WEBGL_PACK: [true, false],
   WEBGL_FORCE_F16_TEXTURES: [true, false],

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -21,6 +21,7 @@ const BACKEND_FLAGS_MAP = {
   wasm: [
     'WASM_HAS_SIMD_SUPPORT',
     'WASM_HAS_MULTITHREAD_SUPPORT',
+    'WASM_THREAD_POOL_SIZE',
     'CHECK_COMPUTATION_FOR_ERRORS',
   ],
   webgl: [
@@ -35,6 +36,7 @@ const TUNABLE_FLAG_NAME_MAP = {
   WEBGL_VERSION: 'webgl version',
   WASM_HAS_SIMD_SUPPORT: 'wasm SIMD',
   WASM_HAS_MULTITHREAD_SUPPORT: 'wasm multithread',
+  WASM_THREAD_POOL_SIZE: 'wasm thread pool size',
   WEBGL_CPU_FORWARD: 'cpu forward',
   WEBGL_PACK: 'webgl pack',
   WEBGL_FORCE_F16_TEXTURES: 'enforce float16',

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -42,9 +42,11 @@ export class BackendWasm extends KernelBackend {
   private dataIdNextNumber = 1;
   dataIdMap: DataStorage<TensorData>;
 
-  constructor(public wasm: BackendWasmModule | BackendWasmThreadedSimdModule) {
+  constructor(public wasm: BackendWasmModule|BackendWasmThreadedSimdModule) {
     super();
-    this.wasm.tfjs.init();
+
+    const threadPoolSize = env().getNumber('WASM_THREAD_POOL_SIZE');
+    this.wasm.tfjs.init(threadPoolSize);
     this.dataIdMap = new DataStorage(this, engine());
   }
 
@@ -343,7 +345,7 @@ export async function init(): Promise<{wasm: BackendWasmModule}> {
       const voidReturnType: string = null;
       // Using the tfjs namespace to avoid conflict with emscripten's API.
       module.tfjs = {
-        init: module.cwrap('init', null, []),
+        init: module.cwrap('init', null, ['number']),
         registerTensor: module.cwrap(
             'register_tensor', null,
             [

--- a/tfjs-backend-wasm/src/cc/backend.h
+++ b/tfjs-backend-wasm/src/cc/backend.h
@@ -96,7 +96,7 @@ extern pthreadpool *threadpool;
 namespace wasm {
 extern "C" {
 // Initializes the WASM backend.
-void init();
+void init(const size_t thread_pool_size);
 
 // Registers a tensor with a tensor ID, size, and the pointer to where the
 // tensor data lives.

--- a/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
+++ b/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
@@ -18,7 +18,7 @@
 export interface BackendWasmModule extends EmscriptenModule {
   // Using the tfjs namespace to avoid conflict with emscripten's API.
   tfjs: {
-    init(): void,
+    init(threadPoolSize: number): void,
     registerTensor(id: number, size: number, memoryOffset: number): void,
     // Disposes the data behind the data bucket.
     disposeData(id: number): void,

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -76,3 +76,22 @@ ENV.registerFlag('CHECK_COMPUTATION_FOR_ERRORS', () => true);
 
 /** Whether the backend needs to wrap input to imageBitmap. */
 ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);
+
+// Register the used thread pool size flag.
+ENV.registerFlag(
+    'WASM_THREAD_POOL_SIZE',
+    () => {
+      // TODO: Enable node support once this is resolved:
+      // https://github.com/tensorflow/tfjs/issues/3830
+      if (ENV.get('IS_NODE')) {
+        return 1;
+      }
+      // This should be the same as PTHREAD_POOL_SIZE in src/cc/BUILD.
+      return Math.min(4, Math.max(1, (navigator.hardwareConcurrency || 1) / 2));
+    },
+    threadPoolSize => {
+      if (threadPoolSize < 0 || threadPoolSize > 4) {
+        throw new Error(`WASM_THREAD_POOL_SIZE must be from 1 to 4, but got ${
+            threadPoolSize}.`);
+      }
+    });

--- a/tfjs-core/src/flags_test.ts
+++ b/tfjs-core/src/flags_test.ts
@@ -123,3 +123,23 @@ describe('async flags test', () => {
     expect(() => tf.env().get(asyncFlagName)).toThrow();
   });
 });
+
+describe('wasm thread test', () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
+  it('default thread pool size', () => {
+    expect(tf.env().getNumber('WASM_THREAD_POOL_SIZE'))
+        .toBeGreaterThanOrEqual(1);
+  });
+
+  it('set thread pool size', () => {
+    tf.env().set('WASM_THREAD_POOL_SIZE', 3);
+    expect(tf.env().getNumber('WASM_THREAD_POOL_SIZE')).toBe(3);
+  });
+
+  it('set invalid thread pool size', () => {
+    // Currently WASM_THREAD_POOL_SIZE should be from 1 to 4.
+    expect(() => tf.env().set('WASM_THREAD_POOL_SIZE', 5)).toThrow();
+  });
+});


### PR DESCRIPTION
This flag indicates how many threads can be used in multi-thread mode, it helps
us to understand the performance difference between wasm and webgpu/webgl.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5053)
<!-- Reviewable:end -->
