### PR TITLE
[webgpu] Move activation policy to program

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -23,9 +23,7 @@ import {backend_util, buffer, DataStorage, DataType, DataValues, engine, env, Ke
 import {Glslang} from '@webgpu/glslang/dist/web-devel/glslang.onefile';
 
 import {BufferManager} from './buffer_manager';
-import {BinaryOpType, getBinaryOpString} from './kernels/binary_ops';
 import {FromPixelsProgram} from './kernels/FromPixels_utils/from_pixels_webgpu';
-import * as unary_op from './kernels/unary_op_webgpu';
 import * as webgpu_program from './kernels/webgpu_program';
 import * as webgpu_util from './webgpu_util';
 
@@ -847,25 +845,6 @@ export class WebGPUBackend extends KernelBackend {
             input =>
                 this.tensorMap.get(input.dataId).bufferInfo.buffer == null &&
                 util.sizeFromShape(input.shape) < sizeThreshold);
-  }
-
-  mapActivationToShaderProgram(
-      activation: backend_util.Activation, packed = false): string {
-    if (activation === 'linear') {
-      return unary_op.LINEAR;
-    } else if (activation === 'relu') {
-      return packed ? unary_op.RELU_VEC4 : unary_op.RELU;
-    } else if (activation === 'elu') {
-      return packed ? unary_op.ELU_VEC4 : unary_op.ELU;
-    } else if (activation === 'relu6') {
-      return unary_op.RELU6;
-    } else if (activation === 'prelu') {
-      return getBinaryOpString(BinaryOpType.PRELU, packed);
-    } else if (activation === 'sigmoid') {
-      return unary_op.SIGMOID;
-    }
-    throw new Error(`Activation ${
-        activation} has not been implemented for the WebGPU backend.`);
   }
 
   numDataIds() {

--- a/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
@@ -97,9 +97,6 @@ export function batchMatMulImpl({
 
   const useVec4 = a.shape[2] % 4 === 0 && b.shape[2] % 4 === 0 && !transposeA &&
       !transposeB && outerShapeB >= 32;
-  const fusedActivation = activation ?
-      backend.mapActivationToShaderProgram(activation, useVec4) :
-      null;
   let program: MatMulPackedProgram|MatMulPackedVec4Program;
   if (useVec4) {
     // TODO: Currently we need to make sure that a.shape[2] and b.shape[2]
@@ -107,13 +104,13 @@ export function batchMatMulImpl({
     // remove this limitation by insert 0 to pack data.
     program = new MatMulPackedVec4Program(
         a3dShape, [batchDim, outerShapeA, outerShapeB],
-        env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, bias,
-        fusedActivation, preluActivationWeights);
+        env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, bias, activation,
+        preluActivationWeights);
   } else {
     program = new MatMulPackedProgram(
         a3dShape, [batchDim, outerShapeA, outerShapeB],
         env().get('WEBGPU_MATMUL_WORK_PER_THREAD') as number, transposeA,
-        transposeB, bias, fusedActivation, preluActivationWeights);
+        transposeB, bias, activation, preluActivationWeights);
   }
   const inputs: TensorInfo[] = [a3d, b3d];
   if (bias) {

--- a/tfjs-backend-webgpu/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/FusedConv2D.ts
@@ -72,21 +72,17 @@ export function fusedConv2d(args: {
 
   const useVec4 =
       convInfo.inChannels % 4 === 0 && convInfo.outChannels % 4 === 0;
-  const packed = !useNaive && useVec4;
-  const fusedActivation = activation ?
-      backend.mapActivationToShaderProgram(activation, packed) :
-      null;
 
   if (useNaive) {
     // TODO(kainino0x): This may be obsolete, but is kept for reference.
     program = new Conv2DNaiveProgram(
-        convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+        convInfo, hasBias, activation, hasPreluActivationWeights);
   } else if (useVec4) {
     program = new Conv2DMMVec4Program(
-        convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+        convInfo, hasBias, activation, hasPreluActivationWeights);
   } else {
     program = new Conv2DMMProgram(
-        convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+        convInfo, hasBias, activation, hasPreluActivationWeights);
   }
 
   const padInfo = [convInfo.padInfo.top, convInfo.padInfo.left];

--- a/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
@@ -44,8 +44,6 @@ export function fusedDepthwiseConv2D(args: {
       filter.shape as [number, number, number, number], strides, $dilations,
       pad, dimRoundingMode, true /* depthwise */);
 
-  const fusedActivation =
-      activation ? backend.mapActivationToShaderProgram(activation) : null;
   const programInputs: TensorInfo[] = [x, filter];
 
   const hasBias = bias != null;
@@ -59,7 +57,7 @@ export function fusedDepthwiseConv2D(args: {
   }
 
   const program = new DepthwiseConv2DProgram(
-      convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
+      convInfo, hasBias, activation, hasPreluActivationWeights);
 
   const dimensions = [
     {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},

--- a/tfjs-backend-webgpu/src/kernels/activation_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/activation_util.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util} from '@tensorflow/tfjs-core';
+
+import {BinaryOpType, getBinaryOpString} from './binary_ops';
+import * as unary_op from './unary_op_webgpu';
+
+export function mapActivationToShaderProgram(
+    activation: backend_util.Activation, packed = false): string {
+  if (activation === null) {
+    return null;
+  } else if (activation === 'linear') {
+    return unary_op.LINEAR;
+  } else if (activation === 'relu') {
+    return packed ? unary_op.RELU_VEC4 : unary_op.RELU;
+  } else if (activation === 'elu') {
+    return packed ? unary_op.ELU_VEC4 : unary_op.ELU;
+  } else if (activation === 'relu6') {
+    return unary_op.RELU6;
+  } else if (activation === 'prelu') {
+    return getBinaryOpString(BinaryOpType.PRELU, packed);
+  } else if (activation === 'sigmoid') {
+    return unary_op.SIGMOID;
+  }
+  throw new Error(`Activation ${
+      activation} has not been implemented for the WebGPU backend.`);
+}

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
@@ -18,6 +18,7 @@
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, tilesFitEvenlyIntoShape} from '../webgpu_util';
+import {mapActivationToShaderProgram} from './activation_util';
 
 import {makeMatMulPackedVec4Source} from './matmul_packed_vec4_webgpu';
 import {WebGPUProgram} from './webgpu_program';
@@ -41,8 +42,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivationWeights = false,
-      hasLeakyreluAlpha = false) {
+      activation: backend_util.Activation = null,
+      hasPreluActivationWeights = false, hasLeakyreluAlpha = false) {
     this.outputShape = convInfo.outShape;
 
     util.assert(
@@ -56,7 +57,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         elementsPerThread);
     this.convInfo = convInfo;
     this.addBias = addBias;
-    this.activation = activation;
+    this.activation =
+        mapActivationToShaderProgram(activation, true);
     this.hasPreluActivationWeights = hasPreluActivationWeights;
     this.hasLeakyreluAlpha = hasLeakyreluAlpha;
     if (this.addBias) {

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_webgpu.ts
@@ -18,6 +18,7 @@
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d, tilesFitEvenlyIntoShape} from '../webgpu_util';
+import {mapActivationToShaderProgram} from './activation_util';
 
 import {makeMatMulPackedSource} from './matmul_packed_webgpu';
 import {WebGPUProgram} from './webgpu_program';
@@ -40,7 +41,8 @@ export class Conv2DMMProgram implements WebGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivationWeights = false) {
+      activation: backend_util.Activation = null,
+      hasPreluActivationWeights = false) {
     this.outputShape = convInfo.outShape;
 
     util.assert(
@@ -65,7 +67,7 @@ export class Conv2DMMProgram implements WebGPUProgram {
     }
     this.convInfo = convInfo;
     this.addBias = addBias;
-    this.activation = activation;
+    this.activation = mapActivationToShaderProgram(activation);
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 
     [this.fitA, this.fitB] = this.getShapeFit();

--- a/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
@@ -18,6 +18,7 @@
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {mapActivationToShaderProgram} from './activation_util';
 
 import {WebGPUProgram} from './webgpu_program';
 
@@ -36,7 +37,8 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivationWeights = false) {
+      activation: backend_util.Activation = null,
+      hasPreluActivationWeights = false) {
     this.outputShape = convInfo.outShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
@@ -55,6 +57,7 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
 
     this.convInfo = convInfo;
     this.addBias = addBias;
+    this.activation = mapActivationToShaderProgram(activation);
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 

--- a/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
@@ -17,6 +17,7 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {mapActivationToShaderProgram} from './activation_util';
 import {WebGPUProgram} from './webgpu_program';
 
 export class DepthwiseConv2DProgram implements WebGPUProgram {
@@ -35,7 +36,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
-      activation: string = null, hasPreluActivation = false) {
+      activation: backend_util.Activation = null, hasPreluActivation = false) {
     this.outputShape = convInfo.outShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
@@ -54,7 +55,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
 
     this.convInfo = convInfo;
     this.addBias = addBias;
-    this.activation = activation;
+    this.activation = mapActivationToShaderProgram(activation);
     this.hasPreluActivation = hasPreluActivation;
 
     this.shaderKey = `depthwise_${activation}_${

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
@@ -15,8 +15,9 @@
  * =============================================================================
  */
 
-import {TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from '../webgpu_util';
+import {mapActivationToShaderProgram} from './activation_util';
 
 import {WebGPUProgram} from './webgpu_program';
 
@@ -180,7 +181,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
 
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
-      rowPerThread: number, bias: TensorInfo = null, activation: string = null,
+      rowPerThread: number, bias: TensorInfo = null,
+      activation: backend_util.Activation = null,
       preluActivationWeights: TensorInfo = null) {
     this.outputShape = outputShape;
     this.workGroupSize = computeWorkGroupSizeForMatMul(
@@ -206,7 +208,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
     this.workPerThread = rowPerThread;
     this.aShape = aShape;
     this.addBias = addBias;
-    this.activation = activation;
+    this.activation =
+        mapActivationToShaderProgram(activation, this.isVec4);
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 
     [this.fitA, this.fitB] = this.getShapeFit();

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {TensorInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from '../webgpu_util';
+import {mapActivationToShaderProgram} from './activation_util';
 
 import {WebGPUProgram} from './webgpu_program';
 
@@ -194,7 +195,7 @@ export class MatMulPackedProgram implements WebGPUProgram {
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
       workPerThread: number, transposeA = false, transposeB = false,
-      bias: TensorInfo = null, activation: string = null,
+      bias: TensorInfo = null, activation: backend_util.Activation = null,
       preluActivationWeights: TensorInfo = null) {
     this.outputShape = outputShape;
     this.dispatchLayout = {x: [2], y: [1], z: [0]};
@@ -233,7 +234,7 @@ export class MatMulPackedProgram implements WebGPUProgram {
     this.transposeA = transposeA;
     this.transposeB = transposeB;
     this.addBias = addBias;
-    this.activation = activation;
+    this.activation = mapActivationToShaderProgram(activation);
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 
     const dimBOuter = this.outputShape[2];


### PR DESCRIPTION
Two goals:
1. Move shader related code to program, this decouples the general ts code and shader code.
2. For future WGSL, the activation(glsl or wgsl) can be decided by each program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5206)
<!-- Reviewable:end -->
