### PR TITLE
[webgpu] Fix that exceeding limitation errors

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
@@ -54,7 +54,8 @@ export class ArgMinMaxProgram implements WebGPUProgram {
 
     // The number of comparisons each thread will do
     this.reductionFactor = 2;
-    const xMaxThreads = 1024;  // gl_MaxComputeWorkGroupSize
+    // Note that the maximum of workgroup X dimension is 256.
+    const xMaxThreads = 256;  // gl_MaxComputeWorkGroupSize.
     const xThreads =
         Math.min(Math.ceil(reduceSize / this.reductionFactor), xMaxThreads);
 

--- a/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
@@ -41,14 +41,15 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
       op: BinaryOpType, aShape: number[], bShape: number[],
       useSharedMemoryWithB: boolean) {
     // This is an experimental value when using shared memory.
-    const workGroupSizeX = 512;
+    // Note that the maximum of workgroup X dimension is 256.
+    const workGroupSizeX = 256;
     this.workGroupSize = [workGroupSizeX, 1, 1];
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.lastDimensionSize = useSharedMemoryWithB ? bShape[0] : aShape[0];
-    if (this.lastDimensionSize < 512) {
+    if (this.lastDimensionSize < 256) {
       this.workPerThread = 1;
-    } else if (this.lastDimensionSize < 1024) {
+    } else if (this.lastDimensionSize < 512) {
       this.workPerThread = 2;
     } else {
       this.workPerThread = 4;

--- a/tfjs-backend-webgpu/src/kernels/binary_ops.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_ops.ts
@@ -29,9 +29,9 @@ export function getBinaryProgram(
     return new BinaryOpVec4Program(op, aShape, bShape);
   }
   const useSharedMemoryWithA =
-      aShape.length === 1 && bShape.length > 1 && aShape[0] < 2048;
+      aShape.length === 1 && bShape.length > 1 && aShape[0] < 1024;
   const useSharedMemoryWithB =
-      bShape.length === 1 && aShape.length > 1 && bShape[0] < 2048;
+      bShape.length === 1 && aShape.length > 1 && bShape[0] < 1024;
   if (useSharedMemoryWithA || useSharedMemoryWithB) {
     return new BinaryOpSharedProgram(op, aShape, bShape, useSharedMemoryWithB);
   } else {

--- a/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_mm_vec4_webgpu.ts
@@ -50,7 +50,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         convInfo.dataFormat === 'channelsLast',
         () => 'TODO: NCHW is unimplemented');
     this.dispatchLayout = {x: [3], y: [1, 2], z: [0]};
-    this.workGroupSize = [16, 16, 1];
+    this.workGroupSize = [8, 8, 1];
     const elementsPerThread: [number, number, number] = [4, 4, 1];
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,

--- a/tfjs-backend-webgpu/src/kernels/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/reduce_webgpu.ts
@@ -42,7 +42,8 @@ export class ReduceProgram implements WebGPUProgram {
     this.outputShape = outputShape.length === 0 ? [1] : outputShape;
 
     this.reductionFactor = 2;
-    const xMaxThreads = 1024;
+    // Note that the maximum of workgroup X dimension is 256.
+    const xMaxThreads = 256;
     const xThreads = Math.min(
         Math.ceil(reduceInfo.inSize / this.reductionFactor), xMaxThreads);
 

--- a/tfjs-backend-webgpu/src/kernels/transpose_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transpose_shared_webgpu.ts
@@ -24,7 +24,8 @@ export class TransposeSharedProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[], y: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [32, 32, 1];
+  // Note that the maximum number of workgroup invocations by webgpu is 256.
+  workGroupSize: [number, number, number] = [16, 16, 1];
 
   constructor(aShape: number[], newDim: number[]) {
     const outputShape: number[] = new Array(aShape.length);

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -86,20 +86,18 @@ export function computeWorkGroupSizeForMatMul(
     dimBOuter: number): [number, number, number] {
   // These are experimental values. Usually, we need to adjust the work group
   // size based on the input shapes to improve the EU occupancy.
-  // 64 (16 x 4) is the default tile size. If one dimension can't be divisible
-  // by 64, it means some threads will be idle. To improve the thread
-  // utilization, reducing the work group size may be a good way.
+  // TODO: WebGPU limits the maximum allowed shared memory size as 16K. To make
+  // sure it doesn't exceed this limitations. Temporarily reduce the work group
+  // size to [8, 8, 1] and the work per thread size is [4, 4, 1]. But we should
+  // revisit it and find the balance between work group size and work per thread
+  // size.
   if (dimAOuter === 1) {
-    return [64, 1, 1];
+    return [32, 1, 1];
   } else if (dimBOuter === 1) {
-    return [1, 64, 1];
-  } else if (dimInner % 64 === 0 && dimBOuter % 64 === 0) {
-    return [16, 16, 1];
-  } else if (dimInner < 192 && dimBOuter < 192) {
-    return [8, 8, 1];
+    return [1, 32, 1];
   }
 
-  return [16, 16, 1];
+  return [8, 8, 1];
 }
 
 export function computeWorkPerThreadForConv2d(

--- a/tfjs-backend-webgpu/yarn.lock
+++ b/tfjs-backend-webgpu/yarn.lock
@@ -891,7 +891,7 @@
   version "0.0.0"
   uid ""
 
-"@tensorflow/tfjs-backend-webgl@link:../tfjs-backend-webgl":
+"@tensorflow/tfjs-backend-webgl@link:../link-package/node_modules/@tensorflow/tfjs-backend-webgl":
   version "0.0.0"
   uid ""
 
@@ -964,11 +964,6 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
-
-"@types/webgl2@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
-  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 "@webgpu/glslang@0.0.12":
   version "0.0.12"


### PR DESCRIPTION
Recently, webgpu adds more strict limitations for the work group size
and shared memory size. This PR fixes those errors caused by exceeding
limitations. It may hurt performance under some situations. The fine
tuning will be added after we have enough experiments.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5385)
<!-- Reviewable:end -->
