### PR TITLE
fix: remove duplicated export * from fused_util

### DIFF
--- a/tfjs-core/src/backends/backend_util.ts
+++ b/tfjs-core/src/backends/backend_util.ts
@@ -36,7 +36,6 @@ export * from '../ops/array_ops_util';
 export * from '../ops/gather_nd_util';
 export * from '../ops/scatter_nd_util';
 export * from '../ops/selu_util';
-export * from '../ops/fused_util';
 export * from '../ops/erf_util';
 export * from '../log';
 export * from '../backends/complex_util';


### PR DESCRIPTION
In `tfjs-core/src/backends/backend_util.ts`, there're duplicated `export * from '../ops/fused_util'` (line 25 and line 39). 

This PR simply remove the duplicate export statements.

The duplication might cause following issue when bundling `tfjs` (for example, use `parcel-bundler`) into a webapp:
![image](https://user-images.githubusercontent.com/10307875/128878496-4939d021-faa4-4a25-9629-3df409c7c649.png)

I have created a simple repo to reproduce this issue, please check [here](https://github.com/whitedogg13/tfjs-pr-test-app)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5450)
<!-- Reviewable:end -->
