### PR TITLE
Use the release docker for all cloudbuild steps

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,13 +1,13 @@
 steps:
 # Install top-level deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
 
 # Generate cloudbuild_generated.yml,
 # which builds and tests all affected packages.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'generate-cloudbuild-for-packages'
   args: ['generate-cloudbuild-for-packages']

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -1,13 +1,13 @@
 steps:
 # Install top-level deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Test generate_cloudbuild.js
 # See #4523 for why this is special-cased into every cloudbuild.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'scripts'
   id: 'test-generate-cloudbuild'
   entrypoint: 'yarn'
@@ -17,14 +17,14 @@ steps:
 # Test run_flaky.js
 # The flaky test runner is important enough to test every time and takes less
 # than 5 seconds.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'test-run-flaky'
   entrypoint: 'yarn'
   args: ['test-run-flaky']
   waitFor: ['yarn-common']
 
 # Lint bazel files.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'buildifier'
   entrypoint: 'yarn'
   args: ['buildifier-ci']
@@ -33,7 +33,7 @@ steps:
 # Bazel tests
 # These use a remote cache and only re-run if changes occurred, so we run them
 # in every build.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'bazel-tests'
   entrypoint: 'bash'
   args:
@@ -45,14 +45,14 @@ steps:
 # The following steps build the link packages, which are temporary packages
 # that help packages that don't build with Bazel load outputs from packages
 # that build with Bazel.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'link-package-core'
   entrypoint: 'yarn'
   id: 'yarn-link-package-core'
   args: ['install']
   waitFor: ['bazel-tests']
 
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'link-package'
   entrypoint: 'yarn'
   id: 'yarn-link-package'

--- a/scripts/cloudbuild_tfjs_core_expected.yml
+++ b/scripts/cloudbuild_tfjs_core_expected.yml
@@ -1,10 +1,10 @@
 steps:
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     entrypoint: yarn
     id: yarn-common
     args:
       - install
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: scripts
     id: test-generate-cloudbuild
     entrypoint: yarn
@@ -12,21 +12,21 @@ steps:
       - test-generate-cloudbuild
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: test-run-flaky
     entrypoint: yarn
     args:
       - test-run-flaky
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: buildifier
     entrypoint: yarn
     args:
       - buildifier-ci
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: bazel-tests
     entrypoint: bash
     args:
@@ -37,7 +37,7 @@ steps:
       - yarn-common
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: link-package-core
     entrypoint: yarn
     id: yarn-link-package-core
@@ -45,7 +45,7 @@ steps:
       - install
     waitFor:
       - bazel-tests
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: link-package
     entrypoint: yarn
     id: yarn-link-package
@@ -54,7 +54,7 @@ steps:
     waitFor:
       - bazel-tests
       - yarn-link-package-core
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter
     entrypoint: yarn
     id: yarn-tfjs-converter
@@ -63,7 +63,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter
     id: lint-tfjs-converter
     entrypoint: yarn
@@ -73,7 +73,7 @@ steps:
       - yarn-tfjs-converter
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: create-pips-tfjs-converter
     entrypoint: bash
     args:
@@ -81,7 +81,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: gcr.io/google-appengine/python
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter/python
     entrypoint: bash
     id: test-python-pip-tfjs-converter
@@ -93,7 +93,7 @@ steps:
       - create-pips-tfjs-converter
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: yarn-tfjs-layers
@@ -102,7 +102,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: build-tfjs-layers
@@ -112,7 +112,7 @@ steps:
       - yarn-tfjs-layers
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: lint-tfjs-layers
@@ -122,7 +122,7 @@ steps:
       - yarn-tfjs-layers
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: test-browser-tfjs-layers
@@ -138,7 +138,7 @@ steps:
       - NIGHTLY=$_NIGHTLY
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: test-snippets-tfjs-layers
@@ -148,7 +148,7 @@ steps:
       - build-tfjs-layers
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: yarn-tfjs-backend-wasm
@@ -157,7 +157,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: gcr.io/learnjs-174218/wasm
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: bash
     id: build-tfjs-backend-wasm
@@ -167,7 +167,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: lint-tfjs-backend-wasm
@@ -177,7 +177,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: test-wasm-tfjs-backend-wasm
@@ -194,7 +194,7 @@ steps:
       - NIGHTLY=$_NIGHTLY
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: gcr.io/learnjs-174218/wasm
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     id: test-bundle-size-tfjs-backend-wasm
     entrypoint: yarn
@@ -205,7 +205,7 @@ steps:
       - build-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-webgpu
     id: yarn-tfjs-backend-webgpu
     entrypoint: yarn
@@ -214,7 +214,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-webgpu
     id: lint-tfjs-backend-webgpu
     entrypoint: yarn
@@ -224,7 +224,7 @@ steps:
       - yarn-tfjs-backend-webgpu
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-webgpu
     entrypoint: yarn
     id: test-webgpu-tfjs-backend-webgpu
