### PR TITLE
BrowserStack: Add option to use CDNs instead of local dependencies

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -118,7 +118,6 @@ function setupBenchmarkEnv(config) {
 async function benchmark(config, runOneBenchmark = runBrowserStackBenchmark) {
   console.log('Preparing configuration files for the test runner.\n');
   setupBenchmarkEnv(config);
-
   console.log(
       `Starting benchmarks using ${cliArgs.webDeps ? 'cdn' : 'local'} ` +
       `dependencies...`);
@@ -147,7 +146,6 @@ function runBrowserStackBenchmark(tabId) {
   return new Promise((resolve, reject) => {
     const args = ['test', '--browserstack', `--browsers=${tabId}`];
     if (cliArgs.webDeps) args.push('--cdn');
-
     const command = `yarn ${args.join(' ')}`;
     console.log(`Running: ${command}`);
 
@@ -213,8 +211,7 @@ function setupHelpMessage() {
         'browsers can be benchmarked.'
   });
   parser.add_argument('--benchmarks', {
-    help: 'Run a preconfigured benchmark from a ' +
-        'user-specified JSON',
+    help: 'Run a preconfigured benchmark from a user-specified JSON',
     action: 'store'
   });
   parser.add_argument(
@@ -242,13 +239,13 @@ if (require.main === module) {
   if (cliArgs.benchmarks) {
     const filePath = resolve(cliArgs.benchmarks);
     if (fs.existsSync(filePath)) {
-      console.log('Found file at ' + filePath);
+      console.log(`Found file at ${filePath}`);
       const config = require(filePath);
       runBenchmarkFromFile(config);
     } else {
       throw new Error(
-          'File could not be found at ' + filePath +
-          '. Please provide a valid path.');
+          `File could not be found at ${filePath}. ` +
+          `Please provide a valid path.`);
     }
   }
 }

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -116,10 +116,12 @@ function setupBenchmarkEnv(config) {
  * @param benchmarkResult Function that benchmarks one browser-device pair
  */
 async function benchmark(config, runOneBenchmark = runBrowserStackBenchmark) {
-  console.log('Preparing configuration files for the test runner.');
+  console.log('Preparing configuration files for the test runner.\n');
   setupBenchmarkEnv(config);
 
-  console.log(`Start benchmarking.`);
+  console.log(
+      `Starting benchmarks using ${cliArgs.webDeps ? 'cdn' : 'local'} ` +
+      `dependencies...`);
   const results = [];
   for (const tabId in config.browsers) {
     results.push(runOneBenchmark(tabId));
@@ -144,6 +146,8 @@ async function benchmark(config, runOneBenchmark = runBrowserStackBenchmark) {
 function runBrowserStackBenchmark(tabId) {
   return new Promise((resolve, reject) => {
     const args = ['test', '--browserstack', `--browsers=${tabId}`];
+    if (cliArgs.webDeps) args.push('--cdn');
+
     const command = `yarn ${args.join(' ')}`;
     console.log(`Running: ${command}`);
 
@@ -208,19 +212,25 @@ function setupHelpMessage() {
         'so that the performance of a TensorFlow model on one or more ' +
         'browsers can be benchmarked.'
   });
-  parser.add_argument(
-    '--benchmarks', {help: 'Run a preconfigured benchmark from a ' +
-    'user-specified JSON', action: 'store'});
+  parser.add_argument('--benchmarks', {
+    help: 'Run a preconfigured benchmark from a ' +
+        'user-specified JSON',
+    action: 'store'
+  });
   parser.add_argument(
       '--outfile', {help: 'write results to outfile', action: 'store_true'});
   parser.add_argument('-v', '--version', {action: 'version', version});
+  parser.add_argument('--webDeps', {
+    help: 'utilizes public, web hosted dependencies instead of local versions',
+    action: 'store_true'
+  });
   cliArgs = parser.parse_args();
   console.dir(cliArgs);
 }
 
 /*Runs a benchmark with a preconfigured file */
 function runBenchmarkFromFile(file, runBenchmark = benchmark) {
-  console.log("Running a preconfigured benchmark...");
+  console.log('Running a preconfigured benchmark...');
   runBenchmark(file);
 }
 
@@ -232,13 +242,13 @@ if (require.main === module) {
   if (cliArgs.benchmarks) {
     const filePath = resolve(cliArgs.benchmarks);
     if (fs.existsSync(filePath)) {
-      console.log("Found file at " + filePath);
+      console.log('Found file at ' + filePath);
       const config = require(filePath);
       runBenchmarkFromFile(config);
-    }
-    else {
-      throw new Error('File could not be found at ' + filePath +
-      '. Please provide a valid path.');
+    } else {
+      throw new Error(
+          'File could not be found at ' + filePath +
+          '. Please provide a valid path.');
     }
   }
 }

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -118,9 +118,11 @@ function setupBenchmarkEnv(config) {
 async function benchmark(config, runOneBenchmark = runBrowserStackBenchmark) {
   console.log('Preparing configuration files for the test runner.\n');
   setupBenchmarkEnv(config);
-  console.log(
-      `Starting benchmarks using ${cliArgs.webDeps ? 'cdn' : 'local'} ` +
-      `dependencies...`);
+  if (require.main === module) {
+    console.log(
+        `Starting benchmarks using ${cliArgs.webDeps ? 'cdn' : 'local'} ` +
+        `dependencies...`);
+  }
   const results = [];
   for (const tabId in config.browsers) {
     results.push(runOneBenchmark(tabId));

--- a/e2e/benchmarks/browserstack-benchmark/karma.conf.js
+++ b/e2e/benchmarks/browserstack-benchmark/karma.conf.js
@@ -53,24 +53,40 @@ module.exports = function(config) {
     extraConfig = localRunConfig;
   }
 
-  config.set({
-    ...extraConfig,
-    frameworks: ['jasmine'],
-    files: [
-      './node_modules/@tensorflow/tfjs-core/dist/tf-core.js',
-      './node_modules/@tensorflow/tfjs-backend-cpu/dist/tf-backend-cpu.js',
-      './node_modules/@tensorflow/tfjs-backend-webgl/dist/tf-backend-webgl.js',
-      './node_modules/@tensorflow/tfjs-layers/dist/tf-layers.js',
-      './node_modules/@tensorflow/tfjs-converter/dist/tf-converter.js',
-      './node_modules/@tensorflow/tfjs-backend-wasm/dist/tf-backend-wasm.js', {
-        pattern: './node_modules/@tensorflow/tfjs-backend-wasm/dist/*',
-        included: false,
-        served: true
-      },
+  let files = [
+    './node_modules/@tensorflow/tfjs-core/dist/tf-core.js',
+    './node_modules/@tensorflow/tfjs-backend-cpu/dist/tf-backend-cpu.js',
+    './node_modules/@tensorflow/tfjs-backend-webgl/dist/tf-backend-webgl.js',
+    './node_modules/@tensorflow/tfjs-layers/dist/tf-layers.js',
+    './node_modules/@tensorflow/tfjs-converter/dist/tf-converter.js',
+    './node_modules/@tensorflow/tfjs-backend-wasm/dist/tf-backend-wasm.js', {
+      pattern: './node_modules/@tensorflow/tfjs-backend-wasm/dist/*',
+      included: false,
+      served: true
+    },
+    {pattern: './benchmark_parameters.json', included: false, served: true},
+    '../util.js', '../benchmark_util.js', '../model_config.js',
+    'benchmark_models.js'
+  ];
+
+  if (config.cdn) {
+    files = [
+      'https://unpkg.com/@tensorflow/tfjs-core@latest/dist/tf-core.js',
+      'https://unpkg.com/@tensorflow/tfjs-backend-cpu@latest/dist/tf-backend-cpu.js',
+      'https://unpkg.com/@tensorflow/tfjs-backend-webgl@latest/dist/tf-backend-webgl.js',
+      'https://unpkg.com/@tensorflow/tfjs-layers@latest/dist/tf-layers.js',
+      'https://unpkg.com/@tensorflow/tfjs-converter@latest/dist/tf-converter.js',
+      'https://unpkg.com/@tensorflow/tfjs-backend-wasm@latest/dist/tf-backend-wasm.js',
       {pattern: './benchmark_parameters.json', included: false, served: true},
       '../util.js', '../benchmark_util.js', '../model_config.js',
       'benchmark_models.js'
-    ],
+    ];
+  }
+
+  config.set({
+    ...extraConfig,
+    frameworks: ['jasmine'],
+    files: files,
     preprocessors: {},
     singleRun: true,
     captureTimeout: 3e5,


### PR DESCRIPTION
Uses the CDN dependencies for BrowserStack benchmarks if the --webDeps argument is added as a command line argument.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5303)
<!-- Reviewable:end -->
