### PR TITLE
[converter] Add required libs to readme

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -439,13 +439,23 @@ version is located.
 
 ## Development
 
-To build **TensorFlow.js converter** from source, we need to clone the project
-and prepare the dev environment:
+To build **TensorFlow.js converter** from source, we need to prepare the dev environment and clone the project.
+
+Bazel builds Python from source, so we install the dependencies required to build it. Since we will be using pip and C extensions, we also install the ssl and foreign functions development packages. On debian, this is done with:
 
 ```bash
-git clone https://github.com/tensorflow/tfjs-converter.git
-cd tfjs-converter
-$ yarn # Installs dependencies.
+sudo apt-get build-dep python3
+sudo apt install libssl-dev libffi-dev
+```
+
+See the [python developer guide](https://devguide.python.org/setup/#install-dependencies) for instructions on installing these for other platforms.
+
+Then, we clone the project and install dependencies with:
+
+```bash
+git clone https://github.com/tensorflow/tfjs.git
+cd tfjs/tfjs-converter
+yarn # Installs dependencies.
 ```
 
 We recommend using [Visual Studio Code](https://code.visualstudio.com/) for


### PR DESCRIPTION
Since we're building python from source for converter, the computer on which it builds needs some additional libs installed.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5639)
<!-- Reviewable:end -->
