### PR TITLE
webgl: Refactor the custom uniforms support

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -713,7 +713,7 @@ export class MathBackendWebGL extends KernelBackend {
     const program = new PackProgram(input.shape);
     const preventEagerUnpackingOutput = true;
     return this.runWebGLProgram(
-        program, [input], input.dtype, null /* customSetup */,
+        program, [input], input.dtype, null /* customUniformValues */,
         preventEagerUnpackingOutput);
   }
 
@@ -734,7 +734,7 @@ export class MathBackendWebGL extends KernelBackend {
     const program = new ReshapePackedProgram(afterShapeAs3D, input3DShape);
     const preventEagerUnpackingOfOutput = true;
     const output = this.runWebGLProgram(
-        program, [input3D], input.dtype, null /* customSetup */,
+        program, [input3D], input.dtype, null /* customUniformValues */,
         preventEagerUnpackingOfOutput);
     return {dataId: output.dataId, shape: afterShape, dtype: output.dtype};
   }
@@ -753,13 +753,13 @@ export class MathBackendWebGL extends KernelBackend {
     const preventEagerUnpackingOfOutput = true;
     const out = this.runWebGLProgram(
         program, [{shape: shapeAs3D, dtype, dataId}], dtype,
-        null /* customSetup */, preventEagerUnpackingOfOutput);
+        null /* customUniformValues */, preventEagerUnpackingOfOutput);
     return {dtype, shape, dataId: out.dataId};
   }
 
   runWebGLProgram(
       program: GPGPUProgram, inputs: TensorInfo[], outputDtype: DataType,
-      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void,
+      customUniformValues?: number[][],
       preventEagerUnpackingOfOutput = false): TensorInfo {
     const output = this.makeTensorInfo(program.outputShape, outputDtype);
     const outData = this.texData.get(output.dataId);
@@ -864,7 +864,7 @@ export class MathBackendWebGL extends KernelBackend {
     }
 
     gpgpu_math.runProgram(
-        this.gpgpu, binary, inputsData, outputData, customSetup);
+        this.gpgpu, binary, inputsData, outputData, customUniformValues);
 
     dataToDispose.forEach(info => this.disposeIntermediateTensorInfo(info));
 
