### PR TITLE
Add flags for controlling when TopK GPU is used

### DIFF
--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -219,3 +219,21 @@ ENV.registerFlag('CPU_HANDOFF_SIZE_THRESHOLD', () => 128);
 
 /** Whether we will use shapes uniforms. */
 ENV.registerFlag('WEBGL_USE_SHAPES_UNIFORMS', () => false);
+
+/**
+ * Threshold for last dimension of input tensor that determines whether
+ * WebGL backend for the Top K op will delegate computation to CPU. If input
+ * is smaller than threshold then CPU will be used
+ *
+ * Default value is 100000.
+ */
+ENV.registerFlag('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', () => 100000);
+
+/**
+ * Threshold for K that determines whether
+ * WebGL backend for the Top K op will delegate computation to CPU. If k
+ * is larger than threshold then CPU will be used
+ *
+ * Default value is 128.
+ */
+ENV.registerFlag('TOPK_K_CPU_HANDOFF_THRESHOLD', () => 128);

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -389,34 +389,34 @@ describe('CPU_HANDOFF_SIZE_THRESHOLD', () => {
   });
 });
 
-describe('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', () => {
+const LAST_DIM_FLAG = 'TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD';
+
+describeWithFlags(LAST_DIM_FLAG, WEBGL_ENVS, () => {
   beforeEach(() => tf.env().reset());
   afterAll(() => tf.env().reset());
 
-  it('returns correct value when TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD is set',
-     () => {
-       tf.env().set('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', 256);
-       expect(tf.env().getNumber('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD'))
-           .toBe(256);
-     });
-
-  it('returns default when TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD is not set',
-     () => {
-       expect(tf.env().getNumber('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD'))
-           .toBe(100000);
-     });
-});
-
-describe('TOPK_K_CPU_HANDOFF_THRESHOLD', () => {
-  beforeEach(() => tf.env().reset());
-  afterAll(() => tf.env().reset());
-
-  it('returns correct value when TOPK_K_CPU_HANDOFF_THRESHOLD is set', () => {
-    tf.env().set('TOPK_K_CPU_HANDOFF_THRESHOLD', 256);
-    expect(tf.env().getNumber('TOPK_K_CPU_HANDOFF_THRESHOLD')).toBe(256);
+  it(`returns correct value when ${LAST_DIM_FLAG} is set`, () => {
+    tf.env().set(LAST_DIM_FLAG, 256);
+    expect(tf.env().getNumber(LAST_DIM_FLAG)).toBe(256);
   });
 
-  it('returns default when TOPK_K_CPU_HANDOFF_THRESHOLD is not set', () => {
-    expect(tf.env().getNumber('TOPK_K_CPU_HANDOFF_THRESHOLD')).toBe(128);
+  it(`returns default when ${LAST_DIM_FLAG} is not set`, () => {
+    expect(tf.env().getNumber(LAST_DIM_FLAG)).toBe(100000);
+  });
+});
+
+const K_FLAG = 'TOPK_K_CPU_HANDOFF_THRESHOLD';
+
+describeWithFlags(K_FLAG, WEBGL_ENVS, () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
+  it(`returns correct value when ${K_FLAG} is set`, () => {
+    tf.env().set(K_FLAG, 256);
+    expect(tf.env().getNumber(K_FLAG)).toBe(256);
+  });
+
+  it(`returns default when ${K_FLAG} is not set`, () => {
+    expect(tf.env().getNumber(K_FLAG)).toBe(128);
   });
 });

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -388,3 +388,35 @@ describe('CPU_HANDOFF_SIZE_THRESHOLD', () => {
     expect(tf.env().getNumber('CPU_HANDOFF_SIZE_THRESHOLD')).toBe(128);
   });
 });
+
+describe('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
+  it('returns correct value when TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD is set',
+     () => {
+       tf.env().set('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', 256);
+       expect(tf.env().getNumber('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD'))
+           .toBe(256);
+     });
+
+  it('returns default when TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD is not set',
+     () => {
+       expect(tf.env().getNumber('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD'))
+           .toBe(100000);
+     });
+});
+
+describe('TOPK_K_CPU_HANDOFF_THRESHOLD', () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
+  it('returns correct value when TOPK_K_CPU_HANDOFF_THRESHOLD is set', () => {
+    tf.env().set('TOPK_K_CPU_HANDOFF_THRESHOLD', 256);
+    expect(tf.env().getNumber('TOPK_K_CPU_HANDOFF_THRESHOLD')).toBe(256);
+  });
+
+  it('returns default when TOPK_K_CPU_HANDOFF_THRESHOLD is not set', () => {
+    expect(tf.env().getNumber('TOPK_K_CPU_HANDOFF_THRESHOLD')).toBe(128);
+  });
+});

--- a/tfjs-backend-webgl/src/kernels/TopK.ts
+++ b/tfjs-backend-webgl/src/kernels/TopK.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, NumericDataType, TensorInfo, TopK, TopKAttrs, TopKInputs, TypedArray, util} from '@tensorflow/tfjs-core';
+import {env, KernelConfig, KernelFunc, NumericDataType, TensorInfo, TopK, TopKAttrs, TopKInputs, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {MathBackendWebGL} from '../backend_webgl';
 import {topKImplCPU} from '../kernel_utils/shared';
@@ -49,10 +49,26 @@ export function topK(
   const {x} = inputs;
   const {k, sorted} = attrs;
 
-  if (backend.shouldExecuteOnCPU([x])) {
+  // Empirically determined constant used to determine last dim threshold for
+  // handing off execution to the CPU.
+  const TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD =
+      env().getNumber('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD');
+
+  // Empirically determined constant used to determine k threshold for handing
+  // off execution to the CPU.
+  const TOPK_K_CPU_HANDOFF_THRESHOLD =
+      env().getNumber('TOPK_K_CPU_HANDOFF_THRESHOLD');
+
+
+  const xShape = x.shape;
+  const lastDim = xShape[xShape.length - 1];
+
+  if (backend.shouldExecuteOnCPU([x]) ||
+      lastDim < TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD ||
+      k > TOPK_K_CPU_HANDOFF_THRESHOLD) {
     const xVals = backend.readSync(x.dataId) as TypedArray;
     const [allTopKVals, allTopKIndices] =
-        topKImplCPU(xVals, x.shape, x.dtype as NumericDataType, k, sorted);
+        topKImplCPU(xVals, xShape, x.dtype as NumericDataType, k, sorted);
 
     return [
       backend.makeTensorInfo(
@@ -61,9 +77,6 @@ export function topK(
           allTopKIndices.shape, allTopKIndices.dtype, allTopKIndices.values)
     ];
   }
-
-  const xShape = x.shape;
-  const lastDim = xShape[xShape.length - 1];
 
   if (k === 0) {
     xShape[xShape.length - 1] = 0;

--- a/tfjs-backend-webgl/src/kernels/TopK.ts
+++ b/tfjs-backend-webgl/src/kernels/TopK.ts
@@ -59,7 +59,6 @@ export function topK(
   const TOPK_K_CPU_HANDOFF_THRESHOLD =
       env().getNumber('TOPK_K_CPU_HANDOFF_THRESHOLD');
 
-
   const xShape = x.shape;
   const lastDim = xShape[xShape.length - 1];
 

--- a/tfjs-core/src/io/browser_files.ts
+++ b/tfjs-core/src/io/browser_files.ts
@@ -152,6 +152,7 @@ class BrowserFiles implements IOHandler {
 
         if (this.weightsFiles.length === 0) {
           resolve({modelTopology});
+          return;
         }
 
         const modelArtifactsPromise = getModelArtifactsForJSON(

--- a/tfjs-core/src/ops/topk_test.ts
+++ b/tfjs-core/src/ops/topk_test.ts
@@ -25,6 +25,12 @@ import {tensor2d} from './tensor2d';
 import {tensor3d} from './tensor3d';
 
 describeWithFlags('topk', ALL_ENVS, () => {
+  beforeAll(() => {
+    // Ensure WebGL environment uses GPU
+    tf.env().set('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', 0);
+    tf.env().set('TOPK_K_CPU_HANDOFF_THRESHOLD', 1024);
+  });
+
   it('1d array with k = 0', async () => {
     const a = tensor1d([20, 10, 40, 30]);
     const {values, indices} = tf.topk(a, 0);
@@ -163,7 +169,7 @@ describeWithFlags('topk', ALL_ENVS, () => {
     expectArraysClose(await values.data(), [2, 2, 1, 1]);
     expectArraysClose(await indices.data(), [1, 2, 0, 3]);
   });
-  
+
   it('lower-index element appears first, k=65', async () => {
     const a = [
       1, 1, 2, 1, 2, 1, 1, 1, 2, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2,
@@ -172,7 +178,7 @@ describeWithFlags('topk', ALL_ENVS, () => {
     ];
     const k = a.length;
     const {values, indices} = tf.topk(a, k);
-    
+
     expectArraysClose(await values.data(), [
       2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
       2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,


### PR DESCRIPTION
These flags allow to use when the WebGL kernel is used instead of CPU for TopK
Fixes https://github.com/tensorflow/tfjs/issues/5325

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5328)
<!-- Reviewable:end -->
