### PR TITLE
[wasm] Fix offset calculation in Conv2DBackpropInput

### DIFF
--- a/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Conv2DBackpropInput.cc
@@ -86,9 +86,9 @@ void Conv2DBackpropInput(
               }
             }
           }
-
-          *out_buf_ptr = dot_prod;
-          out_buf_ptr++;
+          size_t dx_offset = x_batch_stride * b + x_row_stride * xr +
+                             x_col_stride * xc + x_channel_stride * d1;
+          *(out_buf_ptr + dx_offset) = dot_prod;
         }
       }
     }

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -15,12 +15,11 @@
  * =============================================================================
  */
 import {env} from './environment';
-
 import {getGlobal} from './global_util';
+import * as log from './log';
 import {NamedGradientMap} from './tape';
 import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
-import * as log from './log';
 
 const kernelRegistry =
     getGlobal('kernelRegistry', () => new Map<string, KernelConfig>());
@@ -80,7 +79,7 @@ export interface TensorInfo {
 }
 
 export interface NamedTensorInfoMap {
-  [name: string]: TensorInfo;
+  [name: string]: TensorInfo|undefined;
 }
 
 export interface NamedAttrMap {

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -15,11 +15,12 @@
  * =============================================================================
  */
 import {env} from './environment';
+
 import {getGlobal} from './global_util';
-import * as log from './log';
 import {NamedGradientMap} from './tape';
 import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
+import * as log from './log';
 
 const kernelRegistry =
     getGlobal('kernelRegistry', () => new Map<string, KernelConfig>());
@@ -79,7 +80,7 @@ export interface TensorInfo {
 }
 
 export interface NamedTensorInfoMap {
-  [name: string]: TensorInfo|undefined;
+  [name: string]: TensorInfo;
 }
 
 export interface NamedAttrMap {

--- a/tfjs-core/src/ops/conv2d_transpose_test.ts
+++ b/tfjs-core/src/ops/conv2d_transpose_test.ts
@@ -113,6 +113,36 @@ describeWithFlags('conv2dTranspose', ALL_ENVS, () => {
     expectArraysClose(await result.data(), expected);
   });
 
+  it('input=3x3x2,output=3x5x2,d2=1,f=2,s=2,inDepth=2,p=same', async () => {
+    const origInputDepth = 2;
+    const origOutputDepth = 2;
+    const inputShape: [number, number, number, number] =
+        [1, 3, 3, origOutputDepth];
+    const fSize = 2;
+    const origPad = 'same';
+    const origStride = 2;
+
+    const x = tf.tensor4d(
+        [
+          0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
+          16., 17
+        ],
+        inputShape);
+    const w = tf.tensor4d(
+        [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.],
+        [fSize, fSize, origInputDepth, origOutputDepth]);
+
+    const result = tf.conv2dTranspose(
+        x, w, [1, 3, 5, origInputDepth], origStride, origPad);
+    const expected = [
+      1,  3,  5,  7,  3,  13, 23, 33, 5,  23, 9,  11, 13,  15, 43,
+      53, 63, 73, 77, 95, 7,  33, 59, 85, 9,  43, 77, 111, 11, 53
+    ];
+
+    expect(result.shape).toEqual([1, 3, 5, origInputDepth]);
+    expectArraysClose(await result.data(), expected);
+  });
+
   // Reference (Python) TensorFlow code:
   //
   // ```py
@@ -316,8 +346,7 @@ describeWithFlags('conv2dTranspose', ALL_ENVS, () => {
     ]);
   });
 
-  it('gradient input=[1,3,3,1] f=[2,2,2,1] s=[1,1] p=explicit',
-     async () => {
+  it('gradient input=[1,3,3,1] f=[2,2,2,1] s=[1,1] p=explicit', async () => {
     const inputDepth = 1;
     const outputDepth = 2;
     const inputShape: [number, number, number, number] = [1, 3, 3, inputDepth];


### PR DESCRIPTION
The previous implementation didn't take into account of various stride values. Fixed now (based on CPU implementation). 

Also added a test to cover the case where inDepth is not 1 (which will trigger the bug).

Fixes #5390 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.