### PR TITLE
[webgl]Add functions for parallel compilation

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -949,7 +949,7 @@ export class MathBackendWebGL extends KernelBackend {
       query = this.startTimer();
     }
 
-    if (!engine().state.compileOnly) {
+    if (!env().get('ENGINE_COMPILE_ONLY')) {
       gpgpu_math.runProgram(
           this.gpgpu, binary, inputsData, outputData, customUniformValues);
     }
@@ -1136,7 +1136,7 @@ export class MathBackendWebGL extends KernelBackend {
       texData.isPacked = outputTexData.isPacked;
       texData.usage = outputTexData.usage;
 
-      if (!engine().state.compileOnly) {
+      if (!env().get('ENGINE_COMPILE_ONLY')) {
         texData.texture = outputTexData.texture;
         // Once uploaded, don't store the values on cpu.
         texData.values = null;

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -1140,10 +1140,12 @@ export class MathBackendWebGL extends KernelBackend {
         texData.texture = outputTexData.texture;
         // Once uploaded, don't store the values on cpu.
         texData.values = null;
+        this.texData.delete(encodedOutputTarget.dataId);
+      } else {
+        this.disposeData(encodedOutputTarget.dataId);
       }
 
       this.disposeIntermediateTensorInfo(tempDenseInputHandle);
-      this.texData.delete(encodedOutputTarget.dataId);
 
       if (shouldTimeProgram) {
         this.uploadWaitMs += util.now() - start;

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -1190,38 +1190,25 @@ export class MathBackendWebGL extends KernelBackend {
 
   checkCompileCompletion() {
     for (const [, binary] of Object.entries(this.binaryCache)) {
-      if (this.gpgpu.gl.getProgramParameter(
-              binary.webGLProgram, this.gpgpu.gl.LINK_STATUS) === false) {
-        if (this.gpgpu.gl.getShaderParameter(
-                binary.fragmentShader, this.gpgpu.gl.COMPILE_STATUS) ===
-            false) {
-          webgl_util.logShaderSourceAndInfoLog(
-              binary.source,
-              this.gpgpu.gl.getShaderInfoLog(binary.fragmentShader));
-          throw new Error('Failed to compile fragment shader.');
-        }
-        throw new Error('Failed to link vertex and fragment shaders.');
-      }
+      this.checkCompletion_(binary);
     }
   }
 
   async checkCompileCompletionAsync(): Promise<boolean[]> {
     const ps = [];
     if (this.gpgpu.parallelCompilationExtension) {
-      console.log(Object.keys(this.binaryCache).length);
       for (const [, binary] of Object.entries(this.binaryCache)) {
-        ps.push(this.checkCompletion(binary, binary.webGLProgram));
+        ps.push(this.checkCompletionAsync_(binary));
       }
       return Promise.all(ps);
     } else {
       for (const [, binary] of Object.entries(this.binaryCache)) {
         const p: Promise<boolean> = new Promise((resolve) => {
-          if (this.gpgpu.gl.getProgramParameter(
-                  binary.webGLProgram, this.gpgpu.gl.LINK_STATUS) === false) {
-            console.log(this.gpgpu.gl.getProgramInfoLog(binary.webGLProgram));
-            throw new Error('Failed to link vertex and fragment shaders.');
-          } else {
+          try {
+            this.checkCompletion_(binary);
             resolve(true);
+          } catch (error) {
+            throw error;
           }
         });
         ps.push(p);
@@ -1230,31 +1217,31 @@ export class MathBackendWebGL extends KernelBackend {
     }
   }
 
-  async checkCompletion(binary: GPGPUBinary, program: WebGLProgram):
-      Promise<boolean> {
+  private async checkCompletionAsync_(binary: GPGPUBinary): Promise<boolean> {
     if (this.gpgpu.gl.getProgramParameter(
-            program,
+            binary.webGLProgram,
             this.gpgpu.parallelCompilationExtension.COMPLETION_STATUS_KHR)) {
-      console.log('completed');
-      if (this.gpgpu.gl.getProgramParameter(
-              binary.webGLProgram, this.gpgpu.gl.LINK_STATUS) === false) {
-        console.log(this.gpgpu.gl.getProgramInfoLog(binary.webGLProgram));
-        if (this.gpgpu.gl.getShaderParameter(
-                binary.fragmentShader, this.gpgpu.gl.COMPILE_STATUS) ===
-            false) {
-          webgl_util.logShaderSourceAndInfoLog(
-              binary.source,
-              this.gpgpu.gl.getShaderInfoLog(binary.fragmentShader));
-          throw new Error('Failed to compile fragment shader.');
-        }
-        throw new Error('Failed to link vertex and fragment shaders.');
-      }
-      return true;
+      return this.checkCompletion_(binary);
     } else {
-      console.log('not completed');
       await nextFrame();
-      return this.checkCompletion(binary, program);
+      return this.checkCompletionAsync_(binary);
     }
+  }
+
+  private checkCompletion_(binary: GPGPUBinary): boolean {
+    if (this.gpgpu.gl.getProgramParameter(
+            binary.webGLProgram, this.gpgpu.gl.LINK_STATUS) === false) {
+      console.log(this.gpgpu.gl.getProgramInfoLog(binary.webGLProgram));
+      if (this.gpgpu.gl.getShaderParameter(
+              binary.fragmentShader, this.gpgpu.gl.COMPILE_STATUS) === false) {
+        webgl_util.logShaderSourceAndInfoLog(
+            binary.source,
+            this.gpgpu.gl.getShaderInfoLog(binary.fragmentShader));
+        throw new Error('Failed to compile fragment shader.');
+      }
+      throw new Error('Failed to link vertex and fragment shaders.');
+    }
+    return true;
   }
 
   getUniformLocations() {

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -1033,137 +1033,84 @@ describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
     tf.removeBackend(customBackendName);
   });
 });
-describeWithFlags('Parallel compilation', WEBGL_ENVS, async () => {
-  fit('does not have memory leak.', async () => {
+describeWithFlags('Parallel compilation', WEBGL_ENVS, () => {
+  // TODO(lina128): Also test async after parallel compilation flag is
+  // implemented in context object. We have to keep the test sync for now,
+  // because it's a global flag, the async test will affect other tests.
+  it('does not have memory leak.', () => {
     const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
-    // describeWithFlags('Parallel compilation', WEBGL_ENVS, () => {
-    //   it('does not have memory leak.', () => {
-    //     const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
+    tf.env().set('WEBGL_CPU_FORWARD', false);
 
-    //     const customWebGLBackendName = 'my-webgl';
-    //     tf.copyRegisteredKernels('webgl', customWebGLBackendName);
-    //     tf.registerBackend(customWebGLBackendName, () => {
-    //       return new MathBackendWebGL();
-    //     });
-    //     tf.setBackend(customWebGLBackendName);
-    //     tf.env().set('WEBGL_CPU_FORWARD', false);
-
-    //     const a0 = tf.tensor1d([1, 1, 1]);
-    //     const b0 = tf.tensor1d([1, 1, 1]);
-    //     const c0 = tf.add(a0, b0);
-    //     const numOfBinaryCacheNoParallelCompillation =
-    //         Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
-    //     // expectArraysClose(await c0.data(), [2, 2, 2]);
-    //     tf.dispose([a0, b0, c0]);
-    //     tf.removeBackend(customWebGLBackendName);
-
-    //     tf.setBackend('webgl');
-    //     const webGLBackend = tf.backend() as MathBackendWebGL;
-    //     tf.env().set('WEBGL_CPU_FORWARD', false);
-
-    //     const startNumBytesAllocated =
-    //         (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
-    //     const startTensor = tf.memory().numTensors;
-    //     const startDataBuckets = webGLBackend.numDataIds();
-
-    //     const a1 = tf.tensor1d([1, 1, 1]);
-    //     const b1 = tf.tensor1d([1, 1, 1]);
-
-    //     tf.engine().state.compileOnly = true;
-
-    //     const c1 = tf.add(a1, b1);
-
-    //     webGLBackend.checkCompileCompletionAsync();
-    //     webGLBackend.getUniformLocations();
-    //     tf.engine().state.compileOnly = false;
-    //     const c2 = tf.add(a1, b1);
-    //     c2.dataSync();
-    //     // await c2.data();
-    //     const c3 = tf.add(a1, b1);
-
-    //     // expectArraysEqual(await c3.data(), [2, 2, 2]);
-
-    //     tf.dispose([a1, b1, c1, c2, c3]);
-    //     const endNumBytesAllocated =
-    //         (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
-    //     const endTensor = tf.memory().numTensors;
-    //     const endDataBuckets = webGLBackend.numDataIds();
-
-    //     expect(startNumBytesAllocated).toEqual(endNumBytesAllocated);
-    //     expect(startTensor).toEqual(endTensor);
-    //     expect(endDataBuckets).toEqual(startDataBuckets);
-
-    //     const numOfBinaryCacheWithParallelCompillation =
-    //         Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
-    //     expect(numOfBinaryCacheWithParallelCompillation)
-    //         .toEqual(numOfBinaryCacheNoParallelCompillation);
-
-    //     tf.env().set('WEBGL_CPU_FORWARD', savedWebGLCPUForward);
-    //   });
-    // })
-    describeWithFlags('Parallel compilation', WEBGL_ENVS, () => {
-      it('does not have memory leak.', () => {
-        const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
-        tf.env().set('WEBGL_CPU_FORWARD', false);
-
-        const customWebGLBackendName = 'my-webgl';
-        tf.copyRegisteredKernels('webgl', customWebGLBackendName);
-        tf.registerBackend(customWebGLBackendName, () => {
-          return new MathBackendWebGL();
-        });
-        tf.setBackend(customWebGLBackendName);
-
-        const a0 = tf.tensor1d([1, 1, 1]);
-        const b0 = tf.tensor1d([1, 1, 1]);
-        const c0 = tf.add(a0, b0);
-        const numOfBinaryCacheNoParallelCompillation =
-            Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION')))
-                .length;
-        // expectArraysClose(await c0.data(), [2, 2, 2]);
-        tf.dispose([a0, b0, c0]);
-        tf.removeBackend(customWebGLBackendName);
-
-        tf.setBackend('webgl');
-        const webGLBackend = tf.backend() as MathBackendWebGL;
-
-        const startNumBytesAllocated =
-            (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
-        const startTensor = tf.memory().numTensors;
-        const startDataBuckets = webGLBackend.numDataIds();
-
-        const a1 = tf.tensor1d([1, 1, 1]);
-        const b1 = tf.tensor1d([1, 1, 1]);
-
-        tf.engine().state.compileOnly = true;
-
-        const c1 = tf.add(a1, b1);
-
-        webGLBackend.checkCompileCompletionAsync();
-        webGLBackend.getUniformLocations();
-        tf.engine().state.compileOnly = false;
-        const c2 = tf.add(a1, b1);
-        c2.dataSync();
-        // await c2.data();
-        const c3 = tf.add(a1, b1);
-
-        // expectArraysEqual(await c3.data(), [2, 2, 2]);
-
-        tf.dispose([a1, b1, c1, c2, c3]);
-        const endNumBytesAllocated =
-            (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
-        const endTensor = tf.memory().numTensors;
-        const endDataBuckets = webGLBackend.numDataIds();
-
-        expect(startNumBytesAllocated).toEqual(endNumBytesAllocated);
-        expect(startTensor).toEqual(endTensor);
-        expect(endDataBuckets).toEqual(startDataBuckets);
-
-        const numOfBinaryCacheWithParallelCompillation =
-            Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION')))
-                .length;
-        expect(numOfBinaryCacheWithParallelCompillation)
-            .toEqual(numOfBinaryCacheNoParallelCompillation);
-
-        tf.env().set('WEBGL_CPU_FORWARD', savedWebGLCPUForward);
-      });
+    const customWebGLBackendName = 'my-webgl';
+    tf.copyRegisteredKernels('webgl', customWebGLBackendName);
+    tf.registerBackend(customWebGLBackendName, () => {
+      return new MathBackendWebGL();
     });
+    tf.setBackend(customWebGLBackendName);
+
+    const a0 = tf.tensor1d([1, 1, 1]);
+    const b0 = tf.tensor1d([1, 1, 1]);
+    const c0 = tf.add(a0, b0);
+    const data = c0.dataSync();
+    const numOfBinaryCacheNoParallelCompillation =
+        Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
+    expectArraysClose(data, [2, 2, 2]);
+    tf.dispose([a0, b0, c0]);
+    tf.removeBackend(customWebGLBackendName);
+
+    // TODO(lina128): Also test use an existing backend after parallel
+    // compilation flag is implemented in context object. The current approach
+    // assumes there's no binary cache, and it doesn't check existing cache.
+    const customWebGLBackendName1 = 'my-webgl1';
+    tf.copyRegisteredKernels('webgl', customWebGLBackendName1);
+    tf.registerBackend(customWebGLBackendName1, () => {
+      return new MathBackendWebGL();
+    });
+    tf.setBackend(customWebGLBackendName1);
+    const webGLBackend = tf.backend() as MathBackendWebGL;
+
+    const startNumBytes = (tf.memory() as WebGLMemoryInfo).numBytesInGPU;
+    const startTensor = tf.memory().numTensors;
+    const startDataBuckets = webGLBackend.numDataIds();
+
+    const a1 = tf.tensor1d([1, 1, 1]);
+    const b1 = tf.tensor1d([1, 1, 1]);
+
+    // Pre-compile round.
+    tf.env().set('ENGINE_COMPILE_ONLY', true);
+    const c1 = tf.add(a1, b1);
+    webGLBackend.checkCompileCompletion();
+    webGLBackend.getUniformLocations();
+
+    // Warm-up upload and download round.
+    tf.env().set('ENGINE_COMPILE_ONLY', false);
+    const c2 = tf.add(a1, b1);
+    c2.dataSync();
+
+    // Actual inference.
+    const c3 = tf.add(a1, b1);
+    expectArraysEqual(c3.dataSync(), [2, 2, 2]);
+
+    tf.dispose([a1, b1, c1, c2, c3]);
+    const endNumBytes = (tf.memory() as WebGLMemoryInfo).numBytesInGPU;
+    const endTensor = tf.memory().numTensors;
+    const endDataBuckets = webGLBackend.numDataIds();
+
+    // We only check numBytesInGPU. For parallel compilation,
+    // numBytesInGPUAllocated will be more because of the two pass uploadToGPU,
+    // but they will all be freed, resulting in endNumbytes equal to
+    // startNumBytes.
+    expect(startNumBytes).toEqual(endNumBytes);
+    expect(startTensor).toEqual(endTensor);
+    expect(endDataBuckets).toEqual(startDataBuckets);
+
+    const numOfBinaryCacheWithParallelCompillation =
+        Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
+    expect(numOfBinaryCacheWithParallelCompillation)
+        .toEqual(numOfBinaryCacheNoParallelCompillation);
+
+    tf.removeBackend(customWebGLBackendName1);
+
+    tf.env().set('WEBGL_CPU_FORWARD', savedWebGLCPUForward);
+  });
+});

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -999,18 +999,12 @@ describeWithFlags('WebGL backend has sync init', WEBGL_ENVS, () => {
   });
 });
 
-<<<<<<< HEAD
 describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
   const customBackendName = 'custom-webgl';
   let flag: boolean;
 
   beforeAll(() => {
     flag = tf.env().getBool('WEBGL_CPU_FORWARD');
-=======
-describeWithFlags('Parallel compilation', WEBGL_ENVS, async () => {
-  it('does not have memory leak.', async () => {
-    const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
->>>>>>> 8829f41f9 (Clean up.)
     tf.env().set('WEBGL_CPU_FORWARD', false);
     const kernelFunc = tf.getKernel('Square', 'webgl').kernelFunc;
     tf.registerKernel(

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -1036,64 +1036,68 @@ describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
 describeWithFlags('Parallel compilation', WEBGL_ENVS, async () => {
   fit('does not have memory leak.', async () => {
     const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
+    // describeWithFlags('Parallel compilation', WEBGL_ENVS, () => {
+    //   it('does not have memory leak.', () => {
+    //     const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
 
-    const customWebGLBackendName = 'my-webgl';
-    tf.copyRegisteredKernels('webgl', customWebGLBackendName);
-    tf.registerBackend(customWebGLBackendName, () => {
-      return new MathBackendWebGL();
-    });
-    tf.setBackend(customWebGLBackendName);
-    tf.env().set('WEBGL_CPU_FORWARD', false);
+    //     const customWebGLBackendName = 'my-webgl';
+    //     tf.copyRegisteredKernels('webgl', customWebGLBackendName);
+    //     tf.registerBackend(customWebGLBackendName, () => {
+    //       return new MathBackendWebGL();
+    //     });
+    //     tf.setBackend(customWebGLBackendName);
+    //     tf.env().set('WEBGL_CPU_FORWARD', false);
 
-    const a0 = tf.tensor1d([1, 1, 1]);
-    const b0 = tf.tensor1d([1, 1, 1]);
-    const c0 = tf.add(a0, b0);
-    const numOfBinaryCacheNoParallelCompillation =
-        Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
-    expectArraysClose(await c0.data(), [2, 2, 2]);
-    tf.dispose([a0, b0, c0]);
-    tf.removeBackend(customWebGLBackendName);
+    //     const a0 = tf.tensor1d([1, 1, 1]);
+    //     const b0 = tf.tensor1d([1, 1, 1]);
+    //     const c0 = tf.add(a0, b0);
+    //     const numOfBinaryCacheNoParallelCompillation =
+    //         Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
+    //     // expectArraysClose(await c0.data(), [2, 2, 2]);
+    //     tf.dispose([a0, b0, c0]);
+    //     tf.removeBackend(customWebGLBackendName);
 
-    tf.setBackend('webgl');
-    const webGLBackend = tf.backend() as MathBackendWebGL;
-    tf.env().set('WEBGL_CPU_FORWARD', false);
+    //     tf.setBackend('webgl');
+    //     const webGLBackend = tf.backend() as MathBackendWebGL;
+    //     tf.env().set('WEBGL_CPU_FORWARD', false);
 
-    const startNumBytesAllocated =
-        (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
-    const startTensor = tf.memory().numTensors;
-    const startDataBuckets = webGLBackend.numDataIds();
+    //     const startNumBytesAllocated =
+    //         (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
+    //     const startTensor = tf.memory().numTensors;
+    //     const startDataBuckets = webGLBackend.numDataIds();
 
-    const a1 = tf.tensor1d([1, 1, 1]);
-    const b1 = tf.tensor1d([1, 1, 1]);
+    //     const a1 = tf.tensor1d([1, 1, 1]);
+    //     const b1 = tf.tensor1d([1, 1, 1]);
 
-    tf.engine().state.compileOnly = true;
+    //     tf.engine().state.compileOnly = true;
 
-    const c1 = tf.add(a1, b1);
+    //     const c1 = tf.add(a1, b1);
 
-    webGLBackend.checkCompileCompletionAsync();
-    webGLBackend.getUniformLocations();
-    tf.engine().state.compileOnly = false;
-    const c2 = tf.add(a1, b1);
-    await c2.data();
-    const c3 = tf.add(a1, b1);
+    //     webGLBackend.checkCompileCompletionAsync();
+    //     webGLBackend.getUniformLocations();
+    //     tf.engine().state.compileOnly = false;
+    //     const c2 = tf.add(a1, b1);
+    //     c2.dataSync();
+    //     // await c2.data();
+    //     const c3 = tf.add(a1, b1);
 
-    expectArraysEqual(await c3.data(), [2, 2, 2]);
+    //     // expectArraysEqual(await c3.data(), [2, 2, 2]);
 
-    tf.dispose([a1, b1, c1, c2, c3]);
-    const endNumBytesAllocated =
-        (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
-    const endTensor = tf.memory().numTensors;
-    const endDataBuckets = webGLBackend.numDataIds();
+    //     tf.dispose([a1, b1, c1, c2, c3]);
+    //     const endNumBytesAllocated =
+    //         (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
+    //     const endTensor = tf.memory().numTensors;
+    //     const endDataBuckets = webGLBackend.numDataIds();
 
-    expect(startNumBytesAllocated).toEqual(endNumBytesAllocated);
-    expect(startTensor).toEqual(endTensor);
-    expect(endDataBuckets).toEqual(startDataBuckets);
+    //     expect(startNumBytesAllocated).toEqual(endNumBytesAllocated);
+    //     expect(startTensor).toEqual(endTensor);
+    //     expect(endDataBuckets).toEqual(startDataBuckets);
 
-    const numOfBinaryCacheWithParallelCompillation =
-        Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
-    expect(numOfBinaryCacheWithParallelCompillation)
-        .toEqual(numOfBinaryCacheNoParallelCompillation);
+    //     const numOfBinaryCacheWithParallelCompillation =
+    //         Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
+    //     expect(numOfBinaryCacheWithParallelCompillation)
+    //         .toEqual(numOfBinaryCacheNoParallelCompillation);
 
-    tf.env().set('WEBGL_CPU_FORWARD', savedWebGLCPUForward);
-  });
-})
+    //     tf.env().set('WEBGL_CPU_FORWARD', savedWebGLCPUForward);
+    //   });
+    // })

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -999,22 +999,12 @@ describeWithFlags('WebGL backend has sync init', WEBGL_ENVS, () => {
   });
 });
 
-<<<<<<< HEAD
 describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
   const customBackendName = 'custom-webgl';
   let flag: boolean;
 
   beforeAll(() => {
     flag = tf.env().getBool('WEBGL_CPU_FORWARD');
-=======
-describeWithFlags('Parallel compilation', WEBGL_ENVS, () => {
-  // TODO(lina128): Change to async test after parallel compilation flag is
-  // implemented in context object. We have to keep it sync for now, because
-  // it's a global flag, the async test will affect other tests.
-  it('does not have memory leak.', () => {
-    console.log('hello world');
-    const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
->>>>>>> 1dd762b99 (.)
     tf.env().set('WEBGL_CPU_FORWARD', false);
     const kernelFunc = tf.getKernel('Square', 'webgl').kernelFunc;
     tf.registerKernel(

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -1033,3 +1033,67 @@ describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
     tf.removeBackend(customBackendName);
   });
 });
+describeWithFlags('Parallel compilation', WEBGL_ENVS, async () => {
+  fit('does not have memory leak.', async () => {
+    const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
+
+    const customWebGLBackendName = 'my-webgl';
+    tf.copyRegisteredKernels('webgl', customWebGLBackendName);
+    tf.registerBackend(customWebGLBackendName, () => {
+      return new MathBackendWebGL();
+    });
+    tf.setBackend(customWebGLBackendName);
+    tf.env().set('WEBGL_CPU_FORWARD', false);
+
+    const a0 = tf.tensor1d([1, 1, 1]);
+    const b0 = tf.tensor1d([1, 1, 1]);
+    const c0 = tf.add(a0, b0);
+    const numOfBinaryCacheNoParallelCompillation =
+        Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
+    expectArraysClose(await c0.data(), [2, 2, 2]);
+    tf.dispose([a0, b0, c0]);
+    tf.removeBackend(customWebGLBackendName);
+
+    tf.setBackend('webgl');
+    const webGLBackend = tf.backend() as MathBackendWebGL;
+    tf.env().set('WEBGL_CPU_FORWARD', false);
+
+    const startNumBytesAllocated =
+        (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
+    const startTensor = tf.memory().numTensors;
+    const startDataBuckets = webGLBackend.numDataIds();
+
+    const a1 = tf.tensor1d([1, 1, 1]);
+    const b1 = tf.tensor1d([1, 1, 1]);
+
+    tf.engine().state.compileOnly = true;
+
+    const c1 = tf.add(a1, b1);
+
+    webGLBackend.checkCompileCompletionAsync();
+    webGLBackend.getUniformLocations();
+    tf.engine().state.compileOnly = false;
+    const c2 = tf.add(a1, b1);
+    await c2.data();
+    const c3 = tf.add(a1, b1);
+
+    expectArraysEqual(await c3.data(), [2, 2, 2]);
+
+    tf.dispose([a1, b1, c1, c2, c3]);
+    const endNumBytesAllocated =
+        (tf.memory() as WebGLMemoryInfo).numBytesInGPUAllocated;
+    const endTensor = tf.memory().numTensors;
+    const endDataBuckets = webGLBackend.numDataIds();
+
+    expect(startNumBytesAllocated).toEqual(endNumBytesAllocated);
+    expect(startTensor).toEqual(endTensor);
+    expect(endDataBuckets).toEqual(startDataBuckets);
+
+    const numOfBinaryCacheWithParallelCompillation =
+        Object.keys(getBinaryCache(tf.ENV.getNumber('WEBGL_VERSION'))).length;
+    expect(numOfBinaryCacheWithParallelCompillation)
+        .toEqual(numOfBinaryCacheNoParallelCompillation);
+
+    tf.env().set('WEBGL_CPU_FORWARD', savedWebGLCPUForward);
+  });
+})

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -999,12 +999,18 @@ describeWithFlags('WebGL backend has sync init', WEBGL_ENVS, () => {
   });
 });
 
+<<<<<<< HEAD
 describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
   const customBackendName = 'custom-webgl';
   let flag: boolean;
 
   beforeAll(() => {
     flag = tf.env().getBool('WEBGL_CPU_FORWARD');
+=======
+describeWithFlags('Parallel compilation', WEBGL_ENVS, async () => {
+  it('does not have memory leak.', async () => {
+    const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
+>>>>>>> 8829f41f9 (Clean up.)
     tf.env().set('WEBGL_CPU_FORWARD', false);
     const kernelFunc = tf.getKernel('Square', 'webgl').kernelFunc;
     tf.registerKernel(

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -999,12 +999,22 @@ describeWithFlags('WebGL backend has sync init', WEBGL_ENVS, () => {
   });
 });
 
+<<<<<<< HEAD
 describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
   const customBackendName = 'custom-webgl';
   let flag: boolean;
 
   beforeAll(() => {
     flag = tf.env().getBool('WEBGL_CPU_FORWARD');
+=======
+describeWithFlags('Parallel compilation', WEBGL_ENVS, () => {
+  // TODO(lina128): Change to async test after parallel compilation flag is
+  // implemented in context object. We have to keep it sync for now, because
+  // it's a global flag, the async test will affect other tests.
+  it('does not have memory leak.', () => {
+    console.log('hello world');
+    const savedWebGLCPUForward = tf.env().get('WEBGL_CPU_FORWARD');
+>>>>>>> 1dd762b99 (.)
     tf.env().set('WEBGL_CPU_FORWARD', false);
     const kernelFunc = tf.getKernel('Square', 'webgl').kernelFunc;
     tf.registerKernel(

--- a/tfjs-backend-webgl/src/gpgpu_context.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context.ts
@@ -21,7 +21,7 @@ import {getWebGLContext, setWebGLContext} from './canvas_util';
 import * as gpgpu_util from './gpgpu_util';
 import * as tex_util from './tex_util';
 import {Texture, TextureConfig} from './tex_util';
-import {WebGL1DisjointQueryTimerExtension, WebGL2DisjointQueryTimerExtension} from './webgl_types';
+import {WebGL1DisjointQueryTimerExtension, WebGL2DisjointQueryTimerExtension, WebGLParallelCompilationExtension} from './webgl_types';
 import * as webgl_util from './webgl_util';
 
 export interface FenceContext {
@@ -37,6 +37,7 @@ export class GPGPUContext {
   colorBufferHalfFloatExtension: {};
   disjointQueryTimerExtension: WebGL2DisjointQueryTimerExtension|
       WebGL1DisjointQueryTimerExtension;
+  parallelCompilationExtension: WebGLParallelCompilationExtension;
   vertexBuffer: WebGLBuffer;
   indexBuffer: WebGLBuffer;
   framebuffer: WebGLFramebuffer;
@@ -58,6 +59,8 @@ export class GPGPUContext {
     // WebGL 2.0 enables texture floats without an extension.
     let COLOR_BUFFER_FLOAT = 'WEBGL_color_buffer_float';
     const COLOR_BUFFER_HALF_FLOAT = 'EXT_color_buffer_half_float';
+    this.parallelCompilationExtension =
+        this.gl.getExtension('KHR_parallel_shader_compile');
     if (env().getNumber('WEBGL_VERSION') === 1) {
       const TEXTURE_FLOAT = 'OES_texture_float';
       const TEXTURE_HALF_FLOAT = 'OES_texture_half_float';

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, engine, env, Tensor, TypedArray, util} from '@tensorflow/tfjs-core';
+import {backend_util, env, Tensor, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {GPGPUContext} from './gpgpu_context';
 import * as shader_compiler from './shader_compiler';
@@ -113,35 +113,17 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
   const fragmentShader = createFragmentShader(gpgpu.gl, source);
   const webGLProgram = gpgpu.createProgram(fragmentShader);
 
-  if (!engine().state.compileOnly) {
-    const {
-      uniformLocations,
-      customUniformLocations,
-      infLoc,
-      nanLoc,
-      inShapesLocations,
-      inTexShapesLocations,
-      outShapeLocation,
-      outShapeStridesLocation,
-      outTexShapeLocation
-    } = getUniformLocations(gpgpu, program, webGLProgram);
-
+  if (!env().get('ENGINE_COMPILE_ONLY')) {
     return {
       program,
       fragmentShader,
       source,
       webGLProgram,
-      uniformLocations,
-      customUniformLocations,
+
+
       inShapeInfos,
       outShapeInfo,
-      infLoc,
-      nanLoc,
-      inShapesLocations,
-      inTexShapesLocations,
-      outShapeLocation,
-      outShapeStridesLocation,
-      outTexShapeLocation
+      ...getUniformLocations(gpgpu, program, webGLProgram)
     };
   } else {
     return {
@@ -149,10 +131,10 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
       fragmentShader,
       source,
       webGLProgram,
-      uniformLocations: null,
-      customUniformLocations: null,
       inShapeInfos,
       outShapeInfo,
+      uniformLocations: null,
+      customUniformLocations: null,
       infLoc: null,
       nanLoc: null,
       inShapesLocations: null,

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -119,8 +119,6 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
       fragmentShader,
       source,
       webGLProgram,
-
-
       inShapeInfos,
       outShapeInfo,
       ...getUniformLocations(gpgpu, program, webGLProgram)

--- a/tfjs-backend-webgl/src/webgl_types.ts
+++ b/tfjs-backend-webgl/src/webgl_types.ts
@@ -44,3 +44,7 @@ export interface WebGLContextAttributes {
   stencil?: boolean;
   failIfMajorPerformanceCaveat?: boolean;
 }
+
+export interface WebGLParallelCompilationExtension {
+  COMPLETION_STATUS_KHR: number;
+}

--- a/tfjs-backend-webgl/src/webgl_util.ts
+++ b/tfjs-backend-webgl/src/webgl_util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {env, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {engine, env, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {getWebGLContext} from './canvas_util';
 import {getTextureConfig} from './tex_util';
@@ -97,6 +97,9 @@ export function createFragmentShader(
       'Unable to create fragment WebGLShader.');
   callAndCheck(gl, () => gl.shaderSource(fragmentShader, fragmentShaderSource));
   callAndCheck(gl, () => gl.compileShader(fragmentShader));
+  if (engine().state.compileOnly) {
+    return fragmentShader;
+  }
   if (gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS) === false) {
     logShaderSourceAndInfoLog(
         fragmentShaderSource, gl.getShaderInfoLog(fragmentShader));
@@ -106,7 +109,7 @@ export function createFragmentShader(
 }
 
 const lineNumberRegex = /ERROR: [0-9]+:([0-9]+):/g;
-function logShaderSourceAndInfoLog(
+export function logShaderSourceAndInfoLog(
     shaderSource: string, shaderInfoLog: string) {
   const lineNumberRegexResult = lineNumberRegex.exec(shaderInfoLog);
   if (lineNumberRegexResult == null) {
@@ -146,6 +149,9 @@ export function createProgram(gl: WebGLRenderingContext): WebGLProgram {
 
 export function linkProgram(gl: WebGLRenderingContext, program: WebGLProgram) {
   callAndCheck(gl, () => gl.linkProgram(program));
+  if (engine().state.compileOnly) {
+    return;
+  }
   if (gl.getProgramParameter(program, gl.LINK_STATUS) === false) {
     console.log(gl.getProgramInfoLog(program));
     throw new Error('Failed to link vertex and fragment shaders.');

--- a/tfjs-backend-webgl/src/webgl_util.ts
+++ b/tfjs-backend-webgl/src/webgl_util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {engine, env, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {env, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {getWebGLContext} from './canvas_util';
 import {getTextureConfig} from './tex_util';

--- a/tfjs-backend-webgl/src/webgl_util.ts
+++ b/tfjs-backend-webgl/src/webgl_util.ts
@@ -97,7 +97,7 @@ export function createFragmentShader(
       'Unable to create fragment WebGLShader.');
   callAndCheck(gl, () => gl.shaderSource(fragmentShader, fragmentShaderSource));
   callAndCheck(gl, () => gl.compileShader(fragmentShader));
-  if (engine().state.compileOnly) {
+  if (env().get('ENGINE_COMPILE_ONLY')) {
     return fragmentShader;
   }
   if (gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS) === false) {
@@ -149,7 +149,7 @@ export function createProgram(gl: WebGLRenderingContext): WebGLProgram {
 
 export function linkProgram(gl: WebGLRenderingContext, program: WebGLProgram) {
   callAndCheck(gl, () => gl.linkProgram(program));
-  if (engine().state.compileOnly) {
+  if (env().get('ENGINE_COMPILE_ONLY')) {
     return;
   }
   if (gl.getProgramParameter(program, gl.LINK_STATUS) === false) {

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -156,8 +156,6 @@ class EngineState {
         }
   };
 
-  compileOnly = false;
-
   dispose() {
     for (const variableName in this.registeredVariables) {
       this.registeredVariables[variableName].dispose();

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -156,6 +156,8 @@ class EngineState {
         }
   };
 
+  compileOnly = false;
+
   dispose() {
     for (const variableName in this.registeredVariables) {
       this.registeredVariables[variableName].dispose();

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -76,3 +76,6 @@ ENV.registerFlag('CHECK_COMPUTATION_FOR_ERRORS', () => true);
 
 /** Whether the backend needs to wrap input to imageBitmap. */
 ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);
+
+/** Experimental flag, whether enter compile only phase. */
+ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);


### PR DESCRIPTION
**This is an experimental feature.**
In this experimental feature, we use a flag (compileOnly) and two APIs (checkCompileCompletion/Async and getUniformLocations) to achieve parallel compilation. The usage is demonstrated in the unit test.

This feature is experimental, it assumes only one model is running by the engine and there's no cached shaders, basically an engine for only one model. It works like this:
1. Compilation round: Just compile shaders in parallel. Then check shaders link status in batch and then set uniform locations.
2. Warm up upload and download round: Upload textures to GPU in batch.
3. Actual inference as normal.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5826)
<!-- Reviewable:end -->
