### PR TITLE
[webgpu] Update @webgpu/types to version 0.1.4

### DIFF
--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@tensorflow/tfjs-backend-cpu": "link:../tfjs-backend-cpu",
     "@webgpu/glslang": "0.0.12",
-    "@webgpu/types": "0.1.3"
+    "@webgpu/types": "0.1.4"
   },
   "peerDependencies": {
     "@tensorflow/tfjs-core": "link:../tfjs-core"

--- a/tfjs-backend-webgpu/src/index.ts
+++ b/tfjs-backend-webgpu/src/index.ts
@@ -43,7 +43,7 @@ if (device_util.isBrowser() && isWebGPUSupported()) {
     const supportTimeQuery = adapter.features.has('timestamp-query');
 
     if (supportTimeQuery) {
-      deviceDescriptor = {nonGuaranteedFeatures: ['timestamp-query' as const ]};
+      deviceDescriptor = {requiredFeatures: ['timestamp-query' as const]};
     } else {
       console.warn(
           `This device doesn't support timestamp-query extension. ` +

--- a/tfjs-backend-webgpu/yarn.lock
+++ b/tfjs-backend-webgpu/yarn.lock
@@ -975,10 +975,10 @@
   resolved "https://registry.yarnpkg.com/@webgpu/glslang/-/glslang-0.0.12.tgz#ee40e8d38c31436508147feaf0f646fde9bb4da6"
   integrity sha512-GfEVo1GUxNfXjO4Z7I06XXYJA45N6sHoKqI5Ptf3vafnPowq2C1woCqVe7frsClMfBB2yLn1vJss2oWl5EdTig==
 
-"@webgpu/types@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.3.tgz#0c223b06e81713ae011fc8986921725a1685d967"
-  integrity sha512-rvqmSxoSMqwIjtvMHOvdvgCtJaz8PS4okXTL47Jyf/X5rDTiRoKEW1U3+XPsWcfY9Hp5gir3A0ksi+Eh81bbyg==
+"@webgpu/types@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.4.tgz#191da2d8767e7d4bcf2a3d30b0f17424dc4b6b9a"
+  integrity sha512-nR0L4xBKUSksLKdFVxcshBL2M9ofAWneYYmK5/5iQJukY4q8a9hcXJwvH7QKQemiK3jxXuCMPkDzFCu/1+5Xvg==
 
 accepts@~1.3.4:
   version "1.3.7"


### PR DESCRIPTION
Use latest WebGPU API to fix warnings in WebGPU backend

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5290)
<!-- Reviewable:end -->