@@ -895,11 +895,11 @@ export class MathBackendWebGL extends KernelBackend {
 
   compileAndRun(
       program: GPGPUProgram, inputs: TensorInfo[], outputDtype?: DataType,
-      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void,
+      customUniformValues?: number[][],
       preventEagerUnpackingOfOutput = false): TensorInfo {
     outputDtype = outputDtype || inputs[0].dtype;
     const outInfo = this.runWebGLProgram(
-        program, inputs, outputDtype, customSetup,
+        program, inputs, outputDtype, customUniformValues,
         preventEagerUnpackingOfOutput);
     return outInfo;
   }

--- a/tfjs-backend-webgl/src/clip_gpu.ts
+++ b/tfjs-backend-webgl/src/clip_gpu.ts
@@ -15,23 +15,18 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class ClipProgram implements GPGPUProgram {
   variableNames = ['A'];
   userCode: string;
   outputShape: number[];
-
-  // Caching uniform locations for speed.
-  minLoc: WebGLUniformLocation;
-  maxLoc: WebGLUniformLocation;
+  customUniforms =
+      [{name: 'minVal', type: 'float'}, {name: 'maxVal', type: 'float'}];
 
   constructor(aShape: number[]) {
     this.outputShape = aShape;
     this.userCode = `
-      uniform float minVal;
-      uniform float maxVal;
 
       void main() {
         float value = getAAtOutCoords();
@@ -43,16 +38,5 @@ export class ClipProgram implements GPGPUProgram {
         setOutput(clamp(value, minVal, maxVal));
       }
     `;
-  }
-
-  getCustomSetupFunc(min: number, max: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.minLoc == null) {
-        this.minLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'minVal');
-        this.maxLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'maxVal');
-      }
-      gpgpu.gl.uniform1f(this.minLoc, min);
-      gpgpu.gl.uniform1f(this.maxLoc, max);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/clip_gpu.ts
+++ b/tfjs-backend-webgl/src/clip_gpu.ts
@@ -16,13 +16,16 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {UniformType} from './shader_compiler';
 
 export class ClipProgram implements GPGPUProgram {
   variableNames = ['A'];
   userCode: string;
   outputShape: number[];
-  customUniforms =
-      [{name: 'minVal', type: 'float'}, {name: 'maxVal', type: 'float'}];
+  customUniforms = [
+    {name: 'minVal', type: 'float' as UniformType},
+    {name: 'maxVal', type: 'float' as UniformType}
+  ];
 
   constructor(aShape: number[]) {
     this.outputShape = aShape;

--- a/tfjs-backend-webgl/src/clip_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/clip_packed_gpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class ClipPackedProgram implements GPGPUProgram {
@@ -24,17 +23,12 @@ export class ClipPackedProgram implements GPGPUProgram {
   packedOutput = true;
   userCode: string;
   outputShape: number[];
-
-  // Caching uniform locations for speed.
-  minLoc: WebGLUniformLocation;
-  maxLoc: WebGLUniformLocation;
+  customUniforms =
+      [{name: 'minVal', type: 'float'}, {name: 'maxVal', type: 'float'}];
 
   constructor(aShape: number[]) {
     this.outputShape = aShape;
     this.userCode = `
-      uniform float minVal;
-      uniform float maxVal;
-
       void main() {
         vec4 value = getAAtOutCoords();
 
@@ -46,16 +40,5 @@ export class ClipPackedProgram implements GPGPUProgram {
         setOutput(clamp(value, vec4(minVal), vec4(maxVal)));
       }
     `;
-  }
-
-  getCustomSetupFunc(min: number, max: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.minLoc == null) {
-        this.minLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'minVal');
-        this.maxLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'maxVal');
-      }
-      gpgpu.gl.uniform1f(this.minLoc, min);
-      gpgpu.gl.uniform1f(this.maxLoc, max);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/clip_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/clip_packed_gpu.ts
@@ -16,6 +16,7 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {UniformType} from './shader_compiler';
 
 export class ClipPackedProgram implements GPGPUProgram {
   variableNames = ['A'];
@@ -23,8 +24,10 @@ export class ClipPackedProgram implements GPGPUProgram {
   packedOutput = true;
   userCode: string;
   outputShape: number[];
-  customUniforms =
-      [{name: 'minVal', type: 'float'}, {name: 'maxVal', type: 'float'}];
+  customUniforms = [
+    {name: 'minVal', type: 'float' as UniformType},
+    {name: 'maxVal', type: 'float' as UniformType}
+  ];
 
   constructor(aShape: number[]) {
     this.outputShape = aShape;

--- a/tfjs-backend-webgl/src/cumsum_gpu.ts
+++ b/tfjs-backend-webgl/src/cumsum_gpu.ts
@@ -15,13 +15,13 @@
  * =============================================================================
  */
 import {GPGPUProgram} from './gpgpu_math';
-import {getCoordsDataType} from './shader_compiler';
+import {getCoordsDataType, UniformType} from './shader_compiler';
 
 export class CumSumProgram implements GPGPUProgram {
   variableNames = ['x'];
   outputShape: number[];
   userCode: string;
-  customUniforms = [{name: 'index', type: 'float'}];
+  customUniforms = [{name: 'index', type: 'float' as UniformType}];
 
   constructor(shape: number[], exclusive: boolean, reverse: boolean) {
     this.outputShape = shape;

--- a/tfjs-backend-webgl/src/cumsum_gpu.ts
+++ b/tfjs-backend-webgl/src/cumsum_gpu.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  * =============================================================================
  */
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 import {getCoordsDataType} from './shader_compiler';
 
@@ -22,9 +21,7 @@ export class CumSumProgram implements GPGPUProgram {
   variableNames = ['x'];
   outputShape: number[];
   userCode: string;
-
-  // Caching uniform location for speed.
-  index: WebGLUniformLocation;
+  customUniforms = [{name: 'index', type: 'float'}];
 
   constructor(shape: number[], exclusive: boolean, reverse: boolean) {
     this.outputShape = shape;
@@ -45,7 +42,6 @@ export class CumSumProgram implements GPGPUProgram {
     }
 
     this.userCode = `
-      uniform float index;
       void main() {
         ${getCoordsDataType(rank)} coords = getOutputCoords();
         int end = ${getFinalCoord(rank, 'coords')};
@@ -59,15 +55,6 @@ export class CumSumProgram implements GPGPUProgram {
         setOutput(val);
       }
     `;
-  }
-
-  getCustomSetupFunc(index: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.index == null) {
-        this.index = gpgpu.getUniformLocation(webGLProgram, 'index');
-      }
-      gpgpu.gl.uniform1f(this.index, index);
-    };
   }
 }
 

--- a/tfjs-backend-webgl/src/fill_gpu.ts
+++ b/tfjs-backend-webgl/src/fill_gpu.ts
@@ -15,35 +15,23 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class FillProgram implements GPGPUProgram {
   variableNames: string[];
   outputShape: number[] = [];
   userCode: string;
-
-  valueLoc: WebGLUniformLocation;
+  customUniforms = [{name: 'value', type: 'float'}];
 
   constructor(shape: number[], value: number) {
     this.variableNames = ['x'];
     this.outputShape = shape;
 
     this.userCode = `
-      uniform float value;
       void main() {
         // Input can be obtained from uniform value.
         setOutput(value);
       }
     `;
-  }
-
-  getCustomSetupFunc(value: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.valueLoc == null) {
-        this.valueLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'value');
-      }
-      gpgpu.gl.uniform1f(this.valueLoc, value);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/fill_gpu.ts
+++ b/tfjs-backend-webgl/src/fill_gpu.ts
@@ -16,12 +16,13 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {UniformType} from './shader_compiler';
 
 export class FillProgram implements GPGPUProgram {
   variableNames: string[];
   outputShape: number[] = [];
   userCode: string;
-  customUniforms = [{name: 'value', type: 'float'}];
+  customUniforms = [{name: 'value', type: 'float' as UniformType}];
 
   constructor(shape: number[], value: number) {
     this.variableNames = ['x'];

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -41,7 +41,8 @@ export interface GPGPUProgram {
    * See `PackingScheme` for details. Defaults to `PackingScheme.SHARED_BATCH`.
    */
   outPackingScheme?: PackingScheme;
-  customUniforms?: Array<{name: string; type: UniformType;}>;
+  customUniforms?:
+      Array<{name: string; arrayIndex?: number; type: UniformType;}>;
 }
 
 export interface GPGPUBinary {
@@ -139,12 +140,8 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
   const customUniformLocations: WebGLUniformLocation[] = [];
   if (program.customUniforms) {
     program.customUniforms.forEach((d, i) => {
-      // d.name may be a uniform array. For example, start[4] in slice_gpu.ts.
-      // In this case, we should use 'start' instead of 'start[4]' to get the
-      // uniform location.
-      const uniformName = d.name.split('[')[0];
       customUniformLocations[i] =
-          gpgpu.getUniformLocation(webGLProgram, uniformName, shouldThrow);
+          gpgpu.getUniformLocation(webGLProgram, d.name, shouldThrow);
     });
   }
 

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -48,7 +48,7 @@ export interface GPGPUBinary {
   webGLProgram: WebGLProgram;
   program: GPGPUProgram;
   uniformLocations: {[name: string]: WebGLUniformLocation};
-  customUniformLocations?: {[name: string]: WebGLUniformLocation};
+  customUniformLocations?: WebGLUniformLocation[];
   source: string;
   inShapeInfos: ShapeInfo[];
   outShapeInfo: ShapeInfo;
@@ -136,14 +136,14 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
         gpgpu.getUniformLocation(webGLProgram, 'outTexShape', shouldThrow);
   }
 
-  const customUniformLocations: {[name: string]: WebGLUniformLocation} = {};
+  const customUniformLocations: WebGLUniformLocation[] = [];
   if (program.customUniforms) {
     program.customUniforms.forEach((d, i) => {
       // d.name may be a uniform array. For example, start[4] in slice_gpu.ts.
       // In this case, we should use 'start' instead of 'start[4]' to get the
       // uniform location.
       const uniformName = d.name.split('[')[0];
-      customUniformLocations[d.name] =
+      customUniformLocations[i] =
           gpgpu.getUniformLocation(webGLProgram, uniformName, shouldThrow);
     });
   }
@@ -332,23 +332,24 @@ export function runProgram<T extends Tensor, K extends Tensor>(
 
   if (binary.program.customUniforms && customUniformValues) {
     binary.program.customUniforms.forEach((d, i) => {
-      const customLoc = binary.customUniformLocations[d.name];
+      const customLoc = binary.customUniformLocations[i];
+      const customValue = customUniformValues[i];
       if (d.type === 'float') {
-        gpgpu.gl.uniform1fv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform1fv(customLoc, customValue);
       } else if (d.type === 'vec2') {
-        gpgpu.gl.uniform2fv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform2fv(customLoc, customValue);
       } else if (d.type === 'vec3') {
-        gpgpu.gl.uniform3fv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform3fv(customLoc, customValue);
       } else if (d.type === 'vec4') {
-        gpgpu.gl.uniform4fv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform4fv(customLoc, customValue);
       } else if (d.type === 'int') {
-        gpgpu.gl.uniform1iv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform1iv(customLoc, customValue);
       } else if (d.type === 'ivec2') {
-        gpgpu.gl.uniform2iv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform2iv(customLoc, customValue);
       } else if (d.type === 'ivec3') {
-        gpgpu.gl.uniform3iv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform3iv(customLoc, customValue);
       } else if (d.type === 'ivec4') {
-        gpgpu.gl.uniform4iv(customLoc, customUniformValues[i]);
+        gpgpu.gl.uniform4iv(customLoc, customValue);
       } else {
         throw Error(`uniform type ${d.type} is not supported yet.`);
       }

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -19,7 +19,7 @@ import {backend_util, env, Tensor, TypedArray, util} from '@tensorflow/tfjs-core
 
 import {GPGPUContext} from './gpgpu_context';
 import * as shader_compiler from './shader_compiler';
-import {InputInfo, ShapeInfo} from './shader_compiler';
+import {InputInfo, ShapeInfo, UniformType} from './shader_compiler';
 import {PackingScheme, TextureData, TextureUsage} from './tex_util';
 
 export interface GPGPUProgram {
@@ -41,14 +41,14 @@ export interface GPGPUProgram {
    * See `PackingScheme` for details. Defaults to `PackingScheme.SHARED_BATCH`.
    */
   outPackingScheme?: PackingScheme;
-  customUniforms?: Array<{name: string; type: string;}>;
+  customUniforms?: Array<{name: string; type: UniformType;}>;
 }
 
 export interface GPGPUBinary {
   webGLProgram: WebGLProgram;
   program: GPGPUProgram;
   uniformLocations: {[name: string]: WebGLUniformLocation};
-  customUniformLocations?: WebGLUniformLocation[];
+  customUniformLocations?: {[name: string]: WebGLUniformLocation};
   source: string;
   inShapeInfos: ShapeInfo[];
   outShapeInfo: ShapeInfo;
@@ -136,12 +136,15 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
         gpgpu.getUniformLocation(webGLProgram, 'outTexShape', shouldThrow);
   }
 
-  const customUniformLocations: WebGLUniformLocation[] = [];
+  const customUniformLocations: {[name: string]: WebGLUniformLocation} = {};
   if (program.customUniforms) {
     program.customUniforms.forEach((d, i) => {
-      const location = gpgpu.getUniformLocation(
-          webGLProgram, d.name.split('[')[0], shouldThrow);
-      customUniformLocations.push(location);
+      // d.name may be a uniform array. For example, start[4] in slice_gpu.ts.
+      // In this case, we should use 'start' instead of 'start[4]' to get the
+      // uniform location.
+      const uniformName = d.name.split('[')[0];
+      customUniformLocations[d.name] =
+          gpgpu.getUniformLocation(webGLProgram, uniformName, shouldThrow);
     });
   }
 
@@ -329,18 +332,23 @@ export function runProgram<T extends Tensor, K extends Tensor>(
 
   if (binary.program.customUniforms && customUniformValues) {
     binary.program.customUniforms.forEach((d, i) => {
+      const customLoc = binary.customUniformLocations[d.name];
       if (d.type === 'float') {
-        gpgpu.gl.uniform1fv(
-            binary.customUniformLocations[i], customUniformValues[i]);
+        gpgpu.gl.uniform1fv(customLoc, customUniformValues[i]);
+      } else if (d.type === 'vec2') {
+        gpgpu.gl.uniform2fv(customLoc, customUniformValues[i]);
+      } else if (d.type === 'vec3') {
+        gpgpu.gl.uniform3fv(customLoc, customUniformValues[i]);
       } else if (d.type === 'vec4') {
-        gpgpu.gl.uniform4fv(
-            binary.customUniformLocations[i], customUniformValues[i]);
+        gpgpu.gl.uniform4fv(customLoc, customUniformValues[i]);
       } else if (d.type === 'int') {
-        gpgpu.gl.uniform1iv(
-            binary.customUniformLocations[i], customUniformValues[i]);
+        gpgpu.gl.uniform1iv(customLoc, customUniformValues[i]);
       } else if (d.type === 'ivec2') {
-        gpgpu.gl.uniform2iv(
-            binary.customUniformLocations[i], customUniformValues[i]);
+        gpgpu.gl.uniform2iv(customLoc, customUniformValues[i]);
+      } else if (d.type === 'ivec3') {
+        gpgpu.gl.uniform3iv(customLoc, customUniformValues[i]);
+      } else if (d.type === 'ivec4') {
+        gpgpu.gl.uniform4iv(customLoc, customUniformValues[i]);
       } else {
         throw Error(`uniform type ${d.type} is not supported yet.`);
       }

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -41,12 +41,14 @@ export interface GPGPUProgram {
    * See `PackingScheme` for details. Defaults to `PackingScheme.SHARED_BATCH`.
    */
   outPackingScheme?: PackingScheme;
+  customUniforms?: Array<{name: string; type: string;}>;
 }
 
 export interface GPGPUBinary {
   webGLProgram: WebGLProgram;
   program: GPGPUProgram;
   uniformLocations: {[name: string]: WebGLUniformLocation};
+  customUniformLocations?: WebGLUniformLocation[];
   source: string;
   inShapeInfos: ShapeInfo[];
   outShapeInfo: ShapeInfo;
@@ -134,11 +136,21 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
         gpgpu.getUniformLocation(webGLProgram, 'outTexShape', shouldThrow);
   }
 
+  const customUniformLocations: WebGLUniformLocation[] = [];
+  if (program.customUniforms) {
+    program.customUniforms.forEach((d, i) => {
+      const location = gpgpu.getUniformLocation(
+          webGLProgram, d.name.split('[')[0], shouldThrow);
+      customUniformLocations.push(location);
+    });
+  }
+
   return {
     program,
     source,
     webGLProgram,
     uniformLocations,
+    customUniformLocations,
     inShapeInfos,
     outShapeInfo,
     infLoc,
@@ -186,9 +198,7 @@ function validateBinaryAndProgram(
 
 export function runProgram<T extends Tensor, K extends Tensor>(
     gpgpu: GPGPUContext, binary: GPGPUBinary, inputs: TensorData[],
-    output: TensorData,
-    customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) =>
-        void): void {
+    output: TensorData, customUniformValues?: number[][]): void {
   if (!binary.program.enableShapeUniforms) {
     validateBinaryAndProgram(binary.inShapeInfos, inputs);
     validateBinaryAndProgram([binary.outShapeInfo], [output]);
@@ -317,8 +327,24 @@ export function runProgram<T extends Tensor, K extends Tensor>(
         output.texData.texShape[1]);
   }
 
-  if (customSetup != null) {
-    customSetup(gpgpu, binary.webGLProgram);
+  if (binary.program.customUniforms && customUniformValues) {
+    binary.program.customUniforms.forEach((d, i) => {
+      if (d.type === 'float') {
+        gpgpu.gl.uniform1fv(
+            binary.customUniformLocations[i], customUniformValues[i]);
+      } else if (d.type === 'vec4') {
+        gpgpu.gl.uniform4fv(
+            binary.customUniformLocations[i], customUniformValues[i]);
+      } else if (d.type === 'int') {
+        gpgpu.gl.uniform1iv(
+            binary.customUniformLocations[i], customUniformValues[i]);
+      } else if (d.type === 'ivec2') {
+        gpgpu.gl.uniform2iv(
+            binary.customUniformLocations[i], customUniformValues[i]);
+      } else {
+        throw Error(`uniform type ${d.type} is not supported yet.`);
+      }
+    });
   }
   gpgpu.executeProgram();
 }

--- a/tfjs-backend-webgl/src/kernels/ClipByValue.ts
+++ b/tfjs-backend-webgl/src/kernels/ClipByValue.ts
@@ -36,8 +36,8 @@ export function clipByValue(args: {
   } else {
     program = new ClipProgram(x.shape);
   }
-  const customSetup = program.getCustomSetupFunc(clipValueMin, clipValueMax);
-  return backend.runWebGLProgram(program, [x], x.dtype, customSetup);
+  const customValues = [[clipValueMin], [clipValueMax]];
+  return backend.runWebGLProgram(program, [x], x.dtype, customValues);
 }
 
 export const clipByValueConfig: KernelConfig = {

--- a/tfjs-backend-webgl/src/kernels/Cumsum.ts
+++ b/tfjs-backend-webgl/src/kernels/Cumsum.ts
@@ -52,10 +52,10 @@ export function cumsum(
 
   for (let i = 0; i <= Math.ceil(Math.log2(size)) - 1; i++) {
     const program = new CumSumProgram(permutedX.shape, false, reverse);
-    const customSetup = program.getCustomSetupFunc(i);
+    const customValues = [[i]];
     const prevResult = result;
     result =
-        backend.runWebGLProgram(program, [result], result.dtype, customSetup);
+        backend.runWebGLProgram(program, [result], result.dtype, customValues);
     backend.disposeIntermediateTensorInfo(prevResult);
   }
   // For exclusive cumsum, shift the end result in the direction of sum

--- a/tfjs-backend-webgl/src/kernels/Fill.ts
+++ b/tfjs-backend-webgl/src/kernels/Fill.ts
@@ -35,8 +35,8 @@ export function fill(args: {backend: MathBackendWebGL, attrs: FillAttrs}):
     return backend.makeTensorInfo(shape, dtype, values);
   } else {
     const program = new FillProgram(shape, value as number);
-    const customSetup = program.getCustomSetupFunc(value as number);
-    return backend.runWebGLProgram(program, [], dtype, customSetup);
+    const customValues = [[value as number]];
+    return backend.runWebGLProgram(program, [], dtype, customValues);
   }
 }
 

--- a/tfjs-backend-webgl/src/kernels/Multinomial.ts
+++ b/tfjs-backend-webgl/src/kernels/Multinomial.ts
@@ -38,9 +38,8 @@ export function multinomial(args: {
   const batchSize = probs.shape[0];
   const numOutcomes = probs.shape[1];
   const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
-  const customSetup = program.getCustomSetupFunc(seed);
-
-  const res = backend.runWebGLProgram(program, [probs], 'int32', customSetup);
+  const customValues = [[seed]];
+  const res = backend.runWebGLProgram(program, [probs], 'int32', customValues);
   if (!normalized) {
     backend.disposeIntermediateTensorInfo(probs);
   }

--- a/tfjs-backend-webgl/src/kernels/PadV2.ts
+++ b/tfjs-backend-webgl/src/kernels/PadV2.ts
@@ -31,8 +31,8 @@ export const padV2 =
           const program = env().getBool('WEBGL_PACK_ARRAY_OPERATIONS') ?
               new PadPackedProgram(x.shape, paddings, constantValue) :
               new PadProgram(x.shape, paddings, constantValue);
-          const customSetup = program.getCustomSetupFunc(constantValue);
-          return backend.runWebGLProgram(program, [x], x.dtype, customSetup);
+          const customValues = [[constantValue]];
+          return backend.runWebGLProgram(program, [x], x.dtype, customValues);
         };
 
 export const padV2Config: KernelConfig = {

--- a/tfjs-backend-webgl/src/kernels/RotateWithOffset.ts
+++ b/tfjs-backend-webgl/src/kernels/RotateWithOffset.ts
@@ -32,10 +32,10 @@ export const rotateWithOffsetConfig: KernelConfig = {
     const program = new RotateProgram((image as Tensor4D).shape, fillValue);
     const [centerX, centerY] =
         backend_util.getImageCenter(center, image.shape[1], image.shape[2]);
-    const customSetup = program.getCustomSetupFunc(
-        centerX, centerY, Math.sin(radians), Math.cos(radians));
+    const customValues =
+        [[centerX, centerY, Math.sin(radians), Math.cos(radians)]];
     const output = webglBackend.runWebGLProgram(
-        program, [image], image.dtype, customSetup);
+        program, [image], image.dtype, customValues);
     return output;
   }
 };

--- a/tfjs-backend-webgl/src/kernels/Slice.ts
+++ b/tfjs-backend-webgl/src/kernels/Slice.ts
@@ -84,8 +84,8 @@ export function slice(
     const program = env().getBool('WEBGL_PACK_ARRAY_OPERATIONS') ?
         new SlicePackedProgram($size) :
         new SliceProgram($size);
-    const customSetup = program.getCustomSetupFunc($begin);
-    return backend.runWebGLProgram(program, [x], x.dtype, customSetup);
+    const customValues = [$begin];
+    return backend.runWebGLProgram(program, [x], x.dtype, customValues);
   }
   backend.uploadToGPU(x.dataId);
   return shallowSlice(x, $begin, $size, backend);

--- a/tfjs-backend-webgl/src/kernels/TopK.ts
+++ b/tfjs-backend-webgl/src/kernels/TopK.ts
@@ -101,10 +101,11 @@ export function topK(
   const runSwap = (dir: number, inc: number, shape: number[]) => {
     const inputs = getInputs();
     const program = new SwapProgram(shape);
-    const customSetup = program.getCustomSetupFunc(
-        lastDim, indices === null /* firstPass */, dir, inc);
+    const fistPass = indices === null ? 1 : 0;
+    const customValues =
+        [[lastDim], [fistPass], [Number.NEGATIVE_INFINITY], [dir], [inc]];
     const prevIndices = indices;
-    indices = backend.runWebGLProgram(program, inputs, 'int32', customSetup);
+    indices = backend.runWebGLProgram(program, inputs, 'int32', customValues);
     disposeIntermediateTensorInfoOrNull(backend, prevIndices);
   };
 
@@ -120,11 +121,11 @@ export function topK(
   for (let indicesSize = lastDimPow2; indicesSize > kPow2; indicesSize /= 2) {
     const inputs = getInputs();
     const mergeProgram = new MergeProgram([batch, indicesSize / 2]);
-    const customSetup = mergeProgram.getCustomSetupFunc(
-        lastDim, indices === null /* firstPass */, kPow2);
+    const firstPass = indices === null ? 1 : 0;
+    const customValues = [[lastDim], [firstPass], [kPow2]];
     const prevIndices = indices;
     indices =
-        backend.runWebGLProgram(mergeProgram, inputs, 'int32', customSetup);
+        backend.runWebGLProgram(mergeProgram, inputs, 'int32', customValues);
     disposeIntermediateTensorInfoOrNull(backend, prevIndices);
 
     // Step 3: rebuild

--- a/tfjs-backend-webgl/src/multinomial_gpu.ts
+++ b/tfjs-backend-webgl/src/multinomial_gpu.ts
@@ -15,23 +15,18 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class MultinomialProgram implements GPGPUProgram {
   variableNames = ['probs'];
   outputShape: number[];
   userCode: string;
-
-  // Caching uniform location for speed.
-  seedLoc: WebGLUniformLocation;
+  customUniforms = [{name: 'seed', type: 'float'}];
 
   constructor(batchSize: number, numOutcomes: number, numSamples: number) {
     this.outputShape = [batchSize, numSamples];
 
     this.userCode = `
-      uniform float seed;
-
       void main() {
         ivec2 coords = getOutputCoords();
         int batch = coords[0];
@@ -52,14 +47,5 @@ export class MultinomialProgram implements GPGPUProgram {
         setOutput(float(${numOutcomes - 1}));
       }
     `;
-  }
-
-  getCustomSetupFunc(seed: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.seedLoc == null) {
-        this.seedLoc = gpgpu.getUniformLocation(webGLProgram, 'seed');
-      }
-      gpgpu.gl.uniform1f(this.seedLoc, seed);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/multinomial_gpu.ts
+++ b/tfjs-backend-webgl/src/multinomial_gpu.ts
@@ -16,12 +16,13 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {UniformType} from './shader_compiler';
 
 export class MultinomialProgram implements GPGPUProgram {
   variableNames = ['probs'];
   outputShape: number[];
   userCode: string;
-  customUniforms = [{name: 'seed', type: 'float'}];
+  customUniforms = [{name: 'seed', type: 'float' as UniformType}];
 
   constructor(batchSize: number, numOutcomes: number, numSamples: number) {
     this.outputShape = [batchSize, numSamples];

--- a/tfjs-backend-webgl/src/pad_gpu.ts
+++ b/tfjs-backend-webgl/src/pad_gpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 import {getCoordsDataType} from './shader_compiler';
 
@@ -23,7 +22,7 @@ export class PadProgram implements GPGPUProgram {
   variableNames = ['x'];
   outputShape: number[];
   userCode: string;
-  valueLoc: WebGLUniformLocation;
+  customUniforms = [{name: 'value', type: 'float'}];
 
   constructor(
       xShape: number[], paddings: Array<[number, number]>,
@@ -42,7 +41,6 @@ export class PadProgram implements GPGPUProgram {
       this.userCode = `
         int start = ${start};
         int end = ${end};
-        uniform float value;
 
         void main() {
           int outC = getOutputCoords();
@@ -70,14 +68,5 @@ export class PadProgram implements GPGPUProgram {
         }
       }
     `;
-  }
-
-  getCustomSetupFunc(value: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.valueLoc == null) {
-        this.valueLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'value');
-      }
-      gpgpu.gl.uniform1f(this.valueLoc, value);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/pad_gpu.ts
+++ b/tfjs-backend-webgl/src/pad_gpu.ts
@@ -16,13 +16,13 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
-import {getCoordsDataType} from './shader_compiler';
+import {getCoordsDataType, UniformType} from './shader_compiler';
 
 export class PadProgram implements GPGPUProgram {
   variableNames = ['x'];
   outputShape: number[];
   userCode: string;
-  customUniforms = [{name: 'value', type: 'float'}];
+  customUniforms = [{name: 'value', type: 'float' as UniformType}];
 
   constructor(
       xShape: number[], paddings: Array<[number, number]>,

--- a/tfjs-backend-webgl/src/pad_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/pad_packed_gpu.ts
@@ -17,7 +17,7 @@
 
 import {GPGPUProgram} from './gpgpu_math';
 import {getChannels} from './packing_util';
-import {getCoordsDataType} from './shader_compiler';
+import {getCoordsDataType, UniformType} from './shader_compiler';
 
 export class PadPackedProgram implements GPGPUProgram {
   variableNames = ['x'];
@@ -25,7 +25,7 @@ export class PadPackedProgram implements GPGPUProgram {
   packedOutput = true;
   outputShape: number[];
   userCode: string;
-  customUniforms = [{name: 'value', type: 'float'}];
+  customUniforms = [{name: 'value', type: 'float' as UniformType}];
 
   constructor(
       xShape: number[], paddings: Array<[number, number]>,

--- a/tfjs-backend-webgl/src/pad_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/pad_packed_gpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 import {getChannels} from './packing_util';
 import {getCoordsDataType} from './shader_compiler';
@@ -26,7 +25,7 @@ export class PadPackedProgram implements GPGPUProgram {
   packedOutput = true;
   outputShape: number[];
   userCode: string;
-  valueLoc: WebGLUniformLocation;
+  customUniforms = [{name: 'value', type: 'float'}];
 
   constructor(
       xShape: number[], paddings: Array<[number, number]>,
@@ -76,7 +75,6 @@ export class PadPackedProgram implements GPGPUProgram {
     this.userCode = `
       const ${dtype} start = ${dtype}(${start});
       const ${dtype} end = ${dtype}(${end});
-      uniform float value;
 
       void main() {
         ${dtype} outputLoc = getOutputCoords();
@@ -85,14 +83,5 @@ export class PadPackedProgram implements GPGPUProgram {
         setOutput(result);
       }
     `;
-  }
-
-  getCustomSetupFunc(value: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.valueLoc == null) {
-        this.valueLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'value');
-      }
-      gpgpu.gl.uniform1f(this.valueLoc, value);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/rotate_gpu.ts
+++ b/tfjs-backend-webgl/src/rotate_gpu.ts
@@ -16,12 +16,13 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {UniformType} from './shader_compiler';
 
 export class RotateProgram implements GPGPUProgram {
   variableNames = ['Image'];
   outputShape: number[] = [];
   userCode: string;
-  customUniforms = [{name: 'params', type: 'vec4'}];
+  customUniforms = [{name: 'params', type: 'vec4' as UniformType}];
   constructor(
       imageShape: [number, number, number, number],
       fillValue: number|[number, number, number]) {

--- a/tfjs-backend-webgl/src/rotate_gpu.ts
+++ b/tfjs-backend-webgl/src/rotate_gpu.ts
@@ -15,14 +15,13 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class RotateProgram implements GPGPUProgram {
   variableNames = ['Image'];
   outputShape: number[] = [];
   userCode: string;
-  paramsLoc: WebGLUniformLocation;
+  customUniforms = [{name: 'params', type: 'vec4'}];
   constructor(
       imageShape: [number, number, number, number],
       fillValue: number|[number, number, number]) {
@@ -40,7 +39,6 @@ export class RotateProgram implements GPGPUProgram {
     }
 
     this.userCode = `
-        uniform vec4 params;
         void main() {
           ivec4 coords = getOutputCoords();
           int x = coords[2];
@@ -59,17 +57,5 @@ export class RotateProgram implements GPGPUProgram {
           setOutput(outputValue);
         }
     `;
-  }
-
-  getCustomSetupFunc(
-      centerX: number, centerY: number, sinFactor: number, cosFactor: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.paramsLoc == null) {
-        this.paramsLoc =
-            gpgpu.getUniformLocationNoThrow(webGLProgram, 'params');
-      }
-      gpgpu.gl.uniform4f(
-          this.paramsLoc, centerX, centerY, sinFactor, cosFactor);
-    };
   }
 }

--- a/tfjs-backend-webgl/src/shader_compiler.ts
+++ b/tfjs-backend-webgl/src/shader_compiler.ts
@@ -36,11 +36,14 @@ export type InputInfo = {
   shapeInfo: ShapeInfo
 };
 
+export type UniformType =
+    'float'|'vec2'|'vec3'|'vec4'|'int'|'ivec2'|'ivec3'|'ivec4';
+
 interface ProgramParams {
   userCode: string;
   enableShapeUniforms?: boolean;
   packedInputs?: boolean;
-  customUniforms?: Array<{name: string; type: string;}>;
+  customUniforms?: Array<{name: string; type: UniformType;}>;
 }
 
 export function makeShader(

--- a/tfjs-backend-webgl/src/shader_compiler.ts
+++ b/tfjs-backend-webgl/src/shader_compiler.ts
@@ -40,6 +40,7 @@ interface ProgramParams {
   userCode: string;
   enableShapeUniforms?: boolean;
   packedInputs?: boolean;
+  customUniforms?: Array<{name: string; type: string;}>;
 }
 
 export function makeShader(
@@ -102,6 +103,11 @@ export function makeShader(
         break;
     }
     prefixSnippets.push(`uniform ivec2 outTexShape;`);
+  }
+  if (program.customUniforms) {
+    program.customUniforms.forEach((d) => {
+      prefixSnippets.push(`uniform ${d.type} ${d.name};`);
+    });
   }
   const inputPrefixSnippet = prefixSnippets.join('\n');
 

--- a/tfjs-backend-webgl/src/shader_compiler.ts
+++ b/tfjs-backend-webgl/src/shader_compiler.ts
@@ -43,7 +43,8 @@ interface ProgramParams {
   userCode: string;
   enableShapeUniforms?: boolean;
   packedInputs?: boolean;
-  customUniforms?: Array<{name: string; type: UniformType;}>;
+  customUniforms?:
+      Array<{name: string; arrayIndex?: number; type: UniformType;}>;
 }
 
 export function makeShader(
@@ -109,7 +110,8 @@ export function makeShader(
   }
   if (program.customUniforms) {
     program.customUniforms.forEach((d) => {
-      prefixSnippets.push(`uniform ${d.type} ${d.name};`);
+      prefixSnippets.push(`uniform ${d.type} ${d.name}${
+          d.arrayIndex ? `[${d.arrayIndex}]` : ''};`);
     });
   }
   const inputPrefixSnippet = prefixSnippets.join('\n');

--- a/tfjs-backend-webgl/src/slice_gpu.ts
+++ b/tfjs-backend-webgl/src/slice_gpu.ts
@@ -23,14 +23,14 @@ export class SliceProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
   rank: number;
-  customUniforms: Array<{name: string; type: UniformType;}>;
+  customUniforms: Array<{name: string; arrayIndex: number; type: UniformType;}>;
 
   constructor(destSize: number[]) {
     this.outputShape = destSize;
     this.rank = destSize.length;
 
     const dtype = getCoordsDataType(this.rank);
-    this.customUniforms = [{name: `start[${this.rank}]`, type: 'int'}];
+    this.customUniforms = [{name: 'start', arrayIndex: this.rank, type: 'int'}];
     const sourceCoords = getCoords(this.rank);
 
     let body: string;

--- a/tfjs-backend-webgl/src/slice_gpu.ts
+++ b/tfjs-backend-webgl/src/slice_gpu.ts
@@ -16,14 +16,14 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
-import {getCoordsDataType} from './shader_compiler';
+import {getCoordsDataType, UniformType} from './shader_compiler';
 
 export class SliceProgram implements GPGPUProgram {
   variableNames = ['source'];
   outputShape: number[];
   userCode: string;
   rank: number;
-  customUniforms: Array<{name: string; type: string;}>;
+  customUniforms: Array<{name: string; type: UniformType;}>;
 
   constructor(destSize: number[]) {
     this.outputShape = destSize;

--- a/tfjs-backend-webgl/src/slice_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/slice_packed_gpu.ts
@@ -17,7 +17,7 @@
 
 import {GPGPUProgram} from './gpgpu_math';
 import {getChannels} from './packing_util';
-import {getCoordsDataType} from './shader_compiler';
+import {getCoordsDataType, UniformType} from './shader_compiler';
 
 export class SlicePackedProgram implements GPGPUProgram {
   variableNames = ['source'];
@@ -26,7 +26,7 @@ export class SlicePackedProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
   rank: number;
-  customUniforms: Array<{name: string; type: string;}>;
+  customUniforms: Array<{name: string; type: UniformType;}>;
 
   constructor(destSize: number[]) {
     this.outputShape = destSize;

--- a/tfjs-backend-webgl/src/slice_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/slice_packed_gpu.ts
@@ -26,12 +26,12 @@ export class SlicePackedProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
   rank: number;
-  customUniforms: Array<{name: string; type: UniformType;}>;
+  customUniforms: Array<{name: string; arrayIndex: number; type: UniformType;}>;
 
   constructor(destSize: number[]) {
     this.outputShape = destSize;
     this.rank = destSize.length;
-    this.customUniforms = [{name: `start[${this.rank}]`, type: 'int'}];
+    this.customUniforms = [{name: 'start', arrayIndex: this.rank, type: 'int'}];
     const dtype = getCoordsDataType(this.rank);
     const coords = getChannels('coords', this.rank);
     const sourceLoc = getChannels('sourceLoc', this.rank);

--- a/tfjs-backend-webgl/src/top_k_gpu.ts
+++ b/tfjs-backend-webgl/src/top_k_gpu.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 import {GPGPUProgram} from './gpgpu_math';
+import {UniformType} from './shader_compiler';
 
 // Based on Algorithm 2 of Bitonic Top K, ref:
 // https://anilshanbhag.in/static/papers/gputopk_sigmod18.pdf
@@ -34,9 +35,11 @@ export class SwapProgram implements GPGPUProgram {
   // means no indices input containing the top K is present yet.
   // |inc| Swaps pairs of indices (0, inc), (1, inc + 1), (2, inc + 2) ...
   customUniforms = [
-    {name: 'n', type: 'int'}, {name: 'firstPass', type: 'int'},
-    {name: 'negativeInf', type: 'float'}, {name: 'dir', type: 'int'},
-    {name: 'inc', type: 'int'}
+    {name: 'n', type: 'int' as UniformType},
+    {name: 'firstPass', type: 'int' as UniformType},
+    {name: 'negativeInf', type: 'float' as UniformType},
+    {name: 'dir', type: 'int' as UniformType},
+    {name: 'inc', type: 'int' as UniformType}
   ];
 
   /**
@@ -99,8 +102,9 @@ export class MergeProgram implements GPGPUProgram {
   // means no indices input containing the top K is present yet.
   // |k| Top k elements desired
   customUniforms = [
-    {name: 'n', type: 'int'}, {name: 'firstPass', type: 'int'},
-    {name: 'k', type: 'int'}
+    {name: 'n', type: 'int' as UniformType},
+    {name: 'firstPass', type: 'int' as UniformType},
+    {name: 'k', type: 'int' as UniformType}
   ];
 
   /**

--- a/tfjs-backend-webgl/src/top_k_gpu.ts
+++ b/tfjs-backend-webgl/src/top_k_gpu.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  * =============================================================================
  */
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 // Based on Algorithm 2 of Bitonic Top K, ref:
@@ -30,13 +29,15 @@ export class SwapProgram implements GPGPUProgram {
   variableNames = ['x', 'indices'];
   outputShape: number[];
   userCode: string;
-
-  // Caching uniform location for speed.
-  n: WebGLUniformLocation;
-  firstPass: WebGLUniformLocation;
-  negativeInf: WebGLUniformLocation;
-  dir: WebGLUniformLocation;
-  inc: WebGLUniformLocation;
+  // |n| Size of the original input of TopK.
+  // |firstPass|indicates if this is the first time swap is being used which
+  // means no indices input containing the top K is present yet.
+  // |inc| Swaps pairs of indices (0, inc), (1, inc + 1), (2, inc + 2) ...
+  customUniforms = [
+    {name: 'n', type: 'int'}, {name: 'firstPass', type: 'int'},
+    {name: 'negativeInf', type: 'float'}, {name: 'dir', type: 'int'},
+    {name: 'inc', type: 'int'}
+  ];
 
   /**
    * @param shape desired output shape (can be larger than input shape, output
@@ -46,16 +47,6 @@ export class SwapProgram implements GPGPUProgram {
     this.outputShape = shape;
 
     this.userCode = `
-       // Size of the original input of TopK
-       uniform int n;
-       // indicates if this is the first time swap is being used
-       // which means no indices input containing the top K is
-       // present yet.
-       uniform int firstPass;
-       uniform float negativeInf;
-       uniform int dir;
-       // Swaps pairs of indices (0, inc), (1, inc + 1), (2, inc + 2) ...
-       uniform int inc;
        void main() {
          ivec2 coords = getOutputCoords();
          int batch = coords[0];
@@ -97,39 +88,20 @@ export class SwapProgram implements GPGPUProgram {
        }
      `;
   }
-
-  getCustomSetupFunc(n: number, firstPass: boolean, dir: number, inc: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      const intUniforms: Array<['n' | 'firstPass' | 'dir' | 'inc', number]> = [
-        ['n', n], ['firstPass', firstPass ? 1 : 0], ['dir', dir], ['inc', inc]
-      ];
-
-      intUniforms.forEach(([uniformName, uniformValue]) => {
-        if (this[uniformName] == null) {
-          this[uniformName] =
-              gpgpu.getUniformLocation(webGLProgram, uniformName);
-        }
-        gpgpu.gl.uniform1i(this[uniformName], uniformValue);
-      });
-
-      if (this.negativeInf == null) {
-        this.negativeInf =
-            gpgpu.getUniformLocation(webGLProgram, 'negativeInf');
-      }
-      gpgpu.gl.uniform1f(this.negativeInf, Number.NEGATIVE_INFINITY);
-    };
-  }
 }
 
 export class MergeProgram implements GPGPUProgram {
   variableNames = ['x', 'indices'];
   outputShape: number[];
   userCode: string;
-
-  // Caching uniform location for speed.
-  n: WebGLUniformLocation;
-  firstPass: WebGLUniformLocation;
-  k: WebGLUniformLocation;
+  // |n| Size of the original input of TopK
+  // |firstPass| indicates if this is the first time swap is being used which
+  // means no indices input containing the top K is present yet.
+  // |k| Top k elements desired
+  customUniforms = [
+    {name: 'n', type: 'int'}, {name: 'firstPass', type: 'int'},
+    {name: 'k', type: 'int'}
+  ];
 
   /**
    * @param shape desired output shape (must be half of the input size)
@@ -138,14 +110,6 @@ export class MergeProgram implements GPGPUProgram {
     this.outputShape = shape;
 
     this.userCode = `
-    // Size of the original input of TopK
-    uniform int n;
-    // indicates if this is the first time swap is being used
-    // which means no indices input containing the top K is
-    // present yet.
-    uniform int firstPass;
-    // Top k elements desired
-    uniform int k;
     void main() {
          // Takes max of indices (0, k), (1, k + 1), (2, k + 2) ...
          ivec2 coords = getOutputCoords();
@@ -180,20 +144,5 @@ export class MergeProgram implements GPGPUProgram {
          setOutput(x0 >= x1 ? float(i0) : float(i1));
        }
      `;
-  }
-
-  getCustomSetupFunc(n: number, firstPass: boolean, k: number) {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      const intUniforms: Array<['n' | 'firstPass' | 'k', number]> =
-          [['n', n], ['firstPass', firstPass ? 1 : 0], ['k', k]];
-
-      intUniforms.forEach(([uniformName, uniformValue]) => {
-        if (this[uniformName] == null) {
-          this[uniformName] =
-              gpgpu.getUniformLocation(webGLProgram, uniformName);
-        }
-        gpgpu.gl.uniform1i(this[uniformName], uniformValue);
-      });
-    };
   }
 }


### PR DESCRIPTION
This PR moves all uniform operations into gpgpu_math file. The program
only process the uniforms and data. With this change, it's convenient to
support a new custom uniform.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5258)
<!-- Reviewable:end -->
