### PR TITLE
[converter] Pin python2 protobuf version to 3.17.3

### DIFF
--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -79,7 +79,6 @@ py_wheel(
     requires = [
         "tensorflow>=2.1.0,<3",
         "six>=1.12.0,<2",
-        "tensorflow-hub>=0.7.0,<0.10",
         "tensorflow-hub>=0.7.0,<0.13",
     ],
     strip_path_prefixes = [
@@ -129,7 +128,6 @@ py_wheel(
         "protobuf==3.17.3",
         "six>=1.12.0,<2",
         "tensorflow-hub>=0.7.0,<0.10",
-        "tensorflow-hub>=0.7.0,<0.13",
     ],
     strip_path_prefixes = [
         "tfjs-converter/python",

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -126,6 +126,7 @@ py_wheel(
     python_tag = "py2",
     requires = [
         "tensorflow>=2.1.0,<3",
+        "protobuf==3.17.3",
         "six>=1.12.0,<2",
         'tensorflow-hub>=0.7.0,<0.10; python_version < "3"',
         'tensorflow-hub>=0.7.0,<0.13; python_version >= "3"',

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -79,8 +79,8 @@ py_wheel(
     requires = [
         "tensorflow>=2.1.0,<3",
         "six>=1.12.0,<2",
-        'tensorflow-hub>=0.7.0,<0.10; python_version < "3"',
-        'tensorflow-hub>=0.7.0,<0.13; python_version >= "3"',
+        "tensorflow-hub>=0.7.0,<0.10",
+        "tensorflow-hub>=0.7.0,<0.13",
     ],
     strip_path_prefixes = [
         "tfjs-converter/python",
@@ -128,8 +128,8 @@ py_wheel(
         "tensorflow>=2.1.0,<3",
         "protobuf==3.17.3",
         "six>=1.12.0,<2",
-        'tensorflow-hub>=0.7.0,<0.10; python_version < "3"',
-        'tensorflow-hub>=0.7.0,<0.13; python_version >= "3"',
+        "tensorflow-hub>=0.7.0,<0.10",
+        "tensorflow-hub>=0.7.0,<0.13",
     ],
     strip_path_prefixes = [
         "tfjs-converter/python",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,4 +1,5 @@
 tensorflow>=2.1.0,<3
+protobuf==3.17.3; python_version < "3"
 numpy~=1.19.2
 six>=1.12.0,<2
 tensorflow-hub>=0.7.0,<0.10; python_version < "3"


### PR DESCRIPTION
Fix tfjs-converter test failure in nightly and presubmit CI.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5635)
<!-- Reviewable:end -->
