### PR TITLE
[docs] Fix wrong ELU op definiton

### DIFF
--- a/tfjs-core/src/ops/elu.ts
+++ b/tfjs-core/src/ops/elu.ts
@@ -25,7 +25,7 @@ import {TensorLike} from '../types';
 import {op} from './operation';
 
 /**
- * Computes exponential linear element-wise: `x > 0 ? e ^ x - 1 : 0`.
+ * Computes exponential linear element-wise: `x > 0 ? x : (e ^ x) - 1`.
  *
  * ```js
  * const x = tf.tensor1d([-1, 1, -3, 2]);


### PR DESCRIPTION
Change `x > 0 ? e ^ x - 1 : 0` to `x > 0 ? x : (e ^ x) - 1`.
Follow the definition in [this paper](https://arxiv.org/pdf/1511.07289v5.pdf).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5474)
<!-- Reviewable:end -->
