### PR TITLE
[E2E] Set CHECK_COMPUTATION_FOR_ERRORS to false for WebGPU backend in

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -160,6 +160,14 @@ async function initDefaultValueMap() {
   for (const flag in TUNABLE_FLAG_DEFAULT_VALUE_MAP) {
     state.flags[flag] = TUNABLE_FLAG_DEFAULT_VALUE_MAP[flag];
   }
+
+  // Remove it once we figure out how to correctly read the tensor data
+  // before the tensor is disposed in profiling mode.
+  if (tf.engine().backendNames().includes('webgpu')) {
+    tf.env().set('CHECK_COMPUTATION_FOR_ERRORS', false);
+    state.flags['CHECK_COMPUTATION_FOR_ERRORS'] = false;
+  }
+
   state.isFlagChanged = false;
 }
 


### PR DESCRIPTION
E2E benchmark

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.