### PR TITLE
Don't try to load weights if there are no weights

### DIFF
--- a/tfjs-core/src/io/browser_files.ts
+++ b/tfjs-core/src/io/browser_files.ts
@@ -152,6 +152,7 @@ class BrowserFiles implements IOHandler {
 
         if (this.weightsFiles.length === 0) {
           resolve({modelTopology});
+          return;
         }
 
         const modelArtifactsPromise = getModelArtifactsForJSON(


### PR DESCRIPTION
The `browser_files.ts` `load()` function resolves early if there are no weights to be loaded, but does not actually return from the function, meaning it still tries to load model weights. This causes the following error:

```
Safari 11.1.2 (Mac OS 10.13.6) ERROR
  An error was thrown in afterAll
  Unhandled promise rejection: Error: Weight file with basename 'model.weights.bin' is not provided. in src/io/browser_files.js (line 227)
  src/io/browser_files.ts:222:26 <- src/io/browser_files.js:227:36
  forEach@[native code]
  checkManifestAndWeightFiles@src/io/browser_files.ts:213:26 <- src/io/browser_files.js:219:32
  loadWeights@src/io/browser_files.ts:181:41 <- src/io/browser_files.js:191:58
  src/io/io_utils.ts:431:26 <- src/io/io_utils.js:471:53
  step@src/io/io_utils.js:48:27
  src/io/io_utils.js:23:75
  initializePromise@[native code]
  Promise@[native code]
  src/io/io_utils.js:19:36
  onload@src/io/browser_files.ts:157:63 <- src/io/browser_files.js:171:92
```

This PR makes it return immediately after resolving.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5310)
<!-- Reviewable:end -->
