### PR TITLE
Upgrade webgpu to 0.0.1-alpha.7

### DIFF
--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-backend-webgpu",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "main": "dist/tf-backend-webgpu.node.js",
   "types": "dist/index.d.ts",
   "jsnext:main": "dist/index.js",


### PR DESCRIPTION
This is a version bump with no feature changes. It's needed in order to correctly publish the package to npm as `latest` instead of `beta`, which alpha.6 was accidentally published as.
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5176)
<!-- Reviewable:end -->
