### PR TITLE
[webgpu] Add WGSL support

### DIFF
--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -42,7 +42,7 @@ ENV.registerFlag('WEBGPU_USE_NAIVE_CONV2D', () => false);
 /**
  * Whether to use GLSL shading language.
  */
- ENV.registerFlag('WEBGPU_USE_GLSL', () => true);
+ ENV.registerFlag('WEBGPU_USE_GLSL', () => false);
 
 /**
  * Whether to use conv2dTranspose_naive which directly implement the

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -40,6 +40,11 @@ ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 4);
 ENV.registerFlag('WEBGPU_USE_NAIVE_CONV2D', () => false);
 
 /**
+ * Whether to use GLSL shading language.
+ */
+ ENV.registerFlag('WEBGPU_USE_GLSL', () => true);
+
+/**
  * Whether to use conv2dTranspose_naive which directly implement the
  * conv2dTranspose logic rather than using a matmul to simulate.
  */

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -42,7 +42,7 @@ ENV.registerFlag('WEBGPU_USE_NAIVE_CONV2D', () => false);
 /**
  * Whether to use GLSL shading language.
  */
- ENV.registerFlag('WEBGPU_USE_GLSL', () => false);
+ ENV.registerFlag('WEBGPU_USE_GLSL', () => true);
 
 /**
  * Whether to use conv2dTranspose_naive which directly implement the

--- a/tfjs-backend-webgpu/src/kernels/Conv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv2D.ts
@@ -47,6 +47,13 @@ export function conv2d(
 
   let program: Conv2DMMProgram|Conv2DNaiveProgram|Conv2DMMVec4Program;
 
+  const padInfo = [convInfo.padInfo.top, convInfo.padInfo.left];
+  const dimensions = [
+    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
+    {type: 'int32', data: [...padInfo]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]}
+  ];
   if (env().getBool('WEBGPU_USE_NAIVE_CONV2D')) {
     // TODO(kainino0x): This may be obsolete, but is kept for reference.
     program = new Conv2DNaiveProgram(convInfo);
@@ -59,18 +66,16 @@ export function conv2d(
        (convInfo.inChannels === 3 && convInfo.padInfo.type === 'VALID')) &&
       convInfo.outChannels % 4 === 0 && convInfo.outChannels >= 64) {
     program = new Conv2DMMVec4Program(convInfo);
+    const dimAOuter = convInfo.outShape[1] * convInfo.outShape[2];
+    const dimBOuter = convInfo.outShape[3];
+    const dimInner =
+        convInfo.filterHeight * convInfo.filterWidth * convInfo.inShape[3];
+    dimensions.push(
+        {type: 'int32', data: [dimAOuter]}, {type: 'int32', data: [dimBOuter]},
+        {type: 'int32', data: [dimInner]});
   } else {
     program = new Conv2DMMProgram(convInfo);
   }
-
-  const padInfo = [convInfo.padInfo.top, convInfo.padInfo.left];
-
-  const dimensions = [
-    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
-    {type: 'int32', data: [...padInfo]},
-    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
-    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]}
-  ];
 
   return backend.runWebGPUProgram(program, [x, filter], x.dtype, dimensions);
 }

--- a/tfjs-backend-webgpu/src/kernels/activation_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/activation_util.ts
@@ -21,19 +21,20 @@ import {BinaryOpType, getBinaryOpString} from './binary_op_util';
 import {getUnaryOpString, UnaryOpType} from './unary_op_util';
 
 export function mapActivationToShaderProgram(
-    activation: backend_util.Activation, packed = false): string {
+    activation: backend_util.Activation, packed = false,
+    useWgsl = false): string {
   if (activation === null) {
     return null;
   } else if (activation === 'linear') {
     return getUnaryOpString(UnaryOpType.LINEAR);
   } else if (activation === 'relu') {
-    return getUnaryOpString(UnaryOpType.RELU, packed);
+    return getUnaryOpString(UnaryOpType.RELU, packed, useWgsl);
   } else if (activation === 'elu') {
     return getUnaryOpString(UnaryOpType.ELU, packed);
   } else if (activation === 'relu6') {
-    return getUnaryOpString(UnaryOpType.RELU6);
+    return getUnaryOpString(UnaryOpType.RELU6, packed, useWgsl);
   } else if (activation === 'prelu') {
-    return getBinaryOpString(BinaryOpType.PRELU, packed);
+    return getBinaryOpString(BinaryOpType.PRELU, packed, useWgsl);
   } else if (activation === 'sigmoid') {
     return getUnaryOpString(UnaryOpType.SIGMOID);
   }

--- a/tfjs-backend-webgpu/src/kernels/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_util.ts
@@ -37,6 +37,7 @@ export enum BinaryOpType {
   COMPLEX_MULTIPLY_IMAG
 }
 
+// GLSL shader.
 const CHECK_NAN_SNIPPET = `
   if (isnan(a)) return a;
   if (isnan(b)) return b;
@@ -112,7 +113,7 @@ const LOGICAL_AND = 'return float(float(a) >= 1.0 && float(b) >= 1.0);';
 const LOGICAL_AND_VEC4 = `return vec4(
   vec4(greaterThanEqual(a, vec4(1.0))) *
   vec4(greaterThanEqual(b, vec4(1.0))));`;
-const MUL ='return a * b;';
+const MUL = 'return a * b;';
 const NOT_EQUAL = 'return float(a != b);';
 const NOT_EQUAL_VEC4 = 'return vec4(notEqual(a, b));';
 const POW = `
@@ -142,16 +143,29 @@ vec4 isNaN = vec4(lessThan(a, vec4(0.0))) * vec4(lessThan(floor(b), b));
 ${CHECK_NAN_SNIPPET_VEC4}
 return result;
 `;
-const PRELU = 'return (a < 0.) ? b * a : a;';
+const PRELU = 'return (a < 0.0) ? b * a : a;';
 const PRELU_VEC4 = `
-vec4 aLessThanZero = vec4(lessThan(a, vec4(0.)));
+vec4 aLessThanZero = vec4(lessThan(a, vec4(0.0)));
 return (aLessThanZero * (b * a)) + ((vec4(1.0) - aLessThanZero) * a);
 `;
 const SQUARED_DIFFERENCE = 'return (a - b) * (a - b);';
 const SUB = 'return a - b;';
 
+// WGSL shader.
+const PRELU_WGSL = `if (a < 0.0) { return b * a; }  return a;`;
+const PRELU_VEC4_WGSL = `
+let aLessThanZero : vec4<bool> = vec4<bool>(a < vec4<f32>(0.0, 0.0, 0.0, 0.0));
+var aLessThanZeroF32 : vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+for (var i : u32 = 0u; i < 4u; i = i + 1u ) {
+  if (aLessThanZero[i]) {
+    aLessThanZeroF32[i] = 1.0;
+  }
+}
+return (vec4<f32>(aLessThanZeroF32) * (b * a)) + ((vec4<f32>(1.0, 1.0, 1.0, 1.0) - vec4<f32>(aLessThanZeroF32)) * a);
+`;
+
 export function getBinaryOpString(
-    type: BinaryOpType, useVec4?: boolean): string {
+    type: BinaryOpType, useVec4?: boolean, useWgsl?: boolean): string {
   switch (type) {
     case BinaryOpType.MUL:
       return MUL;
@@ -180,7 +194,11 @@ export function getBinaryOpString(
     case BinaryOpType.INT_DIV:
       return useVec4 ? INT_DIV_VEC4 : INT_DIV;
     case BinaryOpType.PRELU:
-      return useVec4 ? PRELU_VEC4 : PRELU;
+      if (useWgsl) {
+        return useVec4 ? PRELU_VEC4_WGSL : PRELU_WGSL;
+      } else {
+        return useVec4 ? PRELU_VEC4 : PRELU;
+      }
     case BinaryOpType.MAX:
       return getMinMaxString('max', useVec4);
     case BinaryOpType.MIN:

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
@@ -254,8 +254,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     const remainderSnippet =
         `// The bounds checking is always needed since we use it to pad zero for
         // the 'same' padding type.
-        if (coordsInBounds4(coord, uniforms.xShape)) {
-          resData = x.numbers[getFlatIndex4(coord, uniforms.xShape) / 4u];
+        if (coordsInBounds4D(coord, uniforms.xShape)) {
+          resData = x.numbers[getFlatIndex4D(coord, uniforms.xShape) / 4u];
         } else {
           resData = vec4<f32>(0.0, 0.0, 0.0, 0.0); }`;
 
@@ -282,7 +282,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
 
     const sampleB = this.fitB ?
         `return W.numbers[row * dimBOuter / 4u + col]` :
-        `if(coordsInBounds2(vec2<u32>(row, col * 4u), vec2<u32>(dimInner, dimBOuter))) {
+        `if(coordsInBounds2D(vec2<u32>(row, col * 4u), vec2<u32>(dimInner, dimBOuter))) {
            return W.numbers[row * dimBOuter / 4u + col];
          }
          return vec4<f32>(0.0, 0.0, 0.0, 0.0);
@@ -294,7 +294,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
       if (this.hasPreluActivationWeights) {
         activationSnippet =
             `fn activation(a : vec4<f32>, outCoord : vec4<u32>) -> vec4<f32>{
-          let b: vec4<f32> = getPreluActivationWeightsAtOutCoords2(outCoord);
+          let b: vec4<f32> = getPreluActivationWeightsAtOutCoordsByCoords(outCoord);
           ${activationOp}
         }`;
       } else if (this.hasLeakyreluAlpha) {
@@ -314,8 +314,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
     }
 
     const addBiasSnippet = this.addBias ?
-        'let coords : vec4<u32>= getOutputCoords(globalId); ' +
-            'value = value + getBiasAtOutCoords2(outCoord);' :
+        'value = value + getBiasAtOutCoordsByCoords(outCoord);' :
         '';
 
     const userCode = `

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
@@ -20,8 +20,8 @@ import {backend_util, util} from '@tensorflow/tfjs-core';
 import {computeDispatch, tilesFitEvenlyIntoShape} from '../webgpu_util';
 import {mapActivationToShaderProgram} from './activation_util';
 
-import {makeMatMulPackedVec4Source} from './matmul_packed_vec4_webgpu';
-import {WebGPUProgram} from './webgpu_program';
+import {makeMatMulPackedVec4Source, makeMatMulPackedVec4SourceWgsl} from './matmul_packed_vec4_webgpu';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class Conv2DMMVec4Program implements WebGPUProgram {
   outputShape: number[];
@@ -30,7 +30,10 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 filterDims, pad, stride, dilation;';
+  uniformsWgsl =
+      'filterDims : vec2<u32>; pad : vec2<u32>; stride : vec2<u32>; dilation : vec2<u32>;';
   workGroupSize: [number, number, number];
+  useWgsl: boolean;
   isVec4 = true;
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
@@ -57,6 +60,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         elementsPerThread);
     this.convInfo = convInfo;
     this.addBias = addBias;
+    this.useWgsl = getUseWgsl();
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
     this.hasLeakyreluAlpha = hasLeakyreluAlpha;
@@ -93,7 +97,6 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
       tilesFitEvenlyIntoShape(tileSizeB, [dimInner, dimBOuter])
     ];
   }
-
   getUserCode(): string {
     const elementsPerThread: [number, number, number] = [4, 4, 1];
     const matMulSource = makeMatMulPackedVec4Source(elementsPerThread);
@@ -171,8 +174,8 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
 
     let activationSnippet = '', applyActivationSnippet = '';
     if (this.activation) {
-      const activationOp =
-          mapActivationToShaderProgram(this.activation, this.isVec4);
+      const activationOp = mapActivationToShaderProgram(
+          this.activation, this.isVec4, this.useWgsl);
       if (this.hasPreluActivationWeights) {
         activationSnippet = `vec4 activation(vec4 a, ivec4 outCoord) {
           vec4 b = getPreluActivationWeightsAtOutCoords(outCoord);
@@ -235,6 +238,125 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
 
           mm_matMul(dimAOuter, dimInner, dimBOuter);
         }
+      `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const elementsPerThread: [number, number, number] = [4, 4, 1];
+    const matMulSource = makeMatMulPackedVec4SourceWgsl(
+        '', '', elementsPerThread, this.workGroupSize);
+
+    const remainder = this.convInfo.inChannels % 4;
+    if (remainder !== 0) {
+      throw Error(`remainder != 0 is not yet supported`);
+    }
+    const remainderSnippet =
+        `// The bounds checking is always needed since we use it to pad zero for
+        // the 'same' padding type.
+        if (coordsInBounds4(coord, uniforms.xShape)) {
+          resData = x.numbers[getFlatIndex4(coord, uniforms.xShape) / 4u];
+        } else {
+          resData = vec4<f32>(0.0, 0.0, 0.0, 0.0); }`;
+
+    const readASnippet = `let outRow : u32 = r / uniforms.outShape[2];
+        let outCol : u32 = r % uniforms.outShape[2];
+        let WRow : u32 = c / (uniforms.filterDims[1] * uniforms.xShape[3]);
+        let WCol : u32 = (c / uniforms.xShape[3]) % uniforms.filterDims[1];
+        let inChCoord : u32 = c % uniforms.xShape[3];
+        let coord : vec4<u32> = vec4<u32>(
+            batch,
+            outRow * uniforms.stride[0] + uniforms.dilation[0] * WRow - uniforms.pad[0],
+            outCol * uniforms.stride[1] + uniforms.dilation[1] * WCol - uniforms.pad[1],
+            inChCoord);
+        var resData : vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        ${remainderSnippet}
+        return resData;`;
+
+    const sampleA =
+        this.fitA ? `${readASnippet}` : `if (r < dimAOuter && c < dimInner) {
+          ${readASnippet}
+         }
+         return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        `;
+
+    const sampleB = this.fitB ?
+        `return W.numbers[row * dimBOuter / 4u + col]` :
+        `if(coordsInBounds2(vec2<u32>(row, col * 4u), vec2<u32>(dimInner, dimBOuter))) {
+           return W.numbers[row * dimBOuter / 4u + col];
+         }
+         return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        `;
+    let activationSnippet = '', applyActivationSnippet = '';
+    if (this.activation) {
+      const activationOp = mapActivationToShaderProgram(
+          this.activation, this.isVec4, this.useWgsl);
+      if (this.hasPreluActivationWeights) {
+        activationSnippet =
+            `fn activation(a : vec4<f32>, outCoord : vec4<u32>) -> vec4<f32>{
+          let b: vec4<f32> = getPreluActivationWeightsAtOutCoords2(outCoord);
+          ${activationOp}
+        }`;
+      } else if (this.hasLeakyreluAlpha) {
+        activationSnippet = `fn activation(a: vec4<f32>) ->vec4<f32> {
+          let b : vec4<f32> = getLeakyreluAlphaAtOutCoords();
+          ${activationOp}
+        }`;
+        throw new Error('Leakyrelu is not supported.');
+      } else {
+        activationSnippet = `
+        fn activation(a : vec4<f32>, outCoord : vec4<u32>) -> vec4<f32>{
+          ${activationOp}
+        }`;
+      }
+
+      applyActivationSnippet = `value = activation(value, outCoord);`;
+    }
+
+    const addBiasSnippet = this.addBias ?
+        'let coords : vec4<u32>= getOutputCoords(globalId); ' +
+            'value = value + getBiasAtOutCoords2(outCoord);' :
+        '';
+
+    const userCode = `
+        ${activationSnippet}
+        fn mm_readA(row : u32, col : u32,  globalId  : vec3<u32>) -> vec4<f32> {
+          let r : u32 = u32(row);
+          let c : u32 = u32(col * 4u);
+          var dimAOuter : u32 = uniforms.outShape[1] * uniforms.outShape[2];
+          var dimBOuter : u32 = uniforms.outShape[3];
+          var dimInner : u32 = uniforms.filterDims[0] * uniforms.filterDims[1] * uniforms.xShape[3];
+          var batch : u32 = u32(globalId.z);
+          ${sampleA}
+        }
+
+        fn mm_readB(row : u32, col : u32) -> vec4<f32> {
+          var dimAOuter : u32 = uniforms.outShape[1] * uniforms.outShape[2];
+          var dimBOuter : u32 = uniforms.outShape[3];
+          var dimInner : u32 = uniforms.filterDims[0] * uniforms.filterDims[1] * uniforms.xShape[3];
+          ${sampleB}
+        }
+
+        fn mm_write(row : u32, col : u32, valueInput : vec4<f32>, globalId  : vec3<u32>) {
+          var dimAOuter : u32 = uniforms.outShape[1] * uniforms.outShape[2];
+          var dimBOuter : u32 = uniforms.outShape[3];
+          var dimInner : u32 = uniforms.filterDims[0] * uniforms.filterDims[1] * uniforms.xShape[3];
+          var batch : u32 = u32(globalId.z);
+          var value  : vec4<f32> = valueInput;
+          if (row < dimAOuter && col * 4u < dimBOuter)
+          {
+            let outCoord : vec4<u32> = vec4<u32>(
+              batch,
+              row / uniforms.outShape[2],
+              row % uniforms.outShape[2],
+              col * 4u);
+            ${addBiasSnippet}
+            ${applyActivationSnippet}
+            setOutput(outCoord[0], outCoord[1], outCoord[2], outCoord[3],
+              value);
+          }
+        }
+        ${matMulSource}
       `;
     return userCode;
   }

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
@@ -455,7 +455,7 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
       if (this.hasPreluActivationWeights) {
         activationSnippet =
             `fn activation(a : vec4<f32>, outCoord :  vec3<i32>) -> vec4<f32>{
-                  vec4 b = getPreluActivationWeightsAtOutCoords2(outCoord);
+                  vec4 b = getPreluActivationWeightsAtOutCoordsByCoords(outCoord);
                   ${this.activation}
                 }`;
       } else {

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
@@ -227,7 +227,6 @@ function getMainCodeWgsl(
 }
 
 export function makeMatMulPackedVec4SourceWgsl(
-    addBiasSnippet: string, applyActivationSnippet: string,
     workPerThread: number[], workGroupSize: [number, number, number]): string {
   const rowPerThread = workPerThread[1];
   const colPerThread = workPerThread[0];  // only support colPerThread = 4
@@ -450,7 +449,7 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
   }
 
   getUserCodeWgsl(): string {
-    let activationSnippet = '', applyActivationSnippet = '';
+    let activationSnippet = '';
     if (this.activation) {
       if (this.hasPreluActivationWeights) {
         activationSnippet =
@@ -464,12 +463,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
                   ${this.activation}
                 }`;
       }
-
-      applyActivationSnippet = 'value = activation(value, outCoord);';
     }
 
-    const addBiasSnippet =
-        this.addBias ? 'value += getBiasAtOutCoords(outCoord);' : '';
     if (this.outputShape[1] <= 1) {
       throw Error(`outputShape[1] <= 1 is not yet supported`);
     }
@@ -479,7 +474,6 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
 
       ${
         makeMatMulPackedVec4SourceWgsl(
-            addBiasSnippet, applyActivationSnippet,
             [this.vecSize, this.workPerThread, 1], this.workGroupSize)}
     `;
     return userCode;

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
@@ -17,9 +17,18 @@
 
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from '../webgpu_util';
+import {getWorkGroupSizeString} from '../webgpu_util_wgsl';
 import {mapActivationToShaderProgram} from './activation_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
+
+interface TileInfo {
+  RowPerThread: number;
+  ColPerThread: number;
+  TileAOuter: number;
+  TileBOuter: number;
+  TileInner: number;
+}
 
 export function makeMatMulPackedVec4Source(workPerThread: number[]): string {
   return `
@@ -110,6 +119,135 @@ export function makeMatMulPackedVec4Source(workPerThread: number[]): string {
   `;
 }
 
+function getSharedArray2DCodeWgsl(tileInfo: TileInfo) {
+  return `
+  var<workgroup> mm_Asub : array<array<vec4<f32>, ${
+      tileInfo.TileInner / tileInfo.ColPerThread}>, ${tileInfo.TileAOuter}>;
+  var<workgroup> mm_Bsub : array<array<vec4<f32>, ${
+      tileInfo.TileBOuter / tileInfo.ColPerThread}>, ${tileInfo.TileInner}>;`;
+}
+
+function getA2DCodeWgsl() {
+  return `
+  mm_Asub[inputRow][inputCol] = mm_readA(globalRow + innerRow, globalColA, globalId);`;
+}
+
+function getB2DCodeWgsl() {
+  return `
+  mm_Bsub[inputRow][inputCol] = mm_readB(t * TileInner + inputRow, globalCol);`;
+}
+
+function getCompute2DCodeWgsl() {
+  return `
+  // Compute acc values for a single thread.
+  for (var k : u32 = 0u; k < TileInner / ColPerThread; k = k + 1u) {
+      BCached[0] = mm_Bsub[k * ColPerThread][tileCol];
+      BCached[1] = mm_Bsub[k * ColPerThread + 1u][tileCol];
+      BCached[2] = mm_Bsub[k * ColPerThread + 2u][tileCol];
+      BCached[3] = mm_Bsub[k * ColPerThread + 3u][tileCol];
+
+      for (var i : u32 = 0u; i < RowPerThread; i = i + 1u) {
+          ACached = mm_Asub[tileRow + i][k];
+          acc[i] = BCached[0] * ACached.x + acc[i];
+          acc[i] = BCached[1] * ACached.y + acc[i];
+          acc[i] = BCached[2] * ACached.z + acc[i];
+          acc[i] = BCached[3] * ACached.w + acc[i];
+      }
+  }`;
+}
+
+function getMainCodeWgsl(
+    getA: string, getB: string, computeAcc: string,
+    workGroupSizeSnippet: string, tileInfo: TileInfo) {
+  return `
+  let RowPerThread : u32 = ${tileInfo.RowPerThread}u;
+  let ColPerThread : u32 = ${
+      tileInfo.ColPerThread}u; // only support ColPerThread = 4
+  let TileAOuter : u32 = ${tileInfo.TileAOuter}u;
+  let TileBOuter : u32 = ${tileInfo.TileBOuter}u;
+  let TileInner : u32 = ${tileInfo.TileInner}u;
+
+  ${workGroupSizeSnippet}
+  fn main([[builtin(local_invocation_id)]] localId : vec3<u32>,
+        [[builtin(global_invocation_id)]] globalId  : vec3<u32>) {
+
+    let tileRow : u32 = localId.y * RowPerThread;
+    let tileCol : u32 = localId.x;
+
+    let globalRow : u32 = globalId.y * RowPerThread;
+    let globalCol : u32 = globalId.x;
+    var dimInner : u32 = uniforms.filterDims[0] * uniforms.filterDims[1] * uniforms.xShape[3];
+    let numTiles : u32 = (dimInner - 1u) / TileInner + 1u;
+
+    var acc: array<vec4<f32>, 4>;
+    var ACached : vec4<f32>;
+    var BCached : array<vec4<f32>, 4>;
+
+    // Without this initialization strange values show up in acc.
+    // TODO: Remove it once the following bug is fixed.
+    // https://bugs.chromium.org/p/tint/issues/detail?id=759
+    for (var index : u32 = 0u; index < RowPerThread; index = index + 1u) {
+        acc[index] = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+
+    var globalColA : u32 = tileCol;
+    let RowPerThreadB : u32 = TileInner / 16u;
+    let tileRowB : u32 = localId.y * RowPerThreadB;
+
+    // Loop over shared dimension.
+    for (var t : u32 = 0u; t < numTiles; t = t + 1u) {
+        // Load one tile of A into local memory.
+        for (var innerRow : u32 = 0u; innerRow < RowPerThread; innerRow = innerRow + 1u) {
+            let inputRow : u32 = tileRow + innerRow;
+            let inputCol : u32 = tileCol;
+            ${getA}
+        }
+        globalColA = globalColA + TileInner / ColPerThread;
+
+        // Load one tile of B into local memory.
+        for (var innerRow : u32 = 0u; innerRow < RowPerThreadB; innerRow = innerRow + 1u) {
+            let inputRow : u32 = tileRowB + innerRow;
+            let inputCol : u32 = tileCol;
+            ${getB}
+        }
+
+        workgroupBarrier();
+
+        ${computeAcc}
+
+        workgroupBarrier();
+    }
+
+    for (var innerRow : u32 = 0u; innerRow < RowPerThread; innerRow = innerRow + 1u) {
+        mm_write(globalRow + innerRow,
+                 globalCol,
+                 acc[innerRow], globalId);
+    }
+}`;
+}
+
+export function makeMatMulPackedVec4SourceWgsl(
+    addBiasSnippet: string, applyActivationSnippet: string,
+    workPerThread: number[], workGroupSize: [number, number, number]): string {
+  const rowPerThread = workPerThread[1];
+  const colPerThread = workPerThread[0];  // only support colPerThread = 4
+  const tileBOuter = workGroupSize[0] * colPerThread;
+  const tileInfo = {
+    RowPerThread: workPerThread[1],
+    ColPerThread: workPerThread[0],
+    TileAOuter: workGroupSize[1] * rowPerThread,
+    TileBOuter: workGroupSize[0] * colPerThread,
+    TileInner: tileBOuter
+  };
+
+  const kMatMulVec4TwoDimensionalSharedArray =
+      getSharedArray2DCodeWgsl(tileInfo) +
+      getMainCodeWgsl(
+          getA2DCodeWgsl(), getB2DCodeWgsl(), getCompute2DCodeWgsl(),
+          getWorkGroupSizeString(workGroupSize), tileInfo);
+  return kMatMulVec4TwoDimensionalSharedArray;
+}
+
 export function makeMatMulVectorVec4Source(): string {
   return `
     vec4 mm_readA(int row, int col);
@@ -170,6 +308,7 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
   workPerThread: number;
   variableNames = ['A', 'B'];
   workGroupSize: [number, number, number] = [16, 16, 1];
+  useWgsl: boolean;
   isVec4 = true;
   aShape: [number, number, number];
   addBias: boolean;
@@ -208,6 +347,7 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
     this.workPerThread = rowPerThread;
     this.aShape = aShape;
     this.addBias = addBias;
+    this.useWgsl = getUseWgsl();
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 
@@ -248,8 +388,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
 
     let activationSnippet = '', applyActivationSnippet = '';
     if (this.activation) {
-      const activationOp =
-          mapActivationToShaderProgram(this.activation, this.isVec4);
+      const activationOp = mapActivationToShaderProgram(
+          this.activation, this.isVec4, this.useWgsl);
       if (this.hasPreluActivationWeights) {
         activationSnippet = `vec4 activation(vec4 a, ivec3 outCoord) {
                   vec4 b = getPreluActivationWeightsAtOutCoords(outCoord);
@@ -305,6 +445,42 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
         batch = int(gl_GlobalInvocationID.z);
         mm_matMul(dimAOuter, dimInner, dimBOuter);
       }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    let activationSnippet = '', applyActivationSnippet = '';
+    if (this.activation) {
+      if (this.hasPreluActivationWeights) {
+        activationSnippet =
+            `fn activation(a : vec4<f32>, outCoord :  vec3<i32>) -> vec4<f32>{
+                  vec4 b = getPreluActivationWeightsAtOutCoords2(outCoord);
+                  ${this.activation}
+                }`;
+      } else {
+        activationSnippet = `
+                fn activation(a : vec4<f32>, outCoord :  vec3<i32>) -> vec4<f32> {
+                  ${this.activation}
+                }`;
+      }
+
+      applyActivationSnippet = 'value = activation(value, outCoord);';
+    }
+
+    const addBiasSnippet =
+        this.addBias ? 'value += getBiasAtOutCoords(outCoord);' : '';
+    if (this.outputShape[1] <= 1) {
+      throw Error(`outputShape[1] <= 1 is not yet supported`);
+    }
+
+    const userCode = `
+      ${activationSnippet}
+
+      ${
+        makeMatMulPackedVec4SourceWgsl(
+            addBiasSnippet, applyActivationSnippet,
+            [this.vecSize, this.workPerThread, 1], this.workGroupSize)}
     `;
     return userCode;
   }

--- a/tfjs-backend-webgpu/src/kernels/unary_op_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_util.ts
@@ -36,6 +36,7 @@ export enum UnaryOpType {
   TO_INT
 }
 
+// GLSL shader.
 const ABS = `return abs(a);`;
 const CEIL = `return ceil(a);`;
 const EXPM1 = `return exp(a) - 1.0;`;
@@ -53,10 +54,10 @@ const ELU_VEC4 = `
 const EXP = `return exp(a);`;
 const FLOOR = `return floor(a);`;
 const LINEAR = `return a;`;
-const LOG = `if (a < 0.0) return 1.0/0.0;
+const LOG = `if (a < 0.0) { return 1.0/0.0; }
   return log(a);`;
 const NEG = `return -a;`;
-const PRELU = `return (a < 0.) ? b * a : a;`;
+const PRELU = `return (a < 0.0) ? b * a : a;`;
 const RELU = 'return max(a, 0.0);';
 const RELU6 = 'return clamp(a, 0.0, 6.0);';
 const RELU_VEC4 = `
@@ -70,7 +71,7 @@ const RELU_VEC4 = `
 
   return result;
 `;
-const RSQRT = `return inversesqrt(a);`;
+const RSQRT = `return 1.0/sqrt(a);`;
 const SIGMOID = `return 1.0 / (1.0 + exp(-1.0 * a));`;
 const SQRT = `return sqrt(a);`;
 const SQUARE = `return a * a;`;
@@ -80,14 +81,52 @@ const TANH = `
 `;
 const TO_INT = `return float(int(a));`;
 
-export function getUnaryOpString(type: UnaryOpType, useVec4?: boolean): string {
+// WGSL shader.
+const ELU_WGSL = `if (a >= 0.0) { return a; }  return (exp(a) - 1.0);`;
+const RELU_WGSL = 'return max(a, 0.0);';
+const RELU6_VEC4_WGSL =
+    'return clamp(a, vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(6.0, 6.0, 6.0, 6.0));';
+const RELU_VEC4_WGSL = `
+  var resBool : vec4<bool> = vec4<bool>(a >= vec4<f32>(0.0, 0.0, 0.0, 0.0));
+  let isNaN : vec4<bool> = isNan(a);
+  var resFloat : vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+
+  for (var i:u32 = 0u; i< 4u; i = i+1u ) {
+    if (resBool[i]) {
+      resFloat[i] = 1.0;
+    }
+  }
+  resFloat = a * resFloat;
+  if (isNaN.r) {
+    resFloat.r = a.r;
+  }
+  if (isNaN.g) {
+    resFloat.g = a.g;
+  }
+  if (isNaN.b) {
+    resFloat.b = a.b;
+  }
+  if (isNaN.a) {
+    resFloat.a = a.a;
+  }
+  return resFloat;
+`;
+
+const TO_INT_WGSL = `return f32(i32((a)));`;
+
+export function getUnaryOpString(
+    type: UnaryOpType, useVec4?: boolean, useWgsl?: boolean): string {
   switch (type) {
     case UnaryOpType.ABS:
       return ABS;
     case UnaryOpType.CEIL:
       return CEIL;
     case UnaryOpType.ELU:
-      return useVec4 ? ELU_VEC4 : ELU;
+      if (useWgsl) {
+        return ELU_WGSL;
+      } else {
+        return useVec4 ? ELU_VEC4 : ELU;
+      }
     case UnaryOpType.EXP:
       return EXP;
     case UnaryOpType.EXPM1:
@@ -103,9 +142,17 @@ export function getUnaryOpString(type: UnaryOpType, useVec4?: boolean): string {
     case UnaryOpType.PRELU:
       return PRELU;
     case UnaryOpType.RELU:
-      return useVec4 ? RELU_VEC4 : RELU;
+      if (useWgsl) {
+        return useVec4 ? RELU_VEC4_WGSL : RELU_WGSL;
+      } else {
+        return useVec4 ? RELU_VEC4 : RELU;
+      }
     case UnaryOpType.RELU6:
-      return RELU6;
+      if (useWgsl) {
+        return useVec4 ? RELU6_VEC4_WGSL : RELU6;
+      } else {
+        return RELU6;
+      }
     case UnaryOpType.RSQRT:
       return RSQRT;
     case UnaryOpType.SIGMOID:
@@ -117,7 +164,7 @@ export function getUnaryOpString(type: UnaryOpType, useVec4?: boolean): string {
     case UnaryOpType.TANH:
       return TANH;
     case UnaryOpType.TO_INT:
-      return TO_INT;
+      return useWgsl ? TO_INT_WGSL : TO_INT;
 
     default:
       throw new Error(`BinaryType ${type} is not implemented!`);

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -75,7 +75,7 @@ export class UnaryOpProgram implements WebGPUProgram {
         let index : u32 = u32(globalId.x);
         if (index < uniforms.size)
         {
-          let a : f32 = getAAtOutCoords(globalId);
+          let a : f32 = getAAtOutCoordsByGlobalId(globalId);
           setOutputFlat(index, unaryOperation(a));
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -17,9 +17,10 @@
 import {util} from '@tensorflow/tfjs-core';
 
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {getWorkGroupSizeString} from '../webgpu_util_wgsl';
 import {getUnaryOpString, UnaryOpType} from './unary_op_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class UnaryOpProgram implements WebGPUProgram {
   outputShape: number[];
@@ -28,6 +29,7 @@ export class UnaryOpProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A'];
   workGroupSize: [number, number, number];
+  useWgsl: boolean;
   op: UnaryOpType;
   size: number;
 
@@ -39,16 +41,16 @@ export class UnaryOpProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
+    this.useWgsl = getUseWgsl();
     this.op = op;
     this.shaderKey = `unary_${op}`;
     this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
-    const opStr = getUnaryOpString(this.op);
     return `
       float unaryOperation(float a) {
-        ${opStr}
+        ${getUnaryOpString(this.op)}
       }
 
       void main() {
@@ -57,6 +59,24 @@ export class UnaryOpProgram implements WebGPUProgram {
         {
           float a = getAAtOutCoords();
           setOutput(index, unaryOperation(a));
+        }
+      }
+      `;
+  }
+
+  getUserCodeWgsl(): string {
+    return `
+      fn unaryOperation(a : f32) -> f32{
+        ${getUnaryOpString(this.op, false, true)}
+      }
+      ${getWorkGroupSizeString(this.workGroupSize)}
+      fn main([[builtin(local_invocation_id)]] localId : vec3<u32>,
+              [[builtin(global_invocation_id)]] globalId  : vec3<u32>) {
+        let index : u32 = u32(globalId.x);
+        if (index < uniforms.size)
+        {
+          let a : f32 = getAAtOutCoords(globalId);
+          setOutputFlat(index, unaryOperation(a));
         }
       }
       `;

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -15,10 +15,11 @@
  * =============================================================================
  */
 
