### PR TITLE
[webgpu] Fix WGSL pow case fail

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_util.ts
@@ -208,14 +208,14 @@ const POW_WGSL = `
   if (b == 0.0) {
     return 1.0;
   }
-  if (i32(round(b % 2.0)) != 1) {
+  if (i32(round(mod(b, 2.0))) != 1) {
     return pow(abs(a), b);
   }
   return sign(a) * pow(abs(a), b);
   `;
 
 const POW_VEC4_WGSL = `
-  let isModRound1Bool = vec4<i32>(round(b % vec4<f32>(2.0))) == vec4<i32>(1);
+  let isModRound1Bool = vec4<i32>(round(modVec4(b, vec4<f32>(2.0)))) == vec4<i32>(1);
   let isModRound1 = vec4<f32>(isModRound1Bool);
   let multiplier = sign(a) * isModRound1 + (vec4<f32>(1.0) - isModRound1);
   var resultTemp = multiplier * pow(abs(a), b);

--- a/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor_wgsl.ts
@@ -206,6 +206,19 @@ const SHADER_PREFIX = `
     return res;
   }
 
+  // The GLSL mod and WGSL '%' are defined differently.
+  // GLSL mod returns the value of x modulo y. This is computed as x - y * floor(x/y).
+  // WGSL '%' is floating point remainder, where sign of non-zero result matches sign of e1.
+  // Component-wise when T is a vector. Result equals to: e1 - e2 * trunc(e1 / e2).
+  // The below mod and modVec4 can be used as alternatives to GLSL's mod, not WGSL's '%'.
+  fn mod(a : f32, b : f32) -> f32 {
+    return a - b * floor(a/b);
+  }
+
+  fn modVec4(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
+    return a - b * floor(a/b);
+  }
+
   fn isNanCustom(val : f32) -> bool {
     if (val > 0.0) {
       return false;

--- a/tfjs-core/src/ops/arithmetic_test.ts
+++ b/tfjs-core/src/ops/arithmetic_test.ts
@@ -941,6 +941,17 @@ describeWithFlags('pow', ALL_ENVS, () => {
     expectArraysClose(await result.data(), expected);
   });
 
+  it('negative base and whole exponent not NaN - vec4', async () => {
+    const a = tf.tensor1d([-2, -3, -4, -5], 'float32');
+    const b = tf.tensor1d([2, -3, 4, -5], 'float32');
+
+    const expected =
+        [Math.pow(-2, 2), Math.pow(-3, -3), Math.pow(-4, 4), Math.pow(-5, -5)];
+    const result = tf.pow(a, b);
+
+    expectArraysClose(await result.data(), expected);
+  });
+
   it('negative base and fract exponent NaN', async () => {
     const a = tf.tensor1d([-2, -3, -4], 'float32');
     const b = tf.tensor1d([2.1, -3.01, 4.1], 'float32');


### PR DESCRIPTION
As commented by amaiorano@google.com https://bugs.chromium.org/p/tint/issues/detail?id=1144#c5:
The GLSL mod and WGSL '%' are defined differently.
GLSL: mod returns the value of x modulo y. This is computed as x - y * floor(x/y).
(See https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/mod.xhtml)

WGSL: '%' is floating point remainder, where sign of non-zero result matches sign of e1. Component-wise when T is a vector.
Result equals to: e1 - e2 * trunc(e1 / e2).
(See https://gpuweb.github.io/gpuweb/wgsl/#arithmetic-expr)

In this PR, mod and modVec4 can be used as alternatives to GLSL's mod, not WGSL's '%'.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5589)
<!-- Reviewable:end -->
