### PR TITLE
[webgl] Run tests out of order

### DIFF
--- a/tfjs-backend-webgl/karma.conf.js
+++ b/tfjs-backend-webgl/karma.conf.js
@@ -160,6 +160,6 @@ module.exports = function(config) {
         os_version: '10'
       },
     },
-    client: {jasmine: {random: false}, args: args}
+    client: {jasmine: {random: true}, args: args}
   })
 }

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -39,7 +39,6 @@ const RENDER_FLOAT32_ENVS = {
 
 describeWithFlags('forced f16 render', RENDER_FLOAT32_ENVS, () => {
   beforeEach(() => {
-    tf.env().reset();
     tf.env().set('WEBGL_RENDER_FLOAT32_ENABLED', false);
   });
   afterAll(() => tf.env().reset());
@@ -54,10 +53,11 @@ describeWithFlags('forced f16 render', RENDER_FLOAT32_ENVS, () => {
     // Silence debug warnings.
     spyOn(console, 'warn');
 
-    tf.enableDebugMode();
+    const debug = tf.env().get('DEBUG');
+    tf.env().set('DEBUG', true);
     const a = () => tf.tensor1d([2, Math.pow(2, 17)], 'float32');
     expect(a).toThrowError();
-    tf.enableProdMode();
+    tf.env().set('DEBUG', debug);
   });
 });
 

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -38,9 +38,11 @@ const RENDER_FLOAT32_ENVS = {
 };
 
 describeWithFlags('forced f16 render', RENDER_FLOAT32_ENVS, () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    tf.env().reset();
     tf.env().set('WEBGL_RENDER_FLOAT32_ENABLED', false);
   });
+  afterAll(() => tf.env().reset());
 
   it('should overflow if larger than 66k', async () => {
     const a = tf.tensor1d([Math.pow(2, 17)], 'float32');
@@ -55,6 +57,7 @@ describeWithFlags('forced f16 render', RENDER_FLOAT32_ENVS, () => {
     tf.enableDebugMode();
     const a = () => tf.tensor1d([2, Math.pow(2, 17)], 'float32');
     expect(a).toThrowError();
+    tf.enableProdMode();
   });
 });
 

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -25,7 +25,6 @@ import * as canvas_util from './canvas_util';
 import {forceHalfFloat, webgl_util} from './webgl';
 
 describe('WEBGL_FORCE_F16_TEXTURES', () => {
-  beforeEach(() => tf.env().reset());
   afterAll(() => tf.env().reset());
 
   it('can be activated via forceHalfFloat utility', () => {
@@ -358,9 +357,6 @@ describe('WEBGL_SIZE_UPLOAD_UNIFORM', () => {
 });
 
 describeWithFlags('WEBGL_DELETE_TEXTURE_THRESHOLD', WEBGL_ENVS, () => {
-  beforeEach(() => tf.env().reset());
-  afterAll(() => tf.env().reset());
-
   it('should throw an error if given a negative value', () => {
     expect(() => tf.env().set('WEBGL_DELETE_TEXTURE_THRESHOLD', -2)).toThrow();
   });

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -25,6 +25,7 @@ import * as canvas_util from './canvas_util';
 import {forceHalfFloat, webgl_util} from './webgl';
 
 describe('WEBGL_FORCE_F16_TEXTURES', () => {
+  beforeEach(() => tf.env().reset());
   afterAll(() => tf.env().reset());
 
   it('can be activated via forceHalfFloat utility', () => {
@@ -357,12 +358,18 @@ describe('WEBGL_SIZE_UPLOAD_UNIFORM', () => {
 });
 
 describeWithFlags('WEBGL_DELETE_TEXTURE_THRESHOLD', WEBGL_ENVS, () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
   it('should throw an error if given a negative value', () => {
     expect(() => tf.env().set('WEBGL_DELETE_TEXTURE_THRESHOLD', -2)).toThrow();
   });
 });
 
 describeWithFlags('WEBGL_FLUSH_THRESHOLD', WEBGL_ENVS, () => {
+  beforeEach(() => tf.env().reset());
+  afterAll(() => tf.env().reset());
+
   it('should return the correct default value', () => {
     if (device_util.isMobile() && tf.env().getBool('IS_CHROME')) {
       expect(tf.env().getNumber('WEBGL_FLUSH_THRESHOLD')).toEqual(1);

--- a/tfjs-core/src/ops/image/threshold_test.ts
+++ b/tfjs-core/src/ops/image/threshold_test.ts
@@ -22,7 +22,7 @@ describeWithFlags('threshold', ALL_ENVS, () => {
   let originalTimeout: number;
   beforeEach(() => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20_000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 40_000;
     tf.env().reset();
   });
   afterAll(() => {

--- a/tfjs-core/src/ops/image/threshold_test.ts
+++ b/tfjs-core/src/ops/image/threshold_test.ts
@@ -23,10 +23,8 @@ describeWithFlags('threshold', ALL_ENVS, () => {
   beforeEach(() => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 40_000;
-    tf.env().reset();
   });
   afterAll(() => {
-    tf.env().reset();
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 

--- a/tfjs-core/src/ops/image/threshold_test.ts
+++ b/tfjs-core/src/ops/image/threshold_test.ts
@@ -19,6 +19,17 @@ import {ALL_ENVS, describeWithFlags} from '../../jasmine_util';
 import {expectArraysEqual} from '../../test_util';
 
 describeWithFlags('threshold', ALL_ENVS, () => {
+  let originalTimeout: number;
+  beforeEach(() => {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20_000;
+    tf.env().reset();
+  });
+  afterAll(() => {
+    tf.env().reset();
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
+
   it('default method binary, no arguments passed but input image', async () => {
     const image: tf.Tensor3D = tf.tensor3d(
     [144,255,51,13,32,59,222,100,51,69,71,222],
@@ -162,5 +173,4 @@ describeWithFlags('threshold', ALL_ENVS, () => {
         0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
     );
   });
-
 });


### PR DESCRIPTION
Allow jasmine tests to run in a random order

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5616)
<!-- Reviewable:end -->
