### PR TITLE
Add missing op categories in converter and tests

### DIFF
--- a/tfjs-converter/scripts/gen_doc.ts
+++ b/tfjs-converter/scripts/gen_doc.ts
@@ -31,7 +31,9 @@ import * as matrices from '../src/operations/op_list/matrices';
 import * as normalization from '../src/operations/op_list/normalization';
 import * as reduction from '../src/operations/op_list/reduction';
 import * as sliceJoin from '../src/operations/op_list/slice_join';
+import * as sparse from '../src/operations/op_list/sparse';
 import * as spectral from '../src/operations/op_list/spectral';
+import * as string from '../src/operations/op_list/string';
 import * as transformation from '../src/operations/op_list/transformation';
 import {OpMapper} from '../src/operations/types';
 
@@ -39,11 +41,10 @@ import {OpMapper} from '../src/operations/types';
 // manually copied over before running this script.
 const JSON_DIR = './tfjs-core.json';
 const DOC_DIR = './docs/';
-
 const ops = [
   arithmetic, basicMath, control, convolution, creation, dynamic, evaluation,
-  logical, image, graph, matrices, normalization, reduction, sliceJoin,
-  spectral, transformation
+  graph, hashtable, image, logical, matrices, normalization, reduction,
+  sliceJoin, sparse, spectral, string, transformation
 ];
 
 async function genDoc() {
@@ -87,13 +88,15 @@ async function genDoc() {
       'Tensorflow', 'Graph', (graph.json as {}) as OpMapper[], output,
       coreApis);
   generateTable(
-      'Operations', 'Logical', (logical.json as {}) as OpMapper[], output,
-      coreApis);
-  generateTable(
       'Operations', 'Hashtable', (hashtable.json as {}) as OpMapper[], output,
       coreApis);
   generateTable(
       'Operations', 'Images', (image.json as {}) as OpMapper[], output,
+      coreApis);
+  generateTable(
+      'Operations', 'Linear Algebra', [] as OpMapper[], output, coreApis);
+  generateTable(
+      'Operations', 'Logical', (logical.json as {}) as OpMapper[], output,
       coreApis);
   generateTable(
       'Operations', 'Matrices', (matrices.json as {}) as OpMapper[], output,
@@ -109,15 +112,19 @@ async function genDoc() {
   generateTable('Tensors', 'RNN', [] as OpMapper[], output, coreApis);
   generateTable('Operations', 'Scan', [] as OpMapper[], output, coreApis);
   generateTable('Operations', 'Segment', [] as OpMapper[], output, coreApis);
+  generateTable('Operations', 'Signal', [] as OpMapper[], output, coreApis);
   generateTable(
       'Tensors', 'Slicing and Joining', (sliceJoin.json as {}) as OpMapper[],
       output, coreApis);
   generateTable(
+      'Operations', 'Sparse', (sparse.json as {}) as OpMapper[], output,
+      coreApis);
+  generateTable(
       'Operations', 'Spectral', (spectral.json as {}) as OpMapper[], output,
       coreApis);
-  generateTable('Operations', 'Signal', [] as OpMapper[], output, coreApis);
   generateTable(
-      'Operations', 'Linear Algebra', [] as OpMapper[], output, coreApis);
+      'Operations', 'String', (string.json as {}) as OpMapper[], output,
+      coreApis);
   generateTable(
       'Tensors', 'Transformations', (transformation.json as {}) as OpMapper[],
       output, coreApis);

--- a/tfjs-converter/src/operations/op_list/op_list_test.ts
+++ b/tfjs-converter/src/operations/op_list/op_list_test.ts
@@ -32,6 +32,9 @@ import * as matrices from './matrices';
 import * as normalization from './normalization';
 import * as reduction from './reduction';
 import * as sliceJoin from './slice_join';
+import * as sparse from './sparse';
+import * as spectral from './spectral';
+import * as string from './string';
 import * as transformation from './transformation';
 
 describe('OpListTest', () => {
@@ -45,16 +48,19 @@ describe('OpListTest', () => {
     basicMath,
     control,
     convolution,
+    creation,
     dynamic,
     evaluation,
-    creation,
-    logical,
-    image,
     graph,
+    image,
+    logical,
     matrices,
     normalization,
     reduction,
     sliceJoin,
+    sparse,
+    spectral,
+    string,
     transformation
   };
   Object.keys(mappersJson).forEach(key => {

--- a/tfjs-converter/src/operations/operation_executor_test.ts
+++ b/tfjs-converter/src/operations/operation_executor_test.ts
@@ -37,7 +37,9 @@ import * as matrices from './executors/matrices_executor';
 import * as normalization from './executors/normalization_executor';
 import * as reduction from './executors/reduction_executor';
 import * as slice_join from './executors/slice_join_executor';
+import * as sparse from './executors/sparse_executor';
 import * as spectral from './executors/spectral_executor';
+import * as string from './executors/string_executor';
 import * as transformation from './executors/transformation_executor';
 import {executeOp} from './operation_executor';
 import {Node} from './types';
@@ -60,9 +62,9 @@ describe('OperationExecutor', () => {
   });
 
   describe('executeOp', () => {
-    [arithmetic, basic_math, convolution, control, creation, dynamic,
-     evaluation, image, graph, logical, matrices, normalization, reduction,
-     slice_join, spectral, transformation]
+    [arithmetic, basic_math, control, convolution, creation, dynamic,
+     evaluation, graph, image, logical, matrices, normalization, reduction,
+     slice_join, sparse, spectral, string, transformation]
         .forEach(category => {
           it('should call ' + category.CATEGORY + ' executor', () => {
             spyOn(category, 'executeOp');
@@ -71,9 +73,9 @@ describe('OperationExecutor', () => {
             expect(category.executeOp).toHaveBeenCalledWith(node, {}, context);
           });
         });
-    [arithmetic, basic_math, convolution, creation, evaluation, image, graph,
-     logical, matrices, normalization, reduction, slice_join, spectral,
-     transformation]
+    [arithmetic, basic_math, convolution, creation, evaluation, graph, image,
+     logical, matrices, normalization, reduction, slice_join, sparse, spectral,
+     string, transformation]
         .forEach(category => {
           it('should call tidy around executor', () => {
             spyOn(tfc, 'tidy');

--- a/tfjs-converter/src/operations/operation_mapper.ts
+++ b/tfjs-converter/src/operations/operation_mapper.ts
@@ -36,7 +36,9 @@ import * as matrices from './op_list/matrices';
 import * as normalization from './op_list/normalization';
 import * as reduction from './op_list/reduction';
 import * as sliceJoin from './op_list/slice_join';
+import * as sparse from './op_list/sparse';
 import * as spectral from './op_list/spectral';
+import * as string from './op_list/string';
 import * as transformation from './op_list/transformation';
 import {Graph, InputParamValue, Node, OpMapper, ParamValue} from './types';
 
@@ -54,8 +56,8 @@ export class OperationMapper {
   private constructor() {
     const ops = [
       arithmetic, basicMath, control, convolution, creation, dynamic,
-      evaluation, logical, image, graph, matrices, normalization, reduction,
-      sliceJoin, spectral, transformation, hashTable
+      evaluation, graph, hashTable, image, logical, matrices, normalization,
+      reduction, sliceJoin, sparse, spectral, string, transformation
     ];
     const mappersJson: OpMapper[] = [].concat(...ops.map(op => op.json));
 

--- a/tfjs-converter/src/operations/operation_mapper_test.ts
+++ b/tfjs-converter/src/operations/operation_mapper_test.ts
@@ -25,21 +25,24 @@ import * as creation from './op_list/creation';
 import * as dynamic from './op_list/dynamic';
 import * as evaluation from './op_list/evaluation';
 import * as graph from './op_list/graph';
+import * as hashTable from './op_list/hash_table';
 import * as image from './op_list/image';
 import * as logical from './op_list/logical';
 import * as matrices from './op_list/matrices';
 import * as normalization from './op_list/normalization';
 import * as reduction from './op_list/reduction';
 import * as sliceJoin from './op_list/slice_join';
+import * as sparse from './op_list/sparse';
 import * as spectral from './op_list/spectral';
+import * as string from './op_list/string';
 import * as transformation from './op_list/transformation';
 import {OperationMapper} from './operation_mapper';
 import {Graph} from './types';
 
 const ops = [
   arithmetic, basicMath, control, convolution, creation, dynamic, evaluation,
-  logical, image, graph, matrices, normalization, reduction, sliceJoin,
-  spectral, transformation
+  graph, hashTable, image, logical, matrices, normalization, reduction,
+  sliceJoin, sparse, spectral, string, transformation
 ];
 const mapper: OperationMapper = OperationMapper.Instance;
 let convertedGraph: Graph;
@@ -53,8 +56,7 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
         dtype: {
           type: tensorflow.DataType.DT_FLOAT,
         },
-        shape:
-            {shape: {dim: [{size: '3'}, {size: 3}, {size: '3'}, {size: 1}]}}
+        shape: {shape: {dim: [{size: '3'}, {size: 3}, {size: '3'}, {size: 1}]}}
       }
     },
     {
@@ -107,10 +109,8 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
       name: 'BiasAdd',
       op: 'BiasAdd',
       input: ['Conv2D', 'Shape'],
-      attr: {
-        T: {type: tensorflow.DataType.DT_FLOAT},
-        dataFormat: {s: 'TkhXQw=='}
-      }
+      attr:
+          {T: {type: tensorflow.DataType.DT_FLOAT}, dataFormat: {s: 'TkhXQw=='}}
     },
     {
       name: 'Cast',
@@ -254,11 +254,8 @@ const SIGNATURE: tensorflow.ISignatureDef = {
     }
   },
   outputs: {
-    squeeze: {
-      name: 'Squeeze',
-      dtype: tensorflow.DataType.DT_FLOAT,
-      tensorShape: {}
-    }
+    squeeze:
+        {name: 'Squeeze', dtype: tensorflow.DataType.DT_FLOAT, tensorShape: {}}
   }
 };
 
@@ -372,8 +369,7 @@ describe('operationMapper without signature', () => {
                 }
               },
               outputs: {
-                identity:
-                    {name: 'Less:z:0', dtype: tensorflow.DataType.DT_BOOL}
+                identity: {name: 'Less:z:0', dtype: tensorflow.DataType.DT_BOOL}
               }
             });
       });

--- a/tfjs-converter/src/operations/types.ts
+++ b/tfjs-converter/src/operations/types.ts
@@ -24,9 +24,9 @@ import {ResourceManager} from '../executor/resource_manager';
 export type ParamType = 'number'|'string'|'string[]'|'number[]'|'bool'|'bool[]'|
     'shape'|'shape[]'|'tensor'|'tensors'|'dtype'|'dtype[]'|'func';
 export type Category = 'arithmetic'|'basic_math'|'control'|'convolution'|
-    'custom'|'dynamic'|'evaluation'|'image'|'creation'|'graph'|'logical'|
-    'matrices'|'normalization'|'reduction'|'slice_join'|'spectral'|
-    'transformation'|'hash_table'|'sparse'|'string';
+    'creation'|'custom'|'dynamic'|'evaluation'|'graph'|'hash_table'|'image'|
+    'logical'|'matrices'|'normalization'|'reduction'|'slice_join'|'sparse'|
+    'spectral'|'string'|'transformation';
 
 // For mapping input or attributes of NodeDef into TensorFlow.js op param.
 export declare interface ParamMapper {


### PR DESCRIPTION
The converter fails to convert models with string ops due to not having that category included in the operation mapper

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5114)
<!-- Reviewable:end -->
