### PR TITLE
[webgl] Fixed nightly test failure

### DIFF
--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -58,7 +58,7 @@ const devConfig = {
   ],
   preprocessors: {'**/*.ts': ['karma-typescript']},
   karmaTypescriptConfig,
-  reporters: ['karma-typescript']
+  reporters: ['dots', 'karma-typescript']
 };
 
 const browserstackConfig = {

--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -58,7 +58,7 @@ const devConfig = {
   ],
   preprocessors: {'**/*.ts': ['karma-typescript']},
   karmaTypescriptConfig,
-  reporters: ['dots', 'karma-typescript']
+  reporters: ['karma-typescript']
 };
 
 const browserstackConfig = {
@@ -123,7 +123,7 @@ module.exports = function(config) {
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: 'latest',
+        browser_version: '90.0',
         os: 'OS X',
         os_version: 'High Sierra'
       },

--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -123,7 +123,7 @@ module.exports = function(config) {
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: 'latest',
+        browser_version: '90.0',
         os: 'OS X',
         os_version: 'High Sierra'
       },

--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -123,6 +123,8 @@ module.exports = function(config) {
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
+        // Firefox 91.0 on browserstack has issue updating the video readyState
+        // for fromPixel video element tests.
         browser_version: '90.0',
         os: 'OS X',
         os_version: 'High Sierra'

--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -123,7 +123,7 @@ module.exports = function(config) {
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: '90.0',
+        browser_version: 'latest',
         os: 'OS X',
         os_version: 'High Sierra'
       },

--- a/tfjs-core/src/ops/from_pixels_async_test.ts
+++ b/tfjs-core/src/ops/from_pixels_async_test.ts
@@ -216,7 +216,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false', BROWSER_ENVS, 
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  xit('fromPixelsAsync for HTMLVideoElement', async () => {
+  it('fromPixelsAsync for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -227,10 +227,8 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false', BROWSER_ENVS, 
     video.appendChild(source);
     document.body.appendChild(video);
 
-    // On mobile safari the ready state is ready immediately so we and skip
-    // firefox browser.
-    if (!!navigator && navigator.userAgent.search('Firefox') < 0 &&
-        video.readyState < 2) {
+    // On mobile safari the ready state is ready immediately.
+    if (video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));
       });
@@ -326,11 +324,8 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true', BROWSER_ENVS, (
     source.type = 'video/mp4';
     video.appendChild(source);
     document.body.appendChild(video);
-    video.load();
 
-    // On mobile safari the ready state is ready immediately so we and skip
-    // firefox browser.
-    console.log(navigator.userAgent, video.readyState);
+    // On mobile safari the ready state is ready immediately.
     if (video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));

--- a/tfjs-core/src/ops/from_pixels_async_test.ts
+++ b/tfjs-core/src/ops/from_pixels_async_test.ts
@@ -216,7 +216,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false', BROWSER_ENVS, 
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  it('fromPixelsAsync for HTMLVideoElement', async () => {
+  xit('fromPixelsAsync for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -227,8 +227,10 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false', BROWSER_ENVS, 
     video.appendChild(source);
     document.body.appendChild(video);
 
-    // On mobile safari the ready state is ready immediately so we
-    if (video.readyState < 2) {
+    // On mobile safari the ready state is ready immediately so we and skip
+    // firefox browser.
+    if (!!navigator && navigator.userAgent.search('Firefox') < 0 &&
+        video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));
       });
@@ -325,8 +327,11 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true', BROWSER_ENVS, (
     video.appendChild(source);
     document.body.appendChild(video);
 
-    // On mobile safari the ready state is ready immediately so we
-    if (video.readyState < 2) {
+    // On mobile safari the ready state is ready immediately so we and skip
+    // firefox browser.
+    console.log(navigator.userAgent, video.readyState);
+    if (!!navigator && navigator.userAgent.search('Firefox') < 0 &&
+        video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));
       });

--- a/tfjs-core/src/ops/from_pixels_async_test.ts
+++ b/tfjs-core/src/ops/from_pixels_async_test.ts
@@ -216,7 +216,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false', BROWSER_ENVS, 
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  xit('fromPixelsAsync for HTMLVideoElement', async () => {
+  it('fromPixelsAsync for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -314,7 +314,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true', BROWSER_ENVS, (
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  xit('fromPixelsAsync for HTMLVideoElement', async () => {
+  it('fromPixelsAsync for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -339,7 +339,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true', BROWSER_ENVS, (
     document.body.removeChild(video);
   });
 
-  xit('canvas and image match', async () => {
+  it('canvas and image match', async () => {
     const img = new Image();
     const size = 80;
     // tslint:disable:max-line-length

--- a/tfjs-core/src/ops/from_pixels_async_test.ts
+++ b/tfjs-core/src/ops/from_pixels_async_test.ts
@@ -62,8 +62,7 @@ describeWithFlags('fromPixelsAsync, mock canvas', NODE_ENVS, () => {
 // Flag 'WRAP_TO_IMAGEBITMAP' is set by customer. The default
 // value is false. The cases below won't try to wrap input to
 // imageBitmap.
-describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false',
-  BROWSER_ENVS, () => {
+describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false', BROWSER_ENVS, () => {
   it('ImageData 1x1x3', async () => {
     const pixels = new ImageData(1, 1);
     pixels.data[0] = 0;
@@ -209,7 +208,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false',
         ',R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
     await new Promise(resolve => {
-        img.onload = () => resolve(img);
+      img.onload = () => resolve(img);
     });
 
     const res = await tf.browser.fromPixelsAsync(img);
@@ -217,7 +216,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false',
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  it('fromPixelsAsync for HTMLVideoElement', async () => {
+  xit('fromPixelsAsync for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -276,10 +275,9 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| false',
 // This flag helps on image, video and canvas input cases
 // for WebGPU backends. We'll cover these inputs with test
 // cases set 'WRAP_TO_IMAGEBITMAP' to true.
-describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true',
-  BROWSER_ENVS, () => {
+describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true', BROWSER_ENVS, () => {
   beforeAll(() => {
-      tf.env().set('WRAP_TO_IMAGEBITMAP', true);
+    tf.env().set('WRAP_TO_IMAGEBITMAP', true);
   });
 
   afterAll(() => {
@@ -308,7 +306,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true',
         ',R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
     await new Promise(resolve => {
-        img.onload = () => resolve(img);
+      img.onload = () => resolve(img);
     });
 
     const res = await tf.browser.fromPixelsAsync(img);
@@ -316,7 +314,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true',
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  it('fromPixelsAsync for HTMLVideoElement', async () => {
+  xit('fromPixelsAsync for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -341,7 +339,7 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true',
     document.body.removeChild(video);
   });
 
-  it('canvas and image match', async () => {
+  xit('canvas and image match', async () => {
     const img = new Image();
     const size = 80;
     // tslint:disable:max-line-length

--- a/tfjs-core/src/ops/from_pixels_async_test.ts
+++ b/tfjs-core/src/ops/from_pixels_async_test.ts
@@ -326,12 +326,12 @@ describeWithFlags('fromPixelsAsync, |WRAP_TO_IMAGEBITMAP| true', BROWSER_ENVS, (
     source.type = 'video/mp4';
     video.appendChild(source);
     document.body.appendChild(video);
+    video.load();
 
     // On mobile safari the ready state is ready immediately so we and skip
     // firefox browser.
     console.log(navigator.userAgent, video.readyState);
-    if (!!navigator && navigator.userAgent.search('Firefox') < 0 &&
-        video.readyState < 2) {
+    if (video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));
       });

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -208,7 +208,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  xit('fromPixels for HTMLVideoElement', async () => {
+  it('fromPixels for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -208,7 +208,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  fit('fromPixels for HTMLVideoElement', async () => {
+  it('fromPixels for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -208,7 +208,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  it('fromPixels for HTMLVideoElement', async () => {
+  xit('fromPixels for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -307,7 +307,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
       expectArraysEqual(await res.data(), [0, 1, 2, 4, 5, 6]);
     });
 
-    it('fromPixels for ImageBitmap outShape changes', async() => {
+    it('fromPixels for ImageBitmap outShape changes', async () => {
       const imageDataWidth = 2;
       const imageDataHeight = 2;
       let numChannel = 3;
@@ -326,18 +326,20 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
       const data = await res.data();
       expect(data.length)
           .toEqual(imageDataHeight * imageDataWidth * numChannel);
-      expectArraysEqual(await res.data(),
-          [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]);
+      expectArraysEqual(
+          await res.data(), [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]);
 
       // Change output shapes
       numChannel = 4;
       const resShapeChange = tf.browser.fromPixels(imageBitmap, numChannel);
-      expect(resShapeChange.shape)
-          .toEqual([imageDataHeight, imageDataWidth, numChannel]);
+      expect(resShapeChange.shape).toEqual([
+        imageDataHeight, imageDataWidth, numChannel
+      ]);
       const data2 = await resShapeChange.data();
       expect(data2.length)
           .toEqual(imageDataHeight * imageDataWidth * numChannel);
-      expectArraysEqual(await resShapeChange.data(),
+      expectArraysEqual(
+          await resShapeChange.data(),
           [0, 1, 2, 255, 4, 5, 6, 255, 8, 9, 10, 255, 12, 13, 14, 255]);
     });
   }

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -208,7 +208,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  xit('fromPixels for HTMLVideoElement', async () => {
+  fit('fromPixels for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -219,10 +219,8 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     video.appendChild(source);
     document.body.appendChild(video);
 
-    // On mobile safari the ready state is ready immediately so we and skip
-    // firefox browser.
-    if (!!navigator && navigator.userAgent.search('Firefox') < 0 &&
-        video.readyState < 2) {
+    // On mobile safari the ready state is ready immediately.
+    if (video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));
       });

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -208,7 +208,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
-  it('fromPixels for HTMLVideoElement', async () => {
+  xit('fromPixels for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;
     const source = document.createElement('source');
@@ -219,8 +219,10 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     video.appendChild(source);
     document.body.appendChild(video);
 
-    // On mobile safari the ready state is ready immediately so we
-    if (video.readyState < 2) {
+    // On mobile safari the ready state is ready immediately so we and skip
+    // firefox browser.
+    if (!!navigator && navigator.userAgent.search('Firefox') < 0 &&
+        video.readyState < 2) {
       await new Promise(resolve => {
         video.addEventListener('loadeddata', () => resolve(video));
       });


### PR DESCRIPTION
Firefox 91.0 on browserstack has issues to update the video readyState properly.
And it is causing our fromPixel videoElement tests to timeout.
This PR will pin firefox version to 90.0 on browserstack, until we verify the latest firefox version
on browserstack is working.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5510)
<!-- Reviewable:end -->
