### PR TITLE
Fixes for the release scripts

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -111,7 +111,10 @@ export const TFLITE_PHASE: Phase = {
 
 export const WEBSITE_PHASE: Phase = {
   packages: ['tfjs-website'],
-  deps: ['tfjs', 'tfjs-node', 'tfjs-vis', 'tfjs-react-native'],
+  deps: [
+    'tfjs', 'tfjs-node', 'tfjs-vis', 'tfjs-react-native', 'tfjs-tflite',
+    '@tensorflow-models/tasks'
+  ],
   scripts: {'tfjs-website': {'after-yarn': ['yarn prep && yarn build-prod']}},
   leaveVersion: true,
   title: 'Update website to latest dependencies.'
@@ -211,14 +214,15 @@ export async function updateDependency(
   console.log(chalk.magenta.bold(`~~~ Update dependency versions ~~~`));
 
   if (deps != null) {
-    const depsLatestVersion: string[] =
-        deps.map(dep => $(`npm view @tensorflow/${dep} dist-tags.latest`));
+    const depsLatestVersion: string[] = deps.map(
+        dep => $(`npm view ${
+            dep.includes('@') ? dep : '@tensorflow/' + dep} dist-tags.latest`));
 
     for (let j = 0; j < deps.length; j++) {
       const dep = deps[j];
 
       let version = '';
-      const depNpmName = `@tensorflow/${dep}`;
+      const depNpmName = dep.includes('@') ? dep : `@tensorflow/${dep}`;
       if (parsedPkg['dependencies'] != null &&
           parsedPkg['dependencies'][depNpmName] != null) {
         version = parsedPkg['dependencies'][depNpmName];

--- a/scripts/release_notes/release_notes.ts
+++ b/scripts/release_notes/release_notes.ts
@@ -261,7 +261,7 @@ parser.addArgument('--project', {
   help:
       'Which project to generate release notes for. One of union|vis. Defaults to union.',
   defaultValue: 'union',
-  choices: ['union', 'vis', 'rn']
+  choices: ['union', 'vis', 'rn', 'tflite']
 });
 
 const args = parser.parseArgs();

--- a/scripts/release_notes/release_notes.ts
+++ b/scripts/release_notes/release_notes.ts
@@ -259,7 +259,7 @@ const parser = new argparse.ArgumentParser();
 
 parser.addArgument('--project', {
   help:
-      'Which project to generate release notes for. One of union|vis. Defaults to union.',
+      'Which project to generate release notes for. One of union|vis|rn|tflite. Defaults to union.',
   defaultValue: 'union',
   choices: ['union', 'vis', 'rn', 'tflite']
 });


### PR DESCRIPTION
- Add "tflite" to the "project" flag of the release-notes tool
- Add the missing deps to the tfjs-website release unit, and allow the script to accpet full package name that is not under `@tensorflow`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5070)
<!-- Reviewable:end -->
