### PR TITLE
enable flush threshold for all mobile devices

### DIFF
--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -199,7 +199,7 @@ ENV.registerFlag(
 ENV.registerFlag(
     'WEBGL_FLUSH_THRESHOLD',
     () => {
-      return device_util.isMobile() && ENV.getBool('IS_CHROME') ? 1 : -1;
+      return device_util.isMobile() ? 1 : -1;
     },
     threshold => {
       if (threshold < 0 && threshold !== -1) {

--- a/tfjs-backend-webgl/src/flags_webgl_test.ts
+++ b/tfjs-backend-webgl/src/flags_webgl_test.ts
@@ -379,7 +379,7 @@ describeWithFlags('WEBGL_FLUSH_THRESHOLD', WEBGL_ENVS, () => {
   afterAll(() => tf.env().reset());
 
   it('should return the correct default value', () => {
-    if (device_util.isMobile() && tf.env().getBool('IS_CHROME')) {
+    if (device_util.isMobile()) {
       expect(tf.env().getNumber('WEBGL_FLUSH_THRESHOLD')).toEqual(1);
     } else {
       expect(tf.env().getNumber('WEBGL_FLUSH_THRESHOLD')).toEqual(-1);


### PR DESCRIPTION
iOS safari 15.0 starts supporting webgl 2, but the performance is significantly slower than pervious version of webgl 1.
Setting following two flags has the potential to reduce the performance loss:
1. WEBGL_FORCE_F16_TEXTURES to true
2. WEBGL_FLUSH_THRESHOLD to 1

This will fix always enable WEBGL_FLUSH_TRESHOLD flag for all mobile devices.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5695)
<!-- Reviewable:end -->
