### PR TITLE
[webgpu] Add depthwise and other 21 programs WGSL support

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
@@ -18,9 +18,10 @@
 import {backend_util} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType} from '../shader_preprocessor';
+import {getCoordsDataTypeWgsl, getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class BatchNormProgram implements WebGPUProgram {
   outputShape: number[];
@@ -29,11 +30,13 @@ export class BatchNormProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames: string[];
   uniforms = 'float varianceEpsilon;';
+  uniformsWgsl = 'varianceEpsilon : f32;';
   // This is an experimental value.
   workGroupSize: [number, number, number] = [128, 1, 1];
   offsetShape: number[]|null;
   scaleShape: number[]|null;
   varianceEpsilon: number;
+  useWgsl: boolean;
 
   constructor(
       xShape: number[], meanShape: number[], varianceShape: number[],
@@ -57,6 +60,7 @@ export class BatchNormProgram implements WebGPUProgram {
     this.offsetShape = offsetShape;
     this.scaleShape = scaleShape;
     this.shaderKey = 'batchNorm';
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -95,6 +99,48 @@ export class BatchNormProgram implements WebGPUProgram {
         float scale = ${scaleSnippet};
         float inv = scale * inversesqrt(variance + float(varianceEpsilon));
         writeResult(coords,dot(vec3(x, -mean, offset), vec3(inv, inv, 1)));
+      }
+  `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    let offsetSnippet = '0.0';
+    if (this.offsetShape != null) {
+      offsetSnippet = 'getOffsetAtOutCoordsByGlobalId(globalId)';
+    }
+
+    let scaleSnippet = '1.0';
+    if (this.scaleShape != null) {
+      scaleSnippet = 'getScaleAtOutCoordsByGlobalId(globalId)';
+    }
+
+    const dim = this.outputShape.length;
+    const coordsDataType = getCoordsDataTypeWgsl(dim);
+    let setOutput =
+        'setOutput(coords[0], coords[1], coords[2], coords[3], value);';
+    if (dim === 2) {
+      setOutput = 'setOutput(coords[0], coords[1], value);';
+    }
+    if (dim === 3) {
+      setOutput = 'setOutput(coords[0], coords[1], coords[2], value);';
+    }
+    const userCode = `
+      fn writeResult(coords : ${coordsDataType}, value : f32) {
+        if (coordsInBounds${dim}D(coords, uniforms.outShape)) {
+          ${setOutput}
+        }
+      }
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let coords = getOutputCoords(globalId);
+        let xValue = getXAtOutCoordsByGlobalId(globalId);
+        let meanValue = getMeanAtOutCoordsByGlobalId(globalId);
+        let varianValue = getVarianceAtOutCoordsByGlobalId(globalId);
+        let offsetValue = ${offsetSnippet};
+        let scaleValue = ${scaleSnippet};
+        let inv = scaleValue * 1.0/sqrt(varianValue + f32(uniforms.varianceEpsilon));
+        writeResult(coords,dot(vec3<f32>(xValue, -meanValue, offsetValue), vec3<f32>(inv, inv, 1.0)));
       }
   `;
     return userCode;

--- a/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/batchnorm_webgpu.ts
@@ -139,7 +139,7 @@ export class BatchNormProgram implements WebGPUProgram {
         let varianValue = getVarianceAtOutCoordsByGlobalId(globalId);
         let offsetValue = ${offsetSnippet};
         let scaleValue = ${scaleSnippet};
-        let inv = scaleValue * 1.0/sqrt(varianValue + f32(uniforms.varianceEpsilon));
+        let inv = scaleValue * inverseSqrt(varianValue + f32(uniforms.varianceEpsilon));
         writeResult(coords,dot(vec3<f32>(xValue, -meanValue, offsetValue), vec3<f32>(inv, inv, 1.0)));
       }
   `;

--- a/tfjs-backend-webgpu/src/kernels/clip_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_vec4_webgpu.ts
@@ -16,21 +16,25 @@
  */
 
 import {util} from '@tensorflow/tfjs-core';
+
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class ClipVec4Program implements WebGPUProgram {
   outputShape: number[];
   shaderKey: string;
   variableNames = ['A'];
   uniforms = 'float minVal; float maxVal;';
+  uniformsWgsl = 'minVal : f32; maxVal : f32;';
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
   isVec4 = true;
   size: number;
+  useWgsl: boolean;
 
   constructor(outputShape: number[]) {
     this.outputShape = outputShape;
@@ -40,6 +44,7 @@ export class ClipVec4Program implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
     this.shaderKey = 'clipVec4';
     this.size = util.sizeFromShape(this.outputShape) / 4;
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -55,6 +60,29 @@ export class ClipVec4Program implements WebGPUProgram {
 
             setOutput(index, clamp(value, minVal, maxVal));
           }
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const userCode = `
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let index = globalId.x;
+        if(index < uniforms.size) {
+          let value = getAAtOutCoordsByGlobalId(globalId);
+          var clampedValue : vec4<f32>;
+          for (var i = 0u; i < 4u; i = i + 1u) {
+            if (isNanCustom(value[i])) {
+              clampedValue[i] = value[i];
+            } else {
+              clampedValue[i] = clamp(value[i], uniforms.minVal, uniforms.maxVal);
+            }
+          }
+
+          setOutputFlat(index, clampedValue);
+        }
       }
     `;
     return userCode;

--- a/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
@@ -17,8 +17,10 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
-import {WebGPUProgram} from './webgpu_program';
+
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class ConcatProgram implements WebGPUProgram {
   outputShape: number[];
@@ -30,6 +32,7 @@ export class ConcatProgram implements WebGPUProgram {
   workGroupSize: [number, number, number] = [64, 1, 1];
   shapes: Array<[number, number]>;
   size: number;
+  useWgsl: boolean;
 
   constructor(shapes: Array<[number, number]>) {
     this.outputShape =
@@ -44,6 +47,7 @@ export class ConcatProgram implements WebGPUProgram {
     // shapes is used by const snippets.
     this.shaderKey = `concat${shapes}`;
     this.size = util.sizeFromShape(this.outputShape);
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -81,6 +85,51 @@ export class ConcatProgram implements WebGPUProgram {
             ivec2 coords = getCoordsFromFlatIndex(flatIndex);
             int yR = coords.x;
             int yC = coords.y;
+
+            ${snippets.join('\n        ')}
+          }
+        }
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const offsets: number[] = new Array(this.shapes.length - 1);
+    const snippets: string[] = [];
+    if (offsets.length > 0) {
+      offsets[0] = this.shapes[0][1];
+      for (let i = 1; i < offsets.length; i++) {
+        offsets[i] = offsets[i - 1] + this.shapes[i][1];
+      }
+
+      snippets.push(`if (yC < ${
+          offsets[0]}u){ setOutput(coords.x, coords.y, getT0(yR, yC)); }`);
+      for (let i = 1; i < offsets.length; i++) {
+        const shift = offsets[i - 1];
+        snippets.push(
+            `elseif (yC < ${offsets[i]}u){ ` +
+            `setOutput(coords.x, coords.y, getT${i}(yR, yC - ${shift}u)); }`);
+      }
+      const lastIndex = offsets.length;
+      const lastShift = offsets[offsets.length - 1];
+      snippets.push(`else { setOutput(coords.x, coords.y, getT${
+          lastIndex}(yR, yC - ${lastShift}u)); }`);
+    } else {
+      snippets.push(`setOutput(coords.x, coords.y, getT0(yR, yC));`);
+    }
+
+    const userCode = `
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let index = globalId.x;
+
+        for(var i = 0u; i < ${this.workPerThread}u; i = i + 1u) {
+          let flatIndex = index * ${this.workPerThread}u + i;
+          if(flatIndex < uniforms.size) {
+            let coords = getCoordsFromFlatIndex(flatIndex);
+            let yR = coords.x;
+            let yC = coords.y;
 
             ${snippets.join('\n        ')}
           }

--- a/tfjs-backend-webgpu/src/kernels/crop_and_resize_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/crop_and_resize_webgpu.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class CropAndResizeProgram implements WebGPUProgram {
   outputShape: number[];
@@ -26,10 +27,12 @@ export class CropAndResizeProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['Image', 'Boxes', 'BoxInd'];
   uniforms = 'float extrapolationValue;';
+  uniformsWgsl = 'extrapolationValue : f32;';
   workGroupSize: [number, number, number] = [64, 1, 1];
   methodId: number;
   cropHeightBiggerThan1: boolean;
   cropWidthBiggerThan1: boolean;
+  useWgsl: boolean;
 
   constructor(
       channnel: number, boxShape: [number, number], cropSize: [number, number],
@@ -45,6 +48,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
     this.cropWidthBiggerThan1 = this.outputShape[2] > 1;
     this.shaderKey = `cropAndResize_${this.methodId}_${
         this.cropHeightBiggerThan1}_${this.cropWidthBiggerThan1}`;
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -133,6 +137,101 @@ export class CropAndResizeProgram implements WebGPUProgram {
             sourceFracIndexCR + vec2(0.5,0.5)));
           float newValue = getImage(
             bInd, sourceNearestCR.y, sourceNearestCR.x, d);
+          writeResult(coords,newValue);
+        }
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const [inputHeightFloat, inputWidthFloat] = [
+      `f32(uniforms.imageShape[1] - 1u)`, `f32(uniforms.imageShape[2] - 1u)`
+    ];
+
+    const [heightRatio, heightScale, inY] = this.cropHeightBiggerThan1 ?
+        [
+          `(${inputHeightFloat} / f32(uniforms.outShape[1] - 1u))`,
+          '(y2-y1) * height_ratio',
+          `y1*${inputHeightFloat} + f32(y)*(height_scale)`,
+        ] :
+        [
+          '0.0',
+          '0.0',
+          `0.5 * (y1+y2) * ${inputHeightFloat}`,
+        ];
+    const [widthRatio, widthScale, inX] = this.cropWidthBiggerThan1 ?
+        [
+          `(${inputWidthFloat} / f32(uniforms.outShape[2] - 1u))`,
+          '(x2-x1) * width_ratio',
+          `x1*${inputWidthFloat} + f32(x)*(width_scale)`,
+        ] :
+        [
+          '0.0',
+          '0.0',
+          `0.5 * (x1+x2) * ${inputWidthFloat}`,
+        ];
+
+    // Reference implementation
+    // tslint:disable-next-line:max-line-length
+    // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/crop_and_resize_op_gpu.cu.cc
+    const userCode = `
+      fn writeResult(coords : vec4<u32>, value : f32) {
+        if (coordsInBounds4D(coords, uniforms.outShape)) {
+          setOutput(coords[0], coords[1], coords[2], coords[3], value);
+        }
+      }
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let height_ratio = f32(${heightRatio});
+        let width_ratio = f32(${widthRatio});
+        let coords = getOutputCoords(globalId);
+        let b = coords[0];
+        let y = coords[1];
+        let x = coords[2];
+        let d = coords[3];
+        // get box vals
+        let y1 = getBoxes(b, 0u);
+        let x1 = getBoxes(b, 1u);
+        let y2 = getBoxes(b, 2u);
+        let x2 = getBoxes(b, 3u);
+        // get image in batch index
+        let bInd = i32(round(getBoxInd(b)));
+        if(bInd < 0 || bInd >= i32(uniforms.outShape[0])) {
+          return;
+        }
+        let height_scale = ${heightScale};
+        let width_scale = ${widthScale};
+        let in_y = ${inY};
+        if( in_y < 0.0 || in_y > ${inputHeightFloat} ) {
+          writeResult(coords, uniforms.extrapolationValue);
+          return;
+        }
+        let in_x = ${inX};
+        if( in_x < 0.0 || in_x > ${inputWidthFloat} ) {
+          writeResult(coords, uniforms.extrapolationValue);
+          return;
+        }
+        let sourceFracIndexCR = vec2<f32>(in_x,in_y);
+        if(${this.methodId} == 1) {
+          // Compute the four integer indices.
+          let sourceFloorCR = vec2<i32>(sourceFracIndexCR);
+          let sourceCeilCR = vec2<i32>(ceil(sourceFracIndexCR));
+          let topLeft = getImage(u32(bInd), u32(sourceFloorCR.y), u32(sourceFloorCR.x), d);
+          let bottomLeft = getImage(u32(bInd), u32(sourceCeilCR.y), u32(sourceFloorCR.x), d);
+          let topRight = getImage(u32(bInd), u32(sourceFloorCR.y), u32(sourceCeilCR.x), d);
+          let bottomRight = getImage(u32(bInd), u32(sourceCeilCR.y), u32(sourceCeilCR.x), d);
+          let fracCR = sourceFracIndexCR - vec2<f32>(sourceFloorCR);
+          let top = topLeft + (topRight - topLeft) * fracCR.x;
+          let bottom = bottomLeft + (bottomRight - bottomLeft) * fracCR.x;
+          let newValue = top + (bottom - top) * fracCR.y;
+          writeResult(coords, newValue);
+        } else {
+          // Compute the coordinators of nearest neighbor point.
+          let sourceNearestCR = vec2<i32>(floor(
+            sourceFracIndexCR + vec2<f32>(0.5,0.5)));
+          let newValue = getImage(
+            u32(bInd), u32(sourceNearestCR.y), u32(sourceNearestCR.x), d);
           writeResult(coords,newValue);
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
@@ -208,8 +208,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
       }
 
       ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
-      fn main([[builtin(local_invocation_id)]] localId : vec3<u32>,
-          [[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
         let coords = getOutputCoords(globalId);
         let batch = coords[0];
         let xRCCorner = vec2<i32>(coords.yz * uniforms.stride - uniforms.pad);

--- a/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/depthwise_conv2d_webgpu.ts
@@ -16,9 +16,12 @@
  */
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
+
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+
 import {mapActivationToShaderProgram} from './activation_util';
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class DepthwiseConv2DProgram implements WebGPUProgram {
   outputShape: number[];
@@ -27,12 +30,15 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'W'];
   uniforms = 'ivec2 pad, stride, dilation, inDims;';
+  uniformsWgsl =
+      `pad : vec2<u32>; stride : vec2<u32>; dilation : vec2<u32>; inDims : vec2<u32>;`;
   // This is an experimental value.
   workGroupSize: [number, number, number] = [256, 1, 1];
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
   activation: backend_util.Activation;
   hasPreluActivation: boolean;
+  useWgsl: boolean;
 
   constructor(
       convInfo: backend_util.Conv2DInfo, addBias = false,
@@ -57,6 +63,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
     this.addBias = addBias;
     this.activation = activation;
     this.hasPreluActivation = hasPreluActivation;
+    this.useWgsl = getUseWgsl();
 
     this.shaderKey = `depthwise_${this.convInfo.filterHeight}_${
         this.convInfo.filterWidth}_${this.activation}_${
@@ -151,6 +158,115 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
                 float xVal = getX(batch, xR, xC, d1);
                 float wVal = getW(wR, wC, d1, q);
                 dotProd += xVal * wVal;
+              }
+            }
+          }
+
+        ${addBiasSnippet}
+        ${applyActivationSnippet}
+        writeResult(batch, coords[1], coords[2], d2, dotProd);
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const channelMul = this.convInfo.outChannels / this.convInfo.inChannels;
+    let activationSnippet = '', applyActivationSnippet = '';
+    if (this.activation) {
+      const activationOp =
+          mapActivationToShaderProgram(this.activation, false, this.useWgsl);
+      if (this.hasPreluActivation) {
+        activationSnippet =
+            `fn activation(a : f32, globalId : vec3<u32>) -> f32 {
+          let b = getPreluActivationWeightsAtOutCoordsByGlobalId(globalId);
+          ${activationOp}
+        }`;
+      } else {
+        activationSnippet = `
+          fn activation(a : f32, globalId : vec3<u32>) -> f32 {
+            ${activationOp}
+          }
+        `;
+      }
+
+      applyActivationSnippet = `dotProd = activation(dotProd, globalId);`;
+    }
+
+    const addBiasSnippet = this.addBias ?
+        'dotProd = dotProd + getBiasAtOutCoordsByGlobalId(globalId);' :
+        '';
+
+    const userCode = `
+      ${activationSnippet}
+
+      fn writeResult(batch : u32, row : u32, col : u32, chan : u32, value : f32) {
+        let coord = vec4<u32>(batch, row, col, chan);
+        if (coordsInBounds4D(coord, uniforms.outShape)) {
+          setOutput(batch, row, col, chan, value);
+        }
+      }
+
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(local_invocation_id)]] localId : vec3<u32>,
+          [[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let coords = getOutputCoords(globalId);
+        let batch = coords[0];
+        let xRCCorner = vec2<i32>(coords.yz * uniforms.stride - uniforms.pad);
+        let d2 = coords[3];
+        let d1 = d2 / ${channelMul}u;
+        let q = d2 - d1 * ${channelMul}u;
+
+        let inputRowStart = xRCCorner.x;
+        let inputColStart = xRCCorner.y;
+        let inputRowEnd = inputRowStart + i32(${
+        this.convInfo.filterHeight}u * uniforms.dilation[0]);
+        let inputColEnd = inputColStart + i32(${
+        this.convInfo.filterWidth}u * uniforms.dilation[1]);
+
+        // Convolve x(?, ?, d1) with w(:, :, d1, q) to get y(yR, yC, d2).
+        // ? = to be determined. : = across all values in that axis.
+        var dotProd = 0.0;
+
+        // Extract if checking out of for loop for performance.
+        if (inputRowStart >= 0 && inputColStart >= 0 &&
+          inputRowEnd < i32(uniforms.inDims[0]) && inputColEnd < i32(uniforms.inDims[1]))
+          {
+            // Here using a constant value |this.convInfo.filterHeight| instead
+            // of uniform value is in order to loop unrolling.
+            for (var wR = 0u; wR < ${
+        this.convInfo.filterHeight}u; wR = wR + 1u) {
+              let xR = inputRowStart + i32(wR * uniforms.dilation[0]);
+
+              for (var wC = 0u; wC < ${
+        this.convInfo.filterWidth}u; wC = wC + 1u) {
+                let xC = inputColStart + i32(wC * uniforms.dilation[1]);
+
+                let xVal = getX(batch, u32(xR), u32(xC), d1);
+                let wVal = getW(wR, u32(wC), d1, q);
+                dotProd = dotProd + xVal * wVal;
+              }
+            }
+          } else {
+            for (var wR = 0u; wR < ${
+        this.convInfo.filterHeight}u; wR = wR + 1u) {
+              let xR = inputRowStart + i32(wR * uniforms.dilation[0]);
+
+              if (xR < 0 || xR >= i32(uniforms.inDims[0])) {
+                continue;
+              }
+
+              for (var wC = 0u; wC < ${
+        this.convInfo.filterWidth}u; wC = wC + 1u) {
+                let xC = inputColStart + i32(wC * uniforms.dilation[1]);
+
+                if (xC < 0 || xC >= i32(uniforms.inDims[1])) {
+                  continue;
+                }
+
+                let xVal = getX(batch, u32(xR), u32(xC), d1);
+                let wVal = getW(wR, wC, d1, q);
+                dotProd = dotProd + xVal * wVal;
               }
             }
           }

--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -69,7 +69,7 @@ export class FillProgram implements WebGPUProgram {
       for (var i = 0u; i < ${this.workPerThread}u; i = i + 1u) {
         let flatIndex = index * ${this.workPerThread}u + i;
         if (flatIndex < uniforms.size) {
-          setOutputFlat(flatIndex, f32(uniforms.value));
+          setOutputFlat(flatIndex, uniforms.value);
         }
       }
     }

--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -15,8 +15,11 @@
  * =============================================================================
  */
 import {util} from '@tensorflow/tfjs-core';
+
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
-import {WebGPUProgram} from './webgpu_program';
+
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class FillProgram implements WebGPUProgram {
   variableNames: string[] = [];
@@ -25,9 +28,11 @@ export class FillProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   uniforms = 'float value;';
+  uniformsWgsl = 'value : f32;';
   workPerThread = 4;
   workGroupSize: [number, number, number] = [16, 1, 1];
   size: number;
+  useWgsl: boolean;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
@@ -38,6 +43,7 @@ export class FillProgram implements WebGPUProgram {
 
     this.shaderKey = 'fill';
     this.size = util.sizeFromShape(this.outputShape);
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -48,6 +54,22 @@ export class FillProgram implements WebGPUProgram {
         int flatIndex = index * ${this.workPerThread} + i;
         if (flatIndex < size) {
           setOutput(flatIndex, float(value));
+        }
+      }
+    }
+  `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const userCode = `
+    ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+    fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+      let index = globalId.x;
+      for (var i = 0u; i < ${this.workPerThread}u; i = i + 1u) {
+        let flatIndex = index * ${this.workPerThread}u + i;
+        if (flatIndex < uniforms.size) {
+          setOutputFlat(flatIndex, f32(uniforms.value));
         }
       }
     }

--- a/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
@@ -18,14 +18,16 @@
 import {util} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType} from '../shader_preprocessor';
+import {getCoordsDataTypeWgsl, getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class MirrorPadProgram implements WebGPUProgram {
   outputShape: number[];
   shaderKey: string;
   uniforms = '';
+  uniformsWgsl = '';
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
@@ -33,6 +35,7 @@ export class MirrorPadProgram implements WebGPUProgram {
   xShape: number[];
   offset: number;
   size: number;
+  useWgsl: boolean;
 
   constructor(
       xShape: number[], paddings: Array<[number, number]>,
@@ -44,10 +47,14 @@ export class MirrorPadProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.xShape = xShape;
-    paddings.map((_, i) => this.uniforms += ` ivec2 pad${i};`);
+    paddings.map((_, i) => {
+      this.uniforms += ` ivec2 pad${i};`;
+      this.uniformsWgsl += ` pad${i} : vec2<u32>;`;
+    });
     this.offset = mode === 'reflect' ? 0 : 1;
     this.shaderKey = `mirrorPad_${mode}`;
     this.size = util.sizeFromShape(this.outputShape);
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -87,6 +94,49 @@ export class MirrorPadProgram implements WebGPUProgram {
           }
           ${dtype} coords = outC - start;
           setOutput(index, getX(${unpackedCoords}));
+        }
+      }
+    `;
+  }
+
+  getUserCodeWgsl(): string {
+    const rank = this.xShape.length;
+    // The length of paddings are same with the rank of the input tensor.
+    const start = this.xShape.map((_, i) => `uniforms.pad${i}[0]`).join(',');
+    const end = this.xShape
+                    .map(
+                        (_, i) => `uniforms.pad${i}[0] + uniforms.xShape${
+                            rank > 1 ? `[${i}]` : ''}`)
+                    .join(',');
+
+    const shaderStart = rank === 1 ? 'start' : 'start[i]';
+    const shaderEnd = rank === 1 ? 'end' : 'end[i]';
+    const shaderOutC = rank === 1 ? 'outC' : 'outC[i]';
+    const dtype = getCoordsDataTypeWgsl(rank);
+    const unpackedCoords = rank > 1 ?
+        ['coords[0]', 'coords[1]', 'coords[2]', 'coords[3]'].slice(0, rank) :
+        'coords';
+
+    return `
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let start = ${dtype}(${start});
+        let end = ${dtype}(${end});
+        var outC = getOutputCoords(globalId);
+        let index = globalId.x;
+        if (index < uniforms.size)
+        {
+          for (var i = 0u; i < ${rank}u; i = i + 1u) {
+            if (${shaderOutC} < ${shaderStart}) {
+              ${shaderOutC} = ${shaderStart} * 2u - ${shaderOutC} - ${
+        this.offset}u;
+            } elseif(${shaderOutC} >= ${shaderEnd}) {
+              ${shaderOutC} = (${shaderEnd} - 1u) * 2u - ${shaderOutC} + ${
+        this.offset}u;
+            }
+          }
+          let coords = outC - start;
+          setOutputFlat(index, getX(${unpackedCoords}));
         }
       }
     `;

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -18,9 +18,11 @@
 import {util} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType} from '../shader_preprocessor';
+import {getCoordsDataTypeWgsl} from '../shader_preprocessor_wgsl';
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class PadProgram implements WebGPUProgram {
   outputShape: number[];
@@ -29,9 +31,11 @@ export class PadProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'float constantValue;';
+  uniformsWgsl = 'constantValue : f32;';
   workGroupSize: [number, number, number] = [64, 1, 1];
   xShape: number[];
   size: number;
+  useWgsl: boolean;
 
   constructor(xShape: number[], paddings: Array<[number, number]>) {
     this.outputShape = paddings.map(
@@ -39,10 +43,14 @@ export class PadProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
-    paddings.map((_, i) => this.uniforms += ` ivec2 pad${i};`);
+    paddings.map((_, i) => {
+      this.uniforms += ` ivec2 pad${i};`;
+      this.uniformsWgsl += ` pad${i} : vec2<u32>;`;
+    });
     this.xShape = xShape;
     this.shaderKey = 'pad';
     this.size = util.sizeFromShape(this.outputShape);
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -83,6 +91,47 @@ export class PadProgram implements WebGPUProgram {
               setOutput(flatIndex, getX(${unpackedCoords}));
             }
           }
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const rank = this.xShape.length;
+    const type = getCoordsDataTypeWgsl(rank);
+    // The length of paddings are same with the rank of the input tensor.
+    const start = this.xShape.map((_, i) => `uniforms.pad${i}[0]`).join(',');
+    const end = this.xShape
+                    .map(
+                        (_, i) => `uniforms.pad${i}[0] + uniforms.xShape${
+                            rank > 1 ? `[${i}]` : ''}`)
+                    .join(',');
+    const startValue = rank > 1 ? `${type}(${start})` : `${start}`;
+    const endValue = rank > 1 ? `${type}(${end})` : `${end}`;
+
+    const leftPadCondition = rank > 1 ? `any(outC < start)` : `outC < start`;
+    const rightPadCondition = rank > 1 ? `any(outC >= end)` : `outC >= end`;
+
+    const unpackedCoords = rank > 1 ?
+        ['coords[0]', 'coords[1]', 'coords[2]', 'coords[3]'].slice(0, rank) :
+        'coords';
+
+    const userCode = `
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let start = ${startValue};
+        let end = ${endValue};
+        let flatIndex = globalId.x;
+        if (flatIndex < uniforms.size) {
+          let outC = getOutputCoords(globalId);
+
+          if (${leftPadCondition} || ${rightPadCondition}) {
+            setOutputFlat(flatIndex, uniforms.constantValue);
+          } else {
+            let coords = outC - start;
+            setOutputFlat(flatIndex, getX(${unpackedCoords}));
+          }
+        }
       }
     `;
     return userCode;

--- a/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool2d_webgpu.ts
@@ -17,9 +17,10 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class Pool2DProgram implements WebGPUProgram {
   outputShape: number[];
@@ -28,10 +29,13 @@ export class Pool2DProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'ivec2 pad, stride, dilation, convDims, filterDims;';
+  uniformsWgsl =
+      `pad : vec2<u32>; stride : vec2<u32>; dilation : vec2<u32>; convDims : vec2<u32>; filterDims : vec2<u32>;`;
   // TODO(jiajia.qin@intel.com): Dynamically choose different workGroupSize for
   // different output shapes.
   workGroupSize: [number, number, number] = [128, 1, 1];
   poolType: 'max'|'avg';
+  useWgsl: boolean;
 
   constructor(convInfo: backend_util.Conv2DInfo, poolType: 'max'|'avg') {
     this.outputShape = convInfo.outShape;
@@ -43,6 +47,7 @@ export class Pool2DProgram implements WebGPUProgram {
 
     this.shaderKey = `pool2D_${poolType}`;
     this.poolType = poolType;
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -83,6 +88,56 @@ export class Pool2DProgram implements WebGPUProgram {
               }
 
               float value = getX(batch, xR, xC, coords[3]);
+              ${updateSnippet}
+            }
+          }
+
+          setOutput(batch, coords[1], coords[2], coords[3], ${returnValue});
+        }
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    let updateSnippet = `resultValue = max(value, resultValue);`;
+    if (this.poolType === 'avg') {
+      updateSnippet = `resultValue = resultValue + value; count = count + 1.0;`;
+    }
+
+    let returnValue = `resultValue`;
+    if (this.poolType === 'avg') {
+      returnValue = `resultValue / count`;
+    }
+
+    const userCode = `
+    ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+    fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let coords = getOutputCoords(globalId);
+        if (coordsInBounds4D(coords, uniforms.outShape)) {
+          let batch = coords[0];
+          let xRCCorner = vec2<i32>(coords.yz * uniforms.stride - uniforms.pad);
+          let xRCorner = xRCCorner.x;
+          let xCCorner = xRCCorner.y;
+
+          var resultValue = ${
+        this.poolType === 'avg' ? '0.0' : '-1.0 / pow(10.0, -20.0)'};
+          var count = 0.0;
+
+          for (var wR = 0u; wR < uniforms.filterDims.x; wR = wR + uniforms.dilation.x) {
+            let xR = xRCorner + i32(wR);
+
+            if (xR < 0 || xR >= i32(uniforms.convDims.x)) {
+              continue;
+            }
+
+            for (var wC = 0u; wC < uniforms.filterDims.y; wC = wC + uniforms.dilation.y) {
+              let xC = xCCorner + i32(wC);
+              if (xC < 0 || xC >= i32(uniforms.convDims.y)) {
+                continue;
+              }
+
+              let value = getX(batch, u32(xR), u32(xC), coords[3]);
               ${updateSnippet}
             }
           }

--- a/tfjs-backend-webgpu/src/kernels/pool_filtersizeone_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool_filtersizeone_webgpu.ts
@@ -17,9 +17,10 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
   outputShape: number[];
@@ -28,7 +29,10 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'ivec2 pad, stride, dilation, convDims, filterDims;';
+  uniformsWgsl =
+      `pad : vec2<u32>; stride : vec2<u32>; dilation : vec2<u32>; convDims : vec2<u32>; filterDims : vec2<u32>;`;
   workGroupSize: [number, number, number] = [256, 1, 1];
+  useWgsl: boolean;
 
   constructor(convInfo: backend_util.Conv2DInfo) {
     this.outputShape = convInfo.outShape;
@@ -38,6 +42,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.shaderKey = 'poolWithFilterSizeEqualsOne';
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -53,6 +58,27 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
           int xCCorner = xRCCorner.y;
 
           float value = getX(batch, xRCorner, xCCorner, d);
+          setOutput(batch, coords[1], coords[2], d, value);
+        }
+      }
+    `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const userCode = `
+    ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+    fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let coords = getOutputCoords(globalId);
+        let batch = coords[0];
+        let d = coords[3];
+
+        if (all(coords < uniforms.outShape)) {
+          let xRCCorner = coords.yz * uniforms.stride;
+          let xRCorner = xRCCorner.x;
+          let xCCorner = xRCCorner.y;
+
+          let value = getX(batch, xRCorner, xCCorner, d);
           setOutput(batch, coords[1], coords[2], d, value);
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/pool_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool_webgpu_test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {test_util} from '@tensorflow/tfjs-core';
+import {describeWebGPU} from '../test_util';
+
+const expectArraysClose = test_util.expectArraysClose;
+
+describeWebGPU('pool', () => {
+  // For PoolWithFilterSizeEqualsOneProgram. This case will fail wasm, so keep
+  // it here. Wasm bug: https://github.com/tensorflow/tfjs/issues/5471.
+  it('x=[4,4,1] f=[1,1] s=2 d=1', async () => {
+    // Feed forward.
+    const a = tf.tensor3d(
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], [4, 4, 1]);
+
+    const windowShape = 1;
+    const padding = 0;
+    const dilationRate: number = undefined;
+    const strides = 2;
+
+    const result =
+        tf.pool(a, windowShape, 'avg', padding, dilationRate, strides);
+
+    expect(result.shape).toEqual([2, 2, 1]);
+    expectArraysClose(await result.data(), [0, 2, 8, 10]);
+  });
+});

--- a/tfjs-backend-webgpu/src/kernels/pool_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/kernels/pool_webgpu_test.ts
@@ -24,6 +24,7 @@ const expectArraysClose = test_util.expectArraysClose;
 describeWebGPU('pool', () => {
   // For PoolWithFilterSizeEqualsOneProgram. This case will fail wasm, so keep
   // it here. Wasm bug: https://github.com/tensorflow/tfjs/issues/5471.
+  // TODO(xing.xu): https://github.com/tensorflow/tfjs/issues/5506.
   it('x=[4,4,1] f=[1,1] s=2 d=1', async () => {
     // Feed forward.
     const a = tf.tensor3d(

--- a/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
@@ -28,7 +28,7 @@ export class SelectProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [16, 1, 1];
+  workGroupSize: [number, number, number] = [64, 1, 1];
   cRank: number;
   rank: number;
   size: number;

--- a/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
@@ -17,9 +17,10 @@
 import {util} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType} from '../shader_preprocessor';
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class SelectProgram implements WebGPUProgram {
   variableNames = ['c', 'a', 'b'];
@@ -27,23 +28,23 @@ export class SelectProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workPerThread = 4;
   workGroupSize: [number, number, number] = [16, 1, 1];
   cRank: number;
   rank: number;
   size: number;
+  useWgsl: boolean;
 
   constructor(cRank: number, shape: number[], rank: number) {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
-        [this.workPerThread, 1, 1]);
+        this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.cRank = cRank;
     this.rank = rank;
     this.shaderKey = 'select';
     this.size = util.sizeFromShape(this.outputShape);
+    this.useWgsl = getUseWgsl();
   }
 
   getUserCode(): string {
@@ -74,18 +75,57 @@ export class SelectProgram implements WebGPUProgram {
     const userCode = `
       void main() {
         int index = int(gl_GlobalInvocationID.x);
+        if (index < size) {
+          ${dtype} resRC = getOutputCoords();
 
-        for (int i = 0; i < ${this.workPerThread}; i++) {
-          int flatIndex = index * ${this.workPerThread} + i;
+          float cVal = getC(${cCoords});
+          if (cVal >= 1.0) {
+            setOutput(index, getA(${abCoords}));
+          } else {
+            setOutput(index, getB(${abCoords}));
+          }
+        }
+      }
+    `;
+    return userCode;
+  }
 
-          if (flatIndex < size) {
-            ${dtype} resRC = getOutputCoords();
-            float cVal = getC(${cCoords});
-            if (cVal >= 1.0) {
-              setOutput(flatIndex,getA(${abCoords}));
-            } else {
-              setOutput(flatIndex,getB(${abCoords}));
-            }
+  getUserCodeWgsl(): string {
+    // TODO(WGSL): below code can be merged with getUserCode.
+    let cCoords;
+    let abCoords;
+    if (this.rank > 4) {
+      throw Error(`Where for rank ${this.rank} is not yet supported`);
+    }
+
+    if (this.rank === 1) {
+      abCoords = `resRC`;
+      cCoords = `resRC`;
+    } else {
+      const currentCoords = ['resRC.x', 'resRC.y', 'resRC.z', 'resRC.w'];
+      const cCoordVars = [];
+      const abCoordVars = [];
+      for (let i = 0; i < this.outputShape.length; i++) {
+        abCoordVars.push(`${currentCoords[i]}`);
+        if (i < this.cRank) {
+          cCoordVars.push(`${currentCoords[i]}`);
+        }
+      }
+      cCoords = cCoordVars.join();
+      abCoords = abCoordVars.join();
+    }
+
+    const userCode = `
+      ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+      fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+        let index = globalId.x;
+        if (index < uniforms.size) {
+          let resRC = getOutputCoords(globalId);
+          let cVal = getC(${cCoords});
+          if (cVal >= 1.0) {
+            setOutputFlat(index, getA(${abCoords}));
+          } else {
+            setOutputFlat(index, getB(${abCoords}));
           }
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/transform_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transform_webgpu.ts
@@ -15,18 +15,22 @@
  * =============================================================================
  */
 
+import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
-import {WebGPUProgram} from './webgpu_program';
+import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
 export class TransformProgram implements WebGPUProgram {
   variableNames = ['Image', 'Transforms'];
   outputShape: number[];
   uniforms = 'int interpolationModeId; int fillModeId; float fillValue;';
+  uniformsWgsl =
+      'interpolationModeId : i32; fillModeId : i32; fillValue : f32;';
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [64, 1, 1];
+  useWgsl: boolean;
 
   constructor(outShape: [number, number, number, number]) {
     this.outputShape = outShape;
@@ -34,6 +38,7 @@ export class TransformProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
     this.shaderKey = 'transform';
+    this.useWgsl = getUseWgsl();
   }
   getUserCode(): string {
     const userCode = `
@@ -143,6 +148,128 @@ export class TransformProgram implements WebGPUProgram {
                   readWithFillValue(batch, int(yCeil), int(xFloor), channel) +
                   (mapX - xFloor) *
                   readWithFillValue(batch, int(yCeil), int(xCeil), channel);
+                  outputValue = (yCeil - mapY) * valueYFloor +
+                  (mapY - yFloor) * valueYCeil;
+                }
+              }
+              setOutput(coords[0], coords[1], coords[2], coords[3], outputValue);
+            }
+          }
+        `;
+    return userCode;
+  }
+
+  getUserCodeWgsl(): string {
+    const userCode = `
+          fn mapCoord(outCoord : f32, len : f32) -> f32{
+            var inCoord = outCoord;
+            if(uniforms.fillModeId == 2) {
+              if (inCoord < 0.0) {
+                if (len <= 1.0) {
+                  inCoord = 0.0;
+                } else {
+                  let sz2 = 2.0 * len;
+                  if (inCoord < sz2) {
+                    inCoord = sz2 * f32(i32(f32(-inCoord / sz2))) +
+                    inCoord;
+                  }
+                  if (inCoord < -len) {
+                    inCoord = inCoord + sz2;
+                  } else {
+                    inCoord = -inCoord - 1.0;
+                  }
+                }
+              } elseif (inCoord > len - 1.0) {
+                if (len <= 1.0) {
+                  inCoord = 0.0;
+                } else {
+                  let sz2 = 2.0 * len;
+                  inCoord = inCoord - sz2 * f32(i32(f32(inCoord / sz2)));
+                  if (inCoord >= len) {
+                    inCoord = sz2 - inCoord - 1.0;
+                  }
+                }
+              }
+              return clamp(inCoord, 0.0, len - 1.0);
+            } elseif (uniforms.fillModeId == 3) {
+              if (inCoord < 0.0) {
+                if (len <= 1.0) {
+                  inCoord = 0.0;
+                } else {
+                  let sz = len - 1.0;
+                  inCoord = inCoord + len * (f32(i32(f32(-inCoord / sz))) + 1.0);
+                }
+              } elseif (inCoord > len - 1.0) {
+                if (len <= 1.0) {
+                  inCoord = 0.0;
+                } else {
+                  let sz = len - 1.0;
+                  inCoord = inCoord - len * f32(i32(f32(inCoord / sz)));
+                }
+              }
+              return clamp(inCoord, 0.0, len - 1.0);
+            } elseif (uniforms.fillModeId == 4) {
+              return clamp(outCoord, 0.0, len - 1.0);
+            }
+            return outCoord;
+          }
+          fn readWithFillValue(batch : i32, coordY : i32, coordX : i32,
+            channel : i32) -> f32 {
+            var outputValue : f32;
+            if (0 <= coordY && coordY < i32(uniforms.imageShape[1]) && 0 <= coordX && coordX < i32(uniforms.imageShape[2])) {
+                outputValue = getImage(u32(batch), u32(coordY), u32(coordX), u32(channel));
+            } else {
+              outputValue = uniforms.fillValue;
+            }
+            return outputValue;
+          }
+
+          ${getWorkGroupSizeStringWgsl(this.workGroupSize)}
+          fn main([[builtin(global_invocation_id)]] globalId : vec3<u32>) {
+            let coords = getOutputCoords(globalId);
+            if (coordsInBounds4D(coords, uniforms.outShape)) {
+              var outputValue : f32;
+              let batch = coords[0];
+              let x = coords[2];
+              let y = coords[1];
+              let channel = coords[3];
+              let xf = f32(x);
+              let yf = f32(y);
+              let a1 = getTransforms(batch, 0u);
+              let a2 = getTransforms(batch, 1u);
+              let a3 = getTransforms(batch, 2u);
+              let b1 = getTransforms(batch, 3u);
+              let b2 = getTransforms(batch, 4u);
+              let b3 = getTransforms(batch, 5u);
+              let c1 = getTransforms(batch, 6u);
+              let c2 = getTransforms(batch, 7u);
+              let projection = c1 * xf + c2 * yf + 1.0;
+              if (projection == 0.0) {
+                outputValue = uniforms.fillValue;
+              } else {
+                let inX = (a1 * xf + a2 * yf + a3) / projection;
+                let inY = (b1 * xf + b2 * yf + b3) / projection;
+                let mapX = mapCoord(inX, f32(uniforms.imageShape[2]));
+                let mapY = mapCoord(inY, f32(uniforms.imageShape[1]));
+
+                if (uniforms.interpolationModeId == 1) {
+                  let coordY = i32(round(mapY));
+                  let coordX = i32(round(mapX));
+                  outputValue = readWithFillValue(i32(batch), coordY, coordX,
+                    i32(channel));
+                } else {
+                  let yFloor = floor(mapY);
+                  let xFloor = floor(mapX);
+                  let yCeil = yFloor + 1.0;
+                  let xCeil = xFloor + 1.0;
+                  let valueYFloor = (xCeil - mapX) *
+                  readWithFillValue(i32(batch), i32(yFloor), i32(xFloor), i32(channel)) +
+                  (mapX - xFloor) *
+                  readWithFillValue(i32(batch), i32(yFloor), i32(xCeil), i32(channel));
+                  let valueYCeil = (xCeil - mapX) *
+                  readWithFillValue(i32(batch), i32(yCeil), i32(xFloor), i32(channel)) +
+                  (mapX - xFloor) *
+                  readWithFillValue(i32(batch), i32(yCeil), i32(xCeil), i32(channel));
                   outputValue = (yCeil - mapY) * valueYFloor +
                   (mapY - yFloor) * valueYCeil;
                 }

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -624,7 +624,13 @@ const TEST_FILTERS: TestFilter[] = [
     excludes: ['upcasts when dtypes dont match']  // Not yet supported.
   },
   {startsWith: 'gatherND '},
-  {include: 'image.transform'}
+  {include: 'image.transform'},
+  {
+    startsWith: 'where ',
+    excludes: [
+      'gradient'  // gradient function not found.
+    ]
+  },
 ];
 
 const customInclude = (testName: string) => {

--- a/tfjs-core/src/ops/avg_pool_test.ts
+++ b/tfjs-core/src/ops/avg_pool_test.ts
@@ -101,8 +101,7 @@ describeWithFlags('avgPool', ALL_ENVS, () => {
     const result = tf.avgPool(x, 3, 1, padding);
 
     expect(result.shape).toEqual([4, 2, 1]);
-    expectArraysClose(
-        await result.data(), [2.5, 3, 4, 4.5, 5.5, 6, 7, 7.5]);
+    expectArraysClose(await result.data(), [2.5, 3, 4, 4.5, 5.5, 6, 7, 7.5]);
   });
 
   it('x=[2,2,3] f=[1,1] s=2 p=1 dimRoundingMode=floor', () => {
@@ -156,8 +155,7 @@ describeWithFlags('avgPool', ALL_ENVS, () => {
     const dy = tf.tensor3d([0, 3, 0, 6, 0, 9, 0, 12], [4, 2, 1]);
     const dx = tf.grad((x: tf.Tensor3D) => x.avgPool(3, 1, padding))(x, dy);
     expect(dx.shape).toEqual(x.shape);
-    expectArraysClose(
-        await dx.data(), [0, 1, 1, 0, 2, 2, 0, 3, 3]);
+    expectArraysClose(await dx.data(), [0, 1, 1, 0, 2, 2, 0, 3, 3]);
   });
 
   it('gradient x=[2,3,3,1] f=[2,2], s=1', async () => {

--- a/tfjs-core/src/ops/clip_by_value_test.ts
+++ b/tfjs-core/src/ops/clip_by_value_test.ts
@@ -30,6 +30,16 @@ describeWithFlags('clipByValue', ALL_ENVS, () => {
     expectArraysClose(await result.data(), [3, -1, 0, 50, -1, 2]);
   });
 
+  it('basic vec4', async () => {
+    const a = tf.tensor1d([3, -1, 0, 100, -7, 2, 5, NaN]);
+    const min = -1;
+    const max = 50;
+
+    const result = tf.clipByValue(a, min, max);
+
+    expectArraysClose(await result.data(), [3, -1, 0, 50, -1, 2, 5, NaN]);
+  });
+
   it('propagates NaNs', async () => {
     const a = tf.tensor1d([3, -1, 0, 100, -7, 2, NaN]);
     const min = -1;


### PR DESCRIPTION
Changed programs:
```
addn_packed_webgpu.ts
batchnorm_webgpu.ts
clip_vec4_webgpu.ts
clip_webgpu.ts
concat_webgpu.ts
crop_and_resize_webgpu.ts
depthwise_conv2d_webgpu.ts
fill_webgpu.ts
gather_nd_webgpu.ts
gather_webgpu.ts
mirror_pad_webgpu.ts
pad_webgpu.ts
pool2d_webgpu.ts
pool_filtersizeone_webgpu.ts
resize_bilinear_webgpu.ts
select_webgpu.ts
slice_webgpu.ts
strided_slice_webgpu.ts
tile_webgpu.ts
transform_webgpu.ts
transpose_shared_webgpu.ts
transpose_webgpu.ts
```

To test WGSL, change WEBGPU_USE_GLSL in tfjs-backend-webgpu/src/flags_webgpu.ts to true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5403)
<!-- Reviewable:end -->
