### PR TITLE
[DRAFT] Add flag WASM_THREAD_POOL_SIZE(async)

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -430,6 +430,7 @@ const TUNABLE_FLAG_VALUE_RANGE_MAP = {
   WEBGL_VERSION: [1, 2],
   WASM_HAS_SIMD_SUPPORT: [true, false],
   WASM_HAS_MULTITHREAD_SUPPORT: [true, false],
+  WASM_THREAD_POOL_SIZE: [1, 2, 3, 4],
   WEBGL_CPU_FORWARD: [true, false],
   WEBGL_PACK: [true, false],
   WEBGL_FORCE_F16_TEXTURES: [true, false],

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -21,6 +21,7 @@ const BACKEND_FLAGS_MAP = {
   wasm: [
     'WASM_HAS_SIMD_SUPPORT',
     'WASM_HAS_MULTITHREAD_SUPPORT',
+    'WASM_THREAD_POOL_SIZE',
     'CHECK_COMPUTATION_FOR_ERRORS',
   ],
   webgl: [
@@ -35,6 +36,7 @@ const TUNABLE_FLAG_NAME_MAP = {
   WEBGL_VERSION: 'webgl version',
   WASM_HAS_SIMD_SUPPORT: 'wasm SIMD',
   WASM_HAS_MULTITHREAD_SUPPORT: 'wasm multithread',
+  WASM_THREAD_POOL_SIZE: 'wasm thread pool size',
   WEBGL_CPU_FORWARD: 'cpu forward',
   WEBGL_PACK: 'webgl pack',
   WEBGL_FORCE_F16_TEXTURES: 'enforce float16',

--- a/tfjs-backend-wasm/src/cc/backend.cc
+++ b/tfjs-backend-wasm/src/cc/backend.cc
@@ -55,15 +55,16 @@ size_t xnn_operator_count = 0;
 // emscripten_num_logical_cores corresponds to navigator.hardwareConcurrency.
 // Many x86-64 processors have 2 threads per core, so we are dividing by 2.
 #ifdef __EMSCRIPTEN_PTHREADS__
-int num_cores = emscripten_num_logical_cores() / 2;
+const int num_cores = emscripten_num_logical_cores() / 2;
 #else
-int num_cores = 1;
+const int num_cores = 1;
 #endif
 
-int min_num_threads = 1;
-int max_num_threads = 4;
-pthreadpool *threadpool = pthreadpool_create(
-    std::min(std::max(num_cores, min_num_threads), max_num_threads));
+const int min_num_threads = 1;
+const int max_num_threads = 4;
+const int thread_pool_size =
+    std::min(std::max(num_cores, min_num_threads), max_num_threads);
+pthreadpool *threadpool = nullptr;
 
 // Registers a disposal callback for a tensor id with a given callback function.
 void register_disposal_callback(const size_t tensor_id,
@@ -88,7 +89,11 @@ extern "C" {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
-void init() { xnn_initialize(nullptr); }
+void init(const size_t thread_pool_size = tfjs::backend::thread_pool_size) {
+  // TODO(xing.xu): call pthreadpool_destroy.
+  tfjs::backend::threadpool = pthreadpool_create(thread_pool_size);
+  xnn_initialize(nullptr);
+}
 
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE

--- a/tfjs-backend-wasm/src/cc/backend.h
+++ b/tfjs-backend-wasm/src/cc/backend.h
@@ -96,7 +96,7 @@ extern pthreadpool *threadpool;
 namespace wasm {
 extern "C" {
 // Initializes the WASM backend.
-void init();
+void init(const size_t thread_pool_size);
 
 // Registers a tensor with a tensor ID, size, and the pointer to where the
 // tensor data lives.

--- a/tfjs-backend-wasm/src/flags_wasm.ts
+++ b/tfjs-backend-wasm/src/flags_wasm.ts
@@ -57,3 +57,22 @@ ENV.registerFlag('WASM_HAS_MULTITHREAD_SUPPORT', async () => {
     return false;
   }
 });
+
+// Register the used thread pool size flag.
+ENV.registerFlag(
+    'WASM_THREAD_POOL_SIZE',
+    async () => {
+      // TODO: Enable node support once this is resolved:
+      // https://github.com/tensorflow/tfjs/issues/3830
+      if (ENV.get('IS_NODE')) {
+        return 1;
+      }
+      // This should be the same as PTHREAD_POOL_SIZE in src/cc/BUILD.
+      return Math.min(4, Math.max(1, (navigator.hardwareConcurrency || 1) / 2));
+    },
+    threadPoolSize => {
+      if (threadPoolSize < 0 || threadPoolSize > 4) {
+        throw new Error(`WASM_THREAD_POOL_SIZE must be from 1 to 4, but got ${
+            threadPoolSize}.`);
+      }
+    });

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -230,3 +230,23 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
         .toThrowError(/The WASM backend was already initialized. Make sure/);
   });
 });
+
+describeWithFlags('wasm thread test', ALL_ENVS, () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
+  it('default thread pool size', async () => {
+    expect(await tf.env().getAsync('WASM_THREAD_POOL_SIZE'))
+        .toBeGreaterThanOrEqual(1);
+  });
+
+  it('set thread pool size', async () => {
+    tf.env().set('WASM_THREAD_POOL_SIZE', 3);
+    expect(await tf.env().getAsync('WASM_THREAD_POOL_SIZE')).toBe(3);
+  });
+
+  it('set invalid thread pool size', () => {
+    // Currently WASM_THREAD_POOL_SIZE should be from 1 to 4.
+    expect(() => tf.env().set('WASM_THREAD_POOL_SIZE', 5)).toThrow();
+  });
+});

--- a/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
+++ b/tfjs-backend-wasm/wasm-out/tfjs-backend-wasm.d.ts
@@ -18,7 +18,7 @@
 export interface BackendWasmModule extends EmscriptenModule {
   // Using the tfjs namespace to avoid conflict with emscripten's API.
   tfjs: {
-    init(): void,
+    init(threadPoolSize: number): void,
     registerTensor(id: number, size: number, memoryOffset: number): void,
     // Disposes the data behind the data bucket.
     disposeData(id: number): void,


### PR DESCRIPTION
This flag indicates how many threads can be used in multi-thread mode, it helps
us to understand the performance difference between wasm and webgpu/webgl.

DRAFT

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5055)
<!-- Reviewable:end -->
