### PR TITLE
[wasm] Remove uses of 'build-deps-ci'

### DIFF
--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -18,7 +18,7 @@ steps:
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'build-deps'
-  args: ['build-deps-ci']
+  args: ['build-deps']
   waitFor: ['yarn-common']
 
 # Build.

--- a/tfjs-backend-wasm/scripts/test-bundle-size.js
+++ b/tfjs-backend-wasm/scripts/test-bundle-size.js
@@ -38,7 +38,7 @@ shell.cd(dirName);
 shell.cd(wasmDirName);
 
 exec(
-    `yarn && yarn build-deps-ci && yarn build-ci && yarn rollup -c`,
+    `yarn && yarn build-deps && yarn build-ci && yarn rollup -c`,
     {silent: false});
 
 const masterMinBundleSize = getFileSizeBytes(bundleFilename);


### PR DESCRIPTION
A prior commit removed `build-deps-ci` from tfjs-backend-wasm's package.json because building for CI is now the same as building for development, but a few references to `build-deps-ci` remained, causing nightly to fail. This PR replaces them with `build-deps`.

[Here's a nightly run of this branch](https://console.cloud.google.com/cloud-build/builds/a405889f-b4e6-4f00-a67a-bfd61df443e3?project=834911136599)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5340)
<!-- Reviewable:end -->
