### PR TITLE
[benchmark] Support collecting and showing per-op stats (latency for now) for tflite models in benchmark tool

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -790,7 +790,7 @@ limitations under the License.
         'https://cdn.jsdelivr.net/npm/@tensorflow-models/pose-detection',
         // Load tfjs-tflite from jsdelivr because it correctly sets the
         // "cross-origin-resource-policy" header.
-        'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-tflite/dist/tf-tflite.js',
+        'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-tflite@latest/dist/tf-tflite.js',
         '../model_config.js',
         '../benchmark_util.js',
         './util.js',

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -582,7 +582,6 @@ limitations under the License.
 
     async function profileMemoryAndKernelTime() {
       await showMsg('Profile memory and kernels');
-      const start = performance.now();
 
       // Reload tflite model with profiling enabled.
       if (isTflite()) {
@@ -595,6 +594,8 @@ limitations under the License.
         state.isModelChanged = true;
         state.isModelLoaded = false;
       }
+
+      const start = performance.now();
 
       let profileInfo;
       if (state.benchmark === 'custom') {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -499,10 +499,7 @@ limitations under the License.
       let start = performance.now();
       const inputSize = parseFloat(state.inputSize);
       if (isTflite()) {
-        if (tfliteModel) {
-          tfliteModel.modelRunner.cleanUp();
-        }
-        tfliteModel = await benchmark.loadTflite();
+        await loadTfliteModel();
       } else {
         model = await benchmark.load(inputSize, state.architecture, state.inputType);
       }
@@ -584,34 +581,40 @@ limitations under the License.
     }
 
     async function profileMemoryAndKernelTime() {
-      if (isTflite()) {
-        await showMsg(null);
-        const tbody = document.querySelector('#kernels tbody');
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = '[TODO] Per-kernel stats not supported yet for TFLite models';
-        appendRow(tbody, nameSpan, '');
-        return;
-      }
-
       await showMsg('Profile memory and kernels');
       const start = performance.now();
+
+      // Reload tflite model with profiling enabled.
+      if (isTflite()) {
+        await loadTfliteModel(true);
+        // This will make sure the model will be reloaded (with profiling disabled) next time
+        // when "Run benchmark" is clicked.
+        //
+        // Without this, the model with profiling *enabled* will continued to be used to measure
+        // the total run time when "Run benchmark" is clicked, which is not accurate.
+        state.isModelChanged = true;
+        state.isModelLoaded = false;
+      }
 
       let profileInfo;
       if (state.benchmark === 'custom') {
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
-          profileInfo = await profileModelInference(model, input);
+          profileInfo = await profileModelInference(model, input, isTflite());
         } finally {
           tf.dispose(input);
         }
       } else {
-        profileInfo = await profileInference(() => predict(model));
+        profileInfo = await profileInference(() => predict(model), isTflite());
       }
 
       const elapsed = performance.now() - start;
       await showMsg(null);
-      appendRow(timeTable, 'Peak memory', printMemory(profileInfo.peakBytes));
-      appendRow(timeTable, 'Leaked tensors', profileInfo.newTensors);
+      // TODO: These are not supported by tflite models yet.
+      if (!isTflite()) {
+        appendRow(timeTable, 'Peak memory', printMemory(profileInfo.peakBytes));
+        appendRow(timeTable, 'Leaked tensors', profileInfo.newTensors);
+      }
       appendRow(timeTable, 'Profile time', printTime(elapsed));
 
       if (state.backend === 'webgl' && !queryTimerIsEnabled()) {
@@ -648,7 +651,10 @@ limitations under the License.
               inputInfo += `input${index}: ${inputShape.length}D[${inputShape}]`;
             }
           });
-          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), inputInfo, kernel.outputShapes, kernel.extraInfo);
+          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2),
+                    inputInfo || '-',
+                    kernel.outputShapes.length !== 0 ? kernel.outputShapes : '-',
+                    kernel.extraInfo || '-');
         });
       } else {
         profileInfo.aggregatedKernels.forEach(r => {
@@ -970,6 +976,14 @@ limitations under the License.
 
     function isTflite() {
       return state.backend === 'tflite';
+    }
+
+    async function loadTfliteModel(enableProfiling = false) {
+      if (tfliteModel) {
+        tfliteModel.modelRunner.cleanUp();
+      }
+      const benchmark = benchmarks[state.benchmark];
+      tfliteModel = await benchmark.loadTflite(enableProfiling);
     }
 
     function updateModelsDropdown(newValues) {

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -96,10 +96,10 @@ const benchmarks = {
           'https://storage.googleapis.com/learnjs-data/mobilenet_v2_100_fused/model.json';
       return tf.loadGraphModel(url);
     },
-    loadTflite: async () => {
+    loadTflite: async (enableProfiling = false) => {
       const url =
           'https://tfhub.dev/tensorflow/lite-model/mobilenet_v2_1.0_224/1/metadata/1';
-      return tflite.loadTFLiteModel(url);
+      return tflite.loadTFLiteModel(url, {enableProfiling});
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
@@ -403,8 +403,8 @@ const benchmarks = {
     load: async () => {
       return loadModelByUrlWithState(state.modelUrl, {}, state);
     },
-    loadTflite: async () => {
-      return tflite.loadTFLiteModel(state.modelUrl);
+    loadTflite: async (enableProfiling = false) => {
+      return tflite.loadTFLiteModel(state.modelUrl, {enableProfiling});
     },
     predictFunc: () => {
       return async (model, customInput) => {


### PR DESCRIPTION
This PR uses the latest tfjs-tflite package that supports getting per-op latency stats, and integrate it with the benchmark tool to show it in the kernel table.

One caveat is that for tflite models, the profiling can only be enabled when loading the model, which is different from tfjs models where we could just wrap the `predict` call in `tf.profile`. To make this work, the tflite model will be loaded first (with enableProfiling=false) during the "total run time" profiling phase, then loaded again (with enableProfiling=true) during the "kernel ops" profiling phase.

The result looks like [this](https://user-images.githubusercontent.com/8752427/144487541-b4b61ccc-5a43-40ed-95de-c48d064c4329.png)


Fixes #5829 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5917)
<!-- Reviewable:end -->
