### PR TITLE
webgpu: fix dispatch size exceeds the limits

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -715,6 +715,9 @@ export class WebGPUBackend extends KernelBackend {
     if (program.size != null) {
       uniformsWithType.push({type: uniformsType, data: [program.size]});
     }
+    if (program.reshapeDispatch) {
+      uniformsWithType.push({type: 'int32', data: program.dispatch});
+    }
     if (programUniforms) {
       uniformsWithType = [...uniformsWithType, ...programUniforms];
     }

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -715,9 +715,7 @@ export class WebGPUBackend extends KernelBackend {
     if (program.size != null) {
       uniformsWithType.push({type: uniformsType, data: [program.size]});
     }
-    if (program.reshapeDispatch) {
-      uniformsWithType.push({type: 'int32', data: program.dispatch});
-    }
+    uniformsWithType.push({type: 'int32', data: program.dispatch});
     if (programUniforms) {
       uniformsWithType = [...uniformsWithType, ...programUniforms];
     }

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -88,7 +88,7 @@ describeWebGPU('backend webgpu', () => {
 
     expect(endNumBytes - startNumBytes).toEqual(48);
     expect(endNumTensors - startNumTensors).toEqual(2);
-    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(-16);
+    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(-36);
 
     tf.test_util.expectArraysClose(
         dData, new Float32Array([9, 12, 15, 19, 26, 33]));

--- a/tfjs-backend-webgpu/src/constants.ts
+++ b/tfjs-backend-webgpu/src/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export const MAX_COMPUTE_WORKGROUP_INVOCATIONS = 256;
+
+export const MAX_COMPUTE_PER_DIMENSION_DISPATCH_SIZE = 65535;
+
+export const MAX_COMPUTE_WORKGROUP_SIZE_X = 256;
+
+export const MAX_COMPUTE_WORKGROUP_SIZE_Y = 256;
+
+export const MAX_COMPUTE_WORKGROUP_SIZE_Z = 256;

--- a/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
@@ -62,7 +62,7 @@ export class AddNPackedProgram implements WebGPUProgram {
     const type = getCoordsDataType(this.outputShape.length);
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         for (int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;
           if (flatIndex < size) {

--- a/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
@@ -54,7 +54,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
       }
 
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if(index < size) {
           float areal = getARealAtOutCoords();
           float aimag = getAImagAtOutCoords();

--- a/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
@@ -19,8 +19,9 @@ import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType} from '../shader_preprocessor';
 import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
-import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {computeDispatch, flatDispatchLayout, reshapeComputeDispatch} from '../webgpu_util';
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
+import {getReshapeDispatchGlobalInvocationID} from '../shader_util';
 
 import {getUseWgsl, WebGPUProgram} from './webgpu_program';
 
@@ -67,12 +68,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
       this.reshapeDispatch = true;
       this.workPerThread = 1;
       this.workGroupSize = [256, 1, 1];
-      const dispatchX = Math.ceil(this.size / 256) > 65535 ? 65535 :
-          Math.ceil(this.size / 256);
-      const dispatchY = Math.ceil(this.size / (256 * 65535)) > 65535 ? 65535 :
-          Math.ceil(this.size / (256 * 65535));
-      const dispatchZ = Math.ceil(this.size / (256 * 65535 * 65535));
-      this.dispatch = [dispatchX, dispatchY, dispatchZ];
+      this.dispatch = reshapeComputeDispatch(this.size, this.workGroupSize);
     } else {
       this.reshapeDispatch = false;
     }
@@ -86,7 +82,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
     // this.lastDimensionSize is used as sharedBuf array size, so can not be
     // used as uniform.
     this.shaderKey = `binaryShared_${op}_${this.lastDimensionSize}_${
-        this.useSharedMemoryWithB}_${this.sizeFit}_${this.reshapeDispatch}`;
+        this.useSharedMemoryWithB}_${this.sizeFit}`;
   }
 
   getUserCode(): string {
@@ -112,9 +108,8 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
             setOutput(flatIndex, binaryOperation(a, b));
           }`;
     const opStr = getBinaryOpString(this.op);
-    const flatIndexSnippet = this.reshapeDispatch ? `int((gl_WorkGroupID.z
-        * 65535 * 65535 + gl_WorkGroupID.y * 65535 + gl_WorkGroupID.x) * 256
-        + gl_LocalInvocationIndex)` : 'int(gl_GlobalInvocationID.x)';
+    const flatIndexSnippet = this.reshapeDispatch ?
+        getReshapeDispatchGlobalInvocationID() : 'int(gl_GlobalInvocationID.x)';
     const userCode = `
         float binaryOperation(float a, float b) {
           ${opStr}

--- a/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_shared_webgpu.ts
@@ -38,6 +38,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
   useWgsl: boolean;
   size: number;
   sizeFit: boolean;
+  reshapeDispatch: boolean;
 
   constructor(
       op: BinaryOpType, aShape: number[], bShape: number[],
@@ -47,6 +48,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
     const workGroupSizeX = 256;
     this.workGroupSize = [workGroupSizeX, 1, 1];
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
+    this.size = util.sizeFromShape(this.outputShape);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.lastDimensionSize = useSharedMemoryWithB ? bShape[0] : aShape[0];
     if (this.lastDimensionSize < 256) {
@@ -59,16 +61,32 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
+    // If the dispatch size exceeds the limit size of the x dimension, we should
+    // reshape dispatch layout on x/y or x/y/z dimensions.
+    if (this.dispatch[0] > 65535) {
+      this.reshapeDispatch = true;
+      this.workPerThread = 1;
+      this.workGroupSize = [256, 1, 1];
+      const dispatchX = Math.ceil(this.size / 256) > 65535 ? 65535 :
+          Math.ceil(this.size / 256);
+      const dispatchY = Math.ceil(this.size / (256 * 65535)) > 65535 ? 65535 :
+          Math.ceil(this.size / (256 * 65535));
+      const dispatchZ = Math.ceil(this.size / (256 * 65535 * 65535));
+      this.dispatch = [dispatchX, dispatchY, dispatchZ];
+    } else {
+      this.reshapeDispatch = false;
+    }
+
     this.useSharedMemoryWithB = useSharedMemoryWithB;
     this.op = op;
     this.useWgsl = getUseWgsl();
     this.size = util.sizeFromShape(this.outputShape);
-    this.sizeFit =
+    this.sizeFit = this.reshapeDispatch ? false :
         this.size % (this.workGroupSize[0] * this.workPerThread) === 0;
     // this.lastDimensionSize is used as sharedBuf array size, so can not be
     // used as uniform.
     this.shaderKey = `binaryShared_${op}_${this.lastDimensionSize}_${
-        this.useSharedMemoryWithB}_${this.sizeFit}`;
+        this.useSharedMemoryWithB}_${this.sizeFit}_${this.reshapeDispatch}`;
   }
 
   getUserCode(): string {
@@ -94,6 +112,9 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
             setOutput(flatIndex, binaryOperation(a, b));
           }`;
     const opStr = getBinaryOpString(this.op);
+    const flatIndexSnippet = this.reshapeDispatch ? `int((gl_WorkGroupID.z
+        * 65535 * 65535 + gl_WorkGroupID.y * 65535 + gl_WorkGroupID.x) * 256
+        + gl_LocalInvocationIndex)` : 'int(gl_GlobalInvocationID.x)';
     const userCode = `
         float binaryOperation(float a, float b) {
           ${opStr}
@@ -101,7 +122,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
 
         shared float sharedBuf[${this.lastDimensionSize}];
         void main() {
-          int index = int(gl_GlobalInvocationID.x);
+          int index = ${flatIndexSnippet};
           int localIndex = int(gl_LocalInvocationIndex);
 
           // Fill in the shared memory buffer. Here we need a loop to make sure

--- a/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
@@ -62,7 +62,7 @@ export class BinaryOpVec4Program implements WebGPUProgram {
       }
 
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         vec4 a = vec4(A[index]);
         vec4 b = vec4(B[index]);
         setOutput(index, binaryOperation(a, b));
@@ -75,7 +75,7 @@ export class BinaryOpVec4Program implements WebGPUProgram {
       }
 
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if (index < size)
         {
           vec4 a = vec4(A[index]);

--- a/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
@@ -66,7 +66,7 @@ export class BinaryOpProgram implements WebGPUProgram {
           }
 
           void main() {
-            int index = int(gl_GlobalInvocationID.x);
+            int index = getGlobalIndex();
 
             float a = float(A[index]);
             float b = float(B[index]);
@@ -81,7 +81,7 @@ export class BinaryOpProgram implements WebGPUProgram {
       }
 
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
 
         ${type} coords = getCoordsFromFlatIndex(index);
 
@@ -98,7 +98,7 @@ export class BinaryOpProgram implements WebGPUProgram {
       }
 
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
 
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;

--- a/tfjs-backend-webgpu/src/kernels/clip_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_vec4_webgpu.ts
@@ -50,7 +50,7 @@ export class ClipVec4Program implements WebGPUProgram {
   getUserCode(): string {
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
           if(index < size) {
             vec4 value = getAAtOutCoords();
             if (any(isnan(value))) {

--- a/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
@@ -50,7 +50,7 @@ export class ClipProgram implements WebGPUProgram {
   getUserCode(): string {
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if(index < size) {
           float value = getAAtOutCoords();
           if (isnan(value)) {

--- a/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
@@ -77,7 +77,7 @@ export class ConcatProgram implements WebGPUProgram {
 
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
 
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;

--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -49,7 +49,7 @@ export class FillProgram implements WebGPUProgram {
   getUserCode(): string {
     const userCode = `
     void main() {
-      int index = int(gl_GlobalInvocationID.x);
+      int index = getGlobalIndex();
       for (int i = 0; i < ${this.workPerThread}; i++) {
         int flatIndex = index * ${this.workPerThread} + i;
         if (flatIndex < size) {

--- a/tfjs-backend-webgpu/src/kernels/gather_nd_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/gather_nd_webgpu.ts
@@ -58,7 +58,7 @@ export class GatherNDProgram implements WebGPUProgram {
     }
     const userCode = `
          void main() {
-          int currentIndex = int(gl_GlobalInvocationID.x);
+          int currentIndex = getGlobalIndex();
           ${dtype} coords = getOutputCoords();
           int flattenIndex = 0;
           for (int j = 0; j < sliceDim; j++) {

--- a/tfjs-backend-webgpu/src/kernels/gather_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/gather_webgpu.ts
@@ -48,7 +48,7 @@ export class GatherProgram implements WebGPUProgram {
     const sourceCoords = getSourceCoords(this.aShape);
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         ivec4 resRC = getOutputCoords();
         if (index < size) {
           setOutput(index, getA(${sourceCoords}));

--- a/tfjs-backend-webgpu/src/kernels/im2col_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/im2col_webgpu.ts
@@ -50,7 +50,7 @@ export class Im2ColProgram implements WebGPUProgram {
 
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
 
         for(int i=0; i<${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;

--- a/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/mirror_pad_webgpu.ts
@@ -80,7 +80,7 @@ export class MirrorPadProgram implements WebGPUProgram {
 
       void main() {
         ${dtype} outC = getOutputCoords();
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if (index < size)
         {
           for (int i = 0; i < ${rank}; i++) {

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -36,20 +36,35 @@ export class PadProgram implements WebGPUProgram {
   xShape: number[];
   size: number;
   useWgsl: boolean;
+  reshapeDispatch: boolean;
 
   constructor(xShape: number[], paddings: Array<[number, number]>) {
     this.outputShape = paddings.map(
         (p, i) => p[0] /* beforePad */ + xShape[i] + p[1] /* afterPad */);
+    this.size = util.sizeFromShape(this.outputShape);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
+    // If the dispatch size exceeds the limit size of the x dimension, we should
+    // reshape dispatch layout on x/y or x/y/z dimensions.
+    if (this.dispatch[0] > 65535) {
+      this.reshapeDispatch = true;
+      this.workGroupSize = [256, 1, 1];
+      const dispatchX = Math.ceil(this.size / 256) > 65535 ? 65535 :
+          Math.ceil(this.size / 256);
+      const dispatchY = Math.ceil(this.size / (256 * 65535)) > 65535 ? 65535 :
+          Math.ceil(this.size / (256 * 65535));
+      const dispatchZ = Math.ceil(this.size / (256 * 65535 * 65535));
+          this.dispatch = [dispatchX, dispatchY, dispatchZ];
+    } else {
+      this.reshapeDispatch = false;
+    }
     paddings.map((_, i) => {
       this.uniforms += ` ivec2 pad${i};`;
       this.uniformsWgsl += ` pad${i} : vec2<u32>;`;
     });
     this.xShape = xShape;
-    this.shaderKey = 'pad';
-    this.size = util.sizeFromShape(this.outputShape);
+    this.shaderKey = `pad_${this.reshapeDispatch}`;
     this.useWgsl = getUseWgsl();
   }
 
@@ -73,13 +88,16 @@ export class PadProgram implements WebGPUProgram {
     const unpackedCoords = rank > 1 ?
         ['coords[0]', 'coords[1]', 'coords[2]', 'coords[3]'].slice(0, rank) :
         'coords';
+    const flatIndexSnippet = this.reshapeDispatch ? `int((gl_WorkGroupID.z
+        * 65535 * 65535 + gl_WorkGroupID.y * 65535 + gl_WorkGroupID.x) * 256
+        + gl_LocalInvocationIndex)` : 'int(gl_GlobalInvocationID.x)';
 
     const userCode = `
       ${type} start = ${startValue};
       ${type} end = ${endValue};
 
       void main() {
-        int flatIndex = int(gl_GlobalInvocationID.x);
+        int flatIndex = ${flatIndexSnippet};
 
           if (flatIndex < size) {
             ${type} outC = getOutputCoords();

--- a/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/pad_webgpu.ts
@@ -48,7 +48,7 @@ export class PadProgram implements WebGPUProgram {
       this.uniformsWgsl += ` pad${i} : vec2<u32>;`;
     });
     this.xShape = xShape;
-    this.shaderKey = `pad`;
+    this.shaderKey = 'pad';
     this.useWgsl = getUseWgsl();
     this.size = util.sizeFromShape(this.outputShape);
   }

--- a/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
@@ -74,7 +74,7 @@ export class SelectProgram implements WebGPUProgram {
     const dtype = getCoordsDataType(this.rank);
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if (index < size) {
           ${dtype} resRC = getOutputCoords();
 

--- a/tfjs-backend-webgpu/src/kernels/slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/slice_webgpu.ts
@@ -69,7 +69,7 @@ export class SliceProgram implements WebGPUProgram {
 
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if (index < size)
         {
           ${dtype} sourceLoc;

--- a/tfjs-backend-webgpu/src/kernels/strided_slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/strided_slice_webgpu.ts
@@ -76,7 +76,7 @@ export class StridedSliceProgram implements WebGPUProgram {
 
     const userCode = `
        void main() {
-         int index = int(gl_GlobalInvocationID.x);
+         int index = getGlobalIndex();
          if (index < size)
          {
            ${this.dtype} coords = getOutputCoords();

--- a/tfjs-backend-webgpu/src/kernels/tile_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/tile_webgpu.ts
@@ -55,7 +55,7 @@ export class TileProgram implements WebGPUProgram {
 
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
         if (index < size) {
           ${dtype} resRC = getOutputCoords();
           setOutput(index, getA(${sourceCoords}));

--- a/tfjs-backend-webgpu/src/kernels/transpose_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transpose_webgpu.ts
@@ -57,7 +57,7 @@ export class TransposeProgram implements WebGPUProgram {
 
     const userCode = `
       void main() {
-        int index = int(gl_GlobalInvocationID.x);
+        int index = getGlobalIndex();
 
         for(int i = 0; i < ${this.workPerThread}; i++) {
           int flatIndex = index * ${this.workPerThread} + i;

--- a/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/unary_op_webgpu.ts
@@ -17,7 +17,9 @@
 import {util} from '@tensorflow/tfjs-core';
 
 import {getWorkGroupSizeStringWgsl} from '../shader_preprocessor_wgsl';
-import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+import {computeDispatch, flatDispatchLayout, reshapeComputeDispatch} from '../webgpu_util';
+import {getUnaryOpString, UnaryOpType} from './unary_op_util';
+import {getReshapeDispatchGlobalInvocationID} from '../shader_util';
 
 import {getUnaryOpString, UnaryOpType} from './unary_op_util';
 import {getUseWgsl, WebGPUProgram} from './webgpu_program';
@@ -43,29 +45,21 @@ export class UnaryOpProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
-    // If the dispatch size exceeds the limit size of the x dimension, we should
-    // reshape dispatch layout on x/y or x/y/z dimensions.
     if (this.dispatch[0] > 65535) {
       this.reshapeDispatch = true;
       this.workGroupSize = [256, 1, 1];
-      const dispatchX = Math.ceil(this.size / 256) > 65535 ? 65535 :
-          Math.ceil(this.size / 256);
-      const dispatchY = Math.ceil(this.size / (256 * 65535)) > 65535 ? 65535 :
-          Math.ceil(this.size / (256 * 65535));
-      const dispatchZ = Math.ceil(this.size / (256 * 65535 * 65535));
-      this.dispatch = [dispatchX, dispatchY, dispatchZ];
+      this.dispatch = reshapeComputeDispatch(this.size, this.workGroupSize);
     } else {
       this.reshapeDispatch = false;
     }
     this.useWgsl = getUseWgsl();
     this.op = op;
-    this.shaderKey = `unary_${op}_${this.reshapeDispatch}`;
+    this.shaderKey = `unary_${op}`;
   }
 
   getUserCode(): string {
-    const flatIndexSnippet = this.reshapeDispatch ? `int((gl_WorkGroupID.z
-        * 65535 * 65535 + gl_WorkGroupID.y * 65535 + gl_WorkGroupID.x) * 256
-        + gl_LocalInvocationIndex)` : 'int(gl_GlobalInvocationID.x)';
+    const flatIndexSnippet = this.reshapeDispatch ?
+        getReshapeDispatchGlobalInvocationID() : 'int(gl_GlobalInvocationID.x)';
     return `
       float unaryOperation(float a) {
         ${getUnaryOpString(this.op)}

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -45,6 +45,7 @@ export interface WebGPUProgram {
   isVec4?: boolean;
   // size is used for bounds checking.
   size?: number;
+  reshapeDispatch?: boolean;
   getUserCode: () => string;
 }
 
@@ -102,10 +103,15 @@ export function makeShaderKey<R extends Rank>(
   if (program.useWgsl) {
     useWgslKey = '_1';
   }
+  let reshapeDispatchKey = '';
+  if (program.reshapeDispatch) {
+    reshapeDispatchKey = '_reshapeDispatch';
+  }
   const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
       shapes.map(shape => shape.length).join(',') + types.join(',') +
       program.variableNames.join(',') + broadcastDimsKey +
-      inputShapesEqualsOutShape + program.shaderKey + useWgslKey;
+      inputShapesEqualsOutShape + program.shaderKey + reshapeDispatchKey +
+      useWgslKey;
   return key;
 }
 

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -45,7 +45,6 @@ export interface WebGPUProgram {
   isVec4?: boolean;
   // size is used for bounds checking.
   size?: number;
-  reshapeDispatch?: boolean;
   getUserCode: () => string;
 }
 
@@ -103,15 +102,10 @@ export function makeShaderKey<R extends Rank>(
   if (program.useWgsl) {
     useWgslKey = '_1';
   }
-  let reshapeDispatchKey = '';
-  if (program.reshapeDispatch) {
-    reshapeDispatchKey = '_reshapeDispatch';
-  }
   const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
       shapes.map(shape => shape.length).join(',') + types.join(',') +
       program.variableNames.join(',') + broadcastDimsKey +
-      inputShapesEqualsOutShape + program.shaderKey + reshapeDispatchKey +
-      useWgslKey;
+      inputShapesEqualsOutShape + program.shaderKey + useWgslKey;
   return key;
 }
 

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -54,6 +54,7 @@ interface ProgramParams {
   uniforms?: string;
   isVec4?: boolean;
   size?: number;
+  reshapeDispatch?: boolean;
   getUserCode: () => string;
 }
 
@@ -113,6 +114,10 @@ export function makeShader(
 
   if (program.size != null) {
     uniformDeclaration += 'int size; ';
+  }
+
+  if (program.reshapeDispatch) {
+    uniformDeclaration += 'ivec3 dispatchSize; ';
   }
 
   if (program.uniforms) {

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -54,7 +54,6 @@ interface ProgramParams {
   uniforms?: string;
   isVec4?: boolean;
   size?: number;
-  reshapeDispatch?: boolean;
   getUserCode: () => string;
 }
 
@@ -116,9 +115,7 @@ export function makeShader(
     uniformDeclaration += 'int size; ';
   }
 
-  if (program.reshapeDispatch) {
-    uniformDeclaration += 'ivec3 dispatchSize; ';
-  }
+  uniformDeclaration += 'ivec3 dispatchSize; ';
 
   if (program.uniforms) {
     uniformDeclaration += program.uniforms;
@@ -207,6 +204,18 @@ const SAMPLING_SNIPPETS = `
   int getFlatIndex(ivec4 coords, ivec4 shape) {
     return int(dot(coords, ivec4(
       shape.y * shape.z * shape.w, shape.z * shape.w, shape.w, 1.)));
+  }
+
+  int getGlobalIndex() {
+    if (dispatchSize.y == 1 && dispatchSize.z == 1)
+    {
+      return int(gl_GlobalInvocationID.x);
+    } else {
+      return int((gl_WorkGroupID.z * dispatchSize.x * dispatchSize.y +
+        gl_WorkGroupID.y * dispatchSize.x + gl_WorkGroupID.x) *
+        (gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z) +
+        gl_LocalInvocationIndex);
+    }
   }
 `;
 
@@ -377,7 +386,7 @@ function getSamplerAtOutputCoords(
     if (isVec4) {
       return `
         vec4 ${funcName}() {
-          return vec4(${texName}[gl_GlobalInvocationID.x]);
+          return vec4(${texName}[getGlobalIndex()]);
         }
 
         vec4 ${funcName}(${type} coords) {
@@ -388,7 +397,7 @@ function getSamplerAtOutputCoords(
     } else {
       return `
       float ${funcName}() {
-        return float(${texName}[gl_GlobalInvocationID.x]);
+        return float(${texName}[getGlobalIndex()]);
       }
 
       float ${funcName}(${type} coords) {
@@ -497,7 +506,7 @@ function generateGetOutputCoords(
   if (x.length === outRank) {
     const dtype = getCoordsDataType(outRank);
     const snippet = `${dtype} getOutputCoords() {
-      return getCoordsFromFlatIndex(int(gl_GlobalInvocationID.x));
+      return getCoordsFromFlatIndex(getGlobalIndex());
     }
     `;
     return [snippet, outRank];

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -206,9 +206,9 @@ const SAMPLING_SNIPPETS = `
       shape.y * shape.z * shape.w, shape.z * shape.w, shape.w, 1.)));
   }
 
+  // Only used when the y/z dimension of workgroup size is 1.
   int getGlobalIndex() {
-    if (dispatchSize.y == 1 && dispatchSize.z == 1)
-    {
+    if (dispatchSize.y == 1 && dispatchSize.z == 1) {
       return int(gl_GlobalInvocationID.x);
     } else {
       return int((gl_WorkGroupID.z * dispatchSize.x * dispatchSize.y +

--- a/tfjs-backend-webgpu/src/shader_util.ts
+++ b/tfjs-backend-webgpu/src/shader_util.ts
@@ -32,10 +32,3 @@ export function symbolicallyComputeStrides(
 
   return strides;
 }
-
-export function getReshapeDispatchflatIndex(): string {
-  return `int((gl_WorkGroupID.z * dispatchSize.x * dispatchSize.y +
-      gl_WorkGroupID.y * dispatchSize.x + gl_WorkGroupID.x) *
-      (gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z) +
-      gl_LocalInvocationIndex)`;
-}

--- a/tfjs-backend-webgpu/src/shader_util.ts
+++ b/tfjs-backend-webgpu/src/shader_util.ts
@@ -32,3 +32,8 @@ export function symbolicallyComputeStrides(
 
   return strides;
 }
+
+export function getReshapeDispatchGlobalInvocationID(): string {
+  return `int((gl_WorkGroupID.z * 65535 * 65535 + gl_WorkGroupID.y * 65535 +
+      gl_WorkGroupID.x) * 256 + gl_LocalInvocationIndex)`;
+}

--- a/tfjs-backend-webgpu/src/shader_util.ts
+++ b/tfjs-backend-webgpu/src/shader_util.ts
@@ -33,7 +33,9 @@ export function symbolicallyComputeStrides(
   return strides;
 }
 
-export function getReshapeDispatchGlobalInvocationID(): string {
-  return `int((gl_WorkGroupID.z * 65535 * 65535 + gl_WorkGroupID.y * 65535 +
-      gl_WorkGroupID.x) * 256 + gl_LocalInvocationIndex)`;
+export function getReshapeDispatchflatIndex(): string {
+  return `int((gl_WorkGroupID.z * dispatchSize.x * dispatchSize.y +
+      gl_WorkGroupID.y * dispatchSize.x + gl_WorkGroupID.x) *
+      (gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z) +
+      gl_LocalInvocationIndex)`;
 }

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -65,13 +65,15 @@ export function computeDispatch(
     return [dispatchX, dispatchY, dispatchZ];
   }
 
-  util.assert(dispatchX > MAX_COMPUTE_PER_DIMENSION_DISPATCH_SIZE && !layout.y
-      && !layout.z, () => `Only support flatted layout to reshape dispatch ` +
-      `size when the dispatch size exceeds the limit size on x dimension.`);
+  util.assert(dispatchX > MAX_COMPUTE_PER_DIMENSION_DISPATCH_SIZE &&
+      layout.y === undefined && layout.z === undefined, () =>
+      'Dispatch size exceeds WebGPU limits in Y or Z dimension.');
 
   let dispatchAverage = Math.ceil(Math.sqrt(dispatchX));
   if (dispatchAverage > MAX_COMPUTE_PER_DIMENSION_DISPATCH_SIZE) {
     dispatchAverage = Math.ceil(Math.cbrt(dispatchX));
+    util.assert(dispatchAverage <= MAX_COMPUTE_PER_DIMENSION_DISPATCH_SIZE,
+        () => 'Total dispatch size exceeds WebGPU maximum.');
     return [dispatchAverage, dispatchAverage, dispatchAverage];
   } else {
     return [dispatchAverage, dispatchAverage, 1];


### PR DESCRIPTION
The maximum values of dispatch size and work group size on x/y/z
dimensions are 65535 and 256, if output data is only flatted on x
dimension and exceeds the limits, we should reshape dispatch layout
on x/y or x/y/z dimensions.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5432)
<!-- Reviewable:end -->
