### PR TITLE
webgpu: optimize matmul with small output size

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
@@ -19,6 +19,7 @@ import {backend_util, env, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
 
+import {MatMulSmallOutputSizeWidthProgram} from './matmul_small_output_size_webgpu';
 import {MatMulPackedVec4Program} from './matmul_packed_vec4_webgpu';
 import {MatMulPackedProgram} from './matmul_packed_webgpu';
 import {reshape} from './Reshape';
@@ -97,9 +98,14 @@ export function batchMatMulImpl({
 
   const useVec4 = a.shape[2] % 4 === 0 && b.shape[2] % 4 === 0 && !transposeA &&
       !transposeB && outerShapeB >= 32;
-  let program: MatMulPackedProgram|MatMulPackedVec4Program;
+  let program: MatMulPackedProgram|MatMulPackedVec4Program
+      |MatMulSmallOutputSizeWidthProgram;
   let dimensions = null;
-  if (useVec4) {
+  if ((a.shape[1] <= 16 || b.shape[2] <= 16) && !transposeA && !transposeB) {
+    program = new MatMulSmallOutputSizeWidthProgram(a3dShape, b3dShape,
+        [batchDim, outerShapeA, outerShapeB], bias, activation,
+        preluActivationWeights);
+  } else if (useVec4) {
     // TODO: Currently we need to make sure that a.shape[2] and b.shape[2]
     // are divisible by 4 since we use vec4 to get data. In future, we can
     // remove this limitation by insert 0 to pack data.

--- a/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
@@ -101,7 +101,10 @@ export function batchMatMulImpl({
   let program: MatMulPackedProgram|MatMulPackedVec4Program
       |MatMulSmallOutputSizeProgram;
   let dimensions = null;
-  if ((a.shape[1] <= 16 || b.shape[2] <= 16) && !transposeA && !transposeB) {
+  if (!transposeA && !transposeB && ((a.shape[1] <= 16 &&
+      (b.shape[2] <= 512 || b.shape[1] >= 2 * b.shape[2])) ||
+      (b.shape[2] <= 16 &&
+      (a.shape[1] <= 512 || a.shape[2] >= 2 * a.shape[1])))) {
     program = new MatMulSmallOutputSizeProgram(a3dShape, b3dShape,
         [batchDim, outerShapeA, outerShapeB], bias, activation,
         preluActivationWeights);

--- a/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/BatchMatMul_impl.ts
@@ -101,6 +101,15 @@ export function batchMatMulImpl({
   let program: MatMulPackedProgram|MatMulPackedVec4Program
       |MatMulSmallOutputSizeProgram;
   let dimensions = null;
+
+  // When the output size is absolutely small or relatively small, we may use
+  // MatMulSmallOutputSizeProgram to get better performance.
+  // Absolutely small size means that the output size is smaller than [16, 512].
+  // Relatively small size means that one demension size of the output is
+  // smaller than 16, and the output size is also more than or equal two times
+  // smaller than each of the two input sizes. For example, if input sizes are
+  // [12, 2048] and [2048, 1024], the output size is [12, 1024], which is
+  // relatively small compared to input sizes.
   if (!transposeA && !transposeB && ((a.shape[1] <= 16 &&
       (b.shape[2] <= 512 || b.shape[1] >= 2 * b.shape[2])) ||
       (b.shape[2] <= 16 &&

--- a/tfjs-backend-webgpu/src/kernels/matmul_small_output_size_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_small_output_size_webgpu.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {WebGPUProgram} from './webgpu_program';
+
+export function makeMatMulSmallOutputSizeWidthSource(
+    aOuterSmall: boolean): string {
+  return `
+  float mm_readA(int row, int col);
+  float mm_readB(int row, int col);
+  void mm_write(int row, int col, float value);
+
+  const int TileAOuter = int(gl_WorkGroupSize.x);
+  const int TileBOuter = int(gl_WorkGroupSize.x);
+  const int TileInner = int(gl_WorkGroupSize.y - gl_WorkGroupSize.x);
+
+  shared float mm_Asub1[TileAOuter][TileInner];
+  shared float mm_Bsub1[TileInner][TileBOuter];
+  shared float mm_Asub2[TileAOuter][TileInner];
+  shared float mm_Bsub2[TileInner][TileBOuter];
+
+  void mm_matMul(int dimAOuter, int dimInner, int dimBOuter) {
+    int tileRowA = int(gl_LocalInvocationID.x);
+    int tileColA = int(gl_LocalInvocationID.y);
+    int tileRowB = int(gl_LocalInvocationID.y);
+    int tileColB = int(gl_LocalInvocationID.x);
+
+    int ${aOuterSmall ? 'globalColB' : 'globalRowA'} =
+        int(gl_GlobalInvocationID.x);
+
+    int numTiles = (dimInner - 1) / TileInner + 1;
+    float acc = 0.0;
+
+    for (int t = 0; t < numTiles; t++) {
+      if (t == 0) {
+        if (tileColA < TileInner) {
+          // Load one tile of A and B into local memory.
+          mm_Asub1[tileRowA][tileColA] =
+              mm_readA(${aOuterSmall ? 'tileRowA' : 'globalRowA'}, tileColA);
+          mm_Bsub1[tileRowB][tileColB] =
+              mm_readB(tileRowB, ${aOuterSmall ? 'globalColB' : 'tileColB'});
+        }
+      } else {
+        if (tileColA < TileInner) {
+          // Load one tile of A and B into local memory.
+          mm_Asub1[tileRowA][tileColA] =
+              mm_readA(${aOuterSmall ? 'tileRowA' : 'globalRowA'},
+                  t * TileInner + tileColA);
+          mm_Bsub1[tileRowB][tileColB] =
+              mm_readB(t * TileInner + tileRowB,
+                  ${aOuterSmall ? 'globalColB' : 'tileColB'});
+        } else {
+          // Compute acc values for a single thread.
+          for (int k = 0; k < TileInner; k++) {
+            acc += mm_Asub2[tileRowA][k] * mm_Bsub2[k][tileColA-TileInner];
+          }
+        }
+      }
+
+      barrier();
+      if (t != 0) {
+        t++;
+      }
+
+      if (t < numTiles) {
+        if (tileColA < TileInner) {
+          // Load one tile of A and B into local memory.
+          mm_Asub2[tileRowA][tileColA] =
+              mm_readA(${aOuterSmall ? 'tileRowA' : 'globalRowA'},
+                  t * TileInner + tileColA);
+          mm_Bsub2[tileRowB][tileColB] =
+              mm_readB(t * TileInner + tileRowB,
+                  ${aOuterSmall ? 'globalColB' : 'tileColB'});
+        } else {
+          // Compute acc values for a single thread.
+          for (int k = 0; k < TileInner; k++) {
+            acc += mm_Asub1[tileRowA][k] * mm_Bsub1[k][tileColA-TileInner];
+          }
+        }
+      }
+
+      barrier();
+    }
+
+    if (tileColA >= TileInner) {
+      mm_write(${aOuterSmall ? 'tileRowA' : 'globalRowA'},
+          ${aOuterSmall ? 'int(gl_WorkGroupSize.x * gl_WorkGroupID.x) + '
+              : ''}tileColA - TileInner, acc);
+    }
+  }
+  `;
+}
+
+export class MatMulSmallOutputSizeWidthProgram implements WebGPUProgram {
+  outputShape: number[];
+  shaderKey: string;
+  dispatchLayout: {x: number[], y: number[], z: number[]};
+  dispatch: [number, number, number];
+  variableNames = ['A', 'B'];
+  workGroupSize: [number, number, number] = [8, 24, 1];
+  aOuterSmall: boolean;
+  addBias: boolean;
+  activation: backend_util.Activation;
+  hasPreluActivationWeights: boolean;
+
+  constructor(
+      aShape: [number, number, number], bShape: [number, number, number],
+      outputShape: [number, number, number], bias: TensorInfo = null,
+      activation: backend_util.Activation = null,
+      preluActivationWeights: TensorInfo = null) {
+    util.assert(aShape[1] <= 16 || bShape[2] <= 16,
+      () => 'This program can be only used when A width is small.');
+    this.outputShape = outputShape;
+
+    this.dispatchLayout = {x: [2], y: [1], z: [0]};
+    if (aShape[1] <= 16) {
+      this.workGroupSize = aShape[1] <= 8 ? [8, 24, 1] : [16, 32, 1];
+      this.dispatch = [Math.ceil(outputShape[2] / this.workGroupSize[0]), 1, 1];
+    } else if (bShape[2] <= 16) {
+      this.workGroupSize = bShape[2] <= 8 ? [8, 24, 1] : [16, 32, 1];
+      this.dispatch = [Math.ceil(outputShape[1] / this.workGroupSize[0]), 1, 1];
+    }
+
+    const addBias = bias != null;
+    if (addBias) {
+      this.variableNames.push('bias');
+    }
+
+    const hasPreluActivationWeights = preluActivationWeights != null;
+    if (hasPreluActivationWeights) {
+      this.variableNames.push('preluActivationWeights');
+    }
+
+    this.addBias = addBias;
+    this.activation = activation;
+    this.hasPreluActivationWeights = hasPreluActivationWeights;
+    this.aOuterSmall = aShape[1] <= 16;
+    if (aShape[1] <= 8) {
+      this.shaderKey = `matMulSmallOutputSize_A_8_${this.activation}`;
+    } else if (aShape[1] <= 16){
+      this.shaderKey = `matMulSmallOutputSize_A_16_${this.activation}`;
+    } else if (bShape[2] <= 8) {
+      this.shaderKey = `matMulSmallOutputSize_B_8_${this.activation}`;
+    } else if (bShape[2] <= 16){
+      this.shaderKey = `matMulSmallOutputSize_B_16_${this.activation}`;
+    }
+  }
+
+  getUserCode(): string {
+    let sampleA;
+
+      sampleA = `coordsInBounds(ivec2(row, col), ivec2(dimAOuter, dimInner)) ?
+            A[batch * batchASize + row * dimInner + col] : 0`;
+
+    let sampleB;
+      sampleB = `coordsInBounds(ivec2(row, col), ivec2(dimInner, dimBOuter)) ?
+            B[batch * batchBSize + row * dimBOuter + col] : 0`;
+
+    const userCode = `
+
+      int dimAOuter = aShape[1];
+      int dimInner = aShape[2];
+      int dimBOuter = bShape[2];
+
+      int batch;
+      ${makeMatMulSmallOutputSizeWidthSource(this.aOuterSmall)}
+      float mm_readA(int row, int col) {
+        int batchASize = aShape[1] * aShape[2];
+        return ${sampleA};
+      }
+      float mm_readB(int row, int col) {
+        int batchBSize = bShape[1] * bShape[2];
+        return ${sampleB};
+      }
+      void mm_write(int row, int col, float value) {
+        ivec3 outCoord = ivec3(batch, row, col);
+        setOutput(batch, row, col, value);
+      }
+      void main() {
+        batch = int(gl_GlobalInvocationID.z);
+        mm_matMul(dimAOuter, dimInner, dimBOuter);
+      }
+    `;
+    return userCode;
+  }
+}

--- a/tfjs-backend-webgpu/src/kernels/matmul_small_output_size_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_small_output_size_webgpu.ts
@@ -16,104 +16,104 @@
  */
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {mapActivationToShaderProgram} from './activation_util';
 import {WebGPUProgram} from './webgpu_program';
 
-export function makeMatMulSmallOutputSizeWidthSource(
-    aOuterSmall: boolean): string {
+export function makeMatMulSmallOutputSizeSource(): string {
   return `
   float mm_readA(int row, int col);
   float mm_readB(int row, int col);
   void mm_write(int row, int col, float value);
-
-  const int TileAOuter = int(gl_WorkGroupSize.x);
+  const int TileAOuter = int(gl_WorkGroupSize.y / 2);
   const int TileBOuter = int(gl_WorkGroupSize.x);
-  const int TileInner = int(gl_WorkGroupSize.y - gl_WorkGroupSize.x);
+  const int TileInner = TileAOuter > TileBOuter ? TileAOuter : TileBOuter;
 
   shared float mm_Asub1[TileAOuter][TileInner];
   shared float mm_Bsub1[TileInner][TileBOuter];
   shared float mm_Asub2[TileAOuter][TileInner];
   shared float mm_Bsub2[TileInner][TileBOuter];
 
+  // If the output size is small for matrix multiplication, avoid to use vec4
+  // and handle some elements per thread to optimally utilize the ALU.
+  // Introduces two shared memory buffers, some logical threads could handle
+  // arithmetic operations and others handle IO operations between barrier api,
+  // makes ALUs and load/store units work simultaneously, could improves
+  // the performance.
   void mm_matMul(int dimAOuter, int dimInner, int dimBOuter) {
-    int tileRowA = int(gl_LocalInvocationID.x);
-    int tileColA = int(gl_LocalInvocationID.y);
-    int tileRowB = int(gl_LocalInvocationID.y);
-    int tileColB = int(gl_LocalInvocationID.x);
-
-    int ${aOuterSmall ? 'globalColB' : 'globalRowA'} =
-        int(gl_GlobalInvocationID.x);
+    int tileRow = int(gl_LocalInvocationID.y);
+    int tileCol = int(gl_LocalInvocationID.x);
+    int globalRow = int(gl_GlobalInvocationID.y);
+    int globalCol = int(gl_GlobalInvocationID.x);
 
     int numTiles = (dimInner - 1) / TileInner + 1;
     float acc = 0.0;
 
+    int globalColA = tileCol;
+    int globalRowB = tileRow;
+    int tileColA = int(gl_LocalInvocationID.x);
+    int tileRowB = int(gl_LocalInvocationID.y);
     for (int t = 0; t < numTiles; t++) {
       if (t == 0) {
-        if (tileColA < TileInner) {
+        if (tileRow < TileAOuter) {
           // Load one tile of A and B into local memory.
-          mm_Asub1[tileRowA][tileColA] =
-              mm_readA(${aOuterSmall ? 'tileRowA' : 'globalRowA'}, tileColA);
-          mm_Bsub1[tileRowB][tileColB] =
-              mm_readB(tileRowB, ${aOuterSmall ? 'globalColB' : 'tileColB'});
+          mm_Asub1[tileRow][tileColA] =
+              mm_readA((globalRow - tileRow) / 2 + tileRow, globalColA);
+          globalColA += TileInner;
+          mm_Bsub1[tileRowB][tileCol] = mm_readB(globalRowB, globalCol);
+          globalRowB += TileInner;
         }
       } else {
-        if (tileColA < TileInner) {
+        if (tileRow < TileAOuter) {
           // Load one tile of A and B into local memory.
-          mm_Asub1[tileRowA][tileColA] =
-              mm_readA(${aOuterSmall ? 'tileRowA' : 'globalRowA'},
-                  t * TileInner + tileColA);
-          mm_Bsub1[tileRowB][tileColB] =
-              mm_readB(t * TileInner + tileRowB,
-                  ${aOuterSmall ? 'globalColB' : 'tileColB'});
+          mm_Asub1[tileRow][tileColA] =
+              mm_readA((globalRow - tileRow) / 2 + tileRow, globalColA);
+          globalColA += TileInner;
+          mm_Bsub1[tileRowB][tileCol] = mm_readB(globalRowB, globalCol);
+          globalRowB += TileInner;
         } else {
           // Compute acc values for a single thread.
           for (int k = 0; k < TileInner; k++) {
-            acc += mm_Asub2[tileRowA][k] * mm_Bsub2[k][tileColA-TileInner];
+            acc += mm_Asub2[tileRow - TileAOuter][k] * mm_Bsub2[k][tileCol];
           }
         }
       }
-
       barrier();
       if (t != 0) {
         t++;
       }
 
       if (t < numTiles) {
-        if (tileColA < TileInner) {
+        if (tileRow < TileAOuter) {
           // Load one tile of A and B into local memory.
-          mm_Asub2[tileRowA][tileColA] =
-              mm_readA(${aOuterSmall ? 'tileRowA' : 'globalRowA'},
-                  t * TileInner + tileColA);
-          mm_Bsub2[tileRowB][tileColB] =
-              mm_readB(t * TileInner + tileRowB,
-                  ${aOuterSmall ? 'globalColB' : 'tileColB'});
+          mm_Asub2[tileRow][tileColA] =
+              mm_readA((globalRow - tileRow) / 2 + tileRow, globalColA);
+          globalColA += TileInner;
+          mm_Bsub2[tileRowB][tileCol] = mm_readB(globalRowB, globalCol);
+          globalRowB += TileInner;
         } else {
           // Compute acc values for a single thread.
           for (int k = 0; k < TileInner; k++) {
-            acc += mm_Asub1[tileRowA][k] * mm_Bsub1[k][tileColA-TileInner];
+            acc += mm_Asub1[tileRow - TileAOuter][k] * mm_Bsub1[k][tileCol];
           }
         }
       }
-
       barrier();
     }
-
-    if (tileColA >= TileInner) {
-      mm_write(${aOuterSmall ? 'tileRowA' : 'globalRowA'},
-          ${aOuterSmall ? 'int(gl_WorkGroupSize.x * gl_WorkGroupID.x) + '
-              : ''}tileColA - TileInner, acc);
+    if (tileRow >= TileAOuter) {
+      mm_write((globalRow - tileRow) / 2 + tileRow - TileAOuter,
+          globalCol, acc);
     }
   }
   `;
 }
 
-export class MatMulSmallOutputSizeWidthProgram implements WebGPUProgram {
+export class MatMulSmallOutputSizeProgram implements WebGPUProgram {
   outputShape: number[];
   shaderKey: string;
   dispatchLayout: {x: number[], y: number[], z: number[]};
   dispatch: [number, number, number];
   variableNames = ['A', 'B'];
-  workGroupSize: [number, number, number] = [8, 24, 1];
-  aOuterSmall: boolean;
+  workGroupSize: [number, number, number] = [8, 16, 1];
   addBias: boolean;
   activation: backend_util.Activation;
   hasPreluActivationWeights: boolean;
@@ -128,13 +128,8 @@ export class MatMulSmallOutputSizeWidthProgram implements WebGPUProgram {
     this.outputShape = outputShape;
 
     this.dispatchLayout = {x: [2], y: [1], z: [0]};
-    if (aShape[1] <= 16) {
-      this.workGroupSize = aShape[1] <= 8 ? [8, 24, 1] : [16, 32, 1];
-      this.dispatch = [Math.ceil(outputShape[2] / this.workGroupSize[0]), 1, 1];
-    } else if (bShape[2] <= 16) {
-      this.workGroupSize = bShape[2] <= 8 ? [8, 24, 1] : [16, 32, 1];
-      this.dispatch = [Math.ceil(outputShape[1] / this.workGroupSize[0]), 1, 1];
-    }
+    this.dispatch = [Math.ceil(outputShape[2] / this.workGroupSize[0]),
+        Math.ceil(outputShape[1] * 2 / this.workGroupSize[1]), outputShape[0]];
 
     const addBias = bias != null;
     if (addBias) {
@@ -149,16 +144,7 @@ export class MatMulSmallOutputSizeWidthProgram implements WebGPUProgram {
     this.addBias = addBias;
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
-    this.aOuterSmall = aShape[1] <= 16;
-    if (aShape[1] <= 8) {
-      this.shaderKey = `matMulSmallOutputSize_A_8_${this.activation}`;
-    } else if (aShape[1] <= 16){
-      this.shaderKey = `matMulSmallOutputSize_A_16_${this.activation}`;
-    } else if (bShape[2] <= 8) {
-      this.shaderKey = `matMulSmallOutputSize_B_8_${this.activation}`;
-    } else if (bShape[2] <= 16){
-      this.shaderKey = `matMulSmallOutputSize_B_16_${this.activation}`;
-    }
+    this.shaderKey = `matMulSmallOutputSize_${this.activation}`;
   }
 
   getUserCode(): string {
@@ -171,14 +157,34 @@ export class MatMulSmallOutputSizeWidthProgram implements WebGPUProgram {
       sampleB = `coordsInBounds(ivec2(row, col), ivec2(dimInner, dimBOuter)) ?
             B[batch * batchBSize + row * dimBOuter + col] : 0`;
 
+    let activationSnippet = '', applyActivationSnippet = '';
+    if (this.activation) {
+      const activationOp = mapActivationToShaderProgram(this.activation);
+      if (this.hasPreluActivationWeights) {
+        activationSnippet = `float activation(float a, ivec3 outCoord) {
+            float b = getPreluActivationWeightsAtOutCoords(outCoord);
+            ${activationOp}
+            }`;
+      } else {
+        activationSnippet = `float activation(float a, ivec3 outCoord) {
+            ${activationOp}
+        }`;
+      }
+
+      applyActivationSnippet = 'value = activation(value, outCoord);';
+    }
+
+    const addBiasSnippet =
+        this.addBias ? 'value += getBiasAtOutCoords(outCoord);' : '';
+
     const userCode = `
+      ${activationSnippet}
 
       int dimAOuter = aShape[1];
       int dimInner = aShape[2];
       int dimBOuter = bShape[2];
-
       int batch;
-      ${makeMatMulSmallOutputSizeWidthSource(this.aOuterSmall)}
+      ${makeMatMulSmallOutputSizeSource()}
       float mm_readA(int row, int col) {
         int batchASize = aShape[1] * aShape[2];
         return ${sampleA};
@@ -188,8 +194,12 @@ export class MatMulSmallOutputSizeWidthProgram implements WebGPUProgram {
         return ${sampleB};
       }
       void mm_write(int row, int col, float value) {
-        ivec3 outCoord = ivec3(batch, row, col);
-        setOutput(batch, row, col, value);
+        if (coordsInBounds(ivec2(row, col), ivec2(dimAOuter, dimBOuter))) {
+          ivec3 outCoord = ivec3(batch, row, col);
+          ${addBiasSnippet}
+          ${applyActivationSnippet}
+          setOutput(batch, row, col, value);
+        }
       }
       void main() {
         batch = int(gl_GlobalInvocationID.z);


### PR DESCRIPTION
Current matmul algorithm dispatches logical threads based on
output size, if output size is small and inner dimension size
is large, there are few threads and every thread should handle
large loads, so the performance is poor.
This patch dispatches logical threads based on output size and
inner dimension size, increases the logical threads, makes load
balancing.
This patches also introduces two shared memory buffers, some
logical threads could handle arithmetic operations and others
handle IO operations between barrier api, makes ALUs and load/store
units work simultaneously, could improves the performance.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5342)
<!-- Reviewable:end -->
