### PR TITLE
 Use a different symlink prefix for wasm builds

### DIFF
--- a/tfjs-backend-wasm/scripts/build-wasm.sh
+++ b/tfjs-backend-wasm/scripts/build-wasm.sh
@@ -24,28 +24,31 @@ set -e
 set -x
 
 # Default build.
-yarn bazel build $BAZEL_REMOTE -c opt //tfjs-backend-wasm/src/cc:tfjs-backend-wasm
+# We pass '--symlink_prefix="wasm-dist/"' because otherwise wasm will change
+# 'dist/bin' to point to k8-opt instead of k8-fastbuild (because of '-c opt')
+# https://docs.bazel.build/versions/main/user-manual.html#configuration-specific-data
+yarn bazel build $BAZEL_REMOTE --symlink_prefix="wasm-dist/" -c opt //tfjs-backend-wasm/src/cc:tfjs-backend-wasm
 # The typescript code and karma config expect the output of emscripten to be in
 # wasm-out/ so we copy the bazel output there.
-cp -f ../../dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm/tfjs-backend-wasm.js \
-      ../../dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm/tfjs-backend-wasm.wasm \
+cp -f ../../wasm-dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm/tfjs-backend-wasm.js \
+      ../../wasm-dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm/tfjs-backend-wasm.wasm \
       ../wasm-out/
 
 if [[ "$1" != "--dev" ]]; then
   # SIMD and threaded + SIMD builds.
-  yarn bazel build $BAZEL_REMOTE -c opt --copt="-msimd128" //tfjs-backend-wasm/src/cc:tfjs-backend-wasm-simd
-  yarn bazel build $BAZEL_REMOTE -c opt --copt="-pthread" --copt="-msimd128" //tfjs-backend-wasm/src/cc:tfjs-backend-wasm-threaded-simd
+  yarn bazel build $BAZEL_REMOTE --symlink_prefix="wasm-dist/" -c opt --copt="-msimd128" //tfjs-backend-wasm/src/cc:tfjs-backend-wasm-simd
+  yarn bazel build $BAZEL_REMOTE --symlink_prefix="wasm-dist/" -c opt --copt="-pthread" --copt="-msimd128" //tfjs-backend-wasm/src/cc:tfjs-backend-wasm-threaded-simd
 
   # Copy SIMD
-  cp -f ../../dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-simd/tfjs-backend-wasm-simd.wasm \
+  cp -f ../../wasm-dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-simd/tfjs-backend-wasm-simd.wasm \
     ../wasm-out/tfjs-backend-wasm-simd.wasm
 
   # Copy threaded
-  cp -f ../../dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-threaded-simd/tfjs-backend-wasm-threaded-simd.js \
+  cp -f ../../wasm-dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-threaded-simd/tfjs-backend-wasm-threaded-simd.js \
     ../wasm-out/tfjs-backend-wasm-threaded-simd.js
-  cp -f ../../dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-threaded-simd/tfjs-backend-wasm-threaded-simd.worker.js \
+  cp -f ../../wasm-dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-threaded-simd/tfjs-backend-wasm-threaded-simd.worker.js \
     ../wasm-out/tfjs-backend-wasm-threaded-simd.worker.js
-  cp -f ../../dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-threaded-simd/tfjs-backend-wasm-threaded-simd.wasm \
+  cp -f ../../wasm-dist/bin/tfjs-backend-wasm/src/cc/tfjs-backend-wasm-threaded-simd/tfjs-backend-wasm-threaded-simd.wasm \
     ../wasm-out/tfjs-backend-wasm-threaded-simd.wasm
 
   node ./create-worker-module.js


### PR DESCRIPTION
This prevents wasm builds from overwriting the `dist/bin` symlink, which points to `k8-fastbuild` on linux, with `k8-opt`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5455)
<!-- Reviewable:end -->
