### PR TITLE
[webgpu] Simplify shader key of binary op and unary op

### DIFF
--- a/tfjs-backend-webgpu/src/kernel_utils/int.ts
+++ b/tfjs-backend-webgpu/src/kernel_utils/int.ts
@@ -17,10 +17,11 @@
 
 import {TensorInfo} from '@tensorflow/tfjs-core';
 import {WebGPUBackend} from '../backend_webgpu';
-import {TO_INT, UnaryOpProgram} from '../kernels/unary_op_webgpu';
+import {UnaryOpProgram} from '../kernels/unary_op_webgpu';
+import {UnaryOpType} from '../kernels/unary_op_util';
 
 export function int(input: TensorInfo, backend: WebGPUBackend): TensorInfo {
-  const program = new UnaryOpProgram(input.shape, TO_INT);
+  const program = new UnaryOpProgram(input.shape, UnaryOpType.TO_INT);
   const output = backend.runWebGPUProgram(program, [input], 'int32');
   return {dataId: output.dataId, shape: output.shape, dtype: output.dtype};
 }

--- a/tfjs-backend-webgpu/src/kernels/Abs.ts
+++ b/tfjs-backend-webgpu/src/kernels/Abs.ts
@@ -18,10 +18,10 @@
 import {Abs, KernelConfig} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {simpleAbsImplCPU} from '../kernel_utils/shared';
-import {ABS} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
 export const abs =
