### PR TITLE
[tflite] Fix the broken demo

### DIFF
--- a/link-package/yarn.lock
+++ b/link-package/yarn.lock
@@ -12,7 +12,7 @@
 "@tensorflow/tfjs-backend-webgl@file:../dist/bin/tfjs-backend-webgl/tfjs-backend-webgl_pkg":
   version "0.0.0"
   dependencies:
-    "@tensorflow/tfjs-backend-cpu" "link:../../.cache/yarn/v6/npm-@tensorflow-tfjs-backend-webgl-0.0.0-8e4fb2ff-5577-4ca0-b455-e1622ae3ee25-1632506441313/node_modules/@tensorflow/link-package/node_modules/@tensorflow/tfjs-backend-cpu"
+    "@tensorflow/tfjs-backend-cpu" "link:../../.cache/yarn/v6/npm-@tensorflow-tfjs-backend-webgl-0.0.0-7561c250-a987-4093-a1fc-a0cbaa5c8e2e-1634333904046/node_modules/@tensorflow/link-package/node_modules/@tensorflow/tfjs-backend-cpu"
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
@@ -25,6 +25,9 @@
 "@tensorflow/tfjs-core@link:../link-package-core/node_modules/@tensorflow/tfjs-core":
   version "0.0.0"
   uid ""
+
+"@tensorflow/tfjs-layers@file:../dist/bin/tfjs-layers/tfjs-layers_pkg":
+  version "0.0.0"
 
 "@tensorflow/tfjs-tflite@link:../dist/bin/tfjs-tflite/tfjs-tflite_pkg":
   version "0.0.0"

--- a/tfjs-tflite/demo/package.json
+++ b/tfjs-tflite/demo/package.json
@@ -18,6 +18,9 @@
     "parcel-plugin-static-files-copy": "^2.2.1",
     "typescript": "3.5.3"
   },
+  "staticFiles": {
+    "staticPath": "../../link-package/node_modules/@tensorflow/tfjs-tflite/dist"
+  },
   "scripts": {
     "build-deps": "cd ../../link-package && yarn build",
     "watch": "cross-env NODE_ENV=development parcel src/index.html --no-hmr --open",


### PR DESCRIPTION
Looks like the demo was broken because the wasm files (from the `tfjs-tflie` package) were not copied to the build target directory so the demo cannot load the wasm loader/binary (server would return a 404 html page).

This PR added the missing `staticFiles` object to `package.json` in order to specify which source directory to copy files from to the build target directory (`dist/`). This functionality is supported by the `parcel-plugin-static-files-copy` npm package which is already there.

Tested locally on my machine.

Fixes #5724

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5732)
<!-- Reviewable:end -->
