### PR TITLE
[tfjs-converter] support float16 data type in conversion and cast op

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -550,17 +550,17 @@ def _find_signature(saved_model_dir, saved_model_tags, signature_def):
   return signature_def_map[signature_def]
 
 def _convert_tf_saved_model(output_dir,
-                           saved_model_dir=None,
-                           keras_model=None,
-                           signature_def='serving_default',
-                           saved_model_tags='serve',
-                           quantization_dtype_map=None,
-                           skip_op_check=False,
-                           strip_debug_ops=False,
-                           weight_shard_size_bytes=1024 * 1024 * 4,
-                           control_flow_v2=False,
-                           experiments=False,
-                           metadata=None):
+                            saved_model_dir=None,
+                            keras_model=None,
+                            signature_def='serving_default',
+                            saved_model_tags='serve',
+                            quantization_dtype_map=None,
+                            skip_op_check=False,
+                            strip_debug_ops=False,
+                            weight_shard_size_bytes=1024 * 1024 * 4,
+                            control_flow_v2=False,
+                            experiments=False,
+                            metadata=None):
   """Take a SavedModel or KerasModel and convert to Tensorflow.js graph model.
 
   Args:
@@ -602,7 +602,7 @@ def _convert_tf_saved_model(output_dir,
   saved_model_sigature = None
   if saved_model_dir:
     saved_model_sigature = _find_signature(saved_model_dir, saved_model_tags,
-                                        signature_def)
+                                           signature_def)
     model = _load_model(saved_model_dir, saved_model_tags_list)
     _check_signature_in_model(model, signature_def)
     concrete_func = model.signatures[signature_def]
@@ -636,7 +636,7 @@ def _convert_tf_saved_model(output_dir,
   except BaseException:
     if saved_model_dir:
       (frozen_graph,
-      frozen_initializer_graph) = _freeze_saved_model_v1(saved_model_dir,
+       frozen_initializer_graph) = _freeze_saved_model_v1(saved_model_dir,
                                                           saved_model_tags_list,
                                                           output_node_names)
     else:
@@ -982,11 +982,11 @@ def convert_keras_model_to_graph_model(keras_model,
     metadata: User defined metadata map.
   """
   _convert_tf_saved_model(output_dir, keras_model=keras_model,
-                                      saved_model_tags=saved_model_tags,
-                                      quantization_dtype_map=quantization_dtype_map,
-                                      skip_op_check=skip_op_check,
-                                      strip_debug_ops=strip_debug_ops,
-                                      weight_shard_size_bytes=weight_shard_size_bytes,
-                                      control_flow_v2=control_flow_v2,
-                                      experiments=experiments,
-                                      metadata=metadata)
+                          saved_model_tags=saved_model_tags,
+                          quantization_dtype_map=quantization_dtype_map,
+                          skip_op_check=skip_op_check,
+                          strip_debug_ops=strip_debug_ops,
+                          weight_shard_size_bytes=weight_shard_size_bytes,
+                          control_flow_v2=control_flow_v2,
+                          experiments=experiments,
+                          metadata=metadata)

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -1030,11 +1030,11 @@ class ConvertTest(tf.test.TestCase):
 
   def test_convert_keras_model_to_saved_model(self):
     keras_model = tf.keras.Sequential(
-      [tf.keras.layers.Dense(1, input_shape=[2])])
+        [tf.keras.layers.Dense(1, input_shape=[2])])
 
     tfjs_path = os.path.join(self._tmp_dir, SAVED_MODEL_DIR)
     tf_saved_model_conversion_v2.convert_keras_model_to_graph_model(
-      keras_model, tfjs_path)
+        keras_model, tfjs_path)
 
     # Check model.json and weights manifest.
     with open(os.path.join(tfjs_path, 'model.json'), 'rt') as f:

