### PR TITLE
Add instructions for how to see Google Cloud Build logs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-
 
 #### Failing tests (click details for information):
 
+Click "Details", and then "View more details on Google Cloud Build" for information about the failure.
+
 <img src="https://user-images.githubusercontent.com/1100749/59696200-8fdb4500-91b9-11e9-9351-949a23fd7c75.png" data-canonical-src="https://user-images.githubusercontent.com/1100749/59696200-8fdb4500-91b9-11e9-9351-949a23fd7c75.png" width=500/>
 
 #### Passing tests:


### PR DESCRIPTION
This took me longer to figure out than I care to admit, so I've added an instruction that says you should click "view more details on Google Cloud Build" after clicking "Details"  :sweat_smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5095)
<!-- Reviewable:end -->
