### PR TITLE
[webgpu] Optimize shader key of concat and resizeBilinear

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/ResizeBilinear.ts
+++ b/tfjs-backend-webgpu/src/kernels/ResizeBilinear.ts
@@ -30,11 +30,18 @@ export function resizeBilinear(args: {
   const {alignCorners, size, halfPixelCenters} = attrs;
 
   const [newHeight, newWidth] = size;
-  const program = new ResizeBilinearProgram(
-      images.shape as [number, number, number, number], newHeight, newWidth,
-      alignCorners, halfPixelCenters);
+  const adjustHeight = alignCorners && newHeight > 1 ? 1.0 : 0.0;
+  const adjustWidth = alignCorners && newWidth > 1 ? 1.0 : 0.0;
+  const halfPixelCentersValue = halfPixelCenters ? 0.5 : 0.0;
+  const uniformData = [
+    {type: 'float32', data: [adjustHeight, adjustWidth]},
+    {type: 'float32', data: [halfPixelCentersValue]}
+  ];
 
-  return backend.runWebGPUProgram(program, [images], 'float32');
+  const program = new ResizeBilinearProgram(
+      images.shape as [number, number, number, number], newHeight, newWidth);
+
+  return backend.runWebGPUProgram(program, [images], 'float32', uniformData);
 }
 
 export const resizeBilinearConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/ResizeNearestNeighbor.ts
+++ b/tfjs-backend-webgpu/src/kernels/ResizeNearestNeighbor.ts
@@ -30,11 +30,19 @@ export function resizeNearestNeighbor(args: {
   const {alignCorners, halfPixelCenters, size} = attrs;
 
   const [newHeight, newWidth] = size;
+  const adjustHeight = alignCorners && newHeight > 1 ? 1.0 : 0.0;
+  const adjustWidth = alignCorners && newWidth > 1 ? 1.0 : 0.0;
+  // When align corners is false, we rounds the value with floor.
+  const roundBase = alignCorners ? 0.5 : 0.0;
+  const uniformData = [
+    {type: 'float32', data: [adjustHeight, adjustWidth]},
+    {type: 'float32', data: [roundBase]}
+  ];
 
   const program = new ResizeNearestNeighborProgram(
       images.shape as [number, number, number, number], newHeight, newWidth,
-      alignCorners, halfPixelCenters);
-  return backend.runWebGPUProgram(program, [images], images.dtype);
+      halfPixelCenters);
+  return backend.runWebGPUProgram(program, [images], images.dtype, uniformData);
 }
 
 export const resizeNearestNeighborConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/concat_webgpu.ts
@@ -62,9 +62,9 @@ export class ConcatProgram implements WebGPUProgram {
                 i - 1})); }`);
       }
       const lastIndex = this.offsetLength;
-      const lastShift = this.offsetLength - 1;
+      const lastShiftIndex = this.offsetLength - 1;
       snippets.push(`else { setOutput(coords.x, coords.y, getT${
-          lastIndex}(yR, yC - uniforms.offset${lastShift})); }`);
+          lastIndex}(yR, yC - uniforms.offset${lastShiftIndex})); }`);
     } else {
       snippets.push(`setOutput(coords.x, coords.y, getT0(yR, yC));`);
     }


### PR DESCRIPTION
This makes shader key of concat, resizeBilinear short and saves warmup
time.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5827)
<!-- Reviewable:end -->
