### PR TITLE
Use CopyExternalImageToTexture() in FromPixels

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -44,7 +44,7 @@ export function fromPixels(args: {
   }
 
   const outShape = [pixels.height, pixels.width, numChannels];
-  let imageData = (pixels as ImageData | backend_util.PixelData).data;
+  const imageData = (pixels as ImageData | backend_util.PixelData).data;
 
   if (env().getBool('IS_BROWSER')) {
     if (!(pixels instanceof HTMLVideoElement) &&

--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -15,12 +15,12 @@
  * =============================================================================
  */
 
-import { env, KernelConfig, KernelFunc } from '@tensorflow/tfjs-core';
-import { FromPixels, FromPixelsAttrs, FromPixelsInputs } from '@tensorflow/tfjs-core';
-import { backend_util, TensorInfo } from '@tensorflow/tfjs-core';
+import {env, KernelConfig, KernelFunc} from '@tensorflow/tfjs-core';
+import {FromPixels, FromPixelsAttrs, FromPixelsInputs} from '@tensorflow/tfjs-core';
+import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
-import { WebGPUBackend } from '../backend_webgpu';
-import { fromPixelsExternalImage } from './FromPixelsExternalImage';
+import {WebGPUBackend} from '../backend_webgpu';
+import {fromPixelsExternalImage} from './FromPixelsExternalImage';
 
 export const fromPixelsConfig: KernelConfig = {
   kernelName: FromPixels,
@@ -35,9 +35,9 @@ export function fromPixels(args: {
   backend: WebGPUBackend,
   attrs: FromPixelsAttrs
 }): TensorInfo {
-  const { inputs, backend, attrs } = args;
-  let { pixels } = inputs;
-  const { numChannels } = attrs;
+  const {inputs, backend, attrs} = args;
+  let {pixels} = inputs;
+  const {numChannels} = attrs;
 
   if (pixels == null) {
     throw new Error('pixels passed to tf.browser.fromPixels() can not be null');
@@ -48,20 +48,20 @@ export function fromPixels(args: {
 
   if (env().getBool('IS_BROWSER')) {
     if (!(pixels instanceof HTMLVideoElement) &&
-      !(pixels instanceof HTMLImageElement) &&
-      !(pixels instanceof HTMLCanvasElement) &&
-      !(pixels instanceof ImageData) && !(pixels instanceof ImageBitmap) &&
-      !(pixels.data instanceof Uint8Array)) {
+        !(pixels instanceof HTMLImageElement) &&
+        !(pixels instanceof HTMLCanvasElement) &&
+        !(pixels instanceof ImageData) && !(pixels instanceof ImageBitmap) &&
+        !(pixels.data instanceof Uint8Array)) {
       throw new Error(
-        'pixels passed to tf.browser.fromPixels() must be either an ' +
-        `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement, ImageData, ` +
-        `ImageBitmap ` +
-        `or {data: Uint32Array, width: number, height: number}, ` +
-        `but was ${(pixels as {}).constructor.name}`);
+          'pixels passed to tf.browser.fromPixels() must be either an ' +
+          `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement, ImageData, ` +
+          `ImageBitmap ` +
+          `or {data: Uint32Array, width: number, height: number}, ` +
+          `but was ${(pixels as {}).constructor.name}`);
     }
 
     if (pixels instanceof HTMLVideoElement ||
-      pixels instanceof HTMLImageElement) {
+        pixels instanceof HTMLImageElement) {
       if (fromPixels2DContext == null) {
         fromPixels2DContext = document.createElement('canvas').getContext('2d');
       }
@@ -72,7 +72,7 @@ export function fromPixels(args: {
     }
 
     if (pixels instanceof ImageBitmap || pixels instanceof HTMLCanvasElement) {
-      return fromPixelsExternalImage({ externalImage: pixels, backend, attrs });
+      return fromPixelsExternalImage({externalImage: pixels, backend, attrs});
     }
   }
 

--- a/tfjs-backend-webgpu/src/kernels/FromPixelsExternalImage.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixelsExternalImage.ts
@@ -15,18 +15,18 @@
  * =============================================================================
  */
 
-import { FromPixelsAttrs, TensorInfo, util } from '@tensorflow/tfjs-core';
-import { WebGPUBackend } from '../backend_webgpu';
-import { FromPixelsProgram } from './FromPixels_utils/from_pixels_webgpu';
+import {FromPixelsAttrs, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {WebGPUBackend} from '../backend_webgpu';
+import {FromPixelsProgram} from './FromPixels_utils/from_pixels_webgpu';
 import * as webgpu_program from './webgpu_program';
 
 export function fromPixelsExternalImage(args: {
-  externalImage: HTMLCanvasElement | ImageBitmap | OffscreenCanvas,
+  externalImage: HTMLCanvasElement|ImageBitmap|OffscreenCanvas,
   backend: WebGPUBackend,
   attrs: FromPixelsAttrs
 }): TensorInfo {
-  const { externalImage, backend, attrs } = args;
-  const { numChannels } = attrs;
+  const {externalImage, backend, attrs} = args;
+  const {numChannels} = attrs;
 
   const outShape = [externalImage.height, externalImage.width, numChannels];
   const size = util.sizeFromShape(outShape);
@@ -48,22 +48,22 @@ export function fromPixelsExternalImage(args: {
   const outputShapes = [output.shape];
   const outputTypes = [output.dtype];
   const key = webgpu_program.makeShaderKey(
-    backend.fromPixelProgram, outputShapes, outputTypes);
+      backend.fromPixelProgram, outputShapes, outputTypes);
 
   const pipeline = backend.getAndSavePipeline(key, () => {
     return webgpu_program.compileProgram(
-      backend.glslang, backend.device, backend.fromPixelProgram,
-      backend.fromPixelLayout.pipelineLayout, [], output, true);
+        backend.glslang, backend.device, backend.fromPixelProgram,
+        backend.fromPixelLayout.pipelineLayout, [], output, true);
   });
 
   backend.fromPixelProgram.setPipeline(pipeline);
 
   backend.queue.copyExternalImageToTexture(
-    { source: externalImage, origin: { x: 0, y: 0 } }, {
-      texture: backend.fromPixelProgram.makeInputTexture(
-        backend.device, externalImage.width, externalImage.height)
-    },
-    [externalImage.width, externalImage.height]);
+      {source: externalImage, origin: {x: 0, y: 0}}, {
+        texture: backend.fromPixelProgram.makeInputTexture(
+            backend.device, externalImage.width, externalImage.height)
+      },
+      [externalImage.width, externalImage.height]);
 
   const info = backend.tensorMap.get(output.dataId);
 

--- a/tfjs-backend-webgpu/src/kernels/FromPixelsExternalImage.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixelsExternalImage.ts
@@ -15,20 +15,20 @@
  * =============================================================================
  */
 
-import {FromPixelsAttrs, TensorInfo, util} from '@tensorflow/tfjs-core';
-import {WebGPUBackend} from '../backend_webgpu';
-import {FromPixelsProgram} from './FromPixels_utils/from_pixels_webgpu';
+import { FromPixelsAttrs, TensorInfo, util } from '@tensorflow/tfjs-core';
+import { WebGPUBackend } from '../backend_webgpu';
+import { FromPixelsProgram } from './FromPixels_utils/from_pixels_webgpu';
 import * as webgpu_program from './webgpu_program';
 
-export function fromPixelsImageBitmap(args: {
-  imageBitmap: ImageBitmap,
+export function fromPixelsExternalImage(args: {
+  externalImage: HTMLCanvasElement | ImageBitmap | OffscreenCanvas,
   backend: WebGPUBackend,
   attrs: FromPixelsAttrs
 }): TensorInfo {
-  const {imageBitmap, backend, attrs} = args;
-  const {numChannels} = attrs;
+  const { externalImage, backend, attrs } = args;
+  const { numChannels } = attrs;
 
-  const outShape = [imageBitmap.height, imageBitmap.width, numChannels];
+  const outShape = [externalImage.height, externalImage.width, numChannels];
   const size = util.sizeFromShape(outShape);
   const strides = util.computeStrides(outShape);
   const uniformData = [size, numChannels, ...strides];
@@ -41,29 +41,29 @@ export function fromPixelsImageBitmap(args: {
   }
 
   // Different outShape will affect preprocessor result,
-  // e.g. getCoordsFromFlatIndex. FromPixelsImageBitmap need
+  // e.g. getCoordsFromFlatIndex. FromPixelsImageExternalImage needs
   // to recompile the pipeline to get the correct result.
-  // FromPixelsImageBitmap leverages webgpu backend pipeline
+  // FromPixelsExternalImage leverages webgpu backend pipeline
   // cache system to avoid useless recompile.
   const outputShapes = [output.shape];
   const outputTypes = [output.dtype];
   const key = webgpu_program.makeShaderKey(
-      backend.fromPixelProgram, outputShapes, outputTypes);
+    backend.fromPixelProgram, outputShapes, outputTypes);
 
   const pipeline = backend.getAndSavePipeline(key, () => {
     return webgpu_program.compileProgram(
-        backend.glslang, backend.device, backend.fromPixelProgram,
-        backend.fromPixelLayout.pipelineLayout, [], output, true);
+      backend.glslang, backend.device, backend.fromPixelProgram,
+      backend.fromPixelLayout.pipelineLayout, [], output, true);
   });
 
   backend.fromPixelProgram.setPipeline(pipeline);
 
-  backend.queue.copyImageBitmapToTexture(
-      {imageBitmap, origin: {x: 0, y: 0}}, {
-        texture: backend.fromPixelProgram.makeInputTexture(
-            backend.device, imageBitmap.width, imageBitmap.height)
-      },
-      [imageBitmap.width, imageBitmap.height]);
+  backend.queue.copyExternalImageToTexture(
+    { source: externalImage, origin: { x: 0, y: 0 } }, {
+      texture: backend.fromPixelProgram.makeInputTexture(
+        backend.device, externalImage.width, externalImage.height)
+    },
+    [externalImage.width, externalImage.height]);
 
   const info = backend.tensorMap.get(output.dataId);
 


### PR DESCRIPTION
WebGPU will deprecate CopyImageBitmapToTexture() in future and
use CopyExternalImageToTexture().

ExternalImage includes ImageBitmap and Canvas(2d/webgl). With the 
new API, tfjs webgpu backend can use Canvas as intermediate resource to
handle video and image element and uploading it to tensor in a sync way.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5202)
<!-- Reviewable:end -->
