### PR TITLE
webgpu: Reduce binary ops shader variants

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/Prelu.ts
+++ b/tfjs-backend-webgpu/src/kernels/Prelu.ts
@@ -20,14 +20,14 @@ import {KernelConfig, KernelFunc, Prelu, PreluInputs, TensorInfo} from '@tensorf
 import {WebGPUBackend} from '../backend_webgpu';
 
 import {BinaryOpType} from './binary_op_util';
-import {BinaryOpProgram} from './binary_op_webgpu';
+import {getBinaryProgram} from './binary_ops';
 
 export function prelu(args: {inputs: PreluInputs, backend: WebGPUBackend}):
     TensorInfo {
   const {inputs, backend} = args;
   const {x, alpha} = inputs;
 
-  const program = new BinaryOpProgram(BinaryOpType.PRELU, x.shape, alpha.shape);
+  const program = getBinaryProgram(BinaryOpType.PRELU, x.shape, alpha.shape);
   return backend.runWebGPUProgram(program, [x, alpha], 'float32');
 }
 

--- a/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_vec4_webgpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {backend_util} from '@tensorflow/tfjs-core';
 import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
@@ -33,13 +32,12 @@ export class BinaryOpVec4Program implements WebGPUProgram {
   isVec4 = true;
   op: BinaryOpType;
   size = true;
-  fitShape: boolean;
 
-  constructor(op: BinaryOpType, aShape: number[], bShape: number[]) {
+  constructor(op: BinaryOpType, outputShape: number[]) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
     const workGroupSizeX = 128;
     this.workGroupSize = [workGroupSizeX, 1, 1];
-    this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
+    this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
         this.dispatchLayout, this.outputShape, this.workGroupSize,

--- a/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/binary_op_webgpu.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {backend_util} from '@tensorflow/tfjs-core';
 import {getMainHeaderAndGlobalIndexString} from '../shader_preprocessor';
 import {computeDispatch, flatDispatchLayout} from '../webgpu_util';
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
@@ -32,11 +31,11 @@ export class BinaryOpProgram implements WebGPUProgram {
   op: BinaryOpType;
   size = true;
 
-  constructor(op: BinaryOpType, aShape: number[], bShape: number[]) {
+  constructor(op: BinaryOpType, outputShape: number[]) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
     const workGroupSizeX = 128;
     this.workGroupSize = [workGroupSizeX, 1, 1];
-    this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
+    this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
 
     this.dispatch = computeDispatch(


### PR DESCRIPTION
PERF

This PR aims to reduce the warmup time by reducing binary ops shader variants.
It may slightly hurt the inference time, but can greatly improve the warmup time.

bodypix-mobilenet reduced ~300ms in the first pass on CFL.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5791)
<!-- Reviewable:end -->
