### PR TITLE
Replace deprecated package '@react-native-community/async-storage'

### DIFF
--- a/tfjs-react-native/integration_rn59/android/settings.gradle
+++ b/tfjs-react-native/integration_rn59/android/settings.gradle
@@ -18,7 +18,7 @@
 apply from: '../node_modules/react-native-unimodules/gradle.groovy'
 includeUnimodulesProjects()
 include ':@react-native-community_async-storage'
-project(':@react-native-community_async-storage').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/async-storage/android')
+project(':@react-native-community_async-storage').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-async-storage/async-storage/android')
 
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(settingsDir, '../node_modules/react-native-fs/android')

--- a/tfjs-react-native/integration_rn59/ios/Podfile
+++ b/tfjs-react-native/integration_rn59/ios/Podfile
@@ -38,7 +38,7 @@ target 'integration_rn59' do
 
   use_unimodules!
 
-  pod 'RNCAsyncStorage', :path => '../node_modules/@react-native-community/async-storage'
+  pod 'RNCAsyncStorage', :path => '../node_modules/@react-native-async-storage/async-storage'
 
   pod 'RNFS', :path => '../node_modules/react-native-fs'
 

--- a/tfjs-react-native/integration_rn59/ios/Podfile.lock
+++ b/tfjs-react-native/integration_rn59/ios/Podfile.lock
@@ -123,7 +123,7 @@ DEPENDENCIES:
   - React/RCTNetwork (from `../node_modules/react-native`)
   - React/RCTText (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNFS (from `../node_modules/react-native-fs`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - UMBarCodeScannerInterface (from `../node_modules/unimodules-barcode-scanner-interface/ios`)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
   React:
     :path: "../node_modules/react-native"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNFS:
     :path: "../node_modules/react-native-fs"
   RNSVG:

--- a/tfjs-react-native/integration_rn59/package.json
+++ b/tfjs-react-native/integration_rn59/package.json
@@ -18,7 +18,7 @@
     "copyunion": "\\cp -rf ../../tfjs/dist node_modules/@tensorflow/tfjs"
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.6.1",
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "@tensorflow-models/blazeface": "^0.0.2",
     "@tensorflow-models/mobilenet": "^2.0.4",
     "@tensorflow-models/posenet": "^2.2.1",

--- a/tfjs-react-native/package.json
+++ b/tfjs-react-native/package.json
@@ -32,7 +32,7 @@
     "update-apk": "./scripts/update-apk.sh"
   },
   "devDependencies": {
-    "@react-native-community/async-storage": "^1.4.2",
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "@tensorflow/tfjs-backend-cpu": "~3.1.0",
     "@tensorflow/tfjs-backend-webgl": "~3.1.0",
     "@tensorflow/tfjs-core": "3.1.0",
@@ -63,7 +63,7 @@
     "jpeg-js": "^0.4.3"
   },
   "peerDependencies": {
-    "@react-native-community/async-storage": "^1.4.2",
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "@tensorflow/tfjs-backend-cpu": "~3.1.0",
     "@tensorflow/tfjs-backend-webgl": "~3.1.0",
     "@tensorflow/tfjs-core": "~3.1.0",

--- a/tfjs-react-native/rollup.config.js
+++ b/tfjs-react-native/rollup.config.js
@@ -43,7 +43,7 @@ function config({plugins = [], output = {}, external = []}) {
     },
     external: [
       '@tensorflow/tfjs-core',
-      '@react-native-community/async-storage',
+      '@react-native-async-storage/async-storage',
       'react-native',
     ],
     onwarn: warning => {

--- a/tfjs-react-native/src/async_storage_io.ts
+++ b/tfjs-react-native/src/async_storage_io.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {AsyncStorageStatic} from '@react-native-community/async-storage';
+import {AsyncStorageStatic} from '@react-native-async-storage/async-storage';
 import {io} from '@tensorflow/tfjs-core';
 import {fromByteArray, toByteArray} from 'base64-js';
 
@@ -76,7 +76,7 @@ class AsyncStorageHandler implements io.IOHandler {
     // library.
     this.asyncStorage =
         // tslint:disable-next-line:no-require-imports
-        require('@react-native-community/async-storage').default;
+        require('@react-native-async-storage/async-storage').default;
   }
 
   /**


### PR DESCRIPTION
Move to first version of '@react-native-async-storage/async-storage'
to introduce minimal changes.

Addresses #4270.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5228)
<!-- Reviewable:end -->
