### PR TITLE
[e2e] Fix converter missing in publishing CI

### DIFF
--- a/e2e/scripts/publish-tfjs-ci.sh
+++ b/e2e/scripts/publish-tfjs-ci.sh
@@ -52,9 +52,9 @@ else
   echo "Publishing version ${RELEASE_VERSION}"
 fi
 
-# Packages to publish.
+# All packages to publish. This includes Bazel packages.
 PACKAGES=("tfjs-core" "tfjs-backend-cpu" "tfjs-backend-webgl" \
-"tfjs-backend-wasm" "tfjs-layers" "tfjs-data" "tfjs" \
+"tfjs-backend-wasm" "tfjs-layers" "tfjs-converter" "tfjs-data" "tfjs" \
 "tfjs-node" "tfjs-node-gpu")
 
 # Packages that build with Bazel


### PR DESCRIPTION
Add converter to the `PACKAGES` variable in e2e's publishing CI tests since it was missing.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5625)
<!-- Reviewable:end -->