--- a/tfjs-converter/python/tensorflowjs/write_weights.py
+++ b/tfjs-converter/python/tensorflowjs/write_weights.py
@@ -27,6 +27,7 @@ from tensorflowjs import read_weights
 _OUTPUT_DTYPES = [np.float16, np.float32, np.int32, np.complex64,
                   np.uint8, np.uint16, np.bool, np.object]
 _AUTO_DTYPE_CONVERSION = {
+    np.dtype(np.float16): np.float32,
     np.dtype(np.float64): np.float32,
     np.dtype(np.int64): np.int32,
     np.dtype(np.complex128): np.complex64}

--- a/tfjs-converter/python/tensorflowjs/write_weights_test.py
+++ b/tfjs-converter/python/tensorflowjs/write_weights_test.py
@@ -545,6 +545,9 @@ class TestWriteWeights(tf.test.TestCase):
         }, {
             'name': 'weight2',
             'data': np.array([[4, 5], [6, 7]], 'float32')
+        }, {
+            'name': 'weight5',
+            'data': np.array([1], 'float16')
         }],
         # Group 2
         [{
@@ -574,6 +577,10 @@ class TestWriteWeights(tf.test.TestCase):
                 'name': 'weight2',
                 'shape': [2, 2],
                 'dtype': 'float32'
+            }, {
+                'name': 'weight5',
+                'shape': [1],
+                'dtype': 'float32'
             }]
         }, {
             'paths': ['group2-shard1of3.bin',
@@ -598,7 +605,7 @@ class TestWriteWeights(tf.test.TestCase):
     group0_shard_2_path = os.path.join(TMP_DIR, 'group1-shard2of2.bin')
     group0_shard_2 = np.fromfile(group0_shard_2_path, 'float32')
     np.testing.assert_array_equal(
-        group0_shard_2, np.array([5, 6, 7], 'float32'))
+        group0_shard_2, np.array([5, 6, 7, 1], 'float32'))
 
     group1_shard_1_path = os.path.join(TMP_DIR, 'group2-shard1of3.bin')
     group1_shard_1 = np.fromfile(group1_shard_1_path, 'int32')

--- a/tfjs-converter/src/data/compiled_api.ts
+++ b/tfjs-converter/src/data/compiled_api.ts
@@ -29,35 +29,61 @@ export declare interface IAny {
 
 /** DataType enum. */
 export enum DataType {
-  'DT_INVALID' = 0,
-  'DT_FLOAT' = 1,
-  'DT_DOUBLE' = 2,
-  'DT_INT32' = 3,
-  'DT_UINT8' = 4,
-  'DT_INT16' = 5,
-  'DT_INT8' = 6,
-  'DT_STRING' = 7,
-  'DT_COMPLEX64' = 8,
-  'DT_INT64' = 9,
-  'DT_BOOL' = 10,
-  'DT_QINT8' = 11,
-  'DT_QUINT8' = 12,
-  'DT_QINT32' = 13,
-  'DT_BFLOAT16' = 14,
-  'DT_FLOAT_REF' = 101,
-  'DT_DOUBLE_REF' = 102,
-  'DT_INT32_REF' = 103,
-  'DT_UINT8_REF' = 104,
-  'DT_INT16_REF' = 105,
-  'DT_INT8_REF' = 106,
-  'DT_STRING_REF' = 107,
-  'DT_COMPLEX64_REF' = 108,
-  'DT_INT64_REF' = 109,
-  'DT_BOOL_REF' = 110,
-  'DT_QINT8_REF' = 111,
-  'DT_QUINT8_REF' = 112,
-  'DT_QINT32_REF' = 113,
-  'DT_BFLOAT16_REF' = 114
+  // Not a legal value for DataType.  Used to indicate a DataType field
+  // has not been set.
+  DT_INVALID = 0,
+
+  // Data types that all computation devices are expected to be
+  // capable to support.
+  DT_FLOAT = 1,
+  DT_DOUBLE = 2,
+  DT_INT32 = 3,
+  DT_UINT8 = 4,
+  DT_INT16 = 5,
+  DT_INT8 = 6,
+  DT_STRING = 7,
+  DT_COMPLEX64 = 8,  // Single-precision complex
+  DT_INT64 = 9,
+  DT_BOOL = 10,
+  DT_QINT8 = 11,     // Quantized int8
+  DT_QUINT8 = 12,    // Quantized uint8
+  DT_QINT32 = 13,    // Quantized int32
+  DT_BFLOAT16 = 14,  // Float32 truncated to 16 bits.  Only for cast ops.
+  DT_QINT16 = 15,    // Quantized int16
+  DT_QUINT16 = 16,   // Quantized uint16
+  DT_UINT16 = 17,
+  DT_COMPLEX128 = 18,  // Double-precision complex
+  DT_HALF = 19,
+  DT_RESOURCE = 20,
+  DT_VARIANT = 21,  // Arbitrary C++ data types
+  DT_UINT32 = 22,
+  DT_UINT64 = 23,
+
+  // Do not use!  These are only for parameters.  Every enum above
+  // should have a corresponding value below (verified by types_test).
+  DT_FLOAT_REF = 101,
+  DT_DOUBLE_REF = 102,
+  DT_INT32_REF = 103,
+  DT_UINT8_REF = 104,
+  DT_INT16_REF = 105,
+  DT_INT8_REF = 106,
+  DT_STRING_REF = 107,
+  DT_COMPLEX64_REF = 108,
+  DT_INT64_REF = 109,
+  DT_BOOL_REF = 110,
+  DT_QINT8_REF = 111,
+  DT_QUINT8_REF = 112,
+  DT_QINT32_REF = 113,
+  DT_BFLOAT16_REF = 114,
+  DT_QINT16_REF = 115,
+  DT_QUINT16_REF = 116,
+  DT_UINT16_REF = 117,
+  DT_COMPLEX128_REF = 118,
+  DT_HALF_REF = 119,
+  DT_RESOURCE_REF = 120,
+  DT_VARIANT_REF = 121,
+  DT_UINT32_REF = 122,
+  DT_UINT64_REF = 123,
 }
 
 /** Properties of a TensorShape. */

--- a/tfjs-converter/src/operations/operation_mapper.ts
+++ b/tfjs-converter/src/operations/operation_mapper.ts
@@ -486,6 +486,7 @@ export function parseDtypeParam(value: string|tensorflow.DataType): DataType {
   }
   switch (value) {
     case tensorflow.DataType.DT_FLOAT:
+    case tensorflow.DataType.DT_HALF:
       return 'float32';
     case tensorflow.DataType.DT_INT32:
     case tensorflow.DataType.DT_INT64:

--- a/tfjs-converter/src/operations/operation_mapper_test.ts
+++ b/tfjs-converter/src/operations/operation_mapper_test.ts
@@ -149,6 +149,12 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
       input: ['BiasAdd'],
       attr: {DstT: {type: tensorflow.DataType.DT_UINT8}}
     },
+    {
+      name: 'Cast3',
+      op: 'Cast',
+      input: ['BiasAdd'],
+      attr: {DstT: {type: tensorflow.DataType.DT_HALF}}
+    },
   ],
   library: {
     function: [
@@ -301,7 +307,7 @@ describe('operationMapper without signature', () => {
       it('should find the graph output nodes', () => {
         expect(convertedGraph.outputs.map(node => node.name)).toEqual([
           'Fill', 'Squeeze', 'Squeeze2', 'Split', 'LogicalNot',
-          'FusedBatchNorm', 'Cast2'
+          'FusedBatchNorm', 'Cast2', 'Cast3'
         ]);
       });
 
@@ -315,7 +321,7 @@ describe('operationMapper without signature', () => {
         expect(Object.keys(convertedGraph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',
           'BiasAdd', 'Cast', 'Squeeze', 'Squeeze2', 'Split', 'LogicalNot',
-          'FusedBatchNorm', 'Cast2'
+          'FusedBatchNorm', 'Cast2', 'Cast3'
         ]);
       });
     });
@@ -477,7 +483,7 @@ describe('operationMapper with signature', () => {
         expect(Object.keys(convertedGraph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',
           'BiasAdd', 'Cast', 'Squeeze', 'Squeeze2', 'Split', 'LogicalNot',
-          'FusedBatchNorm', 'Cast2'
+          'FusedBatchNorm', 'Cast2', 'Cast3'
         ]);
       });
     });
@@ -538,6 +544,10 @@ describe('operationMapper with signature', () => {
       it('should map params with uint8 dtype', () => {
         expect(convertedGraph.nodes['Cast2'].attrParams['dtype'].value)
             .toEqual('int32');
+      });
+      it('should map params with half dtype', () => {
+        expect(convertedGraph.nodes['Cast3'].attrParams['dtype'].value)
+            .toEqual('float32');
       });
     });
   });

