### PR TITLE
[E2E] Set WebGL as baseline for pose-detection correctness test

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -216,7 +216,13 @@ limitations under the License.
 
         // load model and run inference
         try {
-          tf.setBackend('cpu');
+          if (state.benchmark === "pose-detection") {
+            tf.setBackend('webgl');
+            await showMsg('Runing on webgl');
+          } else {
+            tf.setBackend('cpu');
+            await showMsg('Runing on cpu');
+          }
           await loadModelAndRecordTime();
           await showMsg('Testing correctness');
           await showInputs();
@@ -239,7 +245,12 @@ limitations under the License.
           const debug = keepIntermediateTensors & (benchmarks[state.benchmark].supportDebug !== false);
           referenceData = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
 
-          await tf.setBackend(state.backend);
+          // webgl correctness test use webgpu as baseline
+          if (state.benchmark === "pose-detection" && state.backend === "webgl") {
+            await tf.setBackend("webgpu");
+          } else {
+            await tf.setBackend(state.backend);
+          }
           await showMsg(`Runing on ${state.backend}`);
           predictionData = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
         } catch (e) {


### PR DESCRIPTION
As CPU backend doesn't support on pose-detection demo, we compare results between WebGL and WebGPU backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5875)
<!-- Reviewable:end -->
