### PR TITLE
webgpu: fix uniform block incorrectly

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -653,6 +653,14 @@ export class WebGPUBackend extends KernelBackend {
       currentOffset += d.data.length + padding;
     });
 
+    // Force the resulting size of uniform block to be evenly divisible
+    // by sizeof(four-component vector).
+    padding = Math.ceil(currentOffset / 4) * 4 - currentOffset;
+    for (let p = 0; p < padding; ++p) {
+      dimUniformsData.push({type: 'int32', data: [0]});
+      dataViewIndex++;
+    }
+
     return this.arrayToDataView(dimUniformsData, dataViewIndex);
   }
 


### PR DESCRIPTION
uniform block size will always be evenly divisible by sizeof(vec4),
so we must pad the ending of uniform block buffer if necessary.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.