### PR TITLE
Fix enumerate_tests.bzl on Windows

### DIFF
--- a/tools/enumerate-tests.ts
+++ b/tools/enumerate-tests.ts
@@ -52,7 +52,7 @@ const parser = new ArgumentParser({
       + " other packages (e.g. WebGPU).",
 });
 
-parser.addArgument('tests', {action: 'store', type: String, nargs: '+'});
+parser.addArgument('test_file_list', {action: 'store', type: String});
 parser.addArgument(['-o', '--output'], {
   action: 'store',
   required: true,
@@ -66,8 +66,14 @@ parser.addArgument(['-r', '--root'], {
 
 const args = parser.parseArgs();
 
+const tests_file_contents = fs.readFileSync(args.test_file_list, 'utf8');
+if (! tests_file_contents) {
+  throw new Error(`Failed to read tests file ${args.test_file_list}`);
+}
+const tests = tests_file_contents.split('\n');
+
 const root: string = path.normalize(args.root);
-const files = (args.tests as string[]).map(filePath => {
+const files = tests.map(filePath => {
   const normalized = path.normalize(filePath);
   if (normalized.slice(0, root.length) !== root) {
     throw new Error(`File ${normalized} is not under root path ${root}`);

--- a/tools/enumerate_tests.bzl
+++ b/tools/enumerate_tests.bzl
@@ -4,20 +4,26 @@ def _enumerate_tests_impl(ctx):
     output_file = ctx.actions.declare_file(ctx.attr.name + ".ts")
     input_paths = [src.path for src in ctx.files.srcs]
 
+    input_paths_file = ctx.actions.declare_file("enumerate_tests_paths")
+    ctx.actions.write(input_paths_file, "\n".join(input_paths))
+
     run_node(
         ctx,
         executable = "enumerate_tests_bin",
-        inputs = ctx.files.srcs,
+        inputs = ctx.files.srcs + [input_paths_file],
         outputs = [output_file],
         arguments = [
             "-r",
             ctx.attr.root_path,
             "-o",
             output_file.path,
-        ] + input_paths,
+            input_paths_file.path,
+        ],
     )
 
-    return [DefaultInfo(files = depset([output_file]))]
+    return [DefaultInfo(
+        files = depset([output_file]),
+    )]
 
 enumerate_tests = rule(
     implementation = _enumerate_tests_impl,

--- a/tools/enumerate_tests.bzl
+++ b/tools/enumerate_tests.bzl
@@ -21,9 +21,7 @@ def _enumerate_tests_impl(ctx):
         ],
     )
 
-    return [DefaultInfo(
-        files = depset([output_file]),
-    )]
+    return [DefaultInfo(files = depset([output_file]))]
 
 enumerate_tests = rule(
     implementation = _enumerate_tests_impl,


### PR DESCRIPTION
Pass test file paths in a temp file instead of through command line arguments.

Fixes #5420. Verified by building on Windows using git bash.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5424)
<!-- Reviewable:end -->
