### PR TITLE
[webgpu] Create FromPixles program as required

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -100,8 +100,8 @@ export class WebGPUBackend extends KernelBackend {
   private downloadWaitMs = 0;
   private computePassNumberInEncoder = 0;
   private querySet: GPUQuerySet;
-  private fromPixelProgram:
-      {copyExternal: FromPixelsProgram, import: FromPixelsImportProgram};
+  private fromPixelProgram?: FromPixelsProgram;
+  private fromPixelImportProgram?: FromPixelsImportProgram;
 
   constructor(device: GPUDevice, glslang: Glslang, supportTimeQuery = false) {
     super();
@@ -143,12 +143,6 @@ export class WebGPUBackend extends KernelBackend {
 
       document.body.appendChild(this.dummyCanvas);
     }
-
-    // Create FromPixelsProgram instance is light weight;
-    this.fromPixelProgram = {
-      copyExternal: new FromPixelsProgram(),
-      import: new FromPixelsImportProgram()
-    };
   }
 
   floatPrecision(): 32 {
@@ -319,16 +313,16 @@ export class WebGPUBackend extends KernelBackend {
   getFromPixelsProgram(type: 'copyExternal'|'import'): FromPixelsProgram {
     switch (type) {
       case 'copyExternal': {
-        if (!this.fromPixelProgram.copyExternal) {
-          this.fromPixelProgram.copyExternal = new FromPixelsProgram();
+        if (!this.fromPixelProgram) {
+          this.fromPixelProgram = new FromPixelsProgram();
         }
-        return this.fromPixelProgram.copyExternal;
+        return this.fromPixelProgram;
       }
       case 'import': {
-        if (!this.fromPixelProgram.import) {
-          this.fromPixelProgram.import = new FromPixelsImportProgram();
+        if (!this.fromPixelImportProgram) {
+          this.fromPixelImportProgram = new FromPixelsImportProgram();
         }
-        return this.fromPixelProgram.import;
+        return this.fromPixelImportProgram;
       }
       default:
         util.assert(false, () => `Unsupported fromPixels shape`);
@@ -921,12 +915,12 @@ export class WebGPUBackend extends KernelBackend {
     }
     this.bufferManager.dispose();
 
-    if (this.fromPixelProgram.copyExternal) {
-      this.fromPixelProgram.copyExternal.dispose();
+    if (this.fromPixelProgram) {
+      this.fromPixelProgram.dispose();
     }
 
-    if (this.fromPixelProgram.import) {
-      this.fromPixelProgram.import.dispose();
+    if (this.fromPixelImportProgram) {
+      this.fromPixelImportProgram.dispose();
     }
 
     this.disposed = true;

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -19,7 +19,7 @@ import {util} from '@tensorflow/tfjs-core';
 import {getGlobalIndexStringWgsl, getMainHeaderStringWgsl} from '../../shader_preprocessor_wgsl';
 
 import {computeDispatch, flatDispatchLayout, WebGPULayout} from '../../webgpu_util';
-import {getUseWgsl, WebGPUProgram} from '../webgpu_program';
+import {WebGPUProgram} from '../webgpu_program';
 
 export class FromPixelsProgram implements WebGPUProgram {
   outputShape: number[] = [0];
@@ -38,7 +38,9 @@ export class FromPixelsProgram implements WebGPUProgram {
   inputTexture: GPUTexture = null;
   layout: WebGPULayout = null;
   lastPixelSize = {width: 0, height: 0};
-  useWgsl: boolean;
+  // Default to WGSL, because GLSL will complain: The provided value
+  // 'read-only' is not a valid enum value of type GPUStorageTextureAccess.
+  useWgsl = true;
   useImport: boolean;
 
   private disposed = false;
@@ -58,7 +60,6 @@ export class FromPixelsProgram implements WebGPUProgram {
 
   constructor() {
     this.shaderKey = 'fromPixels';
-    this.useWgsl = getUseWgsl();
     this.useImport = false;
   }
 


### PR DESCRIPTION
Two goals for this PR:
1. When fromPixel isn't used, such as using tensor as input, no need to construct fromPixels programs. 
2. In current design, we can not get URLSearchParams related flags from WebGPUBackend's constructor(This scenario is from e2e). If doing so, will result in cycle dependence:
```
setFlags(from URLSearchParams, such as WEBGPU_USE_GLSL) call tf(from loadScripts). This means we need call loadScripts before setFlags.

loadScript will initialize WebGPU backend and new FromPixlesProgram. FromPixlesProgram needs to check flag WEBGPU_USE_GLSL. This means we need call setFlags before loadScripts.
```
To fix this cycle dependence,  one method is to avoid call new FromPixlesProgram when initialize WebGPU Backend, this is the second goal of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5610)
<!-- Reviewable:end -->
