### PR TITLE
[webgl] replace texImage2D with texStorage2D + texSubImage2D

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -312,7 +312,7 @@ export class MathBackendWebGL extends KernelBackend {
       // For performance reason, only check it for debugging. In production,
       // it doesn't handle this use case anyway, so behavior is not changed.
       if (!env().getBool('WEBGL_DOWNLOAD_FLOAT_ENABLED') &&
-        env().getNumber('WEBGL_VERSION') === 2) {
+          env().getNumber('WEBGL_VERSION') === 2) {
         throw new Error(
             `tensor.data() with WEBGL_DOWNLOAD_FLOAT_ENABLED=false and ` +
             `WEBGL_VERSION=2 not yet supported.`);
@@ -827,7 +827,10 @@ export class MathBackendWebGL extends KernelBackend {
           texData.isPacked = true;
           texData.shape = input.shape;
         }
-      } else if (!!texData.isPacked !== !!program.packedInputs) {
+      }
+
+      this.uploadToGPU(input.dataId);
+      if (!!texData.isPacked !== !!program.packedInputs) {
         input = texData.isPacked ? this.unpackTensor(input) :
                                    this.packTensor(input);
         dataToDispose.push(input);
@@ -853,7 +856,6 @@ export class MathBackendWebGL extends KernelBackend {
         savedInput.shape = targetShape;
       }
 
-      this.uploadToGPU(input.dataId);
       return {shape: input.shape, texData, isUniform: false};
     });
 
