### PR TITLE
fix nms calculation for negative coordinates

### DIFF
--- a/tfjs-core/src/backends/non_max_suppression_impl.ts
+++ b/tfjs-core/src/backends/non_max_suppression_impl.ts
@@ -181,8 +181,8 @@ function intersectionOverUnion(boxes: TypedArray, i: number, j: number) {
   const intersectionXmin = Math.max(xminI, xminJ);
   const intersectionYmax = Math.min(ymaxI, ymaxJ);
   const intersectionXmax = Math.min(xmaxI, xmaxJ);
-  const intersectionArea = Math.max(intersectionYmax - intersectionYmin, 0.0) *
-      Math.max(intersectionXmax - intersectionXmin, 0.0);
+  const intersectionArea = Math.abs(intersectionYmax - intersectionYmin) *
+      Math.abs(intersectionXmax - intersectionXmin);
   return intersectionArea / (areaI + areaJ - intersectionArea);
 }
 


### PR DESCRIPTION
quick solution for #5856 although a better overall implementation of `intersectionOverUnion` would be nice