--- a/tfjs-converter/tools/compiled_api.d.ts
+++ b/tfjs-converter/tools/compiled_api.d.ts
@@ -39,7 +39,12 @@ export namespace tensorflow {
 
   /** DataType enum. */
   enum DataType {
+    // Not a legal value for DataType.  Used to indicate a DataType field
+    // has not been set.
     DT_INVALID = 0,
+
+    // Data types that all computation devices are expected to be
+    // capable to support.
     DT_FLOAT = 1,
     DT_DOUBLE = 2,
     DT_INT32 = 3,
@@ -47,13 +52,25 @@ export namespace tensorflow {
     DT_INT16 = 5,
     DT_INT8 = 6,
     DT_STRING = 7,
-    DT_COMPLEX64 = 8,
+    DT_COMPLEX64 = 8,  // Single-precision complex
     DT_INT64 = 9,
     DT_BOOL = 10,
-    DT_QINT8 = 11,
-    DT_QUINT8 = 12,
-    DT_QINT32 = 13,
-    DT_BFLOAT16 = 14,
+    DT_QINT8 = 11,     // Quantized int8
+    DT_QUINT8 = 12,    // Quantized uint8
+    DT_QINT32 = 13,    // Quantized int32
+    DT_BFLOAT16 = 14,  // Float32 truncated to 16 bits.  Only for cast ops.
+    DT_QINT16 = 15,    // Quantized int16
+    DT_QUINT16 = 16,   // Quantized uint16
+    DT_UINT16 = 17,
+    DT_COMPLEX128 = 18,  // Double-precision complex
+    DT_HALF = 19,
+    DT_RESOURCE = 20,
+    DT_VARIANT = 21,  // Arbitrary C++ data types
+    DT_UINT32 = 22,
+    DT_UINT64 = 23,
+
+    // Do not use!  These are only for parameters.  Every enum above
+    // should have a corresponding value below (verified by types_test).
     DT_FLOAT_REF = 101,
     DT_DOUBLE_REF = 102,
     DT_INT32_REF = 103,
@@ -67,7 +84,16 @@ export namespace tensorflow {
     DT_QINT8_REF = 111,
     DT_QUINT8_REF = 112,
     DT_QINT32_REF = 113,
-    DT_BFLOAT16_REF = 114
+    DT_BFLOAT16_REF = 114,
+    DT_QINT16_REF = 115,
+    DT_QUINT16_REF = 116,
+    DT_UINT16_REF = 117,
+    DT_COMPLEX128_REF = 118,
+    DT_HALF_REF = 119,
+    DT_RESOURCE_REF = 120,
+    DT_VARIANT_REF = 121,
+    DT_UINT32_REF = 122,
+    DT_UINT64_REF = 123,
   }
 
   /** Properties of a TensorShape. */


### PR DESCRIPTION
auto converter float16 to float32 in converter, and support cast op for DT_HALF type to float32

fixed https://github.com/tensorflow/tfjs/issues/5847

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5858)
<!-- Reviewable:end -->
