### PR TITLE
[benchmark] Add initial support for tflite models

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -283,7 +283,7 @@ limitations under the License.
     const parameterTable = document.querySelector('#parameters tbody');
     const modelInputsTable = document.querySelector('#modelInputs tbody');
 
-    let model, predict, chartWidth;
+    let model, tfliteModel, predict, chartWidth;
 
     async function showMsg(message) {
       if (message != null) {
@@ -387,7 +387,9 @@ limitations under the License.
       if (state.benchmark === 'custom') {
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
-          timeInfo = await timeModelInference(model, input, warmupTimes);
+          timeInfo = isTflite() ?
+              await timeInference(()=>predict(input), warmupTimes) :
+              await timeModelInference(model, input, warmupTimes);
         } finally {
           tf.dispose(input);
         }
@@ -407,7 +409,8 @@ limitations under the License.
       }
       let variableShape = false;
       const modelInputsElement = document.getElementById('modelInputs');
-      if (model['inputs'] == null) {
+      const inputs = isTflite() ? tfliteModel.inputs : model.inputs;
+      if (inputs == null) {
         modelInputsElement.style.display = 'none';
       } else {
         modelInputsElement.style.display = '';
@@ -488,16 +491,27 @@ limitations under the License.
       if (benchmark['load'] == null) {
         throw new Error(`Please provide a load method for '${state.benchmark}' model.`);
       }
+      if ((benchmark['loadTflite'] == null || benchmark['predictFuncTflite'] == null) && isTflite()) {
+        throw new Error(`Please provide a loadTflite and a predictFuncTflite method for '${state.benchmark}' model.`);
+      }
 
       await showMsg('Loading the model');
       let start = performance.now();
       const inputSize = parseFloat(state.inputSize);
-      model = await benchmark.load(inputSize, state.architecture, state.inputType);
+      if (isTflite()) {
+        if (tfliteModel) {
+          tfliteModel.modelRunner.cleanUp();
+        }
+        tfliteModel = await benchmark.loadTflite();
+      } else {
+        model = await benchmark.load(inputSize, state.architecture, state.inputType);
+      }
       state.inputs = [];
-      if (model.inputs) {
+      const inputs = isTflite() ? tfliteModel.inputs : model.inputs
+      if (inputs) {
         // construct the input state for the model
-        for (let modelInputIndex = 0; modelInputIndex < model.inputs.length; modelInputIndex++) {
-          let modelInput = model.inputs[modelInputIndex];
+        for (let modelInputIndex = 0; modelInputIndex < inputs.length; modelInputIndex++) {
+          let modelInput = inputs[modelInputIndex];
           if (modelInput.shape == null) continue;
           let shape = modelInput.shape.map(e => e == null ? -1 : e);
           state.inputs.push({
@@ -508,7 +522,7 @@ limitations under the License.
           });
         }
       }
-      predict = benchmark.predictFunc(inputSize);
+      predict = isTflite() ? benchmark.predictFuncTflite() : benchmark.predictFunc(inputSize);
       const elapsed = performance.now() - start;
 
       await showMsg(null);
@@ -549,7 +563,9 @@ limitations under the License.
       if (state.benchmark === 'custom') {
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
-          timeInfo = await timeModelInference(model, input, numRuns);
+          timeInfo = isTflite() ?
+              await timeInference(()=>predict(input), numRuns) :
+              await timeModelInference(model, input, numRuns);
         } finally {
           tf.dispose(input);
         }
@@ -568,6 +584,15 @@ limitations under the License.
     }
 
     async function profileMemoryAndKernelTime() {
+      if (isTflite()) {
+        await showMsg(null);
+        const tbody = document.querySelector('#kernels tbody');
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = '[TODO] Per-kernel stats not supported yet for TFLite models';
+        appendRow(tbody, nameSpan, '');
+        return;
+      }
+
       await showMsg('Profile memory and kernels');
       const start = performance.now();
 
@@ -659,7 +684,7 @@ limitations under the License.
     }
 
     async function runBenchmark() {
-      if (!tf.engine().backendNames().includes(state.backend)) {
+      if (!tf.engine().backendNames().includes(state.backend) && !isTflite()) {
         return;
       }
       await tf.ready();
@@ -757,6 +782,9 @@ limitations under the License.
         'https://cdn.jsdelivr.net/npm/@tensorflow-models/posenet@2',
         'https://cdn.jsdelivr.net/npm/@tensorflow-models/body-pix@2',
         'https://cdn.jsdelivr.net/npm/@tensorflow-models/pose-detection',
+        // Load tfjs-tflite from jsdelivr because it correctly sets the
+        // "cross-origin-resource-policy" header.
+        'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-tflite/dist/tf-tflite.js',
         '../model_config.js',
         '../benchmark_util.js',
         './util.js',
@@ -889,7 +917,8 @@ limitations under the License.
       modelParameterFolder.open();
 
       const envFolder = gui.addFolder('Environment');
-      const backendsController = envFolder.add(state, 'backend', ['wasm', 'webgl', 'cpu', 'webgpu']);
+      const backendsController = envFolder.add(
+        state, 'backend', ['wasm', 'webgl', 'cpu', 'webgpu', 'tflite']);
       backendsController.onChange(async backend => {
         // TODO: Failed to set backend
         if (state.backend === 'webgpu' && !tf.engine().backendNames().includes(state.backend)) {
@@ -899,7 +928,31 @@ limitations under the License.
         } else {
           showMsg(null);
         }
-        await tf.setBackend(backend);
+        if (isTflite()) {
+          // Remove the "Test correctness" button which doesn't apply to tfjs-tflite.
+          correctnessButton.remove();
+          correctnessButton = null;
+
+          // Update models drop down to only show models that support tflite.
+          const tfliteBenchmarks = Object.keys(benchmarks)
+            .filter(name => benchmarks[name].loadTflite);
+          updateModelsDropdown(tfliteBenchmarks);
+          modelController.setValue(tfliteBenchmarks[0]);
+          state.isModelLoaded = false;
+          state.isModelChanged = true;
+        } else {
+          // Show the "Test correctness" button and re-populate models dropdown when changed from
+          // tflite to non-tflite backend.
+          if (correctnessButton == null) {
+            correctnessButton = gui.add(state, 'testCorrectness');
+            const tfliteBenchmarks = Object.keys(benchmarks);
+            updateModelsDropdown(tfliteBenchmarks);
+            modelController.setValue(tfliteBenchmarks[0]);
+            state.isModelLoaded = false;
+            state.isModelChanged = true;
+          }
+          await tf.setBackend(backend);
+        }
         await showFlagSettingsAndReturnTunableFlagControllers(envFolder, state.backend);
       });
       envFolder.open();
@@ -913,6 +966,15 @@ limitations under the License.
       showVersions();
       await showEnvironment();
       updateGUIFromURLState();
+    }
+
+    function isTflite() {
+      return state.backend === 'tflite';
+    }
+
+    function updateModelsDropdown(newValues) {
+      const tfliteBenchmarksHtml = newValues.map(name => `<option value="${name}">${name}</option>`);
+      modelController.domElement.children[0].innerHTML = tfliteBenchmarksHtml;
     }
 
     onPageLoad();

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -491,8 +491,8 @@ limitations under the License.
       if (benchmark['load'] == null) {
         throw new Error(`Please provide a load method for '${state.benchmark}' model.`);
       }
-      if ((benchmark['loadTflite'] == null || benchmark['predictFuncTflite'] == null) && isTflite()) {
-        throw new Error(`Please provide a loadTflite and a predictFuncTflite method for '${state.benchmark}' model.`);
+      if ((benchmark['loadTflite'] == null) && isTflite()) {
+        throw new Error(`Please provide a loadTflite method for '${state.benchmark}' model.`);
       }
 
       await showMsg('Loading the model');
@@ -522,7 +522,7 @@ limitations under the License.
           });
         }
       }
-      predict = isTflite() ? benchmark.predictFuncTflite() : benchmark.predictFunc(inputSize);
+      predict = benchmark.predictFunc(inputSize);
       const elapsed = performance.now() - start;
 
       await showMsg(null);
@@ -945,9 +945,9 @@ limitations under the License.
           // tflite to non-tflite backend.
           if (correctnessButton == null) {
             correctnessButton = gui.add(state, 'testCorrectness');
-            const tfliteBenchmarks = Object.keys(benchmarks);
-            updateModelsDropdown(tfliteBenchmarks);
-            modelController.setValue(tfliteBenchmarks[0]);
+            const allBenchmarks = Object.keys(benchmarks);
+            updateModelsDropdown(allBenchmarks);
+            modelController.setValue(allBenchmarks[0]);
             state.isModelLoaded = false;
             state.isModelChanged = true;
           }

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -31,6 +31,7 @@ const BACKEND_FLAGS_MAP = {
     'CHECK_COMPUTATION_FOR_ERRORS', 'WEBGL_USE_SHAPES_UNIFORMS',
     'KEEP_INTERMEDIATE_TENSORS'
   ],
+  tflite: [],
 };
 if (tf.engine().backendNames().includes('webgpu')) {
   BACKEND_FLAGS_MAP['webgpu'] =

--- a/e2e/benchmarks/local-benchmark/main.css
+++ b/e2e/benchmarks/local-benchmark/main.css
@@ -101,6 +101,7 @@ div[id*='trendline-container'] path {
   padding: 7px;
   position: absolute;
   top: 15px;
+  z-index: 100;
 }
 
 .table {

--- a/e2e/scripts/deploy-benchmarks.sh
+++ b/e2e/scripts/deploy-benchmarks.sh
@@ -22,10 +22,17 @@ set -e
 PROJECT="jstensorflow"
 
 if [[ "$1" == "--dev" ]]; then
-  firebase serve \
-    --config benchmarks/firebase_staging.json \
-    --only hosting:tfjs-benchmarks-staging \
-    --project ${PROJECT}
+  # Deploy to the preview channel.
+  #
+  # Use the second command line parameter as the feature name which will be
+  # part of the preview URL. Use the current date+time as fallback.
+  feature_name="${2:-$(date '+%Y%m%d-%H%M%S')}"
+  firebase hosting:channel:deploy \
+    "${feature_name}" \
+    --config benchmarks/firebase.json \
+    --only tfjs-benchmarks \
+    --project ${PROJECT} \
+    --expires 14d
 elif [[ "$1" == "--staging"  ]]; then
   firebase deploy \
     --config benchmarks/firebase_staging.json \


### PR DESCRIPTION
This PR enables benchmarking TFLite models using tfjs-tflite. For now, it only supports overall run time. The kernel/op level stats will be implemented soon (waiting for internal changes to be checked in and deployed).

You can try the following using this [preview link](https://tfjs-benchmarks--20211118-151611-qbhl4xat.web.app/local-benchmark/).

**Benchmark mobilenet_v2 with tflite**
(this is the only pre-trained model supported by tfjs-tflite for now)

- Select "tflite" from the "backend" drop down.
- The "models" drop down should update to only include "mobilenet_v2" and "custom"
- Make sure the "mobilenet_v2" is selected
- Click "Run benchmark"

**Benchmark custom tflite models**

- Select "tflite" from the "backend" drop down.
- Select "custom" from the "models" drop down.
- Entry a url. For example this cartoongan model: https://tfhub.dev/sayakpaul/lite-model/cartoongan/fp16/1
- Maybe change numRuns to 10
- Click "Run benchmark"  

See #5829 
 
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5870)
<!-- Reviewable:end -->
