### PR TITLE
[webgl]Refactor GPGPUBinary.

### DIFF
--- a/tfjs-backend-webgl/src/gpgpu_context.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context.ts
@@ -275,13 +275,9 @@ export class GPGPUContext {
 
   private vertexAttrsAreBound = false;
 
-  public createProgram(fragmentShaderSource: string|WebGLShader): WebGLProgram {
+  public createProgram(fragmentShader: WebGLShader): WebGLProgram {
     this.throwIfDisposed();
     const gl = this.gl;
-    const fragmentShader: WebGLShader =
-        fragmentShaderSource instanceof WebGLShader ?
-        fragmentShaderSource :
-        webgl_util.createFragmentShader(gl, fragmentShaderSource);
     if (this.vertexShader == null) {
       this.vertexShader = gpgpu_util.createVertexShader(gl);
     }

--- a/tfjs-backend-webgl/src/gpgpu_context.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context.ts
@@ -275,10 +275,12 @@ export class GPGPUContext {
 
   private vertexAttrsAreBound = false;
 
-  public createProgram(fragmentShaderSource: string): WebGLProgram {
+  public createProgram(fragmentShaderSource: string|WebGLShader): WebGLProgram {
     this.throwIfDisposed();
     const gl = this.gl;
     const fragmentShader: WebGLShader =
+        fragmentShaderSource instanceof WebGLShader ?
+        fragmentShaderSource :
         webgl_util.createFragmentShader(gl, fragmentShaderSource);
     if (this.vertexShader == null) {
       this.vertexShader = gpgpu_util.createVertexShader(gl);

--- a/tfjs-backend-webgl/src/gpgpu_context_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context_test.ts
@@ -24,6 +24,7 @@ import * as canvas_util from './canvas_util';
 import {getGlslDifferences} from './glsl_version';
 import {GPGPUContext, linearSearchLastTrue} from './gpgpu_context';
 import * as tex_util from './tex_util';
+import {createFragmentShader} from './webgl_util';
 
 const DOWNLOAD_FLOAT_ENVS = {
   flags: {'WEBGL_DOWNLOAD_FLOAT_ENABLED': true},
@@ -127,7 +128,9 @@ describeWithFlags(
             ${glsl.output} = vec4(2,0,0,0);
           }
         `;
-        program = gpgpu.createProgram(src);
+        // tslint:disable-next-line: max-line-length
+        const fragmentShader = createFragmentShader(gpgpu.gl, src);
+        program = gpgpu.createProgram(fragmentShader);
         output = gpgpu.createFloat32MatrixTexture(4, 4);
         gpgpu.uploadDenseMatrixToTexture(output, 4, 4, new Float32Array(16));
         gpgpu.setOutputMatrixTexture(output, 4, 4);
@@ -176,7 +179,8 @@ describeWithFlags('GPGPUContext', DOWNLOAD_FLOAT_ENVS, () => {
       precision highp float;
       void main() {}
     `;
-    const program = gpgpu.createProgram(src);
+    const fragmentShader = createFragmentShader(gpgpu.gl, src);
+    const program = gpgpu.createProgram(fragmentShader);
     const result = gpgpu.createFloat32MatrixTexture(1, 1);
     gpgpu.setOutputMatrixTexture(result, 1, 1);
     gpgpu.setProgram(program);

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -21,6 +21,7 @@ import {GPGPUContext} from './gpgpu_context';
 import * as shader_compiler from './shader_compiler';
 import {InputInfo, ShapeInfo, UniformType} from './shader_compiler';
 import {PackingScheme, TextureData, TextureUsage} from './tex_util';
+import {createFragmentShader} from './webgl_util';
 
 export interface GPGPUProgram {
   variableNames: string[];
@@ -51,6 +52,7 @@ export interface GPGPUBinary {
   uniformLocations: {[name: string]: WebGLUniformLocation};
   customUniformLocations?: WebGLUniformLocation[];
   source: string;
+  fragmentShader: WebGLShader;
   inShapeInfos: ShapeInfo[];
   outShapeInfo: ShapeInfo;
   infLoc: WebGLUniformLocation;
@@ -96,8 +98,8 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
     flatOffset: null
   };
   const source = shader_compiler.makeShader(inputInfos, outShapeInfo, program);
-
-  const webGLProgram = gpgpu.createProgram(source);
+  const fragmentShader = createFragmentShader(gpgpu.gl, source);
+  const webGLProgram = gpgpu.createProgram(fragmentShader);
 
   // Add special uniforms (NAN, INFINITY)
   let infLoc: WebGLUniformLocation = null;
@@ -147,6 +149,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
 
   return {
     program,
+    fragmentShader,
     source,
     webGLProgram,
     uniformLocations,


### PR DESCRIPTION
Refactor GPGPUBinary's data structure to include fragmentShader, so that we can retrieve it from the GPGPUBinary cache.

This refactor allows us to check compilation status of fragmentShaders in a batch, rather than in serial order.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5796)
<!-- Reviewable:end -->
