### PR TITLE
[react-native] Add option to TensorCamera to not use custom shaders to resize camera image texture

### DIFF
--- a/tfjs-react-native/src/camera/camera.ts
+++ b/tfjs-react-native/src/camera/camera.ts
@@ -142,7 +142,7 @@ export async function toTexture(
  */
 export function fromTexture(
     gl: WebGL2RenderingContext, texture: WebGLTexture, sourceDims: Dimensions,
-    targetShape: Dimensions, useCustomShadersToResize = true,
+    targetShape: Dimensions, useCustomShadersToResize = false,
     options: FromTextureOptions = {}): tf.Tensor3D {
   tf.util.assert(
       targetShape.depth === 3 || targetShape.depth === 4,

--- a/tfjs-react-native/src/camera/camera.ts
+++ b/tfjs-react-native/src/camera/camera.ts
@@ -135,12 +135,15 @@ export async function toTexture(
  * @param texture the texture to convert into a tensor
  * @param sourceDims source dimensions of input texture (width, height, depth)
  * @param targetShape desired shape of output tensor
+ * @param useCustomShadersToResize whether to use custom shaders to resize
+ *   texture.
  *
  * @doc {heading: 'Media', subheading: 'Camera'}
  */
 export function fromTexture(
     gl: WebGL2RenderingContext, texture: WebGLTexture, sourceDims: Dimensions,
-    targetShape: Dimensions, options: FromTextureOptions = {}): tf.Tensor3D {
+    targetShape: Dimensions, useCustomShadersToResize = true,
+    options: FromTextureOptions = {}): tf.Tensor3D {
   tf.util.assert(
       targetShape.depth === 3 || targetShape.depth === 4,
       () => 'fromTexture Error: target depth must be 3 or 4');
@@ -188,7 +191,8 @@ export function fromTexture(
           ' "bilinear" or "nearest_neighbor"');
 
   const resizedTexture = runResizeProgram(
-      gl, texture, sourceDims, targetShape, alignCorners, interpolation);
+      gl, texture, sourceDims, targetShape, alignCorners,
+      useCustomShadersToResize, interpolation);
   const downloadedTextureData =
       downloadTextureData(gl, resizedTexture, targetShape);
 

--- a/tfjs-react-native/src/camera/camera_stream.tsx
+++ b/tfjs-react-native/src/camera/camera_stream.tsx
@@ -77,7 +77,7 @@ const DEFAULT_USE_CUSTOM_SHADERS_TO_RESIZE = false;
  *   tensor.
  *   - If it is set to false (default and recommended), the resize will be done
  *     by the underlying GL system when drawing the camera image texture to the
- *     target output texture with TEXTURE_MIN_FILTER/TEXTURE_MAX_FILTER set to
+ *     target output texture with TEXTURE_MIN_FILTER/TEXTURE_MAG_FILTER set to
  *     gl.LINEAR, and there is no need to provide `cameraTextureWidth` and
  *     `cameraTextureHeight` props below.
  *   - If it is set to true (legacy), the resize will be done by the custom

--- a/tfjs-react-native/src/camera/camera_test.ts
+++ b/tfjs-react-native/src/camera/camera_test.ts
@@ -66,7 +66,7 @@ describeWithFlags('toTexture', RN_ENVS, () => {
     const texture = await toTexture(gl, inTensor);
 
     const outTensor = fromTexture(
-        gl, texture, {width, height, depth}, {width, height, depth});
+        gl, texture, {width, height, depth}, {width, height, depth}, true);
 
     expectArraysEqual(await inTensor.data(), await outTensor.data());
     expectArraysEqual(inTensor.shape, outTensor.shape);

--- a/tfjs-react-native/src/camera/camera_test.ts
+++ b/tfjs-react-native/src/camera/camera_test.ts
@@ -168,6 +168,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
           width: inShape[1],
           depth: inShape[2],
         },
+        true,
         {
           alignCorners: false,
           interpolation: 'nearest_neighbor',
@@ -192,6 +193,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
           width: inShape[1],
           depth: inShape[2],
         },
+        true,
         {
           alignCorners: true,
           interpolation: 'nearest_neighbor',
@@ -231,6 +233,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
              width: expectedShape[1],
              depth: expectedShape[2],
            },
+           true,
            {alignCorners: false, interpolation: 'nearest_neighbor'},
        );
 
@@ -267,6 +270,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
              width: expectedShape[1],
              depth: expectedShape[2],
            },
+           true,
            {alignCorners: true, interpolation: 'nearest_neighbor'},
        );
 
@@ -304,6 +308,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
           width: expectedShape[1],
           depth: expectedShape[2],
         },
