### PR TITLE
[E2E] Wait for backend initialization complete before benchmark testing

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -168,6 +168,7 @@ limitations under the License.
         });
       },
       testCorrectness: async () => {
+        await tf.ready();
         if (!tf.engine().backendNames().includes(state.backend)) {
           return;
         }
@@ -442,7 +443,6 @@ limitations under the License.
     }
 
     async function loadModelAndRecordTime() {
-      await tf.ready();
       updateStateFromURLState();
       const benchmark = benchmarks[state.benchmark];
       state.modelType = benchmark['type'];
@@ -619,6 +619,7 @@ limitations under the License.
     }
 
     async function runBenchmark() {
+      await tf.ready();
       if (!tf.engine().backendNames().includes(state.backend)) {
         return;
       }

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -442,6 +442,7 @@ limitations under the License.
     }
 
     async function loadModelAndRecordTime() {
+      await tf.ready();
       updateStateFromURLState();
       const benchmark = benchmarks[state.benchmark];
       state.modelType = benchmark['type'];

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -168,10 +168,10 @@ limitations under the License.
         });
       },
       testCorrectness: async () => {
-        await tf.ready();
         if (!tf.engine().backendNames().includes(state.backend)) {
           return;
         }
+        await tf.ready();
         if (state.isFlagChanged) {
           await setEnvFlags(state.flags);
           envDiv.innerHTML = '';
@@ -619,10 +619,10 @@ limitations under the License.
     }
 
     async function runBenchmark() {
-      await tf.ready();
       if (!tf.engine().backendNames().includes(state.backend)) {
         return;
       }
+      await tf.ready();
       if (state.isFlagChanged) {
         await setEnvFlags(state.flags);
         envDiv.innerHTML = '';


### PR DESCRIPTION
Factory function for WebGPU backend is an async function https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-webgpu/src/index.ts#L29.
So before using any other functions like tf.tensor() we should add `await tf.ready()` to make sure WebGPU backend entirely initialized.
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5272)
<!-- Reviewable:end -->
