### PR TITLE
[wasm] Add boolean data type support for min/max

### DIFF
--- a/tfjs-backend-wasm/src/cc/kernels/Max.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Max.cc
@@ -72,6 +72,9 @@ void Max(const size_t x_id, const DType dtype, const size_t reduce_size,
     case DType::int32:
       max<int32_t>(x_info.i32(), out_size, reduce_size, out_info.i32_write());
       break;
+    case DType::boolean:
+      max<bool>(x_info.b(), out_size, reduce_size, out_info.b_write());
+      break;
     default:
       util::warn("Max failed. Unknown dtype %d", dtype);
   }

--- a/tfjs-backend-wasm/src/cc/kernels/Min.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/Min.cc
@@ -73,6 +73,9 @@ void Min(const size_t x_id, const DType dtype, const size_t reduce_size,
     case DType::int32:
       min<int32_t>(x_info.i32(), out_size, reduce_size, out_info.i32_write());
       break;
+    case DType::boolean:
+      min<bool>(x_info.b(), out_size, reduce_size, out_info.b_write());
+      break;
     default:
       util::warn("Min failed. Unknown dtype %d", dtype);
   }


### PR DESCRIPTION
Our other backends already support boolean type for min/max, so this PR adds it to the WASM backend.

Fixes #5900 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5922)
<!-- Reviewable:end -->