+        true,
         {alignCorners: false, interpolation: 'nearest_neighbor'},
     );
 
@@ -342,6 +347,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
           width: expectedShape[1],
           depth: expectedShape[2],
         },
+        true,
         {alignCorners: true, interpolation: 'nearest_neighbor'},
     );
 
@@ -393,6 +399,7 @@ describeWithFlags('fromTexture:nearestNeighbor', RN_ENVS, () => {
           width: inShape[1],
           depth: 3,
         },
+        true,
         {
           alignCorners: true,
           interpolation: 'nearest_neighbor',
@@ -465,6 +472,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: inShape[1],
           depth: inShape[2],
         },
+        true,
         {
           alignCorners: false,
           interpolation: 'bilinear',
@@ -489,6 +497,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: inShape[1],
           depth: inShape[2],
         },
+        true,
         {
           alignCorners: true,
           interpolation: 'bilinear',
@@ -527,6 +536,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: expectedShape[1],
           depth: expectedShape[2],
         },
+        true,
         {alignCorners: false, interpolation: 'bilinear'},
     );
 
@@ -562,6 +572,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: expectedShape[1],
           depth: expectedShape[2],
         },
+        true,
         {alignCorners: true, interpolation: 'bilinear'},
     );
 
@@ -599,6 +610,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: expectedShape[1],
           depth: expectedShape[2],
         },
+        true,
         {alignCorners: false, interpolation: 'bilinear'},
     );
 
@@ -636,6 +648,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: expectedShape[1],
           depth: expectedShape[2],
         },
+        true,
         {alignCorners: true, interpolation: 'bilinear'},
     );
 
@@ -687,6 +700,7 @@ describeWithFlags('fromTexture:bilinear', RN_ENVS, () => {
           width: inShape[1],
           depth: 3,
         },
+        true,
         {
           alignCorners: true,
           interpolation: 'bilinear',

--- a/tfjs-react-native/src/camera/draw_texture_program_info.ts
+++ b/tfjs-react-native/src/camera/draw_texture_program_info.ts
@@ -15,8 +15,10 @@
  * =============================================================================
  */
 
-export function vertexShaderSource(flipHorizontal: boolean) {
+export function vertexShaderSource(
+    flipHorizontal: boolean, flipVertical: boolean) {
   const horizontalScale = flipHorizontal ? -1 : 1;
+  const verticalScale = flipVertical ? -1 : 1;
   return `#version 300 es
 precision highp float;
 
@@ -27,7 +29,8 @@ out vec2 uv;
 
 void main() {
   // Invert geometry to match the image orientation from the camera.
-  gl_Position = vec4(position * vec2(${horizontalScale}., -1.), 0, 1);
+  gl_Position = vec4(position * vec2(${horizontalScale}., ${
+      verticalScale}. * -1.), 0, 1);
   uv = texCoords;
 }`;
 }

--- a/tfjs-react-native/yarn.lock
+++ b/tfjs-react-native/yarn.lock
@@ -66,12 +66,12 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@react-native-community/async-storage@^1.4.2":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.1.tgz#25f821b4f6b13abe005ad67e47c6f1cee9f27b24"
-  integrity sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==
+"@react-native-async-storage/async-storage@^1.13.0":
+  version "1.15.7"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.7.tgz#736ac5cfe211b081e70389e80c237398d1451f08"
+  integrity sha512-ctD51BxjBxSSZ/3xCxQ//e10nP3rWFuOABsOGCGCqCXO4ypznK+fcWONHI6fIZubfV5KdyBJnNXcKtXRjocE5Q==
   dependencies:
-    deep-assign "^3.0.0"
+    merge-options "^3.0.4"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -651,13 +651,6 @@ decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
-
-deep-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
-  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
-  dependencies:
-    is-obj "^1.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1404,11 +1397,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -1423,6 +1411,11 @@ is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-stream@^2.0.0:
   version "2.0.0"
@@ -1615,6 +1608,13 @@ meow@^9.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This will help solve the problem where it is hard to figure out camera texture sizes for all kinds of devices/camera preview sizes. See code comments below for more details.

Tested with an expo project with movenet that I plan to check into tfjs-examples repo after this PR is merged.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5626)
<!-- Reviewable:end -->
