### PR TITLE
[e2e] Fix pose detection correctness test

### DIFF
--- a/e2e/benchmarks/local-benchmark/util.js
+++ b/e2e/benchmarks/local-benchmark/util.js
@@ -71,8 +71,14 @@ function areClose(a, e, epsilon) {
   if (!isFinite(a) && !isFinite(e)) {
     return true;
   }
-  if (isNaN(a) || isNaN(e) || Math.abs(a - e) > epsilon) {
-    return false;
+  if (Math.abs(a) >= 1) {
+    if (isNaN(a) || isNaN(e) || Math.abs(a - e) / Math.abs(a) > 0.01) {
+      return false;
+    }
+  } else {
+    if (isNaN(a) || isNaN(e) || Math.abs(a - e) > epsilon) {
+      return false;
+    }
   }
   return true;
 }
@@ -145,6 +151,7 @@ function expectArraysPredicateFuzzy(actual, expected, predicate, errorRate) {
   }
 }
 
+// TODO: support relative comparison for array.
 function expectArraysClose(actual, expected, epsilon, key) {
   if (epsilon == null) {
     epsilon = tf.test_util.testEpsilon();


### PR DESCRIPTION
For pose-detection, the returned value is predict result * imageSize.
This means the error will be magnified by imageSize, which results in
comparasion fail. So here uses relative comparision.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.