### PR TITLE
Fix fromPixels inconsistent value issue.

### DIFF
--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -142,6 +142,8 @@ function fromPixels_(
             typeof OffscreenCanvasRenderingContext2D !== 'undefined') {
           // @ts-ignore
           fromPixels2DContext = new OffscreenCanvas(1, 1).getContext('2d');
+          const tempTensor = fromPixels_(pixels);
+          tempTensor.dispose();
         } else {
           throw new Error(
               'Cannot parse input in current context. ' +
@@ -149,14 +151,14 @@ function fromPixels_(
         }
       } else {
         fromPixels2DContext = document.createElement('canvas').getContext('2d');
+        // Use a 1x1 image to warm up the canvas. After the initial drawing,
+        // canvas will draw on GPU.
+        const img = new Image();
+        img.src = 'data:image/gif;base64' +
+            ',R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+        const tempTensor = fromPixels_(img);
+        tempTensor.dispose();
       }
-      // Use a 1x1 image to warm up the canvas. After the initial drawing,
-      // canvas will draw on GPU.
-      const img = new Image();
-      img.src = 'data:image/gif;base64' +
-          ',R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
-      const tempTensor = fromPixels_(pixels);
-      tempTensor.dispose();
     }
     fromPixels2DContext.canvas.width = width;
     fromPixels2DContext.canvas.height = height;

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -150,11 +150,18 @@ function fromPixels_(
       } else {
         fromPixels2DContext = document.createElement('canvas').getContext('2d');
       }
+      // Use a 1x1 image to warm up the canvas. After the initial drawing,
+      // canvas will draw on GPU.
+      const img = new Image();
+      img.src = 'data:image/gif;base64' +
+          ',R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+      const tempTensor = fromPixels_(pixels);
+      tempTensor.dispose();
     }
     fromPixels2DContext.canvas.width = width;
     fromPixels2DContext.canvas.height = height;
     fromPixels2DContext.drawImage(
-      pixels as HTMLVideoElement, 0, 0, width, height);
+        pixels as HTMLVideoElement, 0, 0, width, height);
     vals = fromPixels2DContext.getImageData(0, 0, width, height).data;
   }
   let values: Int32Array;

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -142,8 +142,6 @@ function fromPixels_(
             typeof OffscreenCanvasRenderingContext2D !== 'undefined') {
           // @ts-ignore
           fromPixels2DContext = new OffscreenCanvas(1, 1).getContext('2d');
-          const tempTensor = fromPixels_(pixels);
-          tempTensor.dispose();
         } else {
           throw new Error(
               'Cannot parse input in current context. ' +
@@ -151,14 +149,9 @@ function fromPixels_(
         }
       } else {
         fromPixels2DContext = document.createElement('canvas').getContext('2d');
-        // Use a 1x1 image to warm up the canvas. After the initial drawing,
-        // canvas will draw on GPU.
-        const img = new Image();
-        img.src = 'data:image/gif;base64' +
-            ',R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
-        const tempTensor = fromPixels_(img);
-        tempTensor.dispose();
       }
+      const tempTensor = fromPixels_(pixels);
+      tempTensor.dispose();
     }
     fromPixels2DContext.canvas.width = width;
     fromPixels2DContext.canvas.height = height;

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -208,6 +208,26 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(10 * 10 * 3);
   });
