### PR TITLE
[tfjs-core] disable logging when prod flag is set

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -28,7 +28,7 @@ import {getTensorsInContainer} from './tensor_util';
 import {BackendValues, DataType, DataValues} from './types';
 import * as util from './util';
 import {bytesFromStringArray, makeOnesTypedArray, now, sizeFromShape} from './util';
-
+import * as log from './log';
 /**
  * A function that computes an output. The save function is for saving tensors
  * computed in the forward pass, that we need in the backward pass.
@@ -259,7 +259,7 @@ export class Engine implements TensorTracker, DataMover {
       factory: () => KernelBackend | Promise<KernelBackend>,
       priority = 1): boolean {
     if (backendName in this.registryFactory) {
-      console.warn(
+      log.warn(
           `${backendName} backend was already registered. ` +
           `Reusing existing backend factory.`);
       return false;
@@ -348,9 +348,9 @@ export class Engine implements TensorTracker, DataMover {
                     return false;
                   }
                   this.pendingBackendInit = null;
-                  console.warn(
+                  log.warn(
                       `Initialization of backend ${backendName} failed`);
-                  console.warn(err.stack || err.message);
+                  log.warn(err.stack || err.message);
                   return false;
                 });
         this.pendingBackendInit = success;
@@ -360,8 +360,8 @@ export class Engine implements TensorTracker, DataMover {
         return {success: true, asyncInit: false};
       }
     } catch (err) {
-      console.warn(`Initialization of backend ${backendName} failed`);
-      console.warn(err.stack || err.message);
+      log.warn(`Initialization of backend ${backendName} failed`);
+      log.warn(err.stack || err.message);
       return {success: false, asyncInit: false};
     }
   }

--- a/tfjs-core/src/environment.ts
+++ b/tfjs-core/src/environment.ts
@@ -17,6 +17,7 @@
 
 import {Platform} from './platforms/platform';
 import {isPromise} from './util_base';
+import * as log from './log';
 
 // Expects flags from URL in the format ?tfjsflags=FLAG1:1,FLAG2:true.
 const TENSORFLOWJS_FLAGS_PREFIX = 'tfjsflags';
@@ -57,7 +58,7 @@ export class Environment {
 
   setPlatform(platformName: string, platform: Platform) {
     if (this.platform != null) {
-      console.warn(
+      log.warn(
           `Platform ${this.platformName} has already been set. ` +
           `Overwriting the platform with ${platform}.`);
     }
@@ -74,7 +75,7 @@ export class Environment {
     // environment is initialized before flags get registered.
     if (this.urlFlags[flagName] != null) {
       const flagValue = this.urlFlags[flagName];
-      console.warn(
+      log.warn(
           `Setting feature override from URL ${flagName}: ${flagValue}.`);
       this.set(flagName, flagValue);
     }

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -20,6 +20,7 @@ import {getGlobal} from './global_util';
 import {NamedGradientMap} from './tape';
 import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
+import * as log from './log';
 
 const kernelRegistry =
     getGlobal('kernelRegistry', () => new Map<string, KernelConfig>());
@@ -139,7 +140,7 @@ export function registerKernel(config: KernelConfig) {
   const {kernelName, backendName} = config;
   const key = makeKey(kernelName, backendName);
   if (kernelRegistry.has(key)) {
-    console.warn(
+    log.warn(
         `The kernel '${kernelName}' for backend ` +
         `'${backendName}' is already registered`);
   }
@@ -161,7 +162,7 @@ export function registerGradient(config: GradConfig) {
     // TODO (yassogba) after 3.0 assess whether we need to keep this gated
     // to debug mode.
     if (env().getBool('DEBUG')) {
-      console.warn(`Overriding the gradient for '${kernelName}'`);
+      log.warn(`Overriding the gradient for '${kernelName}'`);
     }
   }
   gradRegistry.set(kernelName, config);

--- a/tfjs-core/src/log.ts
+++ b/tfjs-core/src/log.ts
@@ -18,13 +18,13 @@
 import {env} from './environment';
 
 export function warn(...msg: Array<{}>): void {
-  if (!env().getBool('IS_TEST')) {
+  if (!(env().getBool('IS_TEST') || env().getBool('PROD'))) {
     console.warn(...msg);
   }
 }
 
 export function log(...msg: Array<{}>): void {
-  if (!env().getBool('IS_TEST')) {
+  if (!(env().getBool('IS_TEST') || env().getBool('PROD'))) {
     console.log(...msg);
   }
 }


### PR DESCRIPTION
fixed https://github.com/tensorflow/tfjs/issues/5349
Users can disable the warning messages by setting `tf.env().set('PROD', true);`

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5368)
<!-- Reviewable:end -->
