### PR TITLE
[webgpu] Use different batch command policy to save warmup time

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -101,6 +101,10 @@ export class WebGPUBackend extends KernelBackend {
   private querySet: GPUQuerySet;
   private fromPixelProgram?: FromPixelsProgram;
   private fromPixelImportProgram?: FromPixelsImportProgram;
+  // For the first execution, we should submit GPU command asap. This can save
+  // warmup time. For the subsequent execution, the batched GPU command is
+  // faster.
+  private warmupDone = false;
 
   constructor(device: GPUDevice, supportTimeQuery = false) {
     super();
@@ -356,6 +360,7 @@ export class WebGPUBackend extends KernelBackend {
       // Data is on the CPU.
       return info.values;
     }
+    this.warmupDone = true;
     const staging = this.acquireBuffer(
         info.bufferInfo.byteSize,
         GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
@@ -819,8 +824,9 @@ export class WebGPUBackend extends KernelBackend {
       this.uniformDisposalQueue.push(uniformInfo);
     }
 
-    if (env().get('WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE') as
-        number <= this.dispatchNumberInEncoder) {
+    if (!this.warmupDone ||
+        env().get('WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE') as
+            number <= this.dispatchNumberInEncoder) {
       this.submitQueue();
     }
 


### PR DESCRIPTION
For the first execution, we should submit GPU command asap. This can save warmup
time. For the subsequent execution, the batched GPU command is faster.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5741)
<!-- Reviewable:end -->