@@ -235,7 +235,7 @@ steps:
       - lint-tfjs-backend-webgpu
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: yarn-tfjs-data
@@ -247,7 +247,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: build-tfjs-data
@@ -260,7 +260,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: lint-tfjs-data
@@ -273,7 +273,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: test-tfjs-data
@@ -287,7 +287,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: test-snippets-tfjs-data
@@ -300,7 +300,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: yarn-tfjs
@@ -318,7 +318,7 @@ steps:
       - yarn-tfjs-data
       - build-tfjs-data
       - lint-tfjs-data
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: build-tfjs
@@ -337,7 +337,7 @@ steps:
       - yarn-tfjs-data
       - build-tfjs-data
       - lint-tfjs-data
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: lint-tfjs
@@ -356,7 +356,7 @@ steps:
       - yarn-tfjs-data
       - build-tfjs-data
       - lint-tfjs-data
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: test-tfjs

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -1,10 +1,10 @@
 steps:
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     entrypoint: yarn
     id: yarn-common
     args:
       - install
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: scripts
     id: test-generate-cloudbuild
     entrypoint: yarn
@@ -12,21 +12,21 @@ steps:
       - test-generate-cloudbuild
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: test-run-flaky
     entrypoint: yarn
     args:
       - test-run-flaky
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: buildifier
     entrypoint: yarn
     args:
       - buildifier-ci
     waitFor:
       - yarn-common
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: bazel-tests
     entrypoint: bash
     args:
@@ -37,7 +37,7 @@ steps:
       - yarn-common
     secretEnv:
       - BROWSERSTACK_KEY
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: link-package-core
     entrypoint: yarn
     id: yarn-link-package-core
@@ -45,7 +45,7 @@ steps:
       - install
     waitFor:
       - bazel-tests
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: link-package
     entrypoint: yarn
     id: yarn-link-package
@@ -54,7 +54,7 @@ steps:
     waitFor:
       - bazel-tests
       - yarn-link-package-core
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter
     entrypoint: yarn
     id: yarn-tfjs-converter
@@ -63,7 +63,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter
     id: lint-tfjs-converter
     entrypoint: yarn
@@ -73,7 +73,7 @@ steps:
       - yarn-tfjs-converter
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     id: create-pips-tfjs-converter
     entrypoint: bash
     args:
@@ -81,7 +81,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: yarn-tfjs-layers
@@ -90,7 +90,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: build-tfjs-layers
@@ -100,7 +100,7 @@ steps:
       - yarn-tfjs-layers
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-layers
     entrypoint: yarn
     id: lint-tfjs-layers
@@ -110,7 +110,7 @@ steps:
       - yarn-tfjs-layers
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: yarn-tfjs-backend-wasm
@@ -119,7 +119,7 @@ steps:
     waitFor:
       - yarn-common
       - yarn-link-package
-  - name: gcr.io/learnjs-174218/wasm
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: bash
     id: build-tfjs-backend-wasm
@@ -129,7 +129,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-backend-wasm
     entrypoint: yarn
     id: lint-tfjs-backend-wasm
@@ -139,7 +139,7 @@ steps:
       - yarn-tfjs-backend-wasm
       - yarn-common
       - yarn-link-package
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: yarn-tfjs-data
@@ -151,7 +151,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: build-tfjs-data
@@ -164,7 +164,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs-data
     entrypoint: yarn
     id: lint-tfjs-data
@@ -177,7 +177,7 @@ steps:
       - yarn-tfjs-layers
       - build-tfjs-layers
       - lint-tfjs-layers
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: yarn-tfjs
@@ -195,7 +195,7 @@ steps:
       - yarn-tfjs-data
       - build-tfjs-data
       - lint-tfjs-data
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: build-tfjs
@@ -214,7 +214,7 @@ steps:
       - yarn-tfjs-data
       - build-tfjs-data
       - lint-tfjs-data
-  - name: 'node:10'
+  - name: gcr.io/learnjs-174218/release
     dir: tfjs
     entrypoint: yarn
     id: lint-tfjs

--- a/tfjs-automl/cloudbuild.yml
+++ b/tfjs-automl/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install tfjs-automl dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'build'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'lint'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn']
 
 # Run node tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'test-js'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build', 'lint']
 
   # Run browser tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-automl'
   entrypoint: 'yarn'
   id: 'test-browser'

--- a/tfjs-backend-wasm/cloudbuild.yml
+++ b/tfjs-backend-wasm/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Install build-deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'gcr.io/learnjs-174218/wasm'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'bash'
   id: 'build'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'lint'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run JS tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-wasm'
   entrypoint: 'yarn'
   id: 'test-wasm'
@@ -48,7 +48,7 @@ steps:
   secretEnv: ['BROWSERSTACK_KEY']
 
 # Check bundle size.
-- name: 'gcr.io/learnjs-174218/wasm'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-wasm'
   id: 'test-bundle-size'
   entrypoint: 'yarn'

