### PR TITLE
Only start browserstack tunnel when running on BrowserStack

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -18,32 +18,32 @@
 const browserstackConfig = {
   hostname: 'bs-local.com',
   reporters: ['dots'],
-  port: 9896,
+  port: 9876,
 };
 
 module.exports = function(config) {
   let browser = 'TEMPLATE_browser';
-  let browserConfig = {};
+  let extraConfig = {};
   if (browser) {
-    browserConfig.browsers = [browser];
-  }
-
-  config.set({
-    ...browserstackConfig,
-    browserStack: {
+    Object.assign(extraConfig, browserstackConfig);
+    extraConfig.browsers = [browser];
+    extraConfig.browserStack = {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY,
       timeout: 900, // Seconds
       tunnelIdentifier:
       `tfjs_${Date.now()}_${Math.floor(Math.random() * 1000)}`
-    },
+    };
+  }
+
+  config.set({
     captureTimeout: 3e5,
     reportSlowerThan: 500,
     browserNoActivityTimeout: 3e5,
     browserDisconnectTimeout: 3e5,
     browserDisconnectTolerance: 0,
     browserSocketTimeout: 1.2e5,
-    ...browserConfig,
+    ...extraConfig,
     customLaunchers: {
       // For browserstack configs see:
       // https://www.browserstack.com/automate/node

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,10 +361,10 @@
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
-  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
+"@types/webgl2@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.6.tgz#1ea2db791362bd8521548d664dbd3c5311cdf4b6"
+  integrity sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==
 
 accepts@~1.3.4:
   version "1.3.7"


### PR DESCRIPTION
Fix web_test's config so it only includes BrowserStack configuration values when a test is run on BrowserStack.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5651)
<!-- Reviewable:end -->
