### PR TITLE
Add support for StringToHashBucketFast conversion

### DIFF
--- a/tfjs-converter/metadata/kernel2op.json
+++ b/tfjs-converter/metadata/kernel2op.json
@@ -495,6 +495,9 @@
   "StridedSlice": [
     "stridedSlice"
   ],
+  "StringToHashBucketFast": [
+    "string.stringToHashBucketFast"
+  ],
   "Sub": [
     "sub"
   ],

--- a/tfjs-converter/python/tensorflowjs/op_list/string.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/string.json
@@ -1,0 +1,20 @@
+[
+  {
+    "tfOpName": "StringToHashBucketFast",
+    "category": "string",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "input",
+        "type": "tensor"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "num_buckets",
+        "name": "numBuckets",
+        "type": "number"
+      }
+    ]
+  }
+]

--- a/tfjs-converter/src/operations/executors/string_executor.ts
+++ b/tfjs-converter/src/operations/executors/string_executor.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Tensor} from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
+import * as tfOps from '@tensorflow/tfjs-core/dist/ops/ops_for_converter';
+
+import {NamedTensorsMap} from '../../data/types';
+import {ExecutionContext} from '../../executor/execution_context';
+import {InternalOpExecutor, Node} from '../types';
+
+import {getParamValue} from './utils';
+
+export const executeOp: InternalOpExecutor =
+    (node: Node, tensorMap: NamedTensorsMap,
+     context: ExecutionContext): Tensor[] => {
+      switch (node.op) {
+        case 'StringToHashBucketFast': {
+          const output = tfOps.string.stringToHashBucketFast(
+              getParamValue('input', node, tensorMap, context) as Tensor,
+              getParamValue('numBuckets', node, tensorMap, context) as number);
+          return [output];
+        }
+        default:
+          throw TypeError(`Node type ${node.op} is not implemented`);
+      }
+    };
+
+export const CATEGORY = 'string';

--- a/tfjs-converter/src/operations/executors/string_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/string_executor_test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {Tensor, test_util} from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
+import * as tfOps from '@tensorflow/tfjs-core/dist/ops/ops_for_converter';
+
+import {ExecutionContext} from '../../executor/execution_context';
+import * as string from '../op_list/string';
+import {Node} from '../types';
+
+import {executeOp} from './string_executor';
+import {createNumberAttr, createTensorAttr, validateParam} from './test_helper';
+
+describe('string', () => {
+  let node: Node;
+  const context = new ExecutionContext({}, {}, {});
+
+  beforeEach(() => {
+    node = {
+      name: 'test',
+      op: '',
+      category: 'string',
+      inputNames: [],
+      inputs: [],
+      inputParams: {},
+      attrParams: {},
+      children: []
+    };
+  });
+
+  describe('executeOp', () => {
+    describe('StringToHashBucketFast', () => {
+      it('should call tfOps.string.stringToHashBucketFast', async () => {
+        spyOn(tfOps.string, 'stringToHashBucketFast').and.callThrough();
+        node.op = 'StringToHashBucketFast';
+        node.inputParams = {input: createTensorAttr(0)};
+        node.attrParams = {numBuckets: createNumberAttr(10)};
+        node.inputNames = ['input'];
+
+        const input = [tfOps.tensor1d(['a', 'b', 'c', 'd'], 'string')];
+        const result = executeOp(node, {input}, context) as Tensor[];
+
+        expect(tfOps.string.stringToHashBucketFast)
+            .toHaveBeenCalledWith(input[0], 10);
+        test_util.expectArraysClose(await result[0].data(), [9, 2, 2, 5]);
+      });
+      it('should match json def', () => {
+        node.op = 'StringToHashBucketFast';
+        node.inputParams = {input: createTensorAttr(0)};
+
+        expect(validateParam(node, string.json)).toBeTruthy();
+      });
+    });
+  });
+});

--- a/tfjs-converter/src/operations/op_list/string.ts
+++ b/tfjs-converter/src/operations/op_list/string.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {OpMapper} from '../types';
+
+export const json: OpMapper[] = [{
+  'tfOpName': 'StringToHashBucketFast',
+  'category': 'string',
+  'inputs': [
+    {'start': 0, 'name': 'input', 'type': 'tensor'},
+  ],
+  'attrs': [{'tfName': 'num_buckets', 'name': 'numBuckets', 'type': 'number'}]
+}];

--- a/tfjs-converter/src/operations/op_mapper_schema.ts
+++ b/tfjs-converter/src/operations/op_mapper_schema.ts
@@ -42,7 +42,7 @@ export const json = {
         'arithmetic', 'basic_math', 'control', 'convolution', 'custom',
         'dynamic', 'evaluation', 'image', 'creation', 'graph', 'logical',
         'matrices', 'normalization', 'reduction', 'slice_join', 'spectral',
-        'transformation', 'sparse'
+        'transformation', 'sparse', 'string'
       ]
     },
     'InputParamMapper': {

--- a/tfjs-converter/src/operations/operation_executor.ts
+++ b/tfjs-converter/src/operations/operation_executor.ts
@@ -40,6 +40,7 @@ import * as reduction from './executors/reduction_executor';
 import * as sliceJoin from './executors/slice_join_executor';
 import * as sparse from './executors/sparse_executor';
 import * as spectral from './executors/spectral_executor';
+import * as string from './executors/string_executor';
 import * as transformation from './executors/transformation_executor';
 import {Node} from './types';
 
@@ -95,6 +96,8 @@ export function executeOp(
             return tfc.tidy(() => sparse.executeOp(node, tensorMap, context));
           case 'spectral':
             return tfc.tidy(() => spectral.executeOp(node, tensorMap, context));
+          case 'string':
+            return tfc.tidy(() => string.executeOp(node, tensorMap, context));
           case 'transformation':
             return tfc.tidy(
                 () => transformation.executeOp(node, tensorMap, context));

--- a/tfjs-converter/src/operations/types.ts
+++ b/tfjs-converter/src/operations/types.ts
@@ -26,7 +26,7 @@ export type ParamType = 'number'|'string'|'string[]'|'number[]'|'bool'|'bool[]'|
 export type Category = 'arithmetic'|'basic_math'|'control'|'convolution'|
     'custom'|'dynamic'|'evaluation'|'image'|'creation'|'graph'|'logical'|
     'matrices'|'normalization'|'reduction'|'slice_join'|'spectral'|
-    'transformation'|'hash_table'|'sparse';
+    'transformation'|'hash_table'|'sparse'|'string';
 
 // For mapping input or attributes of NodeDef into TensorFlow.js op param.
 export declare interface ParamMapper {


### PR DESCRIPTION
ref #4838

Added StringToHashBucketFast op support for the graph model executor.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5067)
<!-- Reviewable:end -->
