### PR TITLE
Use system python and node:16 for CI

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -228,51 +228,52 @@ else
 fi
 """
 
-http_archive(
-    name = "python3_interpreter",
-    build_file_content = """
-exports_files(["python3_bin"])
-filegroup(
-    name = "files",
-    srcs = glob(["bazel_install_py3/**"], exclude = ["**/* *"]),
-    visibility = ["//visibility:public"],
-)
-""",
-    patch_cmds = [
-        "mkdir $(pwd)/bazel_install_py3",
-        _py3_configure,
-        "make",
-        "make install",
-        "ln -s bazel_install_py3/bin/python3 python3_bin",
-    ],
-    sha256 = "fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2",
-    strip_prefix = "Python-3.8.11",
-    urls = ["https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tar.xz"],
-)
+# http_archive(
+#     name = "python3_interpreter",
+#     build_file_content = """
+# exports_files(["python3_bin"])
+# filegroup(
+#     name = "files",
+#     srcs = glob(["bazel_install_py3/**"], exclude = ["**/* *"]),
+#     visibility = ["//visibility:public"],
+# )
+# """,
+#     patch_cmds = [
+#         "mkdir $(pwd)/bazel_install_py3",
+#         _py3_configure,
+#         "make",
+#         "make install",
+#         "ln -s bazel_install_py3/bin/python3 python3_bin",
+#     ],
+#     sha256 = "fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2",
+#     strip_prefix = "Python-3.8.11",
+#     urls = ["https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tar.xz"],
+# )
 
-http_archive(
-    name = "python2_interpreter",
-    build_file_content = """
-exports_files(["python_bin"])
-filegroup(
-    name = "files",
-    srcs = glob(["bazel_install_py2/**"], exclude = ["**/* *"]),
-    visibility = ["//visibility:public"],
-)
-""",
-    patch_cmds = [
-        "mkdir $(pwd)/bazel_install_py2",
-        _py2_configure,
-        "make",
-        "make install",
-        "ln -s bazel_install_py2/bin/python python_bin",
-    ],
-    sha256 = "a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1",
-    strip_prefix = "Python-2.7.13",
-    urls = ["https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz"],
-)
+# http_archive(
+#     name = "python2_interpreter",
+#     build_file_content = """
+# exports_files(["python_bin"])
+# filegroup(
+#     name = "files",
+#     srcs = glob(["bazel_install_py2/**"], exclude = ["**/* *"]),
+#     visibility = ["//visibility:public"],
+# )
+# """,
+#     patch_cmds = [
+#         "mkdir $(pwd)/bazel_install_py2",
+#         _py2_configure,
+#         "make",
+#         "make install",
+#         "ln -s bazel_install_py2/bin/python python_bin",
+#     ],
+#     sha256 = "a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1",
+#     strip_prefix = "Python-2.7.13",
+#     urls = ["https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz"],
+# )
 
