### PR TITLE
[converter] added wizard deps to the package

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/BUILD
+++ b/tfjs-converter/python/tensorflowjs/converters/BUILD
@@ -15,6 +15,7 @@ py_library(
         ":keras_h5_conversion",
         ":keras_tfjs_loader",
         ":tf_saved_model_conversion_v2",
+        ":wizard",
     ],
 )
 


### PR DESCRIPTION
fixed https://github.com/tensorflow/tfjs/issues/5805
this deps is missing after the bazel migration.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5817)
<!-- Reviewable:end -->