-import {DataType, Rank, ShapeMap, TensorInfo} from '@tensorflow/tfjs-core';
+import {DataType, env, Rank, ShapeMap, TensorInfo} from '@tensorflow/tfjs-core';
 import {Glslang} from '@webgpu/glslang/dist/web-devel/glslang.onefile';
 
 import * as shader_preprocessor from '../shader_preprocessor';
+import * as shader_preprocessor_wgsl from '../shader_preprocessor_wgsl';
 
 export interface WebGPUProgram {
   // The unique key to distinguish different shader source code.
@@ -31,6 +32,7 @@ export interface WebGPUProgram {
   dispatch: [number, number, number];
   variableNames: string[];
   uniforms?: string;
+  uniforms_wgsl?: string;
   // Size of register cache in one dimension (assumes square cache).
   // Each thread writes to workPerThread * workPerThread locations in the output
   // buffer.
@@ -39,6 +41,7 @@ export interface WebGPUProgram {
   // in a thread group. Individual dimensions determines thread layout within
   // the group.
   workGroupSize?: [number, number, number];
+  useWgsl?: boolean;
   isVec4?: boolean;
   // size is used for bounds checking.
   size?: number;
@@ -70,27 +73,43 @@ export const compileProgram =
      isFromPixel = false): GPUComputePipeline => {
       const outputData = {dtype: output.dtype, shape: output.shape};
 
-      const source = shader_preprocessor.makeShader(
-          inputsData, outputData, program, isFromPixel);
-      const result = glslang.compileGLSLZeroCopy(source, 'compute', false);
-      if (result.data.length === 0) {
-        throw new Error('Shader compilation failed');
+      let source;
+      let module;
+      if (program.useWgsl) {
+        source = shader_preprocessor_wgsl.makeShader(
+            inputsData, outputData, program, isFromPixel);
+        module = device.createShaderModule({code: source});
+      } else {
+        source = shader_preprocessor.makeShader(
+            inputsData, outputData, program, isFromPixel);
+        const result = glslang.compileGLSLZeroCopy(source, 'compute', false);
+        if (result.data.length === 0) {
+          throw new Error('Shader compilation failed');
+        }
+        result.free();
+        module = device.createShaderModule({code: result.data});
       }
-
-      const module = device.createShaderModule({code: result.data});
       const pipeline = device.createComputePipeline(
           {layout: pipelineLayout, compute: {module, entryPoint: 'main'}});
 
-      result.free();
       return pipeline;
     };
 
 export function makeShaderKey<R extends Rank>(
     program: WebGPUProgram, shapes: Array<ShapeMap[R]>, types: string[],
     broadcastDimsKey = '', inputShapesEqualsOutShape = ''): string {
+  let useWgslKey = '';
+  if (program.useWgsl) {
+    useWgslKey = '_1';
+  }
   const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
       shapes.map(shape => shape.length).join(',') + types.join(',') +
       program.variableNames.join(',') + broadcastDimsKey +
-      inputShapesEqualsOutShape + program.shaderKey;
+      inputShapesEqualsOutShape + program.shaderKey + useWgslKey;
   return key;
+}
+
+// This is global flag, but program may ignore this flag.
+export function getUseWgsl () {
+  return !env().getBool('WEBGPU_USE_GLSL');
 }

--- a/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
@@ -1,0 +1,604 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, DataType, util} from '@tensorflow/tfjs-core';
+import {symbolicallyComputeStrides} from './shader_util';
+
+export function getCoordsDataTypeWgsl(rank: number): string {
+  if (rank <= 1) {
+    return 'u32';
+  } else if (rank === 2) {
+    return 'vec2<u32>';
+  } else if (rank === 3) {
+    return 'vec3<u32>';
+  } else if (rank === 4) {
+    return 'vec4<u32>';
+  } else {
+    throw Error(`GPU for rank ${rank} is not yet supported`);
+  }
+}
+
+type DataTypeWGSL = 'f32'|'i32'|'vec4<f32>'|'vec4<i32>'|'vec4<bool>';
+function mapToTypesWgsl(type: DataType, isVec4: boolean): DataTypeWGSL|
+    DataType {
+  if (type === 'float32') {
+    return isVec4 ? 'vec4<f32>' : 'f32';
+  } else if (type === 'int32') {
+    return isVec4 ? 'vec4<i32>' : 'i32';
+  } else if (type === 'bool') {
+    return isVec4 ? 'vec4<bool>' : 'bool';
+  }
+
+  return type;
+}
+
+interface ProgramParams {
+  dispatchLayout: {x: number[], y?: number[], z?: number[]};
+  workGroupSize?: [number, number, number];
+  variableNames: string[];
+  uniforms?: string;
+  uniformsWgsl?: string;
+  isVec4?: boolean;
+  size?: number;
+  getUserCode: () => string;
+  getUserCodeWgsl?: () => string;
+}
+
+export interface InputInfo {
+  dtype: DataType;
+  shape: number[];
+  name: string;
+}
+
+export function makeShader(
+    inputInfo: InputInfo[], outputData: {dtype: DataType, shape: number[]},
+    program: ProgramParams, isFromPixel = false): string {
+  const outputBufferStr =
+      `    layout(std430, set = 0, binding = 0) writeonly buffer ssbOut {
+      ${mapToTypesWgsl(outputData.dtype, program.isVec4)} result[];
+    };`;
+  if (isFromPixel === true) {
+    const getCoords = generateGetCoordsFromFlatIndex(outputData.shape);
+    return [
+      SHADER_PREFIX, outputBufferStr, program.getUserCodeWgsl(), getCoords
+    ].join('\n');
+  }
+
+  const prefixSnippets: string[] = [];
+
+  let uniformDeclaration = '[[block]] struct Uniforms { NAN : u32; ';
+  program.variableNames.forEach((x, i) => {
+    uniformDeclaration += `${x.charAt(0).toLowerCase() + x.slice(1)}Shape : ${
+        getCoordsDataTypeWgsl(inputInfo[i].shape.length)}; `;
+  });
+  uniformDeclaration +=
+      `outShape : ${getCoordsDataTypeWgsl(outputData.shape.length)} ; `;
+  const stridesLength = outputData.shape.length - 1;
+  uniformDeclaration += `
+       outShapeStrides: ${getCoordsDataTypeWgsl(stridesLength)}; `;
+
+  if (program.size != null) {
+    uniformDeclaration += 'size : u32; ';
+  }
+
+  if (program.uniformsWgsl) {
+    uniformDeclaration += program.uniformsWgsl;
+  }
+  uniformDeclaration += '};';
+
+  prefixSnippets.push(uniformDeclaration);
+
+  // Output buffer.
+  prefixSnippets.push(`
+    [[block]] struct Matrix0 {
+        numbers: array<${mapToTypesWgsl(outputData.dtype, program.isVec4)}>;
+    };
+
+    [[group(0), binding(0)]] var<storage> result : [[access(write)]] Matrix0;
+  `);
+  program.variableNames.forEach((x, i) => {
+    prefixSnippets.push(`
+    [[block]] struct Matrix${1 + i} {
+      numbers: array<${mapToTypesWgsl(inputInfo[i].dtype, program.isVec4)}>;
+    };
+    [[group(0), binding(${1 + i})]] var<storage> ${
+        x} : [[access(read)]] Matrix${1 + i};
+    `);
+  });
+
+  if (uniformDeclaration !== '') {
+    prefixSnippets.push(`
+    [[group(0), binding(${
+        1 + program.variableNames.length})]] var<uniform> uniforms : Uniforms;
+    `);
+  }
+
+  const [getOutputCoords, dispatchLayoutRank] =
+      generateGetOutputCoords(outputData.shape, program.dispatchLayout);
+  const getCoords = generateGetCoordsFromFlatIndex(outputData.shape);
+
+  const sources = [
+    SHADER_PREFIX, prefixSnippets.join('\n'), SAMPLING_SNIPPETS, getCoords,
+    getOutputCoords,
+    getSetOutputSnippet(outputData.shape, outputData.dtype, program.isVec4)
+  ];
+  if (dispatchLayoutRank === outputData.shape.length) {
+    // Input sampling snippet is only meaningful when the output isn't getting
+    // implicitly reshaped (like it does in conv2d_matmul).
+    const inputSamplingSnippet =
+        inputInfo
+            .map(
+                x => getInputSamplingSnippet(
+                    x, outputData.shape, program.isVec4,
+                    program.dispatchLayout.x.length ===
+                        outputData.shape.length))
+            .join('\n');
+    sources.push(inputSamplingSnippet);
+  }
+
+  sources.push(program.getUserCodeWgsl());
+  const source = sources.join('\n');
+  return source;
+}
+
+const SHADER_PREFIX = `
+  fn idiv(a: i32, b: i32, sign: f32) -> i32 {
+    var res: i32 = a / b;
+    let mod: i32 = a % b;
+    if (sign < 0. && mod != 0) {
+      res = res - 1;
+    }
+    return res;
+  }
+  // Checks whether coordinates lie within the bounds of the shape.
+  fn coordsInBounds4(coord: vec4<u32>, shape: vec4<u32>) -> bool {
+    return all(coord >= vec4<u32>(0u, 0u, 0u, 0u)) &&
+        all(coord < shape);
+  }
+  fn coordsInBounds3(coord: vec3<u32>, shape: vec3<u32>) -> bool{
+    return all(coord >= vec3<u32>(0u, 0u, 0u)) &&
+        all(coord < shape);
+  }
+  fn coordsInBounds2(coord: vec2<u32>, shape: vec2<u32>) -> bool {
+    return all(coord >= vec2<u32>(0u, 0u)) &&
+        all(coord < shape);
+  }
+  `;
+const SAMPLING_SNIPPETS = `
+  fn getFlatIndex1(coord : u32, shape : u32) -> u32 {
+    return coord;
+  }
+
+  fn getFlatIndex2(coords : vec2<u32>, shape : vec2<u32>) -> u32 {
+    return u32(dot(vec2<f32>(coords), vec2<f32>(f32(shape.y), 1.0)));
+  }
+
+  fn getFlatIndex3(coords : vec3<u32>, shape : vec3<u32>) -> u32 {
+    return u32(dot(vec3<f32>(coords), vec3<f32>(f32(shape.y) * f32(shape.z), f32(shape.z), 1.0)));
+  }
+
+  fn getFlatIndex4(coords : vec4<u32>, shape : vec4<u32>) -> u32 {
+    return u32(dot(vec4<f32>(coords), vec4<f32>(
+        f32(shape.y) * f32(shape.z) * f32(shape.w), f32(shape.z) * f32(shape.w), f32(shape.w), 1.0)));
+  }
+`;
+
+function getSetOutputSnippet(
+    outShape: number[], outBufferType: DataType, isVec4: boolean): string {
+  const outRank = outShape.length;
+  const wgslType = mapToTypesWgsl(outBufferType, isVec4);
+  let snippet;
+  if (isVec4) {
+    snippet = `fn setOutputFlat(flatIndex : u32, value : vec4<f32>) {
+      result.numbers[flatIndex] = ${
+        wgslType === 'vec4<i32>' ?
+            'vec4<i32>(value)' :
+            (wgslType === 'vec4<bool>' ? 'vec4<bool>(value)' : 'value')};
+    }
+    fn setOutputFlatI32(flatIndex : u32, value : vec4<i32>) {
+      result.numbers[flatIndex] = ${
+        wgslType === 'vec4<f32>' ?
+            'vec4<f32>(value)' :
+            (wgslType === 'vec4<bool>' ? 'vec4<bool>(value)' : 'value')};
+    }`;
+  } else {
+    snippet = `fn setOutputFlat(flatIndex : u32, value : f32) {
+      result.numbers[flatIndex] = ${
+        wgslType === 'i32' ? 'i32(value)' :
+                             (wgslType === 'bool' ? 'bool(value)' : 'value')};
+    }
+    fn setOutputFlatI32(flatIndex : u32, value : i32) {
+      result.numbers[flatIndex] = ${
+        wgslType === 'f32' ? 'f32(value)' :
+                             (wgslType === 'bool' ? 'bool(value)' : 'value')};
+    }`;
+  }
+
+  if (outRank >= 2) {
+    switch (outRank) {
+      case 2:
+        snippet += `
+        fn getOutputFlatIndex(coords : vec2<u32>) -> u32 {
+          return u32(dot(vec2<f32>(coords), vec2<f32>(f32(uniforms.outShapeStrides), 1.0)));
+        }
+        `;
+        break;
+      case 3:
+        snippet += `
+        fn getOutputFlatIndex(coords : vec3<u32>) -> u32 {
+          return u32(dot(vec3<f32>(coords), vec3<f32>(f32(uniforms.outShapeStrides.x), f32(uniforms.outShapeStrides.y), 1.0)));
+        }
+        `;
+        break;
+      case 4:
+        snippet += `
+        fn getOutputFlatIndex(coords : vec4<u32>) -> u32 {
+          return u32(dot(vec4<f32>(coords), vec4<f32>(
+            f32(uniforms.outShapeStrides.x), f32(uniforms.outShapeStrides.y), f32(uniforms.outShapeStrides.z), 1.0)));
+        }
+        `;
+        break;
+      default:
+        util.assert(false, () => `Unsupported ${outRank}D shape`);
+        break;
+    }
+    const dims = ['d0', 'd1', 'd2', 'd3'].slice(0, outRank);
+    const type = getCoordsDataTypeWgsl(outRank);
+
+    if (isVec4) {
+      snippet += `
+      fn setOutput(${
+          dims.map(d => `${d} : u32`).join(', ')}, value : vec4<f32>) {
+        let flatIndex : u32 = getOutputFlatIndex(${type}(${dims.join(', ')}));
+        setOutputFlat(flatIndex / 4u, value);
+      }
+      fn setOutputVectorI32(${
+          dims.map(d => `${d} : u32`).join(', ')}, value : vec4<i32>) {
+        let flatIndex : u32 = getOutputFlatIndex(${type}(${dims.join(', ')}));
+        setOutputFlatI32(flatIndex / 4u, value);
+      }
+    `;
+    } else {
+      snippet += `
+      fn setOutput(${dims.map(d => `${d} : u32`).join(', ')}, value : f32) {
+        let flatIndex : u32 = getOutputFlatIndex(${type}(${dims.join(', ')}));
+        setOutputFlat(flatIndex, value);
+      }
+      fn setOutputI32(${dims.map(d => `${d} : u32`).join(', ')}, value : i32) {
+        let flatIndex : u32 = getOutputFlatIndex(${type}(${dims.join(', ')}));
+        setOutputFlatI32(flatIndex, value);
+      }
+    `;
+    }
+  }
+
+  return snippet;
+}
+
+function getInputSamplingSnippet(
+    inInfo: InputInfo, outShape: number[], isVec4: boolean,
+    isFlatDispatchLayout: boolean): string {
+  let res = getSamplerFromInInfo(inInfo, isVec4);
+
+  const inShape = inInfo.shape;
+  if (inShape.length <= outShape.length) {
+    res += getSamplerAtOutputCoords(
+        inInfo, outShape, isVec4, isFlatDispatchLayout);
+  }
+
+  return res;
+}
+
+function getSamplerFromInInfo(inInfo: InputInfo, isVec4: boolean): string {
+  const texName = inInfo.name;
+  const rank = inInfo.shape.length;
+  const type = getCoordsDataTypeWgsl(rank);
+  const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+  const dims = ['d0', 'd1', 'd2', 'd3'].slice(0, rank);
+  const inputs = dims.map(d => `${d} : u32`).join(', ');
+
+  if (rank < 1) {
+    if (isVec4) {
+      return `
+        fn ${funcName}() -> vec4<f32>{
+          return ${texName}.numbers[0];
+        }
+      `;
+    }
+
+    return `
+      fn ${funcName}() ->f32 {
+        return ${texName}.numbers[0];
+      }
+    `;
+  }
+
+  const shapeStr =
+      `uniforms.${texName.charAt(0).toLowerCase() + texName.slice(1)}Shape`;
+  let rankStr = `${rank}`;
+  if (rank === 0) {
+    rankStr = '1';
+  }
+
+  if (isVec4) {
+    return `
+      fn ${funcName}(${inputs}) -> vec4<f32>{
+        return ${texName}.numbers[getFlatIndex${rankStr}(${type}(${
+        dims.join(',')}),
+          ${shapeStr}) / 4u];
+      }
+      `;
+  }
+
+  return `
+    fn ${funcName}(${inputs}) -> f32 {
+      return f32(${texName}.numbers[getFlatIndex${rankStr}(${type}(${
+      dims.join(',')}),
+        ${shapeStr})]);
+    }
+   `;
+}
+
+export function getSamplerAtOutputCoords(
+    inInfo: InputInfo, outShape: number[], isVec4: boolean,
+    isFlatDispatchLayout: boolean): string {
+  const texName = inInfo.name;
+  const texFuncSnippet = texName.charAt(0).toUpperCase() + texName.slice(1);
+
+  const funcName = 'get' + texFuncSnippet + 'AtOutCoords';
+
+  const inRank = inInfo.shape.length;
+  const outRank = outShape.length;
+  const type = getCoordsDataTypeWgsl(outRank);
+
+  // If the inShape equals the outShape and the dispatch layout is flat, we can
+  // directly use |gl_GlobalInvocationID.x| as the index and don't need coords
+  // conversion between these two shapes.
+  if (util.arraysEqual(inInfo.shape, outShape) && isFlatDispatchLayout) {
+    if (isVec4) {
+      return `
+        fn ${funcName}(globalId : vec3<u32>) -> vec4<f32> {
+          return ${texName}.numbers[globalId.x];
+        }
+
+        fn ${funcName}2(coords : ${type}) -> vec4<f32> {
+          return ${texName}.numbers[${
+          outRank > 1 ? 'getOutputFlatIndex(coords)' : 'coords'} / 4u];
+        }
+        `;
+    } else {
+      return `
+      fn ${funcName}(globalId : vec3<u32>) -> f32 {
+        return f32(${texName}.numbers[globalId.x]);
+      }
+
+      fn ${funcName}2(coords : ${type}) -> f32 {
+        return f32(${texName}.numbers[${
+          outRank > 1 ? 'getOutputFlatIndex(coords)' : 'coords'}]);
+      }
+      `;
+    }
+  }
+
+  const broadcastDims = backend_util.getBroadcastDims(inInfo.shape, outShape);
+  const rankDiff = outRank - inRank;
+
+  let coordsSnippet = '';
+
+  if (inRank === 0) {
+    if (isVec4) {
+      return `
+      fn ${funcName}(globalId : vec3<u32>) -> vec4<f32> {
+        return get${texFuncSnippet}();
+      }
+
+      fn ${funcName}2(coords : ${type}) -> vec4<f32> {
+        return get${texFuncSnippet}();
+      }
+    `;
+    }
+    return `
+      fn ${funcName}(globalId : vec3<u32>) -> f32{
+        return get${texFuncSnippet}();
+      }
+
+      fn ${funcName}2(coords : ${type}) -> f32{
+        return get${texFuncSnippet}();
+      }
+    `;
+  } else {
+    if (outRank < 2 && broadcastDims.length >= 1) {
+      coordsSnippet = 'coords = 0u;';
+    } else {
+      coordsSnippet =
+          broadcastDims.map(d => `coords[${d + rankDiff}u] = 0u;`).join('\n');
+    }
+  }
+
+  let unpackedCoordsSnippet = '';
+  if (outRank < 2 && inRank > 0) {
+    unpackedCoordsSnippet = 'coords';
+  } else {
+    if (outRank > 1) {
+      const coordsType = getCoordsDataTypeWgsl(inRank);
+      const coordsValues =
+          inInfo.shape.map((s, i) => `coords[${i + rankDiff}u]`).join(', ');
+      unpackedCoordsSnippet = `${coordsType}(${coordsValues})`;
+    } else {
+      unpackedCoordsSnippet = 'coords';
+    }
+  }
+
+  const shapeStr =
+      `uniforms.${texName.charAt(0).toLowerCase() + texName.slice(1)}Shape`;
+  const rankStr = `${inRank}`;
+  if (isVec4) {
+    return `
+      fn ${funcName}(globalId : vec3<u32>) -> vec4<f32> {
+        var coords : ${type} = getOutputCoords(globalId);
+        ${coordsSnippet}
+        return ${texName}.numbers[getFlatIndex${rankStr}(${
+        unpackedCoordsSnippet}, ${shapeStr}) / 4u];
+      }
+
+      fn ${funcName}2(coordsIn : ${type}) -> vec4<f32> {
+        var coords : ${type} = coordsIn;
+        ${coordsSnippet}
+        return ${texName}.numbers[getFlatIndex${rankStr}(${
+        unpackedCoordsSnippet}, ${shapeStr}) / 4u];
+      }
+    `;
+  }
+
+  return `
+    fn ${funcName}(globalId : vec3<u32>) ->f32 {
+      var coords : ${type} = getOutputCoords(globalId);
+      ${coordsSnippet}
+      return f32(${texName}.numbers[getFlatIndex${rankStr}(${
+      unpackedCoordsSnippet}, ${shapeStr})]);
+    }
+
+    fn ${funcName}2(coordsIn : ${type}) ->f32 {
+      var coords : ${type} = coordsIn;
+      ${coordsSnippet}
+      return f32(${texName}.numbers[getFlatIndex${rankStr}(${
+      unpackedCoordsSnippet}, ${shapeStr})]);
+    }
+  `;
+}
+
+/**
+ * Generates getOutputCoords() function that computes output coordinates from
+ * dispatch geometry to reduce arithmetic.
+ */
+export function generateGetOutputCoords(
+    outShape: number[],
+    dispatchLayout: {x: number[], y?: number[], z?: number[]}):
+    [string, number] {
+  const {x, y = [], z = []} = dispatchLayout;
+
+  const outRank = outShape.length;
+  if (x.length === outRank) {
+    const dtype = getCoordsDataTypeWgsl(outRank);
+    const snippet = `fn getOutputCoords(globalId : vec3<u32>) -> ${dtype}{
+      return getCoordsFromFlatIndex(u32(globalId.x));
+    }
+    `;
+    return [snippet, outRank];
+  }
+
+  let gatherDimensionsStr = '';
+  const dims = [x, y, z];
+
+  let rank = 0;
+
+  for (let i = 0; i < dims.length; i++) {
+    const arr = dims[i];
+
+    if (arr.length === 0) {
+      continue;
+    }
+
+    rank += arr.length;
+
+    if (arr.length === 1) {
+      gatherDimensionsStr += `let d${arr[0]} : u32 =
+        u32(globalId[${i}]);`;
+    } else {
+      const strides = symbolicallyComputeStrides(arr, 'uniforms.outShape');
+      gatherDimensionsStr += `let index${i} : u32 =
+          u32(globalId[${i}]);`;
+      for (let j = 0; j < strides.length; j++) {
+        gatherDimensionsStr +=
+            `let d${arr[j]} : u32 = index${i} / ${strides[j]};`;
+
+        if (j === strides.length - 1) {
+          gatherDimensionsStr += `let d${arr[j + 1]} : u32 = ` +
+              `index${i} - d${arr[j]} * ${strides[j]};`;
+        } else {
+          gatherDimensionsStr +=
+              `index${i} = index${i} - d${arr[j]} * ${strides[j]};`;
+        }
+      }
+    }
+  }
+
+  const dimensions = [];
+  for (let i = 0; i < rank; i++) {
+    dimensions.push(`d${i}`);
+  }
+
+  const dtype = getCoordsDataTypeWgsl(rank);
+  let snippet = `fn getOutputCoords(globalId : vec3<u32>) -> ${dtype}{
+    ${gatherDimensionsStr}
+  `;
+  if (dimensions.length === 0) {
+    snippet += `return ${dtype}(0);}`;
+  } else {
+    snippet += `return ${dtype}(${dimensions.join(',')});}`;
+  }
+
+  return [snippet, rank];
+}
+
+/**
+ * Derives logical coordinates from a flat index. Performs integer division
+ * with each stride and decrements the index until the index equals the final
+ * dimension coordinate.
+ */
+function generateGetCoordsFromFlatIndex(shape: number[]): string {
+  const rank = shape.length;
+
+  if (rank <= 1) {
+    return `fn getCoordsFromFlatIndex(index : u32) ->u32 {return index; }`;
+  }
+
+  const strides = util.computeStrides(shape);
+  const dtype = getCoordsDataTypeWgsl(rank);
+
+  const coords: string[] = [];
+  for (let i = 0; i < rank; i++) {
+    coords.push(`d${i}`);
+  }
+
+  if (strides.length === 1) {
+    return `    fn getCoordsFromFlatIndex(index : u32) -> vec2<u32>{
+      let d0 = index / uniforms.outShapeStrides; let d1 = index - d0 * uniforms.outShapeStrides;
+      return vec2<u32>(d0,d1);
+    }`;
+  }
+  const snippet = 'var index2 : u32 = index;' +
+      strides
+          .map((_, i) => {
+            const line1 = `let ${
+                coords[i]} :u32 = index2 / uniforms.outShapeStrides[${i}]`;
+            const line2 = i === strides.length - 1 ?
+                `let ${coords[i + 1]}  : u32 = index2 - ${
+                    coords[i]} * uniforms.outShapeStrides[${i}]` :
+                `index2 = index2 - ${coords[i]} * uniforms.outShapeStrides[${
+                    i}]`;
+            return `${line1}; ${line2};`;
+          })
+          .join('');
+
+  return `
+    fn getCoordsFromFlatIndex(index : u32) -> ${dtype} {
+      ${snippet}
+      return ${dtype}(${coords.join(',')});
+    }
+  `;
+}

--- a/tfjs-backend-webgpu/src/webgpu_util_wgsl.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util_wgsl.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export function getWorkGroupSizeString(workGroupSize: [number, number, number]):
+    string {
+  if (workGroupSize == null) {
+    return '';
+  }
+  return `
+  [[stage(compute), workgroup_size(${workGroupSize[0]}, ${workGroupSize[1]}, ${
+      workGroupSize[2]})]]
+`;
+}


### PR DESCRIPTION
This is the general framework for WGSL support, currently only unary and part conv2d path are tested.
To test WGSL, change WEBGPU_USE_GLSL in tfjs-backend-webgpu/src/flags_webgpu.ts to false.

Matmul changes is based on:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/dawn/src/tests/perf_tests/ShaderRobustnessPerf.cpp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5231)
<!-- Reviewable:end -->
