### PR TITLE
[converter] lock keras version to 2.6.0

### DIFF
--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -48,6 +48,7 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     requires = [
+        "keras<=2.6.0",
         "tensorflow-estimator<=2.6.0",
         "tensorflow>=2.1.0,<3",
         "six>=1.12.0,<2",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,3 +1,4 @@
+keras<=2.6.0
 tensorflow-estimator<=2.6.0
 tensorflow>=2.1.0,<3
 protobuf==3.17.3; python_version < "3"


### PR DESCRIPTION
keras 2.7.0 not compatible with TF 2.6.1, lock the keras version to 2.6.0
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5809)
<!-- Reviewable:end -->
