### PR TITLE
[wasm] Make it more obvious for calling setWasmPaths when WASM backend is loaded from script tag

### DIFF
--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -137,8 +137,15 @@ import {setWasmPaths} from '@tensorflow/tfjs-backend-wasm';
 // setWasmPaths accepts a `prefixOrFileMap` argument which can be either a
 // string or an object. If passing in a string, this indicates the path to
 // the directory where your WASM binaries are located.
-setWasmPaths('www.yourdomain.com/'); // or tf.wasm.setWasmPaths when using <script> tags.
+setWasmPaths('www.yourdomain.com/');
 tf.setBackend('wasm').then(() => {...});
+```
+
+If the WASM backend is imported through `<script>` tag, `setWasmPaths` needs to
+be called on the `tf.wasm` object:
+
+```ts
+tf.wasm.setWasmPaths('www.yourdomain.com/');
 ```
 
 Note that if you call `setWasmPaths` with a string, it will be used to load


### PR DESCRIPTION
Related to #5336 

Previously we mentioned this in the code snippet comment which is easy to miss. This PR extracts it into a separate paragraph.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5477)
<!-- Reviewable:end -->