+  it('fromPixels for HTMLImageElement load twice.', async () => {
+    const img = new Image();
+    img.src =
+        // tslint:disable-next-line:max-line-length
+        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCMRXhpZgAATU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAFCgAwAEAAAAAQAAADwAAAAA/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ1B2M2Y8AsgTpgAmY7PhCfv/AABEIADwAUAMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgv/xAC1EAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp6vHy8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAAAAQIDBAUGBwgJCgv/xAC1EQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2wBDAAkGBxMSEhUSEhIVFRUXFxUWFRUVFRUVDxUVFhUWFxUVFRUYHSggGBolGxUVITEhJSkrLi4uFx8zODMtNygtLiv/2wBDAQoKCg4NDhsQEBotIB8fLS0tLS0tLS0tLSstLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLSstLS0tLS3/3QAEAAX/2gAMAwEAAhEDEQA/APP/AAlPI3nFOX2g5J9O5roPDuouWZJpEPdSCM1ydxbeXCWUtuzjKE42nrnFNtrlR5eACV5wRyOPWtYyWg1C7sehavfNEu8OFGO4zn6Vk6JczyOpWQu0p4P8KDvkdgACawdfcvGuX98A5rp/CMe22mQpt2x9f4mLhi2fToKKk+VN/cV7K0kt7nS6cXJXcjlWLASFlCnHQ4HI3dvwputWG7Dxu0bKRkg/Kc9AynsemeoNOOtrJE4gUyFBjA4BI4wD7GqxvG2q0qFGIKsD3Ddf1ANccK8m7s2qUEl7pUa8lZ9iuy9skAjI681vW68DPXFcxfXKxMkhJ5by/wDZzWsl43mBcjHpjnGOtd0Jc2pySVmbPlinooxVdZKej1oyD//Q8lstTkh3AdCCpBGR6VDHcYx6jv7V21zYxQwkjBcck9VOeoKmsSNY5QRsAUAkYGMYq3oPU2Bpm5IZThdwXI4HPUGtjUw8Fo5b77A4AHXsC3sM1zXhmBJnKzMxQLwuT1zXZarajyAuSQ2doPJCAd/bjH1NZ1pLk+42hzSkmyXQ9Y86FTCqoCqhiAvDfxbvQ5HoaNZL7Pnb7xwg5znHB55Jzz0rlvBUMgusxllTygXx93dwF9ieDWlfW8hulMkpf72zcMbSQRxjjvXDzJStf0OxXlG9hdQTzrafA5GHUf7SAMB/MfjWFB4pdYEDDMgyUkIHKZ4B/Sup05MCRO6OQR/skDH4EVkWVgjyfZTHlG3FW/uLnkZ+prtoVZJNI4akFc6LQ7rzVWVWDJjB9Q/cGrkuqRxsqM2Gbp/+usW60g2kJSNmaLfuYA8j8fSqEOsrzG4yB8xxgkDqOa6ee7sYch//0fMtOuDJIInYlMngntnpmtLxLAIpEQfLCyjheOh5GfyrNvLD7PdiJHDdCGIx1zwfyrS8SxGWSBQ64bCbifkVu+TWnLvcaegonjtfLaL5i567uQnAx+ddolpJekpG2yMffkI56YCqvtzjt39jxv8AYASdbeSXzM42tAAwG4ng5zt6dTXrGl24iiwP/r+nPvWGJ3S7G+Hd7lOLTUhUJENpAAB67iOhcd6rXEIlGdoWRTyOpVhzwe4PY1ZeYCQZPU4FVdfnMTxzJ3yjDs4ALAH8jz2zXPJRO2jGU3yLfp/kZ1zIuR1SQ8EjGTjsQeoqtYp5dxznJUkE8AqTzWvqCLPEJIjhgcg/xKw6hhWUsrltsmAwHy5IP3vQnnFXR9yVns+pzVqb16NdB+oXjMjgcjDcV5Q90d5ZcjPHXnHpXsslioh46kfqRXi9yhV2B6hmB+oJBrskrHHe5//S8la4Z5leYdSuR0yAea69NLQzKjRZgJ3oCc4IHII9DmsCOzWVyGzwuRg4rtbVf9WPRTz36CuujCLun0sQ20tDkTKbeVntVCkb0KkE7iTkAAfQY+tevwlhCm772xd31wM/rXiuoyst4wV2GJRjHYkqCf1Ne43R4rhxSVzswz3OWvyTcQrkj5iT7jGP61F4o1JHKRJyI8lj23Ebdo+gzn3xWP4vnYXcYBI+U9OD1HeqJriq6SPby+kv4j6Ghb6g8R3I2OxB5Vh6MO9PmvzNJGGUDa3AGe/qe49qyC1afh+MNcID2BP4ggf1NaUr3SNsWoNSm46pM3bm8wMd815RqaFppmUEgOxPtz/jXsuuWCIRtzyCfYfT2ryTxMNlxIq8BtpIHQk5r0JM+VtY/9k=';
+
+    await new Promise(resolve => {
+      img.onload = () => resolve(img);
+    });
+
+    const numTensorsBefore = tf.memory().numTensors;
+    const imgTensor1 = tf.browser.fromPixels(img);
+    const imgTensor2 = tf.browser.fromPixels(img);
+    const data1 = await imgTensor1.data();
+    const data2 = await imgTensor2.data();
+    imgTensor1.dispose();
+    imgTensor2.dispose();
+    expectArraysEqual(data2, data1);
+    expect(tf.memory().numTensors).toEqual(numTensorsBefore);
+  });
   it('fromPixels for HTMLVideoElement', async () => {
     const video = document.createElement('video');
     video.autoplay = true;

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -225,8 +225,6 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data2 = await imgTensor2.data();
     imgTensor1.dispose();
     imgTensor2.dispose();
-    console.log(data1);
-    console.log(data2);
     expectArraysEqual(data2, data1);
     expect(tf.memory().numTensors).toEqual(numTensorsBefore);
   });

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -225,6 +225,8 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data2 = await imgTensor2.data();
     imgTensor1.dispose();
     imgTensor2.dispose();
+    console.log(data1);
+    console.log(data2);
     expectArraysEqual(data2, data1);
     expect(tf.memory().numTensors).toEqual(numTensorsBefore);
   });


### PR DESCRIPTION
Fixed #5482

The original issue happens because the first few rendering happens on CPU, and later rendering happens on GPU. Because the rendering engine is different, the value after render optimization is slightly different. There are three ways to solve this problem:
(1) Warm up the canvas so that it starts rendering on GPU. And then only use GPU rendering result.
(2) Recreate the canvas every time, and only use CPU rendering result.
(3) Use the [canvas-2d-api](https://github.com/fserb/canvas2d) [willReadFrequently](https://github.com/fserb/canvas2D/blob/master/spec/will-read-frequently.md) to keep rendering on CPU and only use CPU rendering result.

I benchmarked the three approaches, run fromPixels for 1000 times with the same image, and here's the result:
(1) 4622ms
(2) 9101ms
(3) 7633ms

Method(1) is the fastest of all, so we chose this solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5864)
<!-- Reviewable:end -->
