### PR TITLE
Add scripts to deploy benchmarks tool to firebase hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ yalc.lock
 yarn-error.log
 cloudbuild_generated.yml
 wasm-dist/
+.firebase/
 
 # User-specific .bazelrc
 .bazelrc.user

--- a/e2e/benchmarks/firebase_prod.json
+++ b/e2e/benchmarks/firebase_prod.json
@@ -1,0 +1,24 @@
+{
+  "hosting": {
+    "site": "tfjs-benchmarks",
+    "public": ".",
+    "ignore": [
+      "firebase_prod.json",
+      "firebase_staging.json"
+    ],
+    // Set up headers for cross-origin isolation.
+    "headers": [{
+      "source": "local-benchmark/",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }]
+  }
+}

--- a/e2e/benchmarks/firebase_prod.json
+++ b/e2e/benchmarks/firebase_prod.json
@@ -6,7 +6,6 @@
       "firebase_prod.json",
       "firebase_staging.json"
     ],
-    // Set up headers for cross-origin isolation.
     "headers": [{
       "source": "local-benchmark/",
       "headers": [

--- a/e2e/benchmarks/firebase_staging.json
+++ b/e2e/benchmarks/firebase_staging.json
@@ -1,0 +1,24 @@
+{
+  "hosting": {
+    "site": "tfjs-benchmarks-staging",
+    "public": ".",
+    "ignore": [
+      "firebase_prod.json",
+      "firebase_staging.json"
+    ],
+    // Set up headers for cross-origin isolation.
+    "headers": [{
+      "source": "local-benchmark/",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }]
+  }
+}

--- a/e2e/benchmarks/firebase_staging.json
+++ b/e2e/benchmarks/firebase_staging.json
@@ -6,7 +6,6 @@
       "firebase_prod.json",
       "firebase_staging.json"
     ],
-    // Set up headers for cross-origin isolation.
     "headers": [{
       "source": "local-benchmark/",
       "headers": [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -64,7 +64,10 @@
     "test": "./scripts/test.sh",
     "coverage": "KARMA_COVERAGE=1 ./scripts/test.sh",
     "test-ci": "./scripts/test-ci.sh",
-    "update-dependency": "ts-node ./scripts/update-dependency.ts"
+    "update-dependency": "ts-node ./scripts/update-dependency.ts",
+    "deploy-benchmarks": "./scripts/deploy-benchmarks.sh",
+    "deploy-benchmarks-dev": "./scripts/deploy-benchmarks.sh --dev",
+    "deploy-benchmarks-staging": "./scripts/deploy-benchmarks.sh --staging"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/e2e/scripts/deploy-benchmarks.sh
+++ b/e2e/scripts/deploy-benchmarks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Deploy content in e2e/benchmarks to firebase hosting.
+
+# Halt if a single command errors
+set -e
+
+PROJECT="jstensorflow"
+
+if [[ "$1" == "--dev" ]]; then
+  firebase serve \
+    --config benchmarks/firebase_staging.json \
+    --only hosting:tfjs-benchmarks-staging \
+    --project ${PROJECT}
+elif [[ "$1" == "--staging"  ]]; then
+  firebase deploy \
+    --config benchmarks/firebase_staging.json \
+    --only hosting:tfjs-benchmarks-staging \
+    --project ${PROJECT}
+else
+  firebase deploy \
+    --config benchmarks/firebase_prod.json \
+    --only hosting:tfjs-benchmarks \
+    --project ${PROJECT}
+fi


### PR DESCRIPTION
I've added two "sites" in our [firebase app](https://firebase.corp.google.com/project/jstensorflow/hosting/sites): `tfjs-benchmarks`, and `tfjs-benchmarks-staging`. This PR added scripts to deploy the content of `e2e/benchmarks` to those sites. They are configured to send the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers which are required for [cross-origin isolation](https://web.dev/coop-coep/) and the multi-threading support in WASM. 

The site is now live: https://tfjs-benchmarks.web.app/local-benchmark/. You can see that the [threaded-simd](https://user-images.githubusercontent.com/8752427/132424858-69b3b414-7264-447f-abb0-0345e6655a9f.png) wasm binary is loaded.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5591)
<!-- Reviewable:end -->
