### PR TITLE
[tfjs-node] support M1 with TF darwin-arm64 build

### DIFF
--- a/tfjs-node/scripts/deps-constants.js
+++ b/tfjs-node/scripts/deps-constants.js
@@ -26,7 +26,8 @@ const LIBTENSORFLOW_VERSION = '2.7.0';
 
 /** Map the os.arch() to arch string in a file name */
 const ARCH_MAPPING = {
-  'x64': 'x86_64'
+  'x64': 'x86_64',
+  'arm64': 'arm64'
 };
 /** Map the os.platform() to the platform value in a file name */
 const PLATFORM_MAPPING = {

--- a/tfjs-node/scripts/install.js
+++ b/tfjs-node/scripts/install.js
@@ -88,6 +88,9 @@ function revertAddonName(orig) {
 function getPlatformLibtensorflowUri() {
   // Exception for mac+gpu user
   if (platform === 'darwin') {
+    if (os.arch() === 'arm64') {
+      return `${BASE_HOST}tf-builds/libtensorflow_r2_7_darwin_arm64_cpu.tar.gz`;
+    }
     system = `cpu-${PLATFORM_MAPPING[platform]}-${ARCH_MAPPING[os.arch()]}`;
   }
 


### PR DESCRIPTION
TF does not provide binary for OSX M1 hardware, we need to create our own build to enable tjfs-node on M1 machines.

Compiled darwin-arm64 c library binary using the community [direction](https://github.com/tensorflow/tfjs/issues/4514#issuecomment-826591952) and TF library building [readme](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/lib_package/README.md)

update tfjs-node install.js to use the binary from our gcp storage.

fixed https://github.com/tensorflow/tfjs/issues/4514
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5899)
<!-- Reviewable:end -->
