### PR TITLE
Use absolute import for version_test

### DIFF
--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 # =============================================================================
 
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "nodejs_test", "pkg_npm")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm")
 load("//tools:copy_to_dist.bzl", "copy_to_dist")
 load("//tools:tfjs_bundle.bzl", "tfjs_bundle")
 

--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -23,7 +23,6 @@ nodejs_test(
     name = "tfjs-backend-cpu_test",
     data = [
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_test_lib",
-        "//tfjs-core:package_json",
     ],
     entry_point = "//tfjs-backend-cpu/src:run_tests.ts",
     link_workspace_root = True,
@@ -99,12 +98,5 @@ pkg_npm(
     deps = [
         ":copy_bundles",
         ":copy_src_to_dist",
-    ],
-)
-
-js_library(
-    name = "package_json",
-    srcs = [
-        ":package.json",
     ],
 )

--- a/tfjs-backend-webgl/BUILD.bazel
+++ b/tfjs-backend-webgl/BUILD.bazel
@@ -14,7 +14,7 @@
 # =============================================================================
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:copy_to_dist.bzl", "copy_to_dist")
 load("//tools:tfjs_bundle.bzl", "tfjs_bundle")
 load("//tools:tfjs_web_test.bzl", "tfjs_web_test")

--- a/tfjs-backend-webgl/BUILD.bazel
+++ b/tfjs-backend-webgl/BUILD.bazel
@@ -113,10 +113,3 @@ tfjs_web_test(
         "//tfjs-core:tf-core.min.js.map",
     ],
 )
-
-js_library(
-    name = "package_json",
-    srcs = [
-        ":package.json",
-    ],
-)

--- a/tfjs-backend-webgl/src/BUILD.bazel
+++ b/tfjs-backend-webgl/src/BUILD.bazel
@@ -79,7 +79,6 @@ esbuild(
     deps = [
         ":tfjs-backend-webgl_lib",
         ":tfjs-backend-webgl_test_lib",
-        "//tfjs-backend-webgl:package_json",
         "//tfjs-core/src:tfjs-core_test_bundle",
     ],
 )

--- a/tfjs-core/BUILD.bazel
+++ b/tfjs-core/BUILD.bazel
@@ -181,7 +181,7 @@ nodejs_test(
 # the package.json so src/version_test.ts can 'require()' it.
 js_library(
     name = "package_json",
-    package_name = "tfjs-core",
+    package_name = "@tensorflow/tfjs-core",
     srcs = [
         ":package.json",
     ],

--- a/tfjs-core/src/version_test.ts
+++ b/tfjs-core/src/version_test.ts
@@ -19,20 +19,7 @@ import {version_core} from './index';
 
 describe('version', () => {
   it('version is contained', () => {
-    let expected: string;
-    // Due to the difference between esbuild and bazel we need to try both
-    // reltive and full path to load the package.json file.
-    try {
-      // For esbuild, the package.json need to be loaded with relative path.
-      // tslint:disable-next-line:no-require-imports
-      expected = require('../package.json').version;
-      console.log(expected);
-    } catch (e) {
-      // In bazel nodejs test, the package.json is exported as js_library with
-      // name tfjs-core. require will need the full path.
-      // tslint:disable-next-line:no-require-imports
-      expected = require('tfjs-core/package.json').version;
-    }
+    const expected = require('@tensorflow/tfjs-core/package.json').version;
     expect(version_core).toBe(expected);
   });
 });


### PR DESCRIPTION
Use an absolute import, `@tensorflow/tfjs-core/package.json`, for the version test. This works for both node and the browser test bundle and also works when running tests outside of Bazel.

Also, remove some unneeded `package_json` targets from other BUILD files.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5416)
<!-- Reviewable:end -->
