### PR TITLE
Extend default web test timeout to 15 minutes

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -27,6 +27,7 @@ module.exports = function(config) {
     browserStack: {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY,
+      timeout: 900, // Seconds
       tunnelIdentifier:
       `tfjs_${Date.now()}_${Math.floor(Math.random() * 1000)}`
     },
@@ -34,7 +35,7 @@ module.exports = function(config) {
     reportSlowerThan: 500,
     browserNoActivityTimeout: 3e5,
     browserDisconnectTimeout: 3e5,
-    browserDisconnectTolerance: 3,
+    browserDisconnectTolerance: 0,
     browserSocketTimeout: 1.2e5,
     browsers: ['TEMPLATE_browser'],
     customLaunchers: {

--- a/tools/tfjs_web_test.bzl
+++ b/tools/tfjs_web_test.bzl
@@ -93,6 +93,8 @@ def tfjs_web_test(name, ci = True, **kwargs):
                 additional_tags.append("ci")
 
         karma_web_test(
+            size = size,
+            timeout = timeout,
             name = "browserstack_{}_{}".format(browser, name),
             config_file = config_file,
             peer_deps = [


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5443)
<!-- Reviewable:end -->
