### PR TITLE
Remove tfjs 2.0 note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 TensorFlow.js is an open-source hardware-accelerated JavaScript library for
 training and deploying machine learning models.
 
-> :warning: We recently released **TensorFlow.js 2.0**. If you have been using TensorFlow.js
-> via a script tag without specifying a version and see an error saying no backends
-> are found, then you should read our [release notes](https://github.com/tensorflow/tfjs/releases/tag/tfjs-v2.0.0)
-> for instructions on how to upgrade.
-
-
 **Develop ML in the Browser** <br/>
 Use flexible and intuitive APIs to build models from scratch using the low-level
 JavaScript linear algebra library or the high-level layers API.


### PR DESCRIPTION
2.0 was released a while ago, so I don't think this note is relevant anymore.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5329)
<!-- Reviewable:end -->
