### PR TITLE
[wasm] Mark 'os' as excluded in browser bundles

### DIFF
--- a/tfjs-backend-wasm/package.json
+++ b/tfjs-backend-wasm/package.json
@@ -38,6 +38,7 @@
   "browser": {
     "fs": false,
     "path": false,
+    "os": false,
     "worker_threads": false,
     "perf_hooks": false
   },


### PR DESCRIPTION
The threaded wasm backend conditionally imports 'os' in node to check how many cores are available (and uses a different method in browsers). This PR adds `"os": false` to the browser field in package.json so bundlers know not to include it when bundling for a browser.

Fixes #4745

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5302)
<!-- Reviewable:end -->