-register_toolchains("//tfjs-converter/python:tfjs_py_toolchain")
+#register_toolchains("//tfjs-converter/python:tfjs_py_toolchain")
+#register_toolchains("@bazel_tools//tools/python:autodetecting_python_toolchain")
 
 http_archive(
     name = "rules_python",
@@ -286,12 +287,12 @@ load("@rules_python//python:pip.bzl", "pip_install")
 # third-party packages specified in the requirements.txt file.
 pip_install(
     name = "tensorflowjs_dev_deps",
-    python_interpreter_target = "@python3_interpreter//:python3_bin",
+    #python_interpreter_target = "@python3_interpreter//:python3_bin",
     requirements = "//tfjs-converter/python:requirements-dev.txt",
 )
 
 pip_install(
     name = "tensorflowjs_deps",
-    python_interpreter_target = "@python3_interpreter//:python3_bin",
+    #python_interpreter_target = "@python3_interpreter//:python3_bin",
     requirements = "//tfjs-converter/python:requirements.txt",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -210,71 +210,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-# Special logic for building python interpreter with OpenSSL from homebrew.
-# See https://devguide.python.org/setup/#macos-and-os-x
-_py3_configure = """
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    ./configure --prefix=$(pwd)/bazel_install_py3 --with-openssl=$(brew --prefix openssl)
-else
-    ./configure --prefix=$(pwd)/bazel_install_py3
-fi
-"""
-
-_py2_configure = """
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    ./configure --prefix=$(pwd)/bazel_install_py2 --with-openssl=$(brew --prefix openssl)
-else
-    ./configure --prefix=$(pwd)/bazel_install_py2
-fi
-"""
-
-# http_archive(
-#     name = "python3_interpreter",
-#     build_file_content = """
-# exports_files(["python3_bin"])
-# filegroup(
-#     name = "files",
-#     srcs = glob(["bazel_install_py3/**"], exclude = ["**/* *"]),
-#     visibility = ["//visibility:public"],
-# )
-# """,
-#     patch_cmds = [
-#         "mkdir $(pwd)/bazel_install_py3",
-#         _py3_configure,
-#         "make",
-#         "make install",
-#         "ln -s bazel_install_py3/bin/python3 python3_bin",
-#     ],
-#     sha256 = "fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2",
-#     strip_prefix = "Python-3.8.11",
-#     urls = ["https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tar.xz"],
-# )
-
-# http_archive(
-#     name = "python2_interpreter",
-#     build_file_content = """
-# exports_files(["python_bin"])
-# filegroup(
-#     name = "files",
-#     srcs = glob(["bazel_install_py2/**"], exclude = ["**/* *"]),
-#     visibility = ["//visibility:public"],
-# )
-# """,
-#     patch_cmds = [
-#         "mkdir $(pwd)/bazel_install_py2",
-#         _py2_configure,
-#         "make",
-#         "make install",
-#         "ln -s bazel_install_py2/bin/python python_bin",
-#     ],
-#     sha256 = "a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1",
-#     strip_prefix = "Python-2.7.13",
-#     urls = ["https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz"],
-# )
-
-#register_toolchains("//tfjs-converter/python:tfjs_py_toolchain")
-#register_toolchains("@bazel_tools//tools/python:autodetecting_python_toolchain")
-
 http_archive(
     name = "rules_python",
     sha256 = "934c9ceb552e84577b0faf1e5a2f0450314985b4d8712b2b70717dc679fdc01b",
@@ -287,12 +222,10 @@ load("@rules_python//python:pip.bzl", "pip_install")
 # third-party packages specified in the requirements.txt file.
 pip_install(
     name = "tensorflowjs_dev_deps",
-    #python_interpreter_target = "@python3_interpreter//:python3_bin",
     requirements = "//tfjs-converter/python:requirements-dev.txt",
 )
 
 pip_install(
     name = "tensorflowjs_deps",
-    #python_interpreter_target = "@python3_interpreter//:python3_bin",
     requirements = "//tfjs-converter/python:requirements.txt",
 )

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,13 +1,13 @@
 steps:
 # Install top-level deps.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
 
 # Generate cloudbuild_generated.yml,
 # which builds and tests all affected packages.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'generate-cloudbuild-for-packages'
   args: ['generate-cloudbuild-for-packages']

--- a/e2e/cloudbuild.yml
+++ b/e2e/cloudbuild.yml
@@ -16,7 +16,7 @@ steps:
   env: ['NIGHTLY=$_NIGHTLY']
 
 # Test.
-- name: 'node:16'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'e2e'
   entrypoint: 'yarn'
   id: 'test'

--- a/e2e/cloudbuild.yml
+++ b/e2e/cloudbuild.yml
@@ -1,14 +1,14 @@
 steps:
 
 # Install packages.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'e2e'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
 
 # Build deps.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'e2e'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -16,7 +16,7 @@ steps:
   env: ['NIGHTLY=$_NIGHTLY']
 
 # Test.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'e2e'
   entrypoint: 'yarn'
   id: 'test'

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -1,13 +1,13 @@
 steps:
 # Install top-level deps.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Test generate_cloudbuild.js
 # See #4523 for why this is special-cased into every cloudbuild.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'scripts'
   id: 'test-generate-cloudbuild'
   entrypoint: 'yarn'
@@ -17,14 +17,14 @@ steps:
 # Test run_flaky.js
 # The flaky test runner is important enough to test every time and takes less
 # than 5 seconds.
-- name: 'node:10'
+- name: 'node:16'
   id: 'test-run-flaky'
   entrypoint: 'yarn'
   args: ['test-run-flaky']
   waitFor: ['yarn-common']
 
 # Lint bazel files.
-- name: 'node:10'
+- name: 'node:16'
   id: 'buildifier'
   entrypoint: 'yarn'
   args: ['buildifier-ci']
@@ -33,7 +33,7 @@ steps:
 # Bazel tests
 # These use a remote cache and only re-run if changes occurred, so we run them
 # in every build.
-- name: 'node:10'
+- name: 'node:16'
   id: 'bazel-tests'
   entrypoint: 'bash'
   args:
@@ -45,14 +45,14 @@ steps:
 # The following steps build the link packages, which are temporary packages
 # that help packages that don't build with Bazel load outputs from packages
 # that build with Bazel.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'link-package-core'
   entrypoint: 'yarn'
   id: 'yarn-link-package-core'
   args: ['install']
   waitFor: ['bazel-tests']
 
-- name: 'node:10'
+- name: 'node:16'
   dir: 'link-package'
   entrypoint: 'yarn'
   id: 'yarn-link-package'

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -122,7 +122,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: test-wasm-tfjs-backend-wasm

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -454,7 +454,7 @@ steps:
     secretEnv:
       - BROWSERSTACK_KEY
       - FIREBASE_KEY
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: yarn-tfjs-node
@@ -466,7 +466,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: build-addon-tfjs-node
@@ -479,7 +479,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: build-tfjs-node
@@ -492,7 +492,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: lint-tfjs-node
@@ -505,7 +505,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: test-tfjs-node
@@ -519,7 +519,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: ensure-cpu-gpu-packages-align-tfjs-node
@@ -531,7 +531,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     id: prep-gpu-tfjs-node-gpu
     entrypoint: yarn
@@ -543,7 +543,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: yarn-tfjs-node-gpu
@@ -556,7 +556,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: build-addon-tfjs-node-gpu
@@ -569,7 +569,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: build-tfjs-node-gpu
@@ -582,7 +582,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: lint-tfjs-node-gpu
@@ -595,7 +595,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: test-tfjs-node-gpu
@@ -609,7 +609,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: ensure-cpu-gpu-packages-align-tfjs-node-gpu

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -654,7 +654,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - build-tfjs-backend-wasm
       - lint-tfjs-backend-wasm
-  - name: 'node:16'
+  - name: gcr.io/learnjs-174218/release
     dir: e2e
     entrypoint: yarn
     id: test-e2e

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -1,10 +1,10 @@
 steps:
-  - name: 'node:10'
+  - name: 'node:16'
     entrypoint: yarn
     id: yarn-common
     args:
       - install
-  - name: 'node:10'
+  - name: 'node:16'
     dir: scripts
     id: test-generate-cloudbuild
     entrypoint: yarn
@@ -12,21 +12,21 @@ steps:
       - test-generate-cloudbuild
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: 'node:16'
     id: test-run-flaky
     entrypoint: yarn
     args:
       - test-run-flaky
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: 'node:16'
     id: buildifier
     entrypoint: yarn
     args:
       - buildifier-ci
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: 'node:16'
     id: bazel-tests
     entrypoint: bash
     args:
@@ -37,7 +37,7 @@ steps:
       - yarn-common
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: 'node:16'
     dir: link-package-core
     entrypoint: yarn
     id: yarn-link-package-core
@@ -45,7 +45,7 @@ steps:
       - install
     waitFor:
       - bazel-tests
-  - name: 'node:10'
+  - name: 'node:16'
     dir: link-package
     entrypoint: yarn
     id: yarn-link-package
@@ -54,7 +54,7 @@ steps:
     waitFor:
       - bazel-tests
       - yarn-link-package-core
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-converter
     entrypoint: yarn
     id: yarn-tfjs-converter
@@ -63,21 +63,21 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-converter
-    entrypoint: yarn
     id: lint-tfjs-converter
+    entrypoint: yarn
     args:
       - lint
     waitFor:
       - yarn-tfjs-converter
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
-    id: 'create-pips-tfjs-converter'
-    entrypoint: 'bash'
+  - name: 'node:16'
+    id: create-pips-tfjs-converter
+    entrypoint: bash
     args:
-      - './tfjs-converter/scripts/create_python_pips.sh'
+      - ./tfjs-converter/scripts/create_python_pips.sh
     waitFor:
       - yarn-common
       - yarn-link-package
@@ -93,7 +93,7 @@ steps:
       - create-pips-tfjs-converter
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: yarn-tfjs-backend-wasm
@@ -102,7 +102,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: gcr.io/learnjs-174218/wasm
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: bash
     id: build-tfjs-backend-wasm
@@ -112,7 +112,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: lint-tfjs-backend-wasm
@@ -122,7 +122,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: test-wasm-tfjs-backend-wasm
@@ -139,7 +139,7 @@ steps:
       - NIGHTLY=$_NIGHTLY
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: gcr.io/learnjs-174218/wasm
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     id: test-bundle-size-tfjs-backend-wasm
     entrypoint: yarn
@@ -150,7 +150,7 @@ steps:
       - build-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     id: yarn-tfjs-backend-webgl
     entrypoint: yarn
@@ -159,7 +159,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     id: build-tfjs-backend-webgl
     entrypoint: yarn
@@ -169,7 +169,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     id: lint-tfjs-backend-webgl
     entrypoint: yarn
@@ -179,7 +179,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     entrypoint: yarn
     id: test-tfjs-backend-webgl
@@ -195,7 +195,7 @@ steps:
       - NIGHTLY=$_NIGHTLY
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgpu
     id: yarn-tfjs-backend-webgpu
     entrypoint: yarn
@@ -204,7 +204,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgpu
     id: lint-tfjs-backend-webgpu
     entrypoint: yarn
@@ -214,7 +214,7 @@ steps:
       - yarn-tfjs-backend-webgpu
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgpu
     entrypoint: yarn
     id: test-webgpu-tfjs-backend-webgpu
@@ -225,7 +225,7 @@ steps:
       - lint-tfjs-backend-webgpu
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: yarn-tfjs-layers
@@ -237,7 +237,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: build-tfjs-layers
@@ -250,7 +250,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: lint-tfjs-layers
@@ -263,7 +263,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: test-browser-tfjs-layers
@@ -282,7 +282,7 @@ steps:
       - NIGHTLY=$_NIGHTLY
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: test-snippets-tfjs-layers
@@ -295,7 +295,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: yarn-tfjs-data
@@ -307,7 +307,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: build-tfjs-data
@@ -320,7 +320,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: lint-tfjs-data
@@ -333,7 +333,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: test-tfjs-data
@@ -347,7 +347,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: test-snippets-tfjs-data
@@ -360,7 +360,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: yarn-tfjs
@@ -381,7 +381,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: build-tfjs
@@ -403,7 +403,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: lint-tfjs
@@ -425,7 +425,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: test-tfjs
@@ -454,7 +454,7 @@ steps:
     secretEnv:
       - BROWSERSTACK_KEY
       - FIREBASE_KEY
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: yarn-tfjs-node
@@ -466,7 +466,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: build-addon-tfjs-node
@@ -479,7 +479,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: build-tfjs-node
@@ -492,7 +492,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: lint-tfjs-node
@@ -505,7 +505,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: test-tfjs-node
@@ -519,7 +519,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: ensure-cpu-gpu-packages-align-tfjs-node
@@ -531,7 +531,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     id: prep-gpu-tfjs-node-gpu
     entrypoint: yarn
@@ -543,7 +543,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: yarn-tfjs-node-gpu
@@ -556,7 +556,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: build-addon-tfjs-node-gpu
@@ -569,7 +569,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: build-tfjs-node-gpu
@@ -582,7 +582,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: lint-tfjs-node-gpu
@@ -595,7 +595,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: test-tfjs-node-gpu
@@ -609,7 +609,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node-gpu
     entrypoint: yarn
     id: ensure-cpu-gpu-packages-align-tfjs-node-gpu
@@ -622,7 +622,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: e2e
     entrypoint: yarn
     id: yarn-e2e
@@ -654,7 +654,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - build-tfjs-backend-wasm
       - lint-tfjs-backend-wasm
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: e2e
     entrypoint: yarn
     id: test-e2e

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -1,10 +1,10 @@
 steps:
-  - name: 'node:10'
+  - name: 'node:16'
     entrypoint: yarn
     id: yarn-common
     args:
       - install
-  - name: 'node:10'
+  - name: 'node:16'
     dir: scripts
     id: test-generate-cloudbuild
     entrypoint: yarn
@@ -12,21 +12,21 @@ steps:
       - test-generate-cloudbuild
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: 'node:16'
     id: test-run-flaky
     entrypoint: yarn
     args:
       - test-run-flaky
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: 'node:16'
     id: buildifier
     entrypoint: yarn
     args:
       - buildifier-ci
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: 'node:16'
     id: bazel-tests
     entrypoint: bash
     args:
@@ -37,7 +37,7 @@ steps:
       - yarn-common
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: 'node:16'
     dir: link-package-core
     entrypoint: yarn
     id: yarn-link-package-core
@@ -45,7 +45,7 @@ steps:
       - install
     waitFor:
       - bazel-tests
-  - name: 'node:10'
+  - name: 'node:16'
     dir: link-package
     entrypoint: yarn
     id: yarn-link-package
@@ -54,7 +54,7 @@ steps:
     waitFor:
       - bazel-tests
       - yarn-link-package-core
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-converter
     entrypoint: yarn
     id: yarn-tfjs-converter
@@ -63,25 +63,25 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-converter
-    entrypoint: yarn
     id: lint-tfjs-converter
+    entrypoint: yarn
     args:
       - lint
     waitFor:
       - yarn-tfjs-converter
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
-    id: 'create-pips-tfjs-converter'
-    entrypoint: 'bash'
+  - name: 'node:16'
+    id: create-pips-tfjs-converter
+    entrypoint: bash
     args:
-      - './tfjs-converter/scripts/create_python_pips.sh'
+      - ./tfjs-converter/scripts/create_python_pips.sh
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: yarn-tfjs-backend-wasm
@@ -90,7 +90,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: gcr.io/learnjs-174218/wasm
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: bash
     id: build-tfjs-backend-wasm
@@ -100,7 +100,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: lint-tfjs-backend-wasm
@@ -110,7 +110,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     id: yarn-tfjs-backend-webgl
     entrypoint: yarn
@@ -119,7 +119,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     id: build-tfjs-backend-webgl
     entrypoint: yarn
@@ -129,7 +129,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-backend-webgl
     id: lint-tfjs-backend-webgl
     entrypoint: yarn
@@ -139,7 +139,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: yarn-tfjs-layers
@@ -151,7 +151,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: build-tfjs-layers
@@ -164,7 +164,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-layers
     entrypoint: yarn
     id: lint-tfjs-layers
@@ -177,7 +177,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: yarn-tfjs-data
@@ -189,7 +189,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: build-tfjs-data
@@ -202,7 +202,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs-data
     entrypoint: yarn
     id: lint-tfjs-data
@@ -215,7 +215,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: yarn-tfjs
@@ -236,7 +236,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: build-tfjs
@@ -258,7 +258,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:10'
+  - name: 'node:16'
     dir: tfjs
     entrypoint: yarn
     id: lint-tfjs
@@ -280,7 +280,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: yarn-tfjs-node
@@ -292,7 +292,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: build-addon-tfjs-node
@@ -305,7 +305,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: build-tfjs-node
@@ -318,7 +318,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: lint-tfjs-node
@@ -331,7 +331,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: test-tfjs-node
@@ -345,7 +345,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: tfjs-node
     entrypoint: yarn
     id: ensure-cpu-gpu-packages-align-tfjs-node
@@ -357,7 +357,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: e2e
     entrypoint: yarn
     id: yarn-e2e
@@ -389,7 +389,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - build-tfjs-backend-wasm
       - lint-tfjs-backend-wasm
-  - name: gcr.io/learnjs-174218/release
+  - name: 'node:16'
     dir: e2e
     entrypoint: yarn
     id: test-e2e

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -280,7 +280,7 @@ steps:
       - yarn-tfjs-backend-webgl
       - build-tfjs-backend-webgl
       - lint-tfjs-backend-webgl
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: yarn-tfjs-node
@@ -292,7 +292,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: build-addon-tfjs-node
@@ -305,7 +305,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: build-tfjs-node
@@ -318,7 +318,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: lint-tfjs-node
@@ -331,7 +331,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: test-tfjs-node
@@ -345,7 +345,7 @@ steps:
       - yarn-tfjs
       - build-tfjs
       - lint-tfjs
-  - name: 'node:16'
+  - name: 'node:10'
     dir: tfjs-node
     entrypoint: yarn
     id: ensure-cpu-gpu-packages-align-tfjs-node

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -389,7 +389,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - build-tfjs-backend-wasm
       - lint-tfjs-backend-wasm
-  - name: 'node:16'
+  - name: gcr.io/learnjs-174218/release
     dir: e2e
     entrypoint: yarn
     id: test-e2e

--- a/tfjs-automl/cloudbuild.yml
+++ b/tfjs-automl/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install tfjs-automl dependencies.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'build'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'lint'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn']
 
 # Run node tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'test-js'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build', 'lint']
 
   # Run browser tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'test-browser'

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run JS tests.
-- name: 'node:16'
+- name: 'node:10' # This test fails with "out of wasm memory" on node:16
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-wasm'

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Install build-deps.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'gcr.io/learnjs-174218/wasm'
+- name: 'node:16'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'bash'
   id: 'build'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'lint'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run JS tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-wasm'
@@ -48,7 +48,7 @@ steps:
   secretEnv: ['BROWSERSTACK_KEY']
 
 # Check bundle size.
-- name: 'gcr.io/learnjs-174218/wasm'
+- name: 'node:16'
   dir: 'tfjs-backend-wasm'
   id: 'test-bundle-size'
   entrypoint: 'yarn'

--- a/tfjs-backend-webgl/cloudbuild.yml
+++ b/tfjs-backend-webgl/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgl'
   id: 'yarn'
   entrypoint: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgl'
   id: 'build-deps'
   entrypoint: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgl'
   id: 'build'
   entrypoint: 'yarn'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', build-deps]
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgl'
   id: 'lint'
   entrypoint: 'yarn'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgl'
   entrypoint: 'yarn'
   id: 'test'

--- a/tfjs-backend-webgpu/cloudbuild.yml
+++ b/tfjs-backend-webgpu/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install webgpu dependencies.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgpu'
   id: 'yarn'
   entrypoint: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgpu'
   id: 'build-deps'
   entrypoint: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgpu'
   id: 'lint'
   entrypoint: 'yarn'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-backend-webgpu'
   entrypoint: 'yarn'
   id: 'test-webgpu'

--- a/tfjs-converter/cloudbuild.yml
+++ b/tfjs-converter/cloudbuild.yml
@@ -2,13 +2,13 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install tfjs-converter dependencies.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-converter'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -16,14 +16,14 @@ steps:
   waitFor: ['yarn-common']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-converter'
   id: 'lint'
   entrypoint: 'yarn'
   args: ['lint']
   waitFor: ['yarn']
 
-- name: 'node:10'
+- name: 'node:16'
   id: 'create-pips'
   entrypoint: 'bash'
   args:

--- a/tfjs-converter/cloudbuild_nightly.yml
+++ b/tfjs-converter/cloudbuild_nightly.yml
@@ -1,20 +1,20 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install converter dependencies
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-converter'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
   waitFor: ['yarn-common']
 
-- name: 'node:10'
+- name: 'node:16'
   id: 'create-pips'
   entrypoint: 'bash'
   args:

--- a/tfjs-converter/package.json
+++ b/tfjs-converter/package.json
@@ -18,6 +18,7 @@
     "@tensorflow/tfjs-core": "link:../link-package-core/node_modules/@tensorflow/tfjs-core"
   },
   "devDependencies": {
+    "@bazel/bazelisk": "^1.10.1",
     "@bazel/ibazel": "^0.15.10",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -3,33 +3,33 @@ load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 
 package(default_visibility = ["//visibility:public"])
 
-py_runtime(
-    name = "python3_runtime",
-    files = ["@python3_interpreter//:files"],
-    interpreter = "@python3_interpreter//:python3_bin",
-    python_version = "PY3",
-    visibility = ["//visibility:public"],
-)
+# py_runtime(
+#     name = "python3_runtime",
+#     files = ["@python3_interpreter//:files"],
+#     interpreter = "@python3_interpreter//:python3_bin",
+#     python_version = "PY3",
+#     visibility = ["//visibility:public"],
+# )
 
-py_runtime(
-    name = "python2_runtime",
-    files = ["@python2_interpreter//:files"],
-    interpreter = "@python2_interpreter//:python_bin",
-    python_version = "PY2",
-    visibility = ["//visibility:public"],
-)
+# py_runtime(
+#     name = "python2_runtime",
+#     files = ["@python2_interpreter//:files"],
+#     interpreter = "@python2_interpreter//:python_bin",
+#     python_version = "PY2",
+#     visibility = ["//visibility:public"],
+# )
 
-py_runtime_pair(
-    name = "tfjs_py_runtime_pair",
-    py2_runtime = ":python2_runtime",
-    py3_runtime = ":python3_runtime",
-)
+# py_runtime_pair(
+#     name = "tfjs_py_runtime_pair",
+#     py2_runtime = ":python2_runtime",
+#     py3_runtime = ":python3_runtime",
+# )
 
-toolchain(
-    name = "tfjs_py_toolchain",
-    toolchain = ":tfjs_py_runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
+# toolchain(
+#     name = "tfjs_py_toolchain",
+#     toolchain = ":tfjs_py_runtime_pair",
+#     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+# )
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -3,34 +3,6 @@ load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 
 package(default_visibility = ["//visibility:public"])
 
-# py_runtime(
-#     name = "python3_runtime",
-#     files = ["@python3_interpreter//:files"],
-#     interpreter = "@python3_interpreter//:python3_bin",
-#     python_version = "PY3",
-#     visibility = ["//visibility:public"],
-# )
-
-# py_runtime(
-#     name = "python2_runtime",
-#     files = ["@python2_interpreter//:files"],
-#     interpreter = "@python2_interpreter//:python_bin",
-#     python_version = "PY2",
-#     visibility = ["//visibility:public"],
-# )
-
-# py_runtime_pair(
-#     name = "tfjs_py_runtime_pair",
-#     py2_runtime = ":python2_runtime",
-#     py3_runtime = ":python3_runtime",
-# )
-
-# toolchain(
-#     name = "tfjs_py_toolchain",
-#     toolchain = ":tfjs_py_runtime_pair",
-#     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-# )
-
 licenses(["notice"])  # Apache 2.0
 
 CONSOLE_SCRIPTS = {

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -1,4 +1,3 @@
-load("@rules_python//python:defs.bzl", "py_runtime_pair")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 
 package(default_visibility = ["//visibility:public"])

--- a/tfjs-converter/yarn.lock
+++ b/tfjs-converter/yarn.lock
@@ -23,6 +23,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@bazel/bazelisk@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.10.1.tgz#46236a43ad58e310c55247f866da0dc6083c3d8b"
+  integrity sha512-IHszNzBO2UrUy6YtsSAsZtnU6I6qpzXGkWdEvGoMxLgJnDsEnsIYniDCUjvjU1KAP+A03eepmCHlyFcRHMSxRA==
+
 "@bazel/ibazel@^0.15.10":
   version "0.15.10"
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.15.10.tgz#cf0cff1aec6d8e7bb23e1fc618d09fbd39b7a13f"

--- a/tfjs-core/cloudbuild.yml
+++ b/tfjs-core/cloudbuild.yml
@@ -1,6 +1,6 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']

--- a/tfjs-data/cloudbuild.yml
+++ b/tfjs-data/cloudbuild.yml
@@ -1,13 +1,13 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -15,7 +15,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -23,7 +23,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'build'
@@ -31,7 +31,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'lint'
@@ -39,7 +39,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tests in node.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'test'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'lint']
 
 # Run data snippets tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'test-snippets'

--- a/tfjs-inference/cloudbuild.yml
+++ b/tfjs-inference/cloudbuild.yml
@@ -1,14 +1,14 @@
 steps:
 
 # Install packages.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
 
 # Build binaries.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'build-binary'
@@ -16,7 +16,7 @@ steps:
   waitFor: ['yarn']
 
 # JS Test.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'test'
@@ -24,7 +24,7 @@ steps:
   waitFor: ['yarn']
 
 # Python Test.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'test-python'

--- a/tfjs-layers/cloudbuild.yml
+++ b/tfjs-layers/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'build'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'lint'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run javascript tests
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'test-browser'
@@ -47,7 +47,7 @@ steps:
   env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
   secretEnv: ['BROWSERSTACK_KEY']
 
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'test-snippets'

--- a/tfjs-node-gpu/cloudbuild.yml
+++ b/tfjs-node-gpu/cloudbuild.yml
@@ -1,20 +1,20 @@
 steps:
 # Prepare tfjs-node-gpu folder, copy files from tfjs-node.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   id: 'prep-gpu'
   entrypoint: 'yarn'
   args: ['prep-gpu']
 
 # Install common dependencies.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
   waitFor: ['prep-gpu']
 
 # Install packages.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common', 'prep-gpu']
 
 # Build add-on.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'build-addon'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn']
 
 # Build deps.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn-common', 'prep-gpu']
 
 # Build.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'build'
@@ -46,7 +46,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'lint'
@@ -54,7 +54,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Unit tests.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'test'
@@ -62,7 +62,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'lint']
 
 # CPU / GPU package alignment.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'ensure-cpu-gpu-packages-align'

--- a/tfjs-node-gpu/cloudbuild.yml
+++ b/tfjs-node-gpu/cloudbuild.yml
@@ -1,20 +1,20 @@
 steps:
 # Prepare tfjs-node-gpu folder, copy files from tfjs-node.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   id: 'prep-gpu'
   entrypoint: 'yarn'
   args: ['prep-gpu']
 
 # Install common dependencies.
-- name: 'node:16'
+- name: 'node:10'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
   waitFor: ['prep-gpu']
 
 # Install packages.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common', 'prep-gpu']
 
 # Build add-on.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'build-addon'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn']
 
 # Build deps.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn-common', 'prep-gpu']
 
 # Build.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'build'
@@ -46,7 +46,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'lint'
@@ -54,7 +54,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Unit tests.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'test'
@@ -62,7 +62,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'lint']
 
 # CPU / GPU package alignment.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node-gpu'
   entrypoint: 'yarn'
   id: 'ensure-cpu-gpu-packages-align'

--- a/tfjs-node/cloudbuild.yml
+++ b/tfjs-node/cloudbuild.yml
@@ -1,12 +1,14 @@
 steps:
 # Install common dependencies.
-- name: 'node:16'
+# We use node:10 instead of a newer version because e2e requires the native
+# module to be built for n-api v7
+- name: 'node:10'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +16,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build add-on.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'build-addon'
@@ -22,7 +24,7 @@ steps:
   waitFor: ['yarn']
 
 # Build deps.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -30,7 +32,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'build'
@@ -38,7 +40,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'lint'
@@ -46,7 +48,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Unit tests.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'test'
@@ -54,7 +56,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'lint']
 
 # CPU / GPU package alignment.
-- name: 'node:16'
+- name: 'node:10'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'ensure-cpu-gpu-packages-align'

--- a/tfjs-node/cloudbuild.yml
+++ b/tfjs-node/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build add-on.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'build-addon'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn']
 
 # Build deps.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'build'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'lint'
@@ -46,7 +46,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Unit tests.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'test'
@@ -54,7 +54,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'lint']
 
 # CPU / GPU package alignment.
