### PR TITLE
Enable the Bazel results ui in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,11 +14,13 @@ build --cxxopt="-fno-exceptions"
 build --cxxopt="-fomit-frame-pointer"
 
 # Remote cache config. Users can add credentials in their .bazelrc.user files.
-build:remote --remote_cache=https://storage.googleapis.com/bazel-remote-cache-tfjs
+build:remote --remote_cache=remotebuildexecution.googleapis.com --auth_enabled=true --google_default_credentials --remote_instance_name=projects/learnjs-174218/instances/default_instance --project_id=learnjs-174218 --remote_timeout=180s
+
+# Stream build results to the results UI
+build:bes --config=remote --bes_backend="buildeventservice.googleapis.com" --bes_timeout=60s --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # Config for Google Cloud continuous integration that uses default credentials.
-build:ci --config=remote
-build:ci --google_default_credentials
+build:ci --config=bes
 
 # This flag is needed to prevent the bazel cache from being invalidated when
 # running bazel via `yarn bazel`.


### PR DESCRIPTION
Enable the Bazel results UI in CI so people can see logs from failed tests run by Bazel.

This PR also necessarily changes the remote build cache to one supported by the build results UI.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5348)
<!-- Reviewable:end -->
