### PR TITLE
webgpu: Refactor some utilities

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -733,10 +733,11 @@ export class WebGPUBackend extends KernelBackend {
     });
     const strides = util.computeStrides(output.shape);
     uniformsWithType.push({type: uniformsType, data: strides});
-    if (program.size != null) {
-      uniformsWithType.push({type: uniformsType, data: [program.size]});
+    if (program.size) {
+      const size = util.sizeFromShape(program.outputShape);
+      uniformsWithType.push(
+          {type: uniformsType, data: [program.isVec4 ? size / 4 : size]});
     }
-    uniformsWithType.push({type: 'uint32', data: program.dispatch});
     if (programUniforms) {
       uniformsWithType = [...uniformsWithType, ...programUniforms];
     }

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -87,7 +87,7 @@ describeWebGPU('backend webgpu', () => {
 
     expect(endNumBytes - startNumBytes).toEqual(48);
     expect(endNumTensors - startNumTensors).toEqual(2);
-    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(-36);
+    expect(endNumBytesInGPU - startNumBytesInGPU).toEqual(-16);
 
     tf.test_util.expectArraysClose(
         dData, new Float32Array([9, 12, 15, 19, 26, 33]));

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {util} from '@tensorflow/tfjs-core';
-import {getGlobalIndexString, getMainHeaderString} from '../../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../../shader_preprocessor';
 
 import {computeDispatch, flatDispatchLayout, WebGPULayout} from '../../webgpu_util';
 import {WebGPUProgram} from '../webgpu_program';
@@ -68,14 +68,13 @@ export class FromPixelsProgram implements WebGPUProgram {
     return `
       [[binding(1), group(0)]] var src: ${textureType};
 
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         let flatIndexBase = index * uniforms.numChannels;
-        let coords = getCoordsFromFlatIndex(flatIndexBase);
-        let values = ${textureLoad};
         for (var i = 0; i < uniforms.numChannels; i = i + 1) {
           let flatIndex = flatIndexBase + i;
           if (flatIndex < uniforms.size) {
+            let coords = getCoordsFromFlatIndex(flatIndexBase);
+            let values = ${textureLoad};
             result.numbers[flatIndex] = i32(floor(255.0 * values[i]));
           }
         }

--- a/tfjs-backend-webgpu/src/kernels/ScatterNd.ts
+++ b/tfjs-backend-webgpu/src/kernels/ScatterNd.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, KernelConfig, KernelFunc, ScatterNd, ScatterNdAttrs, ScatterNdInputs, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, KernelConfig, KernelFunc, ScatterNd, ScatterNdAttrs, ScatterNdInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
 
@@ -49,8 +49,11 @@ export function scatterNd(args: {
   const type = flattenX.dtype;
   const output =
       fill({backend, attrs: {shape: flattenShape, value: 0, dtype: type}});
-  const uniformData =
-      [{type: 'int32', data: [sliceRank]}, {type: 'int32', data: strides}];
+  const size = util.sizeFromShape(flattenX.shape);
+  const uniformData = [
+    {type: 'int32', data: [sliceRank]}, {type: 'int32', data: strides},
+    {type: 'int32', data: [size]}
+  ];
   const program = new ScatterOptimizedProgram(
       flattenX.shape, sliceRank, flattenIndices.shape.length,
       flattenX.shape.length, strides, flattenShape, type);

--- a/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/addn_packed_webgpu.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,7 +28,7 @@ export class AddNPackedProgram implements WebGPUProgram {
   variableNames: string[];
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
-  size: number;
+  size = true;
 
   constructor(shapes: number[][]) {
     this.outputShape = shapes[0];
@@ -40,7 +38,6 @@ export class AddNPackedProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
     this.shaderKey = 'addN';
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -58,8 +55,7 @@ export class AddNPackedProgram implements WebGPUProgram {
                           .join(' + ');
 
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         for (var i = 0; i < ${this.workPerThread}; i = i + 1) {
           let flatIndex = index * ${this.workPerThread} + i;
           if (flatIndex < uniforms.size) {

--- a/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getCoordsDataType, getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
+import {getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -108,8 +108,6 @@ export class ArgMinMaxProgram implements WebGPUProgram {
       }
     `;
 
-    const outputCoordsType = getCoordsDataType(this.outputShape.length);
-
     const indexOutputCoords = (outputCoords: string, index: string) => {
       if (this.outputShape.length === 1) {
         return outputCoords;
@@ -140,8 +138,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
       // This function outputs the offset to the first value along
       // |axis| and the stride to get the next value of the input along |axis|.
       fn getInputCoordInfo(globalId : vec3<u32>) -> vec2<i32>{
-        let outputCoords : ${
-        outputCoordsType} = getOutputCoordsWithNonFlatDispatchLayout(globalId);
+        let outputCoords = getOutputCoordsWithNonFlatDispatchLayout(globalId);
         var i = ${this.outputShape.length - 1};
 
         var stride = 1;

--- a/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/argminmax_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getCoordsDataType, getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getCoordsDataType, getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -139,9 +139,9 @@ export class ArgMinMaxProgram implements WebGPUProgram {
       // add back the index along the reduced dimension to |outputCoords|.
       // This function outputs the offset to the first value along
       // |axis| and the stride to get the next value of the input along |axis|.
-      fn getInputCoordInfo(globalId : vec3<u32>, globalIndex : i32) -> vec2<i32>{
+      fn getInputCoordInfo(globalId : vec3<u32>) -> vec2<i32>{
         let outputCoords : ${
-        outputCoordsType} = getOutputCoords(globalId, globalIndex);
+        outputCoordsType} = getOutputCoordsWithNonFlatDispatchLayout(globalId);
         var i = ${this.outputShape.length - 1};
 
         var stride = 1;
@@ -167,9 +167,8 @@ export class ArgMinMaxProgram implements WebGPUProgram {
         return coordInfo[0] + coordInfo[1] * index;
       }
 
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
-        let coordInfo = getInputCoordInfo(globalId, index);
+      ${getNonFlatDispatchLayoutMainHeaderString()} {
+        let coordInfo = getInputCoordInfo(globalId);
 
         var bestIndex = 0;
         var bestValue = f32(x.numbers[getInputIndex(coordInfo, bestIndex)]);

--- a/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_complex_webgpu.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import {backend_util, util} from '@tensorflow/tfjs-core';
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {backend_util} from '@tensorflow/tfjs-core';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
 
@@ -30,7 +30,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [128, 1, 1];
   op: BinaryOpType;
-  size: number;
+  size = true;
 
   constructor(op: BinaryOpType, aShape: number[], bShape: number[]) {
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
@@ -40,7 +40,6 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
 
     this.shaderKey = `binaryOpComplex_${op}`;
     this.op = op;
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -51,13 +50,12 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
         ${opStr}
       }
 
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         if(index < uniforms.size) {
-          let areal = getARealAtOutCoordsByGlobalId(globalId, index);
-          let aimag = getAImagAtOutCoordsByGlobalId(globalId, index);
-          let breal = getBRealAtOutCoordsByGlobalId(globalId, index);
-          let bimag = getBImagAtOutCoordsByGlobalId(globalId, index);
+          let areal = getARealAtOutCoordsByGlobalIndex(index);
+          let aimag = getAImagAtOutCoordsByGlobalIndex(index);
+          let breal = getBRealAtOutCoordsByGlobalIndex(index);
+          let bimag = getBImagAtOutCoordsByGlobalIndex(index);
           setOutputFlat(index, binaryOpComplex(areal, aimag, breal, bimag));
         }
       }

--- a/tfjs-backend-webgpu/src/kernels/clip_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_vec4_webgpu.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -32,7 +30,7 @@ export class ClipVec4Program implements WebGPUProgram {
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
   isVec4 = true;
-  size: number;
+  size = true;
 
   constructor(outputShape: number[]) {
     this.outputShape = outputShape;
@@ -41,15 +39,13 @@ export class ClipVec4Program implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize,
         [this.workPerThread, 1, 1]);
     this.shaderKey = 'clipVec4';
-    this.size = util.sizeFromShape(this.outputShape) / 4;
   }
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         if(index < uniforms.size) {
-          let value = getAAtOutCoordsByGlobalId(globalId, index);
+          let value = getAAtOutCoordsByGlobalIndex(index);
           var clampedValue : vec4<f32>;
           for (var i = 0; i < 4; i = i + 1) {
             if (isNanCustom(value[i])) {

--- a/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/clip_webgpu.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -32,7 +30,7 @@ export class ClipProgram implements WebGPUProgram {
   workGroupSize: [number, number, number] = [64, 1, 1];
   minVal: number;
   maxVal: number;
-  size: number;
+  size = true;
 
   constructor(outputShape: number[]) {
     this.outputShape = outputShape;
@@ -41,15 +39,13 @@ export class ClipProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.shaderKey = 'clip';
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         if(index < uniforms.size) {
-          let value = getAAtOutCoordsByGlobalId(globalId, index);
+          let value = getAAtOutCoordsByGlobalIndex(index);
           if (isNanCustom(value)) {
             setOutputFlat(index, value);
             return;

--- a/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
@@ -15,9 +15,9 @@
  * =============================================================================
  */
 
-import {backend_util, util} from '@tensorflow/tfjs-core';
+import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -31,7 +31,7 @@ export class ConcatProgram implements WebGPUProgram {
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
   shapes: Array<[number, number]>;
-  size: number;
+  size = true;
 
   constructor(shapes: Array<[number, number]>) {
     this.outputShape =
@@ -45,7 +45,6 @@ export class ConcatProgram implements WebGPUProgram {
     this.shapes = shapes;
     // shapes is used by const snippets.
     this.shaderKey = `concat${shapes}`;
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -74,8 +73,7 @@ export class ConcatProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         for(var i = 0; i < ${this.workPerThread}; i = i + 1) {
           let flatIndex = index * ${this.workPerThread} + i;
           if(flatIndex < uniforms.size) {

--- a/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_naive_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {mapActivationToShaderProgram} from './activation_util';
@@ -117,9 +117,8 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
         }
       }
 
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
-        let coords = getOutputCoords(globalId, index);
+      ${getFlatDispatchLayoutMainHeaderString()} {
+        let coords = getOutputCoordsWithFlatDispatchLayout(globalId, localId, numWorkgroups);
         let batch = coords[0];
         let outChannel = coords[3];
 

--- a/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/fill_webgpu.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-import {util} from '@tensorflow/tfjs-core';
 
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -29,7 +28,7 @@ export class FillProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   uniforms = 'value : f32;';
   workGroupSize: [number, number, number] = [64, 1, 1];
-  size: number;
+  size = true;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
@@ -38,13 +37,11 @@ export class FillProgram implements WebGPUProgram {
         this.dispatchLayout, this.outputShape, this.workGroupSize);
 
     this.shaderKey = 'fill';
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const userCode = `
-    ${getMainHeaderString()} {
-      ${getGlobalIndexString()}
+    ${getMainHeaderAndGlobalIndexString()}
       if (index < uniforms.size) {
         setOutputFlat(index, uniforms.value);
       }

--- a/tfjs-backend-webgpu/src/kernels/flip_left_right_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/flip_left_right_webgpu.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -29,7 +27,7 @@ export class FlipLeftRightProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   workGroupSize: [number, number, number] = [64, 1, 1];
-  size: number;
+  size = true;
 
   constructor(imageShape: [number, number, number, number]) {
     this.outputShape = imageShape;
@@ -37,16 +35,13 @@ export class FlipLeftRightProgram implements WebGPUProgram {
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize);
     this.shaderKey = 'flipLeftRight';
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
-
+      ${getMainHeaderAndGlobalIndexString()}
         if (index < uniforms.size) {
-          let coords = getOutputCoords(globalId, index);
+          let coords = getCoordsFromFlatIndex(index);
           let coordX = uniforms.xShape[2] - coords[2] - 1;
           let outputValue = getX(coords[0], coords[1], coordX, coords[3]);
           setOutputFlat(index, outputValue);

--- a/tfjs-backend-webgpu/src/kernels/im2col_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/im2col_webgpu.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -34,7 +32,7 @@ export class Im2ColProgram implements WebGPUProgram {
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
   isChannelsLast: boolean;
-  size: number;
+  size = true;
 
   constructor(outputShape: number[], isChannelsLast: boolean) {
     this.outputShape = outputShape;
@@ -44,7 +42,6 @@ export class Im2ColProgram implements WebGPUProgram {
         [this.workPerThread, 1, 1]);
     this.isChannelsLast = isChannelsLast;
     this.shaderKey = `im2col_${this.isChannelsLast}`;
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -52,8 +49,7 @@ export class Im2ColProgram implements WebGPUProgram {
     const colDim = this.isChannelsLast ? 1 : 2;
 
     const userCode = `
-    ${getMainHeaderString()} {
-      ${getGlobalIndexString()}
+    ${getMainHeaderAndGlobalIndexString()}
 
       for(var i = 0; i<${this.workPerThread}; i = i + 1) {
         let flatIndex = index * ${this.workPerThread} + i;

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_vec4_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
-import {getMainHeaderString} from '../shader_preprocessor';
+import {getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from '../webgpu_util';
 
 import {mapActivationToShaderProgram} from './activation_util';
@@ -44,7 +44,7 @@ export function makeMatMulPackedVec4Source(
   let TileBOuter = ${tileInfo.TileBOuter};
   let TileInner = ${tileInfo.TileInner};
 
-  ${getMainHeaderString()} {
+  ${getNonFlatDispatchLayoutMainHeaderString()} {
 
     let tileRow = i32(localId.y) * RowPerThread;
     let tileCol = i32(localId.x);
@@ -111,7 +111,7 @@ export function makeMatMulVectorVec4Source(
   return `
   var<workgroup> mm_Asub : array<vec4<f32>, ${workGroupSize[0]}>;
   let tileSize = ${workGroupSize[0] * 4};
-  ${getMainHeaderString()} {
+  ${getNonFlatDispatchLayoutMainHeaderString()} {
     let tileCol = i32(localId.x);
     let globalCol = i32(globalId.x);
     let globalRow = i32(globalId.y);

--- a/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_packed_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
-import {getMainHeaderString} from '../shader_preprocessor';
+import {getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from '../webgpu_util';
 
 import {mapActivationToShaderProgram} from './activation_util';
@@ -31,7 +31,7 @@ export function makeMatMulPackedSource(
   return `
     var<workgroup> mm_Asub : array<array<f32, ${tileInner}>, ${tileAOuter}>;
     var<workgroup> mm_Bsub : array<array<f32, ${tileBOuter}>, ${tileInner}>;
-    ${getMainHeaderString()} {
+    ${getNonFlatDispatchLayoutMainHeaderString()} {
       let tileRow = i32(localId.y) * ${workPerThread[1]};
       let tileCol = i32(localId.x) * ${workPerThread[0]};
 
@@ -129,7 +129,7 @@ export function makeMatMulVectorSource(workGroupSize: [number, number, number]):
     let TileSize = ${workGroupSize[0] * 4};
     var<workgroup> mm_Asub : array<vec4<f32>, ${workGroupSize[0]}>;
 
-    ${getMainHeaderString()} {
+    ${getNonFlatDispatchLayoutMainHeaderString()} {
       let tileCol = i32(localId.x);
       let globalCol = i32(globalId.x);
       let globalRow = i32(globalId.y);

--- a/tfjs-backend-webgpu/src/kernels/matmul_reduce.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_reduce.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {computeDispatch} from '../webgpu_util';
 
 import {mapActivationToShaderProgram} from './activation_util';
@@ -26,9 +26,8 @@ import {WebGPUProgram} from './webgpu_program';
 export function makeMatMulReduceSource(): string {
   return `
     var<workgroup> sumValues : array<f32, workGroupSizeX>;
-    ${getMainHeaderString()} {
-      ${getGlobalIndexString()}
-      let coords = getOutputCoords(globalId, index);
+    ${getNonFlatDispatchLayoutMainHeaderString()} {
+      let coords = getOutputCoordsWithNonFlatDispatchLayout(globalId);
       let batch = coords[0];
       let row = coords[1];
       let col = coords[2];

--- a/tfjs-backend-webgpu/src/kernels/matmul_small_output_size_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/matmul_small_output_size_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
-import {getMainHeaderString} from '../shader_preprocessor';
+import {getNonFlatDispatchLayoutMainHeaderString} from '../shader_preprocessor';
 import {mapActivationToShaderProgram} from './activation_util';
 import {WebGPUProgram} from './webgpu_program';
 
@@ -37,7 +37,7 @@ export function makeMatMulSmallOutputSizeSource(
   // arithmetic operations and others handle IO operations between barrier api,
   // makes ALUs and load/store units work simultaneously, could improves
   // the performance.
-  ${getMainHeaderString()} {
+  ${getNonFlatDispatchLayoutMainHeaderString()} {
     let tileRow = i32(localId.y);
     let tileCol = i32(localId.x);
     let globalRow = i32(globalId.y);

--- a/tfjs-backend-webgpu/src/kernels/scatter_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/scatter_webgpu.ts
@@ -15,8 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-import {getCoordsDataType, getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getCoordsDataType, getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,7 +29,7 @@ export class ScatterProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [64, 1, 1];
   workPerThread = 4;
-  size: number;
+  size = true;
   indicesSnippet: string;
   strideString: string;
   updatesSnippet: string;
@@ -47,7 +46,6 @@ export class ScatterProgram implements WebGPUProgram {
     const sliceDimGreaterThanOne = sliceDim > 1;
     this.shaderKey =
         `scatter_${indicesRank}_${updatesRank}_${sliceDimGreaterThanOne}`;
-    this.size = util.sizeFromShape(this.outputShape);
     const stridesType = getCoordsDataType(strides.length);
     this.uniforms =
         `updateSize : i32; sliceDim : i32; strides: ${stridesType};`;
@@ -73,8 +71,7 @@ export class ScatterProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
 
         let globalIndex = index * ${this.workPerThread};
         if (globalIndex < uniforms.size) {

--- a/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/select_webgpu.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-import {util} from '@tensorflow/tfjs-core';
 
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,7 +29,7 @@ export class SelectProgram implements WebGPUProgram {
   workGroupSize: [number, number, number] = [64, 1, 1];
   cRank: number;
   rank: number;
-  size: number;
+  size = true;
 
   constructor(cRank: number, shape: number[], rank: number) {
     this.outputShape = shape;
@@ -41,7 +40,6 @@ export class SelectProgram implements WebGPUProgram {
     this.cRank = cRank;
     this.rank = rank;
     this.shaderKey = 'select';
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -70,10 +68,9 @@ export class SelectProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
         if (index < uniforms.size) {
-          let resRC = getOutputCoords(globalId, index);
+          let resRC = getCoordsFromFlatIndex(index);
           let cVal = getC(${cCoords});
           if (cVal >= 1.0) {
             setOutputFlat(index, getA(${abCoords}));

--- a/tfjs-backend-webgpu/src/kernels/transform_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transform_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -28,6 +28,7 @@ export class TransformProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workGroupSize: [number, number, number] = [64, 1, 1];
+  size = true;
 
   constructor(outShape: [number, number, number, number]) {
     this.outputShape = outShape;
@@ -102,10 +103,9 @@ export class TransformProgram implements WebGPUProgram {
             return outputValue;
           }
 
-          ${getMainHeaderString()} {
-            ${getGlobalIndexString()}
-            let coords = getOutputCoords(globalId, index);
-            if (coordsInBounds4D(coords, uniforms.outShape)) {
+          ${getMainHeaderAndGlobalIndexString()}
+            if (index < uniforms.size) {
+              let coords = getCoordsFromFlatIndex(index);
               var outputValue : f32;
               let batch = coords[0];
               let x = coords[2];
@@ -152,7 +152,7 @@ export class TransformProgram implements WebGPUProgram {
                   (mapY - yFloor) * valueYCeil;
                 }
               }
-              setOutput(coords[0], coords[1], coords[2], coords[3], outputValue);
+              setOutputFlat(index, outputValue);
             }
           }
         `;

--- a/tfjs-backend-webgpu/src/kernels/transpose_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/transpose_webgpu.ts
@@ -15,8 +15,7 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
-import {getCoordsDataType, getGlobalIndexString, getMainHeaderString} from '../shader_preprocessor';
+import {getCoordsDataType, getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 
 import {WebGPUProgram} from './webgpu_program';
@@ -30,7 +29,7 @@ export class TransposeProgram implements WebGPUProgram {
   workPerThread = 4;
   workGroupSize: [number, number, number] = [64, 1, 1];
   newDim: number[];
-  size: number;
+  size = true;
 
   constructor(aShape: number[], newDim: number[]) {
     const outputShape: number[] = new Array(aShape.length);
@@ -45,7 +44,6 @@ export class TransposeProgram implements WebGPUProgram {
 
     this.newDim = newDim;
     this.shaderKey = `transpose_${newDim}`;
-    this.size = util.sizeFromShape(this.outputShape);
   }
 
   getUserCode(): string {
@@ -53,8 +51,7 @@ export class TransposeProgram implements WebGPUProgram {
     const switched = getSwitchedCoords(this.newDim);
 
     const userCode = `
-      ${getMainHeaderString()} {
-        ${getGlobalIndexString()}
+      ${getMainHeaderAndGlobalIndexString()}
 
         for(var i = 0; i < ${this.workPerThread}; i = i + 1) {
           let flatIndex = index * ${this.workPerThread} + i;

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -39,8 +39,8 @@ export interface WebGPUProgram {
   // the group.
   workGroupSize: [number, number, number];
   isVec4?: boolean;
-  // size is used for bounds checking.
-  size?: number;
+  // Whether to use output size for bounds checking.
+  size?: boolean;
   // Whether to use atomic built-in functions.
   atomic?: boolean;
   getUserCode: () => string;

--- a/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/kernels/webgpu_program.ts
@@ -83,9 +83,10 @@ export const compileProgram =
 export function makeShaderKey<R extends Rank>(
     program: WebGPUProgram, shapes: Array<ShapeMap[R]>, types: string[],
     broadcastDimsKey = '', inputShapesEqualsOutShape = ''): string {
-  const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
+  const key = program.shaderKey + '_' +
+      (program.workGroupSize ? program.workGroupSize.join(',') : '') +
       shapes.map(shape => shape.length).join(',') + types.join(',') +
       program.variableNames.join(',') + broadcastDimsKey +
-      inputShapesEqualsOutShape + program.shaderKey;
+      inputShapesEqualsOutShape;
   return key;
 }


### PR DESCRIPTION
Use num_workgroups builtin instead of custom uniform.
Move the calculation of size out of program.
Simplify the getUserCode of binary ops.
Rename getXXXAtOutCoordsByGloablId to getXXXAtOutCoordsByGloablIndex
Split getOutputCoords to getOutputCoordsWithFlatDispatchLayout &
getOutputCoordsWithNonFlatDispatchLayout

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5785)
<!-- Reviewable:end -->