-- name: 'gcr.io/learnjs-174218/release'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'ensure-cpu-gpu-packages-align'

--- a/tfjs-react-native/cloudbuild.yml
+++ b/tfjs-react-native/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install react native dependencies.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-react-native'
   id: 'yarn'
   entrypoint: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build tfjs-react-native.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-react-native'
   id: 'build'
   entrypoint: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn']
 
 # Run unit tests in react native. Tests against version published on NPM.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-react-native/integration_rn59'
   id: 'test-ci'
   entrypoint: 'yarn'

--- a/tfjs-vis/cloudbuild.yml
+++ b/tfjs-vis/cloudbuild.yml
@@ -1,13 +1,13 @@
 
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install tfjs-vis dependencies.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -15,7 +15,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Run vis tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs-vis'
   entrypoint: 'yarn'
   id: 'test-vis'

--- a/tfjs/cloudbuild.yml
+++ b/tfjs/cloudbuild.yml
@@ -1,13 +1,13 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'node:16'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -15,7 +15,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -23,7 +23,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'build'
@@ -31,7 +31,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'lint'
@@ -39,7 +39,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tfjs tests.
-- name: 'node:10'
+- name: 'node:16'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'test'


### PR DESCRIPTION
This PR makes Bazel use the system's available python2 and python3 instead of building from source. It also switches many steps to node:16 because node:10's python3 is at 3.5, which does not support format strings that are needed by esbuild's toolchain.

A few steps do not yet use node:16:
1. e2e tests still use the release docker because they require some of the dependencies it installs.
2. tfjs-node[-gpu] still use node:10 because they need to build for n-api v7 for the e2e tests.
3. tfjs-backend-wasm tests use node:10 because they fail with 'out of wasm memory' on node:16.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5620)
<!-- Reviewable:end -->
