### PR TITLE
Remove redeclared value uniform

### DIFF
--- a/tfjs-backend-webgl/src/pad_gpu.ts
+++ b/tfjs-backend-webgl/src/pad_gpu.ts
@@ -56,7 +56,6 @@ export class PadProgram implements GPGPUProgram {
     this.userCode = `
       ${type} start = ${type}(${start});
       ${type} end = ${type}(${end});
-      uniform float value;
 
       void main() {
         ${type} outC = getOutputCoords();


### PR DESCRIPTION
Fixes redeclaration of value error in shader due to value already being declared in uniforms

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5312)
<!-- Reviewable:end -->