@@ -1005,25 +1007,32 @@ export class MathBackendWebGL extends KernelBackend {
 
       let program;
       let width = texShape[1], height = texShape[0];
-      const isByteArray = values instanceof Uint8Array
-                          || values instanceof Uint8ClampedArray;
+      const isByteArray =
+          values instanceof Uint8Array || values instanceof Uint8ClampedArray;
 
-      if (isPacked) {
+      if (isPacked || !isByteArray) {
         [width, height] = tex_util.getPackedMatrixTextureShapeWidthHeight(
             texShape[0], texShape[1]);
+      }
+
+      if (isPacked) {
         program = new EncodeMatrixPackedProgram(shapeAs3D, isByteArray);
       } else {
         program = new EncodeMatrixProgram(shapeAs3D, isByteArray);
       }
 
-      const tempDenseInputHandle = this.makeTensorInfo([height, width], dtype);
+      const tempDenseInputTexShape: [number, number] =
+          isByteArray ? [height, width] : texShape;
+      const tempDenseInputHandle =
+          this.makeTensorInfo(tempDenseInputTexShape, dtype);
+      const tempDenseInputTexData =
+          this.texData.get(tempDenseInputHandle.dataId);
       if (isByteArray) {
-        this.texData.get(tempDenseInputHandle.dataId).usage =
-            TextureUsage.PIXELS;
+        tempDenseInputTexData.usage = TextureUsage.PIXELS;
       } else {
-        this.texData.get(tempDenseInputHandle.dataId).usage =
-            TextureUsage.UPLOAD;
+        tempDenseInputTexData.usage = TextureUsage.UPLOAD;
       }
+      tempDenseInputTexData.texShape = tempDenseInputTexShape;
       this.gpgpu.uploadDenseMatrixToTexture(
           this.getTexture(tempDenseInputHandle.dataId), width, height,
           values as TypedArray);

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -1010,6 +1010,8 @@ export class MathBackendWebGL extends KernelBackend {
       const isByteArray =
           values instanceof Uint8Array || values instanceof Uint8ClampedArray;
 
+      // texture for float array is PhysicalTextureType.PACKED_2X2_FLOAT32, we
+      // need to make sure the upload uses the same packed size
       if (isPacked || !isByteArray) {
         [width, height] = tex_util.getPackedMatrixTextureShapeWidthHeight(
             texShape[0], texShape[1]);
@@ -1021,6 +1023,9 @@ export class MathBackendWebGL extends KernelBackend {
         program = new EncodeMatrixProgram(shapeAs3D, isByteArray);
       }
 
+      // TexShape for float array needs to be the original shape, which byte
+      // array needs to be packed size. This allow the data upload shape to be
+      // matched with texture creation logic.
       const tempDenseInputTexShape: [number, number] =
           isByteArray ? [height, width] : texShape;
       const tempDenseInputHandle =

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -509,7 +509,7 @@ describeWithFlags('computeBytes counts bytes correctly', WEBGL2_ENVS, () => {
     bytesForTex = computeBytes(
         shapeRC, PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE, gpgpu.gl,
         gpgpu.textureConfig, true /* isPacked */);
-    expect(bytesForTex).toBe(32);
+    expect(bytesForTex).toBe(8);
 
     bytesForTex = computeBytes(
         shapeRC, PhysicalTextureType.PACKED_2X2_FLOAT32, gpgpu.gl,

--- a/tfjs-backend-webgl/src/gpgpu_context_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context_test.ts
@@ -131,8 +131,8 @@ describeWithFlags(
         // tslint:disable-next-line: max-line-length
         const fragmentShader = createFragmentShader(gpgpu.gl, src);
         program = gpgpu.createProgram(fragmentShader);
-        output = gpgpu.createFloat32MatrixTexture(4, 4);
-        gpgpu.uploadDenseMatrixToTexture(output, 4, 4, new Float32Array(16));
+        output = gpgpu.createPackedMatrixTexture(4, 4);
+        gpgpu.uploadDenseMatrixToTexture(output, 2, 2, new Float32Array(16));
         gpgpu.setOutputMatrixTexture(output, 4, 4);
         gpgpu.setProgram(program);
       });

--- a/tfjs-backend-webgl/src/gpgpu_util.ts
+++ b/tfjs-backend-webgl/src/gpgpu_util.ts
@@ -74,7 +74,6 @@ function createAndConfigureTexture(
             tex2d, 0, internalFormat, width, height, 0, textureFormat,
             textureType, null));
   } else {
-    // console.log('create', width, height, internalFormat);
     webgl_util.callAndCheck(
         gl,
         () => (gl as WebGL2RenderingContext)
@@ -195,7 +194,6 @@ export function uploadDenseMatrixToTexture(
   }
 
   dataForUpload.set(data);
-  // console.log('upload', width, height);
   if (env().getNumber('WEBGL_VERSION') === 2) {
     webgl_util.callAndCheck(
         gl,
@@ -218,7 +216,6 @@ export function uploadPixelDataToTexture(
     pixels: PixelData|ImageData|HTMLImageElement|HTMLCanvasElement|
     HTMLVideoElement|ImageBitmap) {
   webgl_util.callAndCheck(gl, () => gl.bindTexture(gl.TEXTURE_2D, texture));
-  // console.log('upload', pixels.width, pixels.height);
   if ((pixels as PixelData).data instanceof Uint8Array) {
     if (env().getNumber('WEBGL_VERSION') === 2) {
       webgl_util.callAndCheck(

--- a/tfjs-backend-webgl/src/tex_util.ts
+++ b/tfjs-backend-webgl/src/tex_util.ts
@@ -205,6 +205,7 @@ export function getTextureConfig(
     defaultNumChannels = 1;
     textureTypeHalfFloat = glany.HALF_FLOAT;
     textureTypeFloat = glany.FLOAT;
+    downloadTextureFormat = glany.RGBA8;
   } else {
     internalFormatFloat = gl.RGBA;
     internalFormatHalfFloat = gl.RGBA;
@@ -217,8 +218,8 @@ export function getTextureConfig(
         textureHalfFloatExtension.HALF_FLOAT_OES :
         null;
     textureTypeFloat = gl.FLOAT;
+    downloadTextureFormat = gl.RGBA;
   }
-  downloadTextureFormat = gl.RGBA;
 
   return {
     internalFormatFloat,

--- a/tfjs-backend-webgl/src/texture_manager.ts
+++ b/tfjs-backend-webgl/src/texture_manager.ts
@@ -195,6 +195,8 @@ function numBytesForInternalFormat(
     return 16;
   } else if (internalFormat === glany.RGBA16F) {
     return 8;
+  } else if (internalFormat === glany.RGBA8) {
+    return 4;
   }
   throw new Error(`Unknown internal format ${internalFormat}`);
 }


### PR DESCRIPTION
This replaces the previous calls of texImage2D where many of the created textures do not match with shape of textures for data uploaded.

fixed https://github.com/tensorflow/tfjs/issues/5861

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5862)
<!-- Reviewable:end -->
