### PR TITLE
Add SigmoidRange layer

### DIFF
--- a/tfjs-layers/src/exports_layers.ts
+++ b/tfjs-layers/src/exports_layers.ts
@@ -11,7 +11,7 @@
 import {InputLayer, InputLayerArgs} from './engine/input_layer';
 import {Layer, LayerArgs} from './engine/topology';
 import {input} from './exports';
-import {ELU, ELULayerArgs, LeakyReLU, LeakyReLULayerArgs, PReLU, PReLULayerArgs, ReLU, ReLULayerArgs, Softmax, SoftmaxLayerArgs, ThresholdedReLU, ThresholdedReLULayerArgs} from './layers/advanced_activations';
+import {ELU, ELULayerArgs, LeakyReLU, LeakyReLULayerArgs, PReLU, PReLULayerArgs, ReLU, ReLULayerArgs, Softmax, SoftmaxLayerArgs, ThresholdedReLU, ThresholdedReLULayerArgs, SigmoidRange, SigmoidRangeLayerArgs} from './layers/advanced_activations';
 import {Conv1D, Conv2D, Conv2DTranspose, Conv3D, ConvLayerArgs, Cropping2D, Cropping2DLayerArgs, SeparableConv2D, SeparableConvLayerArgs, UpSampling2D, UpSampling2DLayerArgs, Conv3DTranspose} from './layers/convolutional';
 import {DepthwiseConv2D, DepthwiseConv2DLayerArgs} from './layers/convolutional_depthwise';
 import {ConvLSTM2D, ConvLSTM2DArgs, ConvLSTM2DCell, ConvLSTM2DCellArgs} from './layers/convolutional_recurrent';
@@ -187,6 +187,30 @@ export function prelu(args?: PReLULayerArgs) {
 export function softmax(args?: SoftmaxLayerArgs) {
   return new Softmax(args);
 }
+
+
+/**
+ * SigmoidRange layer.
+ * It follows
+ * `sigmoid(x) * (max - min) + min`
+ * the output of the layer will be between max and min
+ * Input shape:
+ *   Arbitrary. Use the configuration `inputShape` when using this layer as the
+ *   first layer in a model.
+ *
+ * Output shape:
+ *   Same shape as the input.
+ *
+ * @doc {
+ *   heading: 'Layers',
+ *   subheading: 'Advanced Activation',
+ *   namespace: 'layers'
+ * }
+ */
+ export function sigmoidRange(args?: SigmoidRangeLayerArgs) {
+  return new SigmoidRange(args);
+}
+
 
 /**
  * Thresholded Rectified Linear Unit.

--- a/tfjs-layers/src/layers/advanced_activations.ts
+++ b/tfjs-layers/src/layers/advanced_activations.ts
@@ -15,6 +15,7 @@
 import {cast, clipByValue, elu, greater, leakyRelu, mul, prelu, relu, serialization, Tensor} from '@tensorflow/tfjs-core';
 
 import {Softmax as softmaxActivation} from '../activations';
+import {Sigmoid as sigmoidActivation} from '../activations';
 import {Constraint, getConstraint, serializeConstraint} from '../constraints';
 import {InputSpec, Layer, LayerArgs} from '../engine/topology';
 import {NotImplementedError, ValueError} from '../errors';
@@ -342,3 +343,57 @@ export class Softmax extends Layer {
   }
 }
 serialization.registerClass(Softmax);
+
+export declare interface SigmoidRangeLayerArgs extends LayerArgs {
+  /**
+   * Floats, max > min,
+   * A minimum and a maximum range for the sigmoid function
+   * min defaults to `0`, and max defaults to `1`
+   */
+   max?: number;
+   min?: number;
+
+}
+
+export class SigmoidRange extends Layer {
+  /** @nocollapse */
+  static className = 'SigmoidRange';
+  readonly max: number;
+  readonly min: number;
+  readonly DEFAULT_MAX = 1.0;
+  readonly DEFAULT_MIN = 0.0;
+  readonly sigmoid: (t: Tensor) => Tensor;
+
+  constructor(args?: SigmoidRangeLayerArgs) {
+    super(args == null ? {} : args);
+    if (args == null) {
+      args = {};
+    }
+
+    if (args.min > args.max) {
+      throw new ValueError(`max can not be smaller or equal to min`);
+    }
+
+    this.max = args.max == null ? this.DEFAULT_MAX : args.max;
+    this.min = args.min == null ? this.DEFAULT_MIN : args.min;
+    this.sigmoid = new sigmoidActivation().apply;
+
+  }
+
+  call(inputs: Tensor|Tensor[], kwargs: Kwargs): Tensor|Tensor[] {
+    const x = getExactlyOneTensor(inputs);
+    return this.sigmoid(x).mul(this.max - this.min).add(this.min);
+  }
+
+  computeOutputShape(inputShape: Shape|Shape[]): Shape|Shape[] {
+    return inputShape;
+  }
+
+  getConfig(): serialization.ConfigDict {
+    const config: serialization.ConfigDict = {max: this.max, min: this.min};
+    const baseConfig = super.getConfig();
+    Object.assign(config, baseConfig);
+    return config;
+  }
+}
+serialization.registerClass(SigmoidRange);


### PR DESCRIPTION
Hello,

This is an implementation of the SigmoidRange layer mentioned in https://github.com/tensorflow/tfjs/issues/5452#issue-965182223 .

The SigmoidRange takes two parameters  **min**  and **max** and forces the output to be between them. The default value of **min** and **max** are **0** and **1** respectively (a normal sigmoid) 
The SigmoidRange equation goes this way:
`SigmoidRange(x)  = sigmoid(x) * (max - min) + min`

Please review it and tell me if I should add anything