### PR TITLE
[e2e] Fix object compare

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -89,7 +89,8 @@ limitations under the License.
   <script src="https://unpkg.com/@tensorflow/tfjs-core@latest/dist/tf-core.js" crossorigin></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-cpu@latest/dist/tf-backend-cpu.js" crossorigin></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-webgl@latest/dist/tf-backend-webgl.js" crossorigin></script>
-  <script src="https://unpkg.com/@tensorflow/tfjs-backend-webgpu@latest/dist/tf-backend-webgpu.min.js" crossorigin></script>
+  <script src="https://unpkg.com/@tensorflow/tfjs-backend-webgpu@latest/dist/tf-backend-webgpu.min.js"
+    crossorigin></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-layers@latest/dist/tf-layers.js" crossorigin></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-converter@latest/dist/tf-converter.js" crossorigin></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-backend-wasm@latest/dist/tf-backend-wasm.js" crossorigin></script>
@@ -142,14 +143,11 @@ limitations under the License.
     function updateGUIFromURLState() {
       if (urlState == null)
         return;
-      if (tunableFlagsControllers != null)
-      {
+      if (tunableFlagsControllers != null) {
         if (tunableFlagsControllers['WEBGL_USE_SHAPES_UNIFORMS'] != null &&
-            urlState.has('WEBGL_USE_SHAPES_UNIFORMS'))
-        {
+          urlState.has('WEBGL_USE_SHAPES_UNIFORMS')) {
           const value = urlState.get('WEBGL_USE_SHAPES_UNIFORMS');
-          if (value === 'true')
-          {
+          if (value === 'true') {
             tunableFlagsControllers['WEBGL_USE_SHAPES_UNIFORMS'].setValue(true);
           } else {
             tunableFlagsControllers['WEBGL_USE_SHAPES_UNIFORMS'].setValue(false);
@@ -223,7 +221,7 @@ limitations under the License.
         // compare results
         try {
           await showMsg(null);
-          tf.test_util.expectArraysClose(referenceData, predictionData);
+          expectObjectsClose(predictionData, referenceData);
           match = true;
         } catch (e) {
           match = false;
@@ -806,10 +804,10 @@ limitations under the License.
         // TODO: Failed to set backend
         if (state.backend === 'webgpu' && !tf.engine().backendNames().includes(state.backend)) {
           showMsg(
-              `WebGPU is not supported. Please use Chrome Canary browser with flag "--enable-unsafe-webgpu" enabled.`);
+            `WebGPU is not supported. Please use Chrome Canary browser with flag "--enable-unsafe-webgpu" enabled.`);
           return;
         } else {
-           showMsg(null);
+          showMsg(null);
         }
         await tf.setBackend(backend);
         await showFlagSettingsAndReturnTunableFlagControllers(envFolder, state.backend);

--- a/e2e/benchmarks/local-benchmark/util.js
+++ b/e2e/benchmarks/local-benchmark/util.js
@@ -66,3 +66,102 @@ function queryTimerIsEnabled() {
   return _tfengine.ENV.getNumber(
              'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0;
 }
+
+function areClose(a, e, epsilon) {
+  if (!isFinite(a) && !isFinite(e)) {
+    return true;
+  }
+  if (isNaN(a) || isNaN(e) || Math.abs(a - e) > epsilon) {
+    return false;
+  }
+  return true;
+}
+
+function expectObjectsPredicate(actual, expected, epsilon, predicate) {
+  let actualKeys = Object.getOwnPropertyNames(actual);
+  let expectedKeys = Object.getOwnPropertyNames(expected);
+  if (actualKeys.length != expectedKeys.length) {
+    throw new Error(`Actual length ${
+        actualKeys.length} not equal Expected length ${expectedKeys.length}`);
+  }
+  for (let i = 0; i < actualKeys.length; i++) {
+    let key = actualKeys[i];
+    let isObject = typeof (actual[key]) === 'object' &&
+        typeof (expected[key]) === 'object';
+    let isArray = tf.util.isTypedArray(actual[key]) &&
+        tf.util.isTypedArray(expected[key]);
+    if (isArray) {
+      expectArraysClose(actual[key], expected[key], epsilon, key);
+    } else if (!isObject && (!predicate(actual[key], expected[key]))) {
+      throw new Error(`Objects differ: actual[${key}] = ${
+          JSON.stringify(actual[key])}, expected[${key}] = ${
+          JSON.stringify(expected[key])}!`);
+    } else if (
+        isObject &&
+        !expectObjectsPredicate(
+            actual[key], expected[key], epsilon, predicate)) {
+      throw new Error(`Objects differ: actual[${key}] = ${
+          JSON.stringify(actual[key])}, expected[${key}] = ${
+          JSON.stringify(expected[key])}!`);
+    }
+  }
+  return true;
+}
+
+function expectObjectsClose(actual, expected, epsilon) {
+  if (epsilon == null) {
+    epsilon = tf.test_util.testEpsilon();
+  }
+  expectObjectsPredicate(
+      actual, expected, epsilon, (a, b) => areClose(a, b, epsilon));
+}
+
+function expectArraysPredicateFuzzy(actual, expected, predicate, errorRate) {
+  if (tf.util.isTypedArray(actual) == false ||
+      tf.util.isTypedArray(expected) == false) {
+    throw new Error(`Actual and Expected are not arrays.`);
+  }
+
+  if (actual.length !== expected.length) {
+    throw new Error(
+        `Arrays have different lengths actual: ${actual.length} vs ` +
+        `expected: ${expected.length}.\n` +
+        `Actual:   ${actual}.\n` +
+        `Expected: ${expected}.`);
+  }
+  let mismatchCount = 0;
+  for (let i = 0; i < expected.length; ++i) {
+    const a = actual[i];
+    const e = expected[i];
+    if (!predicate(a, e)) {
+      mismatchCount++;
+      const maxMismatch = Math.floor(errorRate * expected.length);
+      if (mismatchCount > maxMismatch) {
+        throw new Error(
+            `Arrays data has more than ${maxMismatch} differs from ${
+                expected.length}: actual[${i}] = ${a}, expected[${i}] = ${
+                e}.\n` +
+            `Actual:   ${actual}.\n` +
+            `Expected: ${expected}.`);
+      }
+    }
+  }
+}
+
+function expectArraysClose(actual, expected, epsilon, key) {
+  if (epsilon == null) {
+    epsilon = tf.test_util.testEpsilon();
+  }
+
+  if (key == 'data') {
+    // For bodypix, the value in data memeber means "1 for the pixels that are
+    // part of the person, and 0 otherwise".
+    // So for these models, we don't expect all data is exactly match. Default
+    // use error rate 0.001 (1/1000).
+    const ERROR_RATE = 0.001;
+    return expectArraysPredicateFuzzy(
+        actual, expected, (a, b) => areClose(a, b, epsilon), ERROR_RATE);
+  } else {
+    return tf.test_util.expectArraysClose(actual, expected, epsilon);
+  }
+}

--- a/e2e/benchmarks/local-benchmark/util.js
+++ b/e2e/benchmarks/local-benchmark/util.js
@@ -92,17 +92,14 @@ function expectObjectsPredicate(actual, expected, epsilon, predicate) {
         tf.util.isTypedArray(expected[key]);
     if (isArray) {
       expectArraysClose(actual[key], expected[key], epsilon, key);
-    } else if (!isObject && (!predicate(actual[key], expected[key]))) {
-      throw new Error(`Objects differ: actual[${key}] = ${
-          JSON.stringify(actual[key])}, expected[${key}] = ${
-          JSON.stringify(expected[key])}!`);
-    } else if (
-        isObject &&
-        !expectObjectsPredicate(
-            actual[key], expected[key], epsilon, predicate)) {
-      throw new Error(`Objects differ: actual[${key}] = ${
-          JSON.stringify(actual[key])}, expected[${key}] = ${
-          JSON.stringify(expected[key])}!`);
+    } else if (isObject) {
+      expectObjectsPredicate(actual[key], expected[key], epsilon, predicate);
+    } else {
+      if (!predicate(actual[key], expected[key])) {
+        throw new Error(`Objects differ: actual[${key}] = ${
+            JSON.stringify(actual[key])}, expected[${key}] = ${
+            JSON.stringify(expected[key])}!`);
+      }
     }
   }
   return true;


### PR DESCRIPTION
The predict results of most models are objects, instead of arrays. Current implementation assumes that the predict results are arrays, which results in some fake pass. For example, when tint changed the shared memory limits, most models should fail the conformance test. However, these cases are passed when we compare these results as arrays.

BUG: https://github.com/tensorflow/tfjs/issues/5397
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5384)
<!-- Reviewable:end -->
