### PR TITLE
Add the missing backend initialization in runKernel

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -535,6 +535,14 @@ export class Engine implements TensorTracker, DataMover {
    */
   runKernel<T extends Tensor|Tensor[]>(
       kernelName: string, inputs: NamedTensorMap, attrs?: NamedAttrMap): T {
+    if (this.backendName == null) {
+      // backend has not been initialized yet (backend initialization is lazy
+      // can be deferred until an op/ kernel is run).
+      // The below getter has side effects that will try to initialize the
+      // backend and set properties like this.backendName
+      // tslint:disable-next-line: no-unused-expression
+      this.backend;
+    }
     const hasKernel = getKernel(kernelName, this.backendName) != null;
     if (!hasKernel) {
       throw new Error(`Kernel '${kernelName}' not registered for backend '${


### PR DESCRIPTION
This is related to #5237 

**Background**

Most of our kernels will create/convert tensors before calling `ENGINE.runKernel` ([example](https://github.com/tensorflow/tfjs/blob/fixrunkernel/tfjs-core/src/ops/greater.ts#L45-L46)). In those cases, `convertToTensor` will eventually call `ENGINE.makeTensor` where `this.backend` will be [referenced](https://github.com/tensorflow/tfjs/blob/fixrunkernel/tfjs-core/src/engine.ts#L808). `this.backend` has a side effect that will [initialize the backend](https://github.com/tensorflow/tfjs/blob/fixrunkernel/tfjs-core/src/engine.ts#L216). This design allows our backend to be lazily initialized. The similar lazy backend initialization also happens in `runKernelFunc`. See this [code block](https://github.com/tensorflow/tfjs/blob/fixrunkernel/tfjs-core/src/engine.ts#L607-L614).

**The problem**

Some kernels do **not** create/convert tensors before calling `ENGINE.runKernel`. For example, [linspace](https://github.com/tensorflow/tfjs/blob/fixrunkernel/tfjs-core/src/ops/linspace.ts#L41), [fill](https://github.com/tensorflow/tfjs/blob/fixrunkernel/tfjs-core/src/ops/fill.ts#L42), etc. As a result, when they call `ENGINE.runKernel`, an error will be thrown when calling `getKernel` [here](https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/engine.ts#L538), because `this.backendName` is not set since the backend has not been initialized.

**The fix**

I copied the code block about lazily initializing backend from `runKernelFunc` to `runKernel` which should fix this problem (tested locally). This was probably missed during the kernel modularization process when we switched from `runKernelFunc` to `runKernel`.   

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5251)
<!-- Reviewable:end -->