--- a/tfjs-backend-webgpu/cloudbuild.yml
+++ b/tfjs-backend-webgpu/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install webgpu dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-webgpu'
   id: 'yarn'
   entrypoint: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-webgpu'
   id: 'build-deps'
   entrypoint: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-webgpu'
   id: 'lint'
   entrypoint: 'yarn'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-backend-webgpu'
   entrypoint: 'yarn'
   id: 'test-webgpu'

--- a/tfjs-converter/cloudbuild.yml
+++ b/tfjs-converter/cloudbuild.yml
@@ -2,13 +2,13 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install tfjs-converter dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-converter'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -16,14 +16,14 @@ steps:
   waitFor: ['yarn-common']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-converter'
   id: 'lint'
   entrypoint: 'yarn'
   args: ['lint']
   waitFor: ['yarn']
 
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'create-pips'
   entrypoint: 'bash'
   args:
@@ -31,7 +31,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Run python tests.
-- name: 'gcr.io/google-appengine/python'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-converter/python'
   entrypoint: 'bash'
   id: 'test-python-pip'

--- a/tfjs-converter/cloudbuild_nightly.yml
+++ b/tfjs-converter/cloudbuild_nightly.yml
@@ -1,20 +1,20 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install converter dependencies
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-converter'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
   waitFor: ['yarn-common']
 
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'create-pips'
   entrypoint: 'bash'
   args:

--- a/tfjs-core/cloudbuild.yml
+++ b/tfjs-core/cloudbuild.yml
@@ -1,6 +1,6 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']

--- a/tfjs-data/cloudbuild.yml
+++ b/tfjs-data/cloudbuild.yml
@@ -1,13 +1,13 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -15,7 +15,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -23,7 +23,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'build'
@@ -31,7 +31,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'lint'
@@ -39,7 +39,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tests in node.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'test'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['yarn', 'build-deps', 'lint']
 
 # Run data snippets tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-data'
   entrypoint: 'yarn'
   id: 'test-snippets'

--- a/tfjs-inference/cloudbuild.yml
+++ b/tfjs-inference/cloudbuild.yml
@@ -1,14 +1,14 @@
 steps:
 
 # Install packages.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'yarn'
   args: ['install']
 
 # Build binaries.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'build-binary'
@@ -16,7 +16,7 @@ steps:
   waitFor: ['yarn']
 
 # JS Test.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'test'
@@ -24,7 +24,7 @@ steps:
   waitFor: ['yarn']
 
 # Python Test.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-inference'
   entrypoint: 'yarn'
   id: 'test-python'

--- a/tfjs-layers/cloudbuild.yml
+++ b/tfjs-layers/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'build'
@@ -30,7 +30,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'lint'
@@ -38,7 +38,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run javascript tests
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'test-browser'
@@ -47,7 +47,7 @@ steps:
   env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
   secretEnv: ['BROWSERSTACK_KEY']
 
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-layers'
   entrypoint: 'yarn'
   id: 'test-snippets'

--- a/tfjs-react-native/cloudbuild.yml
+++ b/tfjs-react-native/cloudbuild.yml
@@ -1,12 +1,12 @@
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install react native dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-react-native'
   id: 'yarn'
   entrypoint: 'yarn'
@@ -14,7 +14,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build tfjs-react-native.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-react-native'
   id: 'build'
   entrypoint: 'yarn'
@@ -22,7 +22,7 @@ steps:
   waitFor: ['yarn']
 
 # Run unit tests in react native. Tests against version published on NPM.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-react-native/integration_rn59'
   id: 'test-ci'
   entrypoint: 'yarn'

--- a/tfjs-vis/cloudbuild.yml
+++ b/tfjs-vis/cloudbuild.yml
@@ -1,13 +1,13 @@
 
 steps:
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install tfjs-vis dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-node'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -15,7 +15,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Run vis tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs-vis'
   entrypoint: 'yarn'
   id: 'test-vis'

--- a/tfjs/cloudbuild.yml
+++ b/tfjs/cloudbuild.yml
@@ -1,13 +1,13 @@
 steps:
 
 # Install common dependencies.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   id: 'yarn-common'
   entrypoint: 'yarn'
   args: ['install']
 
 # Install packages.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'yarn'
@@ -15,7 +15,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build deps.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'build-deps'
@@ -23,7 +23,7 @@ steps:
   waitFor: ['yarn-common']
 
 # Build.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'build'
@@ -31,7 +31,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Lint.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'lint'
@@ -39,7 +39,7 @@ steps:
   waitFor: ['yarn', 'build-deps']
 
 # Run tfjs tests.
-- name: 'node:10'
+- name: 'gcr.io/learnjs-174218/release'
   dir: 'tfjs'
   entrypoint: 'yarn'
   id: 'test'


### PR DESCRIPTION
Make all cloudbuild CI steps use the release docker, as described in #5640.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5669)
<!-- Reviewable:end -->
