### PR TITLE
[webgpu] Use WGSL as default shading language

### DIFF
--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -42,7 +42,7 @@ ENV.registerFlag('WEBGPU_USE_NAIVE_CONV2D', () => false);
 /**
  * Whether to use GLSL shading language.
  */
-ENV.registerFlag('WEBGPU_USE_GLSL', () => true);
+ENV.registerFlag('WEBGPU_USE_GLSL', () => false);
 
 /**
  * Whether to use conv2dTranspose_naive which directly implement the


### PR DESCRIPTION
For WGSL, all unit tests got passed, and no obvious perf regression was found. So we use WGSL as default.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5621)
<!-- Reviewable:end -->
