### PR TITLE
webgpu: Use atomic function to optimize scatterNd

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -28,16 +28,14 @@ export class FillProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   uniforms = 'value : f32;';
-  workPerThread = 4;
-  workGroupSize: [number, number, number] = [16, 1, 1];
+  workGroupSize: [number, number, number] = [64, 1, 1];
   size: number;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
-        [this.workPerThread, 1, 1]);
+        this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.shaderKey = 'fill';
     this.size = util.sizeFromShape(this.outputShape);
@@ -47,11 +45,8 @@ export class FillProgram implements WebGPUProgram {
     const userCode = `
     ${getMainHeaderString()} {
       ${getGlobalIndexString()}
-      for (var i = 0; i < ${this.workPerThread}; i = i + 1) {
-        let flatIndex = index * ${this.workPerThread} + i;
-        if (flatIndex < uniforms.size) {
-          setOutputFlat(flatIndex, uniforms.value);
-        }
+      if (index < uniforms.size) {
+        setOutputFlat(index, uniforms.value);
       }
     }
   `;

--- a/tfjs-backend-webgpu/src/kernels/scatter_optimized_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/scatter_optimized_webgpu.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {DataType, util} from '@tensorflow/tfjs-core';
+
+import {getCoordsDataType, getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
+
+import {WebGPUProgram} from './webgpu_program';
+
+export class ScatterOptimizedProgram implements WebGPUProgram {
+  variableNames = ['updates', 'indices'];
+  uniforms: string;
+  outputShape: number[];
+  shaderKey: string;
+  dispatchLayout: {x: number[]};
+  dispatch: [number, number, number];
+  workGroupSize: [number, number, number] = [64, 1, 1];
+  size: number;
+  updatesRank: number;
+  indicesRank: number;
+  sliceDimGreaterThanOne: boolean;
+  atomic = true;
+  type: DataType;
+
+  constructor(
+      flattenXShape: number[], sliceDim: number, indicesRank: number,
+      updatesRank: number, strides: number[], shape: number[],
+      outputDtype: DataType) {
+    this.outputShape = shape;
+    this.type = outputDtype;
+    this.dispatchLayout = flatDispatchLayout(flattenXShape);
+    // Dispatching based on |updates| shape instead of output shape.
+    this.dispatch =
+        computeDispatch(this.dispatchLayout, flattenXShape, this.workGroupSize);
+    this.sliceDimGreaterThanOne = sliceDim > 1;
+    this.shaderKey = `scatter_${indicesRank}_${updatesRank}_${
+        this.sliceDimGreaterThanOne}_${outputDtype}`;
+    this.size = util.sizeFromShape(flattenXShape);
+    const stridesType = getCoordsDataType(strides.length);
+    this.uniforms = `sliceDim : i32; strides: ${stridesType};`;
+    this.updatesRank = updatesRank;
+    this.indicesRank = indicesRank;
+  }
+
+  getUserCode(): string {
+    let indicesString = '';
+    if (this.indicesRank === 1) {
+      indicesString = 'coords[0]';
+    } else if (this.indicesRank === 2) {
+      indicesString = 'coords[0], j';
+    }
+    const indicesSnippet = `getIndices(${indicesString})`;
+
+    const strideString = this.sliceDimGreaterThanOne ? 'uniforms.strides[j]' :
+                                                       'uniforms.strides';
+
+    let updatesString = '';
+    let outCoordsString = '';
+    let getUpdatesCoordsFromFlatIndex = '';
+    if (this.updatesRank === 1) {
+      updatesString = 'coords[0]';
+      outCoordsString = 'flattenedIndex';
+      getUpdatesCoordsFromFlatIndex = `
+      fn getUpdatesCoordsFromFlatIndex(index : i32) -> i32 {
+        return index;
+      }
+      `;
+    } else if (this.updatesRank === 2) {
+      updatesString = 'coords[0], coords[1]';
+      outCoordsString = 'vec2<i32>(flattenedIndex, coords[1])';
+      getUpdatesCoordsFromFlatIndex = `
+      fn getUpdatesCoordsFromFlatIndex(index : i32) -> vec2<i32> {
+        let d0 = index / uniforms.updatesShape[1];
+        let d1 = index - d0 * uniforms.updatesShape[1];
+        return vec2<i32>(d0, d1);
+      }
+      `;
+    }
+    const updatesSnippet = `getUpdates(${updatesString})`;
+
+    // atomicAdd only supports uint/int type. For float, we use
+    // atomicCompareExchangeWeak to simulate.
+    const atomicAddSnippet = this.type === 'int32' ?
+        `ignore(atomicAdd(&(result.numbers[flatIndex]), i32(updateValue)));` :
+        `
+     var oldI32 = atomicLoad(&(result.numbers[flatIndex]));
+     var assumed = oldI32 - 1;
+     for (; assumed != oldI32;) {
+       assumed = oldI32;
+       let new = bitcast<f32>(assumed) + updateValue;
+       let newI32 = bitcast<i32>(new);
+       oldI32 = atomicCompareExchangeWeak(&(result.numbers[flatIndex]), assumed, newI32)[0];
+     }
+     `;
+
+    const userCode = `
+    ${getUpdatesCoordsFromFlatIndex}
+
+      ${getMainHeaderString()} {
+        ${getGlobalIndexString()}
+
+        if (index < uniforms.size) {
+          let coords = getUpdatesCoordsFromFlatIndex(index);
+          var flattenedIndex = 0;
+          for (var j = 0; j < uniforms.sliceDim; j = j + 1) {
+            let indexInside = i32(round(${indicesSnippet}));
+            flattenedIndex = flattenedIndex + indexInside * ${strideString};
+          }
+          let updateValue = ${updatesSnippet};
+          let flatIndex = getOutputFlatIndex(${outCoordsString});
+
+         ${atomicAddSnippet}
+        }
+      }`;
+    return userCode;
+  }
+}

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -41,6 +41,8 @@ export interface WebGPUProgram {
   isVec4?: boolean;
   // size is used for bounds checking.
   size?: number;
+  // Whether to use atomic built-in functions.
+  atomic?: boolean;
   getUserCode: () => string;
 }
 


### PR DESCRIPTION
PERF

With this change, the total time of scatterND in USE(batchSize=30) is
further reduced to less than 1ms, while the revious one is larger than
20ms.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5682)
<!-- Reviewable:end -->
