### PR TITLE
Use ImportToTexture to handle video in FromPixels

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -26,16 +26,12 @@ import {BufferManager} from './buffer_manager';
 import {FromPixelsProgram} from './kernels/FromPixels_utils/from_pixels_webgpu';
 import * as webgpu_program from './kernels/webgpu_program';
 import * as webgpu_util from './webgpu_util';
+import {WebGPULayout} from './webgpu_util';
 
 export interface WebGPUMemoryInfo extends backend_util.MemoryInfo {
   numBytesInGPU: number;
   numBytesAllocatedInGPU: number;
   unreliable: boolean;
-}
-
-export interface WebGPULayout {
-  bindGroupLayout: GPUBindGroupLayout;
-  pipelineLayout: GPUPipelineLayout;
 }
 
 type BufferInfo = {

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -78,4 +78,4 @@ ENV.registerFlag('WEBGPU_USE_PROFILE_TOOL', () => false);
 /**
  * Whether to use import API.
  */
-ENV.registerFlag('WEBGPU_USE_IMPORT', () => false);
+ENV.registerFlag('WEBGPU_USE_IMPORT', () => true);

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -42,7 +42,7 @@ ENV.registerFlag('WEBGPU_USE_NAIVE_CONV2D', () => false);
 /**
  * Whether to use GLSL shading language.
  */
- ENV.registerFlag('WEBGPU_USE_GLSL', () => true);
+ENV.registerFlag('WEBGPU_USE_GLSL', () => true);
 
 /**
  * Whether to use conv2dTranspose_naive which directly implement the
@@ -74,3 +74,8 @@ ENV.registerFlag('CPU_HANDOFF_SIZE_THRESHOLD', () => 128);
  * TFJS webgpu backend.
  */
 ENV.registerFlag('WEBGPU_USE_PROFILE_TOOL', () => false);
+
+/**
+ * Whether to use import API.
+ */
+ENV.registerFlag('WEBGPU_USE_IMPORT', () => false);

--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -20,7 +20,7 @@ import {FromPixels, FromPixelsAttrs, FromPixelsInputs} from '@tensorflow/tfjs-co
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {fromPixelsExternalImage} from './FromPixelsExternalImage';
+import {fromPixelsExternalImage, fromPixelsImportTexture} from './FromPixelsExternalImage';
 
 export const fromPixelsConfig: KernelConfig = {
   kernelName: FromPixels,
@@ -58,6 +58,12 @@ export function fromPixels(args: {
           `ImageBitmap ` +
           `or {data: Uint32Array, width: number, height: number}, ` +
           `but was ${(pixels as {}).constructor.name}`);
+    }
+
+    if (env().getBool('WEBGPU_USE_IMPORT')) {
+      if (pixels instanceof HTMLVideoElement) {
+        return fromPixelsImportTexture({externalImage: pixels, backend, attrs});
+      }
     }
 
     if (pixels instanceof HTMLVideoElement ||

--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -20,7 +20,7 @@ import {FromPixels, FromPixelsAttrs, FromPixelsInputs} from '@tensorflow/tfjs-co
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {fromPixelsExternalImage, fromPixelsImportTexture} from './FromPixelsExternalImage';
+import {fromPixelsExternalImage} from './FromPixelsExternalImage';
 
 export const fromPixelsConfig: KernelConfig = {
   kernelName: FromPixels,
@@ -62,7 +62,8 @@ export function fromPixels(args: {
 
     if (env().getBool('WEBGPU_USE_IMPORT')) {
       if (pixels instanceof HTMLVideoElement) {
-        return fromPixelsImportTexture({externalImage: pixels, backend, attrs});
+        return fromPixelsExternalImage(
+            {externalImage: pixels, backend, attrs, useImport: true});
       }
     }
 
@@ -78,7 +79,8 @@ export function fromPixels(args: {
     }
 
     if (pixels instanceof ImageBitmap || pixels instanceof HTMLCanvasElement) {
-      return fromPixelsExternalImage({externalImage: pixels, backend, attrs});
+      return fromPixelsExternalImage(
+          {externalImage: pixels, backend, attrs, useImport: false});
     }
   }
 

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_import_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_import_webgpu.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC. All Rights Reserved.
+ * Copyright 2021 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_import_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_import_webgpu.ts
@@ -15,11 +15,11 @@
  * =============================================================================
  */
 
-import {WebGPULayout} from '../../backend_webgpu';
+import {WebGPULayout} from '../../webgpu_util';
 import {FromPixelsProgram} from './from_pixels_webgpu';
 
 export class FromPixelsImportProgram extends FromPixelsProgram {
-  useWgsl: boolean = true;
+  useWgsl = true;
   layout: WebGPULayout = null;
 
   getUserCodeWgsl(): string {

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_import_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_import_webgpu.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {FromPixelsProgram} from './from_pixels_webgpu';
+
+export class FromPixelsImportProgram extends FromPixelsProgram {
+  useWgsl = true;
+
+  getUserCodeWgsl(): string {
+    const userCode = `
+    [[binding(2), group(0)]] var src: texture_external;
+
+    [[stage(compute), workgroup_size(${this.workGroupSize[0]}, 1, 1)]]
+    fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
+      var flatIndexBase = i32(GlobalInvocationID.x) * uniforms.numChannels;
+      var coords: vec3<u32> = getCoordsFromFlatIndex(u32(flatIndexBase));
+      var texR: i32 = i32(coords[0]);
+      var texC: i32 = i32(coords[1]);
+      var depth: i32 = i32(coords[2]);
+      var values = textureLoad(src, vec2<i32>(texC, texR));
+      for (var i: i32 = 0; i < uniforms.numChannels; i = i + 1) {
+        var value = values[i];
+        var flatIndex = i32(flatIndexBase) + i;
+        if (flatIndex < uniforms.size) {
+          result.numbers[u32(flatIndex)] = i32(floor(255.0 * value));
+        }
+      }
+    }
+`;
+    return userCode;
+  }
+
+  getImportTexture(device: GPUDevice, externalImage: HTMLVideoElement):
+      GPUExternalTexture {
+    const externalTextureDescriptor = {source: externalImage};
+    return device.importExternalTexture(externalTextureDescriptor);
+  }
+}

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -53,8 +53,7 @@ export class FromPixelsProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
   }
 
-  constructor(outputShape: number[]) {
-    this.updateOutputShape(outputShape);
+  constructor() {
     this.shaderKey = 'fromPixels';
   }
 

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -132,7 +132,7 @@ export class FromPixelsProgram implements WebGPUProgram {
         size: [pixelWidth, pixelHeight],
         format: 'rgba8unorm',
         usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE |
-               GPUTextureUsage.RENDER_ATTACHMENT,
+            GPUTextureUsage.RENDER_ATTACHMENT,
       });
       this.lastPixelSize.width = pixelWidth;
       this.lastPixelSize.height = pixelHeight;

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -16,9 +16,8 @@
  */
 
 import {util} from '@tensorflow/tfjs-core';
-import {WebGPULayout} from '../../backend_webgpu';
 
-import {computeDispatch, flatDispatchLayout} from '../../webgpu_util';
+import {computeDispatch, flatDispatchLayout, WebGPULayout} from '../../webgpu_util';
 import {WebGPUProgram} from '../webgpu_program';
 
 export class FromPixelsProgram implements WebGPUProgram {

--- a/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
@@ -80,9 +80,31 @@ export function getWorkGroupSizeStringWgsl(
 export function makeShader(
     inputInfo: InputInfo[], outputData: {dtype: DataType, shape: number[]},
     program: ProgramParams, isFromPixel = false): string {
-  const prefixSnippets: string[] = [];
+  if (isFromPixel === true) {
+    const getCoords = generateGetCoordsFromFlatIndex(outputData.shape);
+    const outputBufferStr = `
+      [[block]] struct Matrix0 {
+        numbers: array<${mapToTypesWgsl(outputData.dtype, program.isVec4)}>;
+      };
+      [[block]] struct Uniform {
+        size            : i32;
+        numChannels     : i32;
+        outShapeStrides : vec2<u32>;
+      };
 
-  let uniformDeclaration = '[[block]] struct Uniforms { NAN : f32; ';
+      [[group(0), binding(0)]] var<storage, write> result : Matrix0;
+      [[group(0), binding(1)]] var<uniform> uniforms: Uniform;
+    `;
+    return [
+      SHADER_PREFIX,
+      outputBufferStr,
+      getCoords,
+      program.getUserCodeWgsl(),
+    ].join('\n');
+  }
+
+  const prefixSnippets: string[] = [];
+  let uniformDeclaration = '[[block]] struct Uniforms { NAN : u32; ';
   program.variableNames.forEach((x, i) => {
     uniformDeclaration += `${x.charAt(0).toLowerCase() + x.slice(1)}Shape : ${
         getCoordsDataTypeWgsl(inputInfo[i].shape.length)}; `;

--- a/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
@@ -93,7 +93,7 @@ export function makeShader(
       };
 
       [[group(0), binding(0)]] var<storage, write> result : Matrix0;
-      [[group(0), binding(1)]] var<uniform> uniforms: Uniform;
+      [[group(0), binding(2)]] var<uniform> uniforms: Uniform;
     `;
     return [
       SHADER_PREFIX,

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -157,3 +157,8 @@ export function isWebGPUSupported(): boolean {
   }
   return true;
 }
+
+export interface WebGPULayout {
+  bindGroupLayout: GPUBindGroupLayout;
+  pipelineLayout: GPUPipelineLayout;
+}


### PR DESCRIPTION
WebGPU provides a new ImportToTexture API to provide
fast uploading path. TFJS fromPixels should adopt this
new API as a preferred one.

This PR integrate this new API but keep it behind a
flag. After the API is stable, we will remove this
flag.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5430)
<!-- Reviewable:end -->
