### PR TITLE
Minor fix for the NamedTensorInfoMap type.

### DIFF
--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -15,12 +15,11 @@
  * =============================================================================
  */
 import {env} from './environment';
-
 import {getGlobal} from './global_util';
+import * as log from './log';
 import {NamedGradientMap} from './tape';
 import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
-import * as log from './log';
 
 const kernelRegistry =
     getGlobal('kernelRegistry', () => new Map<string, KernelConfig>());
@@ -80,7 +79,7 @@ export interface TensorInfo {
 }
 
 export interface NamedTensorInfoMap {
-  [name: string]: TensorInfo;
+  [name: string]: TensorInfo|undefined;
 }
 
 export interface NamedAttrMap {


### PR DESCRIPTION
Without this, the build would fail in Angular apps that use typescript 4+ which has more strict check.

The failed code:

```ts
export interface FusedConv2DInputs extends NamedTensorInfoMap {
  x: TensorInfo;
  filter: TensorInfo;
  bias?: TensorInfo;  // <--- Error: Property 'bias' of type 'TensorInfo | undefined' is not assignable to string index type 'TensorInfo'.
  preluActivationWeights?: TensorInfo;  // <--- Same error
}
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5523)
<!-- Reviewable:end -->
