### PR TITLE
libtensorflow path name replacing

### DIFF
--- a/tfjs-node/binding.gyp
+++ b/tfjs-node/binding.gyp
@@ -55,7 +55,7 @@
                 'install_name_tool',
                 "-change",
                 "@rpath/libtensorflow.2.dylib",
-                "@loader_path/../../deps/lib/libtensorflow.dylib",
+                "@loader_path/../../deps/lib/libtensorflow.2.dylib",
                 "<(PRODUCT_DIR)/tfjs_binding.node"
               ]
             },


### PR DESCRIPTION
The path name referencing darwin libtensorflow dylib fixed, to be the same as that of libtensorflow_framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5171)
<!-- Reviewable:end -->
