### PR TITLE
[webgpu] Upgrade clang-format version from 1.2.4 to 1.5.0

### DIFF
--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -44,7 +44,7 @@
     "@tensorflow/tfjs-converter": "link:../tfjs-converter",
     "@tensorflow/tfjs-core": "link:../tfjs-core",
     "@types/jasmine": "~3.0.0",
-    "clang-format": "~1.2.4",
+    "clang-format": "~1.5.0",
     "jasmine": "~3.1.0",
     "jasmine-core": "~3.1.0",
     "karma": "~6.3.1",

--- a/tfjs-backend-webgpu/yarn.lock
+++ b/tfjs-backend-webgpu/yarn.lock
@@ -1385,10 +1385,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-clang-format@~1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.4.tgz#4bb4b0a98180428deb093cf20982e9fc1af20b6c"
-  integrity sha512-sw+nrGUp3hvmANd1qF8vZPuezSYQAiXgGBiEtkXTtJnnu6b00fCqkkDIsnRKrNgg4nv6NYZE92ejvOMIXZoejw==
+clang-format@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.5.0.tgz#1bd4c47b66a1a02556b192b93f5505e7ccec84fb"
+  integrity sha512-C1LucFX7E+ABVYcPEbBHM4PYQ2+WInXsqsLpFlQ9cmRfSbk7A7b1I06h/nE4bQ3MsyEkb31jY2gC0Dtc76b4IA==
   dependencies:
     async "^1.5.2"
     glob "^7.0.0"


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/5226
Fix unexpected formatting of `as const` cast, this bug was fixed after
version 1.3.0

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5225)
<!-- Reviewable:end -->