-    unaryKernelFunc({opSnippet: ABS, cpuKernelImpl: simpleAbsImplCPU});
+    unaryKernelFunc({opType: UnaryOpType.ABS, cpuKernelImpl: simpleAbsImplCPU});
 
 export const absConfig: KernelConfig = {
   kernelName: Abs,

--- a/tfjs-backend-webgpu/src/kernels/Add.ts
+++ b/tfjs-backend-webgpu/src/kernels/Add.ts
@@ -18,7 +18,7 @@
 import {Add, KernelConfig} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {addImplCPU as cpuAdd} from '../kernel_utils/shared';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const addKernelFunc = binaryKernelFunc({
   opSnippet: BinaryOpType.ADD,

--- a/tfjs-backend-webgpu/src/kernels/Ceil.ts
+++ b/tfjs-backend-webgpu/src/kernels/Ceil.ts
@@ -18,11 +18,10 @@
 import {Ceil, KernelConfig} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {ceilImplCPU} from '../kernel_utils/shared';
-
-const CEIL = `return ceil(a);`;
+import {UnaryOpType} from './unary_op_util';
 
 export const ceil =
-    unaryKernelFunc({opSnippet: CEIL, cpuKernelImpl: ceilImplCPU});
+    unaryKernelFunc({opType: UnaryOpType.CEIL, cpuKernelImpl: ceilImplCPU});
 
 export const ceilConfig: KernelConfig = {
   kernelName: Ceil,

--- a/tfjs-backend-webgpu/src/kernels/Elu.ts
+++ b/tfjs-backend-webgpu/src/kernels/Elu.ts
@@ -17,9 +17,9 @@
 
 import {Elu, KernelConfig} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {ELU} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const elu = unaryKernelFunc({opSnippet: ELU});
+export const elu = unaryKernelFunc({opType: UnaryOpType.ELU});
 
 export const eluConfig: KernelConfig = {
   kernelName: Elu,

--- a/tfjs-backend-webgpu/src/kernels/Equal.ts
+++ b/tfjs-backend-webgpu/src/kernels/Equal.ts
@@ -20,7 +20,7 @@ import {Equal, KernelConfig} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {equalImplCPU as cpuEqual} from '../kernel_utils/shared';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const equal = binaryKernelFunc(
     {opSnippet: BinaryOpType.EQUAL, dtype: 'bool', cpuKernelImpl: cpuEqual});

--- a/tfjs-backend-webgpu/src/kernels/Exp.ts
+++ b/tfjs-backend-webgpu/src/kernels/Exp.ts
@@ -18,9 +18,10 @@
 import {Exp, KernelConfig} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {expImplCPU} from '../kernel_utils/shared';
-import {EXP} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const exp = unaryKernelFunc({opSnippet: EXP, cpuKernelImpl: expImplCPU});
+export const exp =
+    unaryKernelFunc({opType: UnaryOpType.EXP, cpuKernelImpl: expImplCPU});
 
 export const expConfig: KernelConfig = {
   kernelName: Exp,

--- a/tfjs-backend-webgpu/src/kernels/Expm1.ts
+++ b/tfjs-backend-webgpu/src/kernels/Expm1.ts
@@ -18,11 +18,10 @@
 import {Expm1, KernelConfig} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {expm1ImplCPU} from '../kernel_utils/shared';
-
-const EXPM1 = `return exp(a) - 1.0;`;
+import {UnaryOpType} from './unary_op_util';
 
 export const expm1 =
-    unaryKernelFunc({opSnippet: EXPM1, cpuKernelImpl: expm1ImplCPU});
+    unaryKernelFunc({opType: UnaryOpType.EXPM1, cpuKernelImpl: expm1ImplCPU});
 
 export const expm1Config: KernelConfig = {
   kernelName: Expm1,

--- a/tfjs-backend-webgpu/src/kernels/Floor.ts
+++ b/tfjs-backend-webgpu/src/kernels/Floor.ts
@@ -19,11 +19,10 @@
 import {Floor, KernelConfig} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {floorImplCPU} from '../kernel_utils/shared';
-
-const FLOOR = `return floor(a);`;
+import {UnaryOpType} from './unary_op_util';
 
 export const floor =
-    unaryKernelFunc({opSnippet: FLOOR, cpuKernelImpl: floorImplCPU});
+    unaryKernelFunc({opType: UnaryOpType.FLOOR, cpuKernelImpl: floorImplCPU});
 
 export const floorConfig: KernelConfig = {
   kernelName: Floor,

--- a/tfjs-backend-webgpu/src/kernels/FloorDiv.ts
+++ b/tfjs-backend-webgpu/src/kernels/FloorDiv.ts
@@ -17,7 +17,7 @@
 
 import {FloorDiv, KernelConfig} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const floorDiv =
     binaryKernelFunc({opSnippet: BinaryOpType.INT_DIV, dtype: 'int32'});

--- a/tfjs-backend-webgpu/src/kernels/Greater.ts
+++ b/tfjs-backend-webgpu/src/kernels/Greater.ts
@@ -20,7 +20,7 @@ import {Greater, KernelConfig} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {greaterImplCPU as cpuGreater} from '../kernel_utils/shared';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const greater = binaryKernelFunc({
   opSnippet: BinaryOpType.GREATER,

--- a/tfjs-backend-webgpu/src/kernels/GreaterEqual.ts
+++ b/tfjs-backend-webgpu/src/kernels/GreaterEqual.ts
@@ -18,7 +18,7 @@
 import {GreaterEqual, KernelConfig} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {greaterEqualImplCPU as cpuGreaterEqual} from '../kernel_utils/shared';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const greaterEqual = binaryKernelFunc({
   opSnippet: BinaryOpType.GREATER_EQUAL,

--- a/tfjs-backend-webgpu/src/kernels/Less.ts
+++ b/tfjs-backend-webgpu/src/kernels/Less.ts
@@ -18,7 +18,7 @@
 import {KernelConfig, Less} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {lessImplCPU as cpuLess} from '../kernel_utils/shared';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const less = binaryKernelFunc(
     {opSnippet: BinaryOpType.LESS, dtype: 'bool', cpuKernelImpl: cpuLess});

--- a/tfjs-backend-webgpu/src/kernels/LessEqual.ts
+++ b/tfjs-backend-webgpu/src/kernels/LessEqual.ts
@@ -18,7 +18,7 @@
 import {KernelConfig, LessEqual} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {lessEqualImplCPU as cpuLessEqual} from '../kernel_utils/shared';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const lessEqual = binaryKernelFunc({
   opSnippet: BinaryOpType.LESS_EQUAL,

--- a/tfjs-backend-webgpu/src/kernels/Log.ts
+++ b/tfjs-backend-webgpu/src/kernels/Log.ts
@@ -18,9 +18,10 @@
 import {KernelConfig, Log} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {logImplCPU} from '../kernel_utils/shared';
-import {LOG} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const log = unaryKernelFunc({opSnippet: LOG, cpuKernelImpl: logImplCPU});
+export const log =
+    unaryKernelFunc({opType: UnaryOpType.LOG, cpuKernelImpl: logImplCPU});
 
 export const logConfig: KernelConfig = {
   kernelName: Log,

--- a/tfjs-backend-webgpu/src/kernels/LogicalAnd.ts
+++ b/tfjs-backend-webgpu/src/kernels/LogicalAnd.ts
@@ -19,7 +19,7 @@ import {KernelConfig, LogicalAnd} from '@tensorflow/tfjs-core';
 
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const logicalAnd = binaryKernelFunc({
   opSnippet: BinaryOpType.LOGICAL_AND,

--- a/tfjs-backend-webgpu/src/kernels/Maximum.ts
+++ b/tfjs-backend-webgpu/src/kernels/Maximum.ts
@@ -20,7 +20,7 @@ import {KernelConfig, Maximum} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {maximumImplCPU as cpuMaximum} from '../kernel_utils/shared';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const maximum = binaryKernelFunc({
   opSnippet: BinaryOpType.MAX,

--- a/tfjs-backend-webgpu/src/kernels/Minimum.ts
+++ b/tfjs-backend-webgpu/src/kernels/Minimum.ts
@@ -20,7 +20,7 @@ import {KernelConfig, Minimum} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {minimumImplCPU as cpuMinimum} from '../kernel_utils/shared';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const minimum = binaryKernelFunc({
   opSnippet: BinaryOpType.MIN,

--- a/tfjs-backend-webgpu/src/kernels/Multiply.ts
+++ b/tfjs-backend-webgpu/src/kernels/Multiply.ts
@@ -18,7 +18,7 @@
 import {KernelConfig, Multiply} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {multiplyImplCPU as cpuMultiply} from '../kernel_utils/shared';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const multiplyKernelFunc = binaryKernelFunc({
   opSnippet: BinaryOpType.MUL,

--- a/tfjs-backend-webgpu/src/kernels/Neg.ts
+++ b/tfjs-backend-webgpu/src/kernels/Neg.ts
@@ -16,10 +16,12 @@
  */
 
 import {KernelConfig, KernelFunc, Neg, NegInputs, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
+
 import {WebGPUBackend} from '../backend_webgpu';
 import {negImplCPU} from '../kernel_utils/shared';
+
+import {UnaryOpType} from './unary_op_util';
 import {UnaryOpProgram} from './unary_op_webgpu';
-import {NEG} from './unary_op_webgpu';
 
 // This doesn't use unaryKernelFunc because negImplCPU is not of type
 // SimpleUnaryKernelImplCPU.
@@ -35,7 +37,7 @@ export function neg(args: {inputs: NegInputs, backend: WebGPUBackend}):
     return backend.makeTensorInfo(newShape, x.dtype, outValues);
   }
 
-  const program = new UnaryOpProgram(x.shape, NEG);
+  const program = new UnaryOpProgram(x.shape, UnaryOpType.NEG);
 
   return backend.runWebGPUProgram(program, [x], x.dtype);
 }

--- a/tfjs-backend-webgpu/src/kernels/NotEqual.ts
+++ b/tfjs-backend-webgpu/src/kernels/NotEqual.ts
@@ -20,7 +20,7 @@ import {KernelConfig, NotEqual} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {notEqualImplCPU as cpuNotEqual} from '../kernel_utils/shared';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const notEqual = binaryKernelFunc({
   opSnippet: BinaryOpType.NOT_EQUAL,

--- a/tfjs-backend-webgpu/src/kernels/Pow.ts
+++ b/tfjs-backend-webgpu/src/kernels/Pow.ts
@@ -18,7 +18,7 @@
 import {KernelConfig, Pow} from '@tensorflow/tfjs-core';
 
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const pow = binaryKernelFunc({
   opSnippet: BinaryOpType.POW,

--- a/tfjs-backend-webgpu/src/kernels/Prelu.ts
+++ b/tfjs-backend-webgpu/src/kernels/Prelu.ts
@@ -18,15 +18,14 @@
 import {KernelConfig, KernelFunc, Prelu, PreluInputs, TensorInfo} from '@tensorflow/tfjs-core';
 import {WebGPUBackend} from '../backend_webgpu';
 import {BinaryOpProgram} from './binary_op_webgpu';
-import {BinaryOpType, getBinaryOpString} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export function prelu(args: {inputs: PreluInputs, backend: WebGPUBackend}):
     TensorInfo {
   const {inputs, backend} = args;
   const {x, alpha} = inputs;
 
-  const program = new BinaryOpProgram(
-      getBinaryOpString(BinaryOpType.PRELU), x.shape, alpha.shape);
+  const program = new BinaryOpProgram(BinaryOpType.PRELU, x.shape, alpha.shape);
   return backend.runWebGPUProgram(program, [x, alpha], x.dtype);
 }
 

--- a/tfjs-backend-webgpu/src/kernels/RealDiv.ts
+++ b/tfjs-backend-webgpu/src/kernels/RealDiv.ts
@@ -19,7 +19,7 @@ import {KernelConfig, KernelFunc, RealDiv} from '@tensorflow/tfjs-core';
 
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const realDiv = binaryKernelFunc({opSnippet: BinaryOpType.DIV});
 

--- a/tfjs-backend-webgpu/src/kernels/Relu.ts
+++ b/tfjs-backend-webgpu/src/kernels/Relu.ts
@@ -17,9 +17,9 @@
 
 import {KernelConfig, Relu} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {RELU} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const relu = unaryKernelFunc({opSnippet: RELU});
+export const relu = unaryKernelFunc({opType: UnaryOpType.RELU});
 
 export const reluConfig: KernelConfig = {
   kernelName: Relu,

--- a/tfjs-backend-webgpu/src/kernels/Relu6.ts
+++ b/tfjs-backend-webgpu/src/kernels/Relu6.ts
@@ -17,9 +17,9 @@
 
 import {KernelConfig, Relu6} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {RELU6} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const relu6 = unaryKernelFunc({opSnippet: RELU6});
+export const relu6 = unaryKernelFunc({opType: UnaryOpType.RELU6});
 
 export const relu6Config: KernelConfig = {
   kernelName: Relu6,

--- a/tfjs-backend-webgpu/src/kernels/Rsqrt.ts
+++ b/tfjs-backend-webgpu/src/kernels/Rsqrt.ts
@@ -18,11 +18,10 @@
 import {KernelConfig, Rsqrt} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {rsqrtImplCPU} from '../kernel_utils/shared';
-
-const RSQRT = `return inversesqrt(a);`;
+import {UnaryOpType} from './unary_op_util';
 
 export const rsqrt =
-    unaryKernelFunc({opSnippet: RSQRT, cpuKernelImpl: rsqrtImplCPU});
+    unaryKernelFunc({opType: UnaryOpType.RSQRT, cpuKernelImpl: rsqrtImplCPU});
 
 export const rsqrtConfig: KernelConfig = {
   kernelName: Rsqrt,

--- a/tfjs-backend-webgpu/src/kernels/Sigmoid.ts
+++ b/tfjs-backend-webgpu/src/kernels/Sigmoid.ts
@@ -17,9 +17,9 @@
 
 import {KernelConfig, Sigmoid} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {SIGMOID} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const sigmoid = unaryKernelFunc({opSnippet: SIGMOID});
+export const sigmoid = unaryKernelFunc({opType: UnaryOpType.SIGMOID});
 
 export const sigmoidConfig: KernelConfig = {
   kernelName: Sigmoid,

--- a/tfjs-backend-webgpu/src/kernels/Sqrt.ts
+++ b/tfjs-backend-webgpu/src/kernels/Sqrt.ts
@@ -17,10 +17,9 @@
 
 import {KernelConfig, Sqrt} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
+import {UnaryOpType} from './unary_op_util';
 
-import {SQRT} from './unary_op_webgpu';
-
-export const sqrt = unaryKernelFunc({opSnippet: SQRT});
+export const sqrt = unaryKernelFunc({opType: UnaryOpType.SQRT});
 
 export const sqrtConfig: KernelConfig = {
   kernelName: Sqrt,

--- a/tfjs-backend-webgpu/src/kernels/Square.ts
+++ b/tfjs-backend-webgpu/src/kernels/Square.ts
@@ -17,7 +17,8 @@
 
 import {KernelConfig, Square, SquareInputs} from '@tensorflow/tfjs-core';
 import {WebGPUBackend} from '../backend_webgpu';
-import {SQUARE, UnaryOpProgram} from './unary_op_webgpu';
+import {UnaryOpProgram} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
 export const squareConfig: KernelConfig = {
   kernelName: Square,
@@ -25,7 +26,7 @@ export const squareConfig: KernelConfig = {
   kernelFunc: ({inputs, backend}) => {
     const {x} = inputs as SquareInputs;
     const webGPUBackend = backend as WebGPUBackend;
-    const program = new UnaryOpProgram(x.shape, SQUARE);
+    const program = new UnaryOpProgram(x.shape, UnaryOpType.SQUARE);
     return webGPUBackend.runWebGPUProgram(program, [x], x.dtype);
   }
 };

--- a/tfjs-backend-webgpu/src/kernels/SquaredDifference.ts
+++ b/tfjs-backend-webgpu/src/kernels/SquaredDifference.ts
@@ -19,7 +19,7 @@ import {KernelConfig, SquaredDifference} from '@tensorflow/tfjs-core';
 
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const squaredDifference = binaryKernelFunc({
   opSnippet: BinaryOpType.SQUARED_DIFFERENCE,

--- a/tfjs-backend-webgpu/src/kernels/Sub.ts
+++ b/tfjs-backend-webgpu/src/kernels/Sub.ts
@@ -18,7 +18,7 @@
 import {KernelConfig, Sub} from '@tensorflow/tfjs-core';
 import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
 import {subImplCPU as cpuSub} from '../kernel_utils/shared';
-import {BinaryOpType} from './binary_ops';
+import {BinaryOpType} from './binary_op_util';
 
 export const sub = binaryKernelFunc({
   opSnippet: BinaryOpType.SUB,

--- a/tfjs-backend-webgpu/src/kernels/Tanh.ts
+++ b/tfjs-backend-webgpu/src/kernels/Tanh.ts
@@ -17,9 +17,9 @@
 
 import {KernelConfig, Tanh} from '@tensorflow/tfjs-core';
 import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
-import {TANH} from './unary_op_webgpu';
+import {UnaryOpType} from './unary_op_util';
 
-export const tanh = unaryKernelFunc({opSnippet: TANH});
+export const tanh = unaryKernelFunc({opType: UnaryOpType.TANH});
 
 export const tanhConfig: KernelConfig = {
   kernelName: Tanh,

--- a/tfjs-backend-webgpu/src/kernels/activation_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/activation_util.ts
@@ -17,25 +17,25 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {BinaryOpType, getBinaryOpString} from './binary_ops';
-import * as unary_op from './unary_op_webgpu';
+import {BinaryOpType, getBinaryOpString} from '../kernels/binary_op_util';
+import {getUnaryOpString, UnaryOpType} from '../kernels/unary_op_util';
 
 export function mapActivationToShaderProgram(
     activation: backend_util.Activation, packed = false): string {
   if (activation === null) {
     return null;
   } else if (activation === 'linear') {
-    return unary_op.LINEAR;
+    return getUnaryOpString(UnaryOpType.LINEAR);
   } else if (activation === 'relu') {
-    return packed ? unary_op.RELU_VEC4 : unary_op.RELU;
+    return getUnaryOpString(UnaryOpType.RELU, packed);
   } else if (activation === 'elu') {
-    return packed ? unary_op.ELU_VEC4 : unary_op.ELU;
+    return getUnaryOpString(UnaryOpType.ELU, packed);
   } else if (activation === 'relu6') {
-    return unary_op.RELU6;
+    return getUnaryOpString(UnaryOpType.RELU6);
   } else if (activation === 'prelu') {
     return getBinaryOpString(BinaryOpType.PRELU, packed);
   } else if (activation === 'sigmoid') {
-    return unary_op.SIGMOID;
+    return getUnaryOpString(UnaryOpType.SIGMOID);
   }
   throw new Error(`Activation ${
       activation} has not been implemented for the WebGPU backend.`);

--- a/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
@@ -19,6 +19,7 @@ import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {BinaryOpType, getBinaryOpString} from './binary_op_util';
 
 import {WebGPUProgram} from './webgpu_program';
 
@@ -32,12 +33,12 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
   workGroupSize: [number, number, number];
   useSharedMemoryWithB: boolean;
   lastDimensionSize: number;
-  op: string;
+  op: BinaryOpType;
   size: number;
   sizeFit: boolean;
 
   constructor(
-      op: string, aShape: number[], bShape: number[],
+      op: BinaryOpType, aShape: number[], bShape: number[],
       useSharedMemoryWithB: boolean) {
     // This is an experimental value when using shared memory.
     const workGroupSizeX = 512;
@@ -88,9 +89,10 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
             ${accessDataSnippet}
             setOutput(flatIndex, binaryOperation(a, b));
           }`;
+    const opStr = getBinaryOpString(this.op);
     const userCode = `
         float binaryOperation(float a, float b) {
-          ${this.op}
+          ${opStr}
         }
 
         shared float sharedBuf[${this.lastDimensionSize}];

--- a/tfjs-backend-webgpu/src/kernels/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_util.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export enum BinaryOpType {
+  MUL,
+  ADD,
+  SUB,
+  DIV,
+  EQUAL,
+  GREATER,
+  GREATER_EQUAL,
+  LESS,
+  LESS_EQUAL,
+  LOGICAL_AND,
+  NOT_EQUAL,
+  SQUARED_DIFFERENCE,
+  INT_DIV,
+  POW,
+  PRELU,
+  MAX,
+  MIN,
+  COMPLEX_MULTIPLY_REAL,
+  COMPLEX_MULTIPLY_IMAG
+}
+
+const CHECK_NAN_SNIPPET = `
+  if (isnan(a)) return a;
+  if (isnan(b)) return b;
+  `;
+const CHECK_NAN_SNIPPET_VEC4 = `
+  result.r = isNaN.r > 0. ? NAN : result.r;
+  result.g = isNaN.g > 0. ? NAN : result.g;
+  result.b = isNaN.b > 0. ? NAN : result.b;
+  result.a = isNaN.a > 0. ? NAN : result.a;
+  `;
+
+function getMinMaxString(op: string, useVec4: boolean) {
+  const checkNanSnippet = useVec4 ? CHECK_NAN_SNIPPET_VEC4 : CHECK_NAN_SNIPPET;
+  return useVec4 ? `
+    vec4 result = vec4(${op}(a, b));
+    vec4 isNaN = min(vec4(isnan(a)) + vec4(isnan(b)), vec4(1.0));
+    ` + checkNanSnippet +
+          `
+    return result;
+  ` :
+                   checkNanSnippet + `
+    return ${op}(a, b);
+  `;
+}
+
+const ADD = 'return a + b;';
+const DIV = 'return a / b;';
+const EQUAL = 'return float(a == b);';
+const EQUAL_VEC4 = 'return vec4(equal(a, b));';
+const GREATER = 'return float(a > b);';
+const GREATER_VEC4 = 'return vec4(greaterThan(a, b));';
+const GREATER_EQUAL = 'return float(a >= b);';
+const GREATER_EQUAL_VEC4 = 'return vec4(greaterThanEqual(a, b));';
+const LESS = 'return float(a < b);';
+const LESS_VEC4 = 'return vec4(lessThan(a, b));';
+const LESS_EQUAL = 'return float(a <= b);';
+const LESS_EQUAL_VEC4 = 'return vec4(lessThanEqual(a, b));';
+const LOGICAL_AND = 'return float(float(a) >= 1.0 && float(b) >= 1.0);';
+const LOGICAL_AND_VEC4 = `return vec4(
+  vec4(greaterThanEqual(a, vec4(1.0))) *
+  vec4(greaterThanEqual(b, vec4(1.0))));`;
+const NOT_EQUAL = 'return float(a != b);';
+const NOT_EQUAL_VEC4 = 'return vec4(notEqual(a, b));';
+const SQUARED_DIFFERENCE = 'return (a - b) * (a - b);';
+const INT_DIV = `
+float s = sign(a) * sign(b);
+int ia = int(round(a));
+int ib = int(round(b));
+return float(idiv(ia, ib, s));
+`;
+const INT_DIV_VEC4 = `
+ivec4 ia = round(a);
+ivec4 ib = round(b);
+bvec4 cond = notEqual(ib, ivec4(0));
+ivec4 result = ivec4(0);
+vec4 s = sign(a) * sign(b);
+
+// Windows (D3D) wants guaranteed non-zero int division at compile-time.
+if (cond[0]) {
+  result[0] = idiv(ia[0], ib[0], s[0]);
+}
+if (cond[1]) {
+  result[1] = idiv(ia[1], ib[1], s[1]);
+}
+if (cond[2]) {
+  result[2] = idiv(ia[2], ib[2], s[2]);
+}
+if (cond[3]) {
+  result[3] = idiv(ia[3], ib[3], s[3]);
+}
+return vec4(result);
+`;
+
+const PRELU = 'return (a < 0.) ? b * a : a;';
+const PRELU_VEC4 = `
+vec4 aLessThanZero = vec4(lessThan(a, vec4(0.)));
+return (aLessThanZero * (b * a)) + ((vec4(1.0) - aLessThanZero) * a);
+`;
+const POW = `
+if(a < 0.0 && floor(b) < b){
+  return NAN;
+}
+if (b == 0.0) {
+  return 1.0;
+}
+return (round(mod(b, 2.0)) != 1) ?
+    pow(abs(a), b) : sign(a) * pow(abs(a), b);
+`;
+const POW_VEC4 = `
+// isModRound1 has 1 for components with round(mod(b, 2.0)) == 1, 0 otherwise.
+vec4 isModRound1 = vec4(equal(round(mod(b, 2.0)), ivec4(1)));
+vec4 multiplier = sign(a) * isModRound1 + (vec4(1.0) - isModRound1);
+vec4 result = multiplier * pow(abs(a), b);
+
+// Ensure that a^0 = 1, including 0^0 = 1 as this correspond to TF and JS
+bvec4 isExpZero = equal(b, vec4(0.0));
+result.r = isExpZero.r ? 1.0 : result.r;
+result.g = isExpZero.g ? 1.0 : result.g;
+result.b = isExpZero.b ? 1.0 : result.b;
+result.a = isExpZero.a ? 1.0 : result.a;
+
+vec4 isNaN = vec4(lessThan(a, vec4(0.0))) * vec4(lessThan(floor(b), b));
+${CHECK_NAN_SNIPPET_VEC4}
+return result;
+`;
+// (Ar + Ai)(Br + Bi) =
+// ArBr + ArBi + AiBr + AiBi = ArBr - AB + ArBi + AiBr
+// Yr = ArBr - AB
+// Yi = ArBi + AiBr
+const COMPLEX_MULTIPLY_REAL = 'return areal * breal - aimag * bimag;';
+const COMPLEX_MULTIPLY_IMAG = 'return areal * bimag + aimag * breal;';
+
+export function getBinaryOpString(
+    type: BinaryOpType, useVec4?: boolean): string {
+  switch (type) {
+    case BinaryOpType.MUL:
+      return 'return a * b;';
+    case BinaryOpType.ADD:
+      return ADD;
+    case BinaryOpType.SUB:
+      return 'return a - b;';
+    case BinaryOpType.DIV:
+      return DIV;
+    case BinaryOpType.EQUAL:
+      return useVec4 ? EQUAL_VEC4 : EQUAL;
+    case BinaryOpType.GREATER:
+      return useVec4 ? GREATER_VEC4 : GREATER;
+    case BinaryOpType.GREATER_EQUAL:
+      return useVec4 ? GREATER_EQUAL_VEC4 : GREATER_EQUAL;
+    case BinaryOpType.LESS:
+      return useVec4 ? LESS_VEC4 : LESS;
+    case BinaryOpType.LESS_EQUAL:
+      return useVec4 ? LESS_EQUAL_VEC4 : LESS_EQUAL;
+    case BinaryOpType.LOGICAL_AND:
+      return useVec4 ? LOGICAL_AND_VEC4 : LOGICAL_AND;
+    case BinaryOpType.NOT_EQUAL:
+      return useVec4 ? NOT_EQUAL_VEC4 : NOT_EQUAL;
+    case BinaryOpType.SQUARED_DIFFERENCE:
+      return SQUARED_DIFFERENCE;
+    case BinaryOpType.INT_DIV:
+      return useVec4 ? INT_DIV_VEC4 : INT_DIV;
+    case BinaryOpType.PRELU:
+      return useVec4 ? PRELU_VEC4 : PRELU;
+    case BinaryOpType.MAX:
+      return getMinMaxString('max', useVec4);
+    case BinaryOpType.MIN:
+      return getMinMaxString('min', useVec4);
+    case BinaryOpType.POW:
+      return useVec4 ? POW_VEC4 : POW;
+    case BinaryOpType.COMPLEX_MULTIPLY_REAL:
+      return COMPLEX_MULTIPLY_REAL;
+    case BinaryOpType.COMPLEX_MULTIPLY_IMAG:
+      return COMPLEX_MULTIPLY_IMAG;
+    default:
+      throw new Error(`BinaryType ${type} is not implemented!`);
+  }
+}

--- a/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
@@ -18,6 +18,7 @@
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {BinaryOpType, getBinaryOpString} from './binary_op_util';
 
 import {WebGPUProgram} from './webgpu_program';
 
@@ -30,11 +31,11 @@ export class BinaryOpVec4Program implements WebGPUProgram {
   workPerThread = 4;
   workGroupSize: [number, number, number];
   isVec4 = true;
-  op: string;
+  op: BinaryOpType;
   size: number;
   fitShape: boolean;
 
-  constructor(op: string, aShape: number[], bShape: number[]) {
+  constructor(op: BinaryOpType, aShape: number[], bShape: number[]) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
     const workGroupSizeX = 128;
     this.workGroupSize = [workGroupSizeX, 1, 1];
@@ -51,10 +52,11 @@ export class BinaryOpVec4Program implements WebGPUProgram {
 
   getUserCode(): string {
     let userCode: string;
+    const opStr = getBinaryOpString(this.op, this.isVec4);
     if (this.fitShape) {
       userCode = `
       vec4 binaryOperation(vec4 a, vec4 b) {
-        ${this.op}
+        ${opStr}
       }
 
       void main() {
@@ -67,7 +69,7 @@ export class BinaryOpVec4Program implements WebGPUProgram {
     } else {
       userCode = `
       vec4 binaryOperation(vec4 a, vec4 b) {
-        ${this.op}
+        ${opStr}
       }
 
       void main() {

--- a/tfjs-backend-webgpu/src/kernels/binary_ops.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_ops.ts
@@ -19,173 +19,22 @@ import {util} from '@tensorflow/tfjs-core';
 import {BinaryOpSharedProgram} from './binary_op_shared_webgpu';
 import {BinaryOpVec4Program} from './binary_op_vec4_webgpu';
 import {BinaryOpProgram} from './binary_op_webgpu';
-
-export enum BinaryOpType {
-  MUL,
-  ADD,
-  SUB,
-  DIV,
-  EQUAL,
-  GREATER,
-  GREATER_EQUAL,
-  LESS,
-  LESS_EQUAL,
-  LOGICAL_AND,
-  NOT_EQUAL,
-  SQUARED_DIFFERENCE,
-  INT_DIV,
-  POW,
-  PRELU,
-  MAX,
-  MIN
-}
-
-const CHECK_NAN_SNIPPET = `
-if (isnan(a)) return a;
-if (isnan(b)) return b;
-`;
-const CHECK_NAN_SNIPPET_VEC4 = `
-result.r = isNaN.r > 0. ? NAN : result.r;
-result.g = isNaN.g > 0. ? NAN : result.g;
-result.b = isNaN.b > 0. ? NAN : result.b;
-result.a = isNaN.a > 0. ? NAN : result.a;
-`;
-
-function getMinMaxString(op: string, useVec4: boolean) {
-  const checkNanSnippet = useVec4 ? CHECK_NAN_SNIPPET_VEC4 : CHECK_NAN_SNIPPET;
-  return useVec4 ? `
-  vec4 result = vec4(${op}(a, b));
-  vec4 isNaN = min(vec4(isnan(a)) + vec4(isnan(b)), vec4(1.0));
-  ` + checkNanSnippet +
-          `
-  return result;
-` :
-                   checkNanSnippet + `
-  return ${op}(a, b);
-`;
-}
-
-export function getBinaryOpString(
-    type: BinaryOpType, useVec4?: boolean): string {
-  switch (type) {
-    case BinaryOpType.MUL:
-      return 'return a * b;';
-    case BinaryOpType.ADD:
-      return 'return a + b;';
-    case BinaryOpType.SUB:
-      return 'return a - b;';
-    case BinaryOpType.DIV:
-      return 'return a / b;';
-    case BinaryOpType.EQUAL:
-      return useVec4 ? 'return vec4(equal(a, b));' : 'return float(a == b);';
-    case BinaryOpType.GREATER:
-      return useVec4 ? 'return vec4(greaterThan(a, b));' :
-                       'return float(a > b);';
-    case BinaryOpType.GREATER_EQUAL:
-      return useVec4 ? 'return vec4(greaterThanEqual(a, b));' :
-                       'return float(a >= b);';
-    case BinaryOpType.LESS:
-      return useVec4 ? 'return vec4(lessThan(a, b));' : 'return float(a < b);';
-    case BinaryOpType.LESS_EQUAL:
-      return useVec4 ? 'return vec4(lessThanEqual(a, b));' :
-                       'return float(a <= b);';
-    case BinaryOpType.LOGICAL_AND:
-      return useVec4 ? `return vec4(
-      vec4(greaterThanEqual(a, vec4(1.0))) *
-      vec4(greaterThanEqual(b, vec4(1.0))));` :
-                       'return float(float(a) >= 1.0 && float(b) >= 1.0);';
-    case BinaryOpType.NOT_EQUAL:
-      return useVec4 ? 'return vec4(notEqual(a, b));' : 'return float(a != b);';
-    case BinaryOpType.SQUARED_DIFFERENCE:
-      return 'return (a - b) * (a - b);';
-    case BinaryOpType.INT_DIV:
-      return useVec4 ? `
-      ivec4 ia = round(a);
-      ivec4 ib = round(b);
-      bvec4 cond = notEqual(ib, ivec4(0));
-      ivec4 result = ivec4(0);
-      vec4 s = sign(a) * sign(b);
-
-      // Windows (D3D) wants guaranteed non-zero int division at compile-time.
-      if (cond[0]) {
-        result[0] = idiv(ia[0], ib[0], s[0]);
-      }
-      if (cond[1]) {
-        result[1] = idiv(ia[1], ib[1], s[1]);
-      }
-      if (cond[2]) {
-        result[2] = idiv(ia[2], ib[2], s[2]);
-      }
-      if (cond[3]) {
-        result[3] = idiv(ia[3], ib[3], s[3]);
-      }
-      return vec4(result);
-    ` :
-                       `
-    float s = sign(a) * sign(b);
-    int ia = int(round(a));
-    int ib = int(round(b));
-    return float(idiv(ia, ib, s));
-  `;
-    case BinaryOpType.PRELU:
-      return useVec4 ? `
-      vec4 aLessThanZero = vec4(lessThan(a, vec4(0.)));
-      return (aLessThanZero * (b * a)) + ((vec4(1.0) - aLessThanZero) * a);
-    ` :
-                       'return (a < 0.) ? b * a : a;';
-    case BinaryOpType.MAX:
-      return getMinMaxString('max', useVec4);
-    case BinaryOpType.MIN:
-      return getMinMaxString('min', useVec4);
-    case BinaryOpType.POW:
-      return useVec4 ? `
-      // isModRound1 has 1 for components with round(mod(b, 2.0)) == 1, 0 otherwise.
-      vec4 isModRound1 = vec4(equal(round(mod(b, 2.0)), ivec4(1)));
-      vec4 multiplier = sign(a) * isModRound1 + (vec4(1.0) - isModRound1);
-      vec4 result = multiplier * pow(abs(a), b);
-
-      // Ensure that a^0 = 1, including 0^0 = 1 as this correspond to TF and JS
-      bvec4 isExpZero = equal(b, vec4(0.0));
-      result.r = isExpZero.r ? 1.0 : result.r;
-      result.g = isExpZero.g ? 1.0 : result.g;
-      result.b = isExpZero.b ? 1.0 : result.b;
-      result.a = isExpZero.a ? 1.0 : result.a;
-
-      vec4 isNaN = vec4(lessThan(a, vec4(0.0))) * vec4(lessThan(floor(b), b));
-      ${CHECK_NAN_SNIPPET_VEC4}
-      return result;
-    ` :
-                       `
-    if(a < 0.0 && floor(b) < b){
-      return NAN;
-    }
-    if (b == 0.0) {
-      return 1.0;
-    }
-    return (round(mod(b, 2.0)) != 1) ?
-        pow(abs(a), b) : sign(a) * pow(abs(a), b);
-  `;
-    default:
-      throw new Error(`BinaryType ${type} is not implemented!`);
-  }
-}
+import {BinaryOpType} from './binary_op_util';
 
 export function getBinaryProgram(
     op: BinaryOpType, aShape: number[], bShape: number[]) {
   const useVec4 =
       util.arraysEqual(aShape, bShape) && util.sizeFromShape(aShape) % 4 === 0;
-  const opStr = getBinaryOpString(op, useVec4);
   if (useVec4) {
-    return new BinaryOpVec4Program(opStr, aShape, bShape);
+    return new BinaryOpVec4Program(op, aShape, bShape);
   }
   const useSharedMemoryWithA =
       aShape.length === 1 && bShape.length > 1 && aShape[0] < 2048;
   const useSharedMemoryWithB =
       bShape.length === 1 && aShape.length > 1 && bShape[0] < 2048;
   if (useSharedMemoryWithA || useSharedMemoryWithB) {
-    return new BinaryOpSharedProgram(
-        opStr, aShape, bShape, useSharedMemoryWithB);
+    return new BinaryOpSharedProgram(op, aShape, bShape, useSharedMemoryWithB);
   } else {
-    return new BinaryOpProgram(opStr, aShape, bShape);
+    return new BinaryOpProgram(op, aShape, bShape);
   }
 }

--- a/tfjs-backend-webgpu/src/kernels/unary_op_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_util.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export enum UnaryOpType {
+  ABS,
+  CEIL,
+  ELU,
+  EXP,
+  EXPM1,
+  FLOOR,
+  LINEAR,
+  LOG,
+  NEG,
+  PRELU,
+  RELU,
+  RELU6,
+  RSQRT,
+  SIGMOID,
+  SQRT,
+  SQUARE,
+  TANH,
+  TO_INT
+}
+
+const ABS = `return abs(a);`;
+const CEIL = `return ceil(a);`;
+const EXPM1 = `return exp(a) - 1.0;`;
+const ELU = `return (a >= 0.0) ? a : (exp(a) - 1.0);`;
+const ELU_VEC4 = `
+  vec4 result;
+
+  result.r = (a.r >= 0.0) ? a.r : (exp(a.r) - 1.0);
+  result.g = (a.g >= 0.0) ? a.g : (exp(a.g) - 1.0);
+  result.b = (a.b >= 0.0) ? a.b : (exp(a.b) - 1.0);
+  result.a = (a.a >= 0.0) ? a.a : (exp(a.a) - 1.0);
+
+  return result;
+`;
+const EXP = `return exp(a);`;
+const FLOOR = `return floor(a);`;
+const LINEAR = `return a;`;
+const LOG = `if (a < 0.0) return 1.0/0.0;
+  return log(a);`;
+const NEG = `return -a;`;
+const PRELU = `return (a < 0.) ? b * a : a;`;
+const RELU = 'return max(a, 0.0);';
+const RELU6 = 'return clamp(a, 0.0, 6.0);';
+const RELU_VEC4 = `
+  vec4 result = a * vec4(greaterThanEqual(a, vec4(0.0)));
+  bvec4 isNaN = isnan(a);
+
+  result.r = isNaN.r ? a.r : result.r;
+  result.g = isNaN.g ? a.g : result.g;
+  result.b = isNaN.b ? a.b : result.b;
+  result.a = isNaN.a ? a.a : result.a;
+
+  return result;
+`;
+const RSQRT = `return inversesqrt(a);`;
+const SIGMOID = `return 1.0 / (1.0 + exp(-1.0 * a));`;
+const SQRT = `return sqrt(a);`;
+const SQUARE = `return a * a;`;
+const TANH = `
+  float e2x = exp(-2.0 * abs(a));
+  return sign(a) * (1.0 - e2x) / (1.0 + e2x);
+`;
+const TO_INT = `return float(int(a));`;
+
+export function getUnaryOpString(type: UnaryOpType, useVec4?: boolean): string {
+  switch (type) {
+    case UnaryOpType.ABS:
+      return ABS;
+    case UnaryOpType.CEIL:
+      return CEIL;
+    case UnaryOpType.ELU:
+      return useVec4 ? ELU_VEC4 : ELU;
+    case UnaryOpType.EXP:
+      return EXP;
+    case UnaryOpType.EXPM1:
+      return EXPM1;
+    case UnaryOpType.FLOOR:
+      return FLOOR;
+    case UnaryOpType.LINEAR:
+      return LINEAR;
+    case UnaryOpType.LOG:
+      return LOG;
+    case UnaryOpType.NEG:
+      return NEG;
+    case UnaryOpType.PRELU:
+      return PRELU;
+    case UnaryOpType.RELU:
+      return useVec4 ? RELU_VEC4 : RELU;
+    case UnaryOpType.RELU6:
+      return RELU6;
+    case UnaryOpType.RSQRT:
+      return RSQRT;
+    case UnaryOpType.SIGMOID:
+      return SIGMOID;
+    case UnaryOpType.SQRT:
+      return SQRT;
+    case UnaryOpType.SQUARE:
+      return SQUARE;
+    case UnaryOpType.TANH:
+      return TANH;
+    case UnaryOpType.TO_INT:
+      return TO_INT;
+
+    default:
+      throw new Error(`BinaryType ${type} is not implemented!`);
+  }
+}

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -17,51 +17,9 @@
 import {util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {getUnaryOpString, UnaryOpType} from './unary_op_util';
 
 import {WebGPUProgram} from './webgpu_program';
-
-export const RELU = 'return max(a, 0.0);';
-export const RELU6 = 'return clamp(a, 0.0, 6.0);';
-export const LINEAR = `return a;`;
-export const ELU = `return (a >= 0.0) ? a : (exp(a) - 1.0);`;
-export const PRELU = `return (a < 0.) ? b * a : a;`;
-
-export const ELU_VEC4 = `
-  vec4 result;
-
-  result.r = (a.r >= 0.0) ? a.r : (exp(a.r) - 1.0);
-  result.g = (a.g >= 0.0) ? a.g : (exp(a.g) - 1.0);
-  result.b = (a.b >= 0.0) ? a.b : (exp(a.b) - 1.0);
-  result.a = (a.a >= 0.0) ? a.a : (exp(a.a) - 1.0);
-
-  return result;
-`;
-
-export const RELU_VEC4 = `
-  vec4 result = a * vec4(greaterThanEqual(a, vec4(0.0)));
-  bvec4 isNaN = isnan(a);
-
-  result.r = isNaN.r ? a.r : result.r;
-  result.g = isNaN.g ? a.g : result.g;
-  result.b = isNaN.b ? a.b : result.b;
-  result.a = isNaN.a ? a.a : result.a;
-
-  return result;
-`;
-
-export const SIGMOID = `return 1.0 / (1.0 + exp(-1.0 * a));`;
-export const ABS = `return abs(a);`;
-export const SQUARE = `return a * a;`;
-export const NEG = `return -a;`;
-export const TANH = `
-  float e2x = exp(-2.0 * abs(a));
-  return sign(a) * (1.0 - e2x) / (1.0 + e2x);
-`;
-export const EXP = `return exp(a);`;
-export const LOG = `if (a < 0.0) return 1.0/0.0;
-  return log(a);`;
-export const TO_INT = `return float(int(a));`;
-export const SQRT = `return sqrt(a);`;
 
 export class UnaryOpProgram implements WebGPUProgram {
   outputShape: number[];
@@ -70,10 +28,10 @@ export class UnaryOpProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A'];
   workGroupSize: [number, number, number];
-  op: string;
+  op: UnaryOpType;
   size: number;
 
-  constructor(outputShape: number[], op: string) {
+  constructor(outputShape: number[], op: UnaryOpType) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
     const workGroupSizeX = 128;
     this.workGroupSize = [workGroupSizeX, 1, 1];
@@ -87,9 +45,10 @@ export class UnaryOpProgram implements WebGPUProgram {
   }
 
   getUserCode(): string {
+    const opStr = getUnaryOpString(this.op);
     return `
       float unaryOperation(float a) {
-        ${this.op}
+        ${opStr}
       }
 
       void main() {


### PR DESCRIPTION
This change is similar to https://github.com/tensorflow/tfjs/pull/5208, but for binary and unary:
1. Use BinaryOpType and UnaryOpType as shader op key instead of op string. This makes shader key shorter, save warmup time.
2. Move shader related code to program, this decouples the general ts code and shader code.
3. For future WGSL, the op(glsl or wgsl) can be decided by each program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5221)
<!-- Reviewable:end -->
