### PR TITLE
add check for valid gl context when reading isContextLost

### DIFF
--- a/tfjs-backend-webgl/src/canvas_util.ts
+++ b/tfjs-backend-webgl/src/canvas_util.ts
@@ -47,7 +47,7 @@ export function getWebGLContext(webGLVersion: number): WebGLRenderingContext {
     }
   }
   const gl = contexts[webGLVersion];
-  if (!gl || gl === null || gl.isContextLost()) {
+  if (gl == null || gl.isContextLost()) {
     delete contexts[webGLVersion];
     return getWebGLContext(webGLVersion);
   }

--- a/tfjs-backend-webgl/src/canvas_util.ts
+++ b/tfjs-backend-webgl/src/canvas_util.ts
@@ -47,7 +47,7 @@ export function getWebGLContext(webGLVersion: number): WebGLRenderingContext {
     }
   }
   const gl = contexts[webGLVersion];
-  if (gl.isContextLost()) {
+  if (!gl || gl === null || gl.isContextLost()) {
     delete contexts[webGLVersion];
     return getWebGLContext(webGLVersion);
   }


### PR DESCRIPTION
Safari with WebGL v1 (v1 is still default although WebGL v2 was added in Safari over 3 years ago)  
destroys GL context on `contextLost` event, so reading `isContextLost()` afterwards results in error:  

> exception: null is not an object (evaluating 'gl.isContextLost')

This is a rare scenario that only occurs if `contextLost` event is captured
(if its ignored, error will still happen but its non-fatal)

Chrome, Firefox or Safari with WebGL v2 enabled are not affected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5825)
<!-- Reviewable:end -->
