### PR TITLE
[webgl] Refactor texture return type to return the actual texShape with the WebGLTexture

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -328,7 +328,7 @@ export class MathBackendWebGL extends KernelBackend {
       const tmpData = this.texData.get(tmpDownloadTarget.dataId);
 
       buffer = this.gpgpu.createBufferFromTexture(
-          tmpData.texture, ...tex_util.getDenseTexShape(shape));
+          tmpData.texture.texture, ...tex_util.getDenseTexShape(shape));
     }
 
     this.pendingRead.set(dataId, []);
@@ -419,10 +419,11 @@ export class MathBackendWebGL extends KernelBackend {
     if (env().getBool('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
       const tmpTarget = this.decode(dataId);
       const tmpData = this.texData.get(tmpTarget.dataId);
-      const vals = this.gpgpu
-                       .downloadMatrixFromPackedTexture(
-                           tmpData.texture, ...tex_util.getDenseTexShape(shape))
-                       .subarray(0, size);
+      const vals =
+          this.gpgpu
+              .downloadMatrixFromPackedTexture(
+                  tmpData.texture.texture, ...tex_util.getDenseTexShape(shape))
+              .subarray(0, size);
 
       this.disposeIntermediateTensorInfo(tmpTarget);
 
@@ -439,11 +440,11 @@ export class MathBackendWebGL extends KernelBackend {
     const output = this.runWebGLProgram(
         program, [{shape: outputShape, dtype, dataId}], 'float32');
     const tmpData = this.texData.get(output.dataId);
-    const vals =
-        this.gpgpu
-            .downloadByteEncodedFloatMatrixFromOutputTexture(
-                tmpData.texture, tmpData.texShape[0], tmpData.texShape[1])
-            .subarray(0, size);
+    const vals = this.gpgpu
+                     .downloadByteEncodedFloatMatrixFromOutputTexture(
+                         tmpData.texture.texture, tmpData.texShape[0],
+                         tmpData.texShape[1])
+                     .subarray(0, size);
     this.disposeIntermediateTensorInfo(output);
 
     return vals;
@@ -618,7 +619,7 @@ export class MathBackendWebGL extends KernelBackend {
 
   getTexture(dataId: DataId): WebGLTexture {
     this.uploadToGPU(dataId);
-    return this.texData.get(dataId).texture;
+    return this.texData.get(dataId).texture.texture;
   }
 
   /**

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -35,7 +35,7 @@ import {simpleAbsImplCPU} from './kernel_utils/shared';
 import {PackProgram} from './pack_gpu';
 import {ReshapePackedProgram} from './reshape_packed_gpu';
 import * as tex_util from './tex_util';
-import {TextureData, TextureUsage} from './tex_util';
+import {Texture, TextureData, TextureUsage} from './tex_util';
 import {TextureManager} from './texture_manager';
 import * as unary_op from './unaryop_gpu';
 import {UnaryOpProgram} from './unaryop_gpu';
@@ -998,6 +998,8 @@ export class MathBackendWebGL extends KernelBackend {
 
     let texShape = texData.texShape;
     if (texShape == null) {
+      // This texShape may not be the final texture shape. For packed or dense
+      // textures, the texShape will be changed when textures are created.
       texShape = webgl_util.getTextureShapeFromLogicalShape(shape, isPacked);
       texData.texShape = texShape;
     }
@@ -1086,7 +1088,7 @@ export class MathBackendWebGL extends KernelBackend {
 
   private acquireTexture(
       texShape: [number, number], texType: TextureUsage, dtype: DataType,
-      isPacked: boolean): WebGLTexture {
+      isPacked: boolean): Texture {
     this.numBytesInGPU += this.computeBytes(texShape, dtype);
     if (!this.warnedAboutMemory &&
         this.numBytesInGPU > this.numMBBeforeWarning * 1024 * 1024) {

--- a/tfjs-backend-webgl/src/gpgpu_context.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context.ts
@@ -20,7 +20,7 @@ import {env, PixelData, TypedArray, util} from '@tensorflow/tfjs-core';
 import {getWebGLContext, setWebGLContext} from './canvas_util';
 import * as gpgpu_util from './gpgpu_util';
 import * as tex_util from './tex_util';
-import {TextureConfig} from './tex_util';
+import {Texture, TextureConfig} from './tex_util';
 import {WebGL1DisjointQueryTimerExtension, WebGL2DisjointQueryTimerExtension} from './webgl_types';
 import * as webgl_util from './webgl_util';
 
@@ -135,22 +135,20 @@ export class GPGPUContext {
     this.disposed = true;
   }
 
-  public createFloat32MatrixTexture(rows: number, columns: number):
-      WebGLTexture {
+  public createFloat32MatrixTexture(rows: number, columns: number): Texture {
     this.throwIfDisposed();
     return gpgpu_util.createFloat32MatrixTexture(
         this.gl, rows, columns, this.textureConfig);
   }
 
-  public createFloat16MatrixTexture(rows: number, columns: number):
-      WebGLTexture {
+  public createFloat16MatrixTexture(rows: number, columns: number): Texture {
     this.throwIfDisposed();
     return gpgpu_util.createFloat16MatrixTexture(
         this.gl, rows, columns, this.textureConfig);
   }
 
   public createUnsignedBytesMatrixTexture(rows: number, columns: number):
-      WebGLTexture {
+      Texture {
     this.throwIfDisposed();
     return gpgpu_util.createUnsignedBytesMatrixTexture(
         this.gl, rows, columns, this.textureConfig);
@@ -172,14 +170,13 @@ export class GPGPUContext {
   }
 
   public createFloat16PackedMatrixTexture(rows: number, columns: number):
-      WebGLTexture {
+      Texture {
     this.throwIfDisposed();
     return gpgpu_util.createFloat16PackedMatrixTexture(
         this.gl, rows, columns, this.textureConfig);
   }
 
-  public createPackedMatrixTexture(rows: number, columns: number):
-      WebGLTexture {
+  public createPackedMatrixTexture(rows: number, columns: number): Texture {
     this.throwIfDisposed();
     return gpgpu_util.createPackedMatrixTexture(
         this.gl, rows, columns, this.textureConfig);

--- a/tfjs-backend-webgl/src/gpgpu_context_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context_test.ts
@@ -92,7 +92,7 @@ describeWithFlags(
       });
 
       it('sets the output texture property to the output texture', () => {
-        texture = gpgpu.createPackedMatrixTexture(1, 1);
+        texture = gpgpu.createPackedMatrixTexture(1, 1).texture;
         gpgpu.setOutputPackedMatrixTexture(texture, 1, 1);
         expect(gpgpu.outputTexture).toBe(texture);
       });
@@ -100,7 +100,7 @@ describeWithFlags(
       it('sets the gl viewport to the output packed texture dimensions', () => {
         const columns = 456;
         const rows = 123;
-        texture = gpgpu.createPackedMatrixTexture(rows, columns);
+        texture = gpgpu.createPackedMatrixTexture(rows, columns).texture;
         gpgpu.setOutputPackedMatrixTexture(texture, rows, columns);
         const [width, height] =
             tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
@@ -131,7 +131,7 @@ describeWithFlags(
         // tslint:disable-next-line: max-line-length
         const fragmentShader = createFragmentShader(gpgpu.gl, src);
         program = gpgpu.createProgram(fragmentShader);
-        output = gpgpu.createPackedMatrixTexture(4, 4);
+        output = gpgpu.createPackedMatrixTexture(4, 4).texture;
         gpgpu.uploadDenseMatrixToTexture(output, 2, 2, new Float32Array(16));
         gpgpu.setOutputMatrixTexture(output, 4, 4);
         gpgpu.setProgram(program);

--- a/tfjs-backend-webgl/src/gpgpu_context_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context_test.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
+// tslint:disable-next-line: no-imports-from-dist
 import {expectArraysEqual} from '@tensorflow/tfjs-core/dist/test_util';
 
 import {WEBGL_ENVS} from './backend_webgl_test_registry';

--- a/tfjs-backend-webgl/src/gpgpu_context_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context_test.ts
@@ -54,7 +54,7 @@ describeWithFlags(
       });
 
       it('sets the output texture property to the output texture', () => {
-        texture = gpgpu.createFloat32MatrixTexture(1, 1);
+        texture = gpgpu.createFloat32MatrixTexture(1, 1).texture;
         gpgpu.setOutputMatrixTexture(texture, 1, 1);
         expect(gpgpu.outputTexture).toBe(texture);
       });
@@ -62,7 +62,7 @@ describeWithFlags(
       it('sets the gl viewport to the output texture dimensions', () => {
         const columns = 456;
         const rows = 123;
-        texture = gpgpu.createFloat32MatrixTexture(rows, columns);
+        texture = gpgpu.createFloat32MatrixTexture(rows, columns).texture;
         gpgpu.setOutputMatrixTexture(texture, rows, columns);
         const expected = new Int32Array([0, 0, columns, rows]);
         expect(gpgpu.gl.getParameter(gpgpu.gl.VIEWPORT)).toEqual(expected);
@@ -181,7 +181,7 @@ describeWithFlags('GPGPUContext', DOWNLOAD_FLOAT_ENVS, () => {
     `;
     const fragmentShader = createFragmentShader(gpgpu.gl, src);
     const program = gpgpu.createProgram(fragmentShader);
-    const result = gpgpu.createFloat32MatrixTexture(1, 1);
+    const result = gpgpu.createFloat32MatrixTexture(1, 1).texture;
     gpgpu.setOutputMatrixTexture(result, 1, 1);
     gpgpu.setProgram(program);
     gpgpu.deleteMatrixTexture(result);

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -210,9 +210,11 @@ export function runProgram<T extends Tensor, K extends Tensor>(
   const outTex = output.texData.texture;
   const outTexShape = output.texData.texShape;
   if (output.texData.isPacked) {
-    gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    gpgpu.setOutputPackedMatrixTexture(
+        outTex.texture, outTexShape[0], outTexShape[1]);
   } else {
-    gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
+    gpgpu.setOutputMatrixTexture(
+        outTex.texture, outTexShape[0], outTexShape[1]);
   }
   gpgpu.setProgram(binary.webGLProgram);
 
@@ -283,7 +285,7 @@ export function runProgram<T extends Tensor, K extends Tensor>(
       gpgpu.gl.uniform1i(varOffsetLoc, input.texData.slice.flatOffset);
     }
 
-    gpgpu.setInputMatrixTexture(input.texData.texture, varLoc, i);
+    gpgpu.setInputMatrixTexture(input.texData.texture.texture, varLoc, i);
   });
 
   const outShapeLoc = binary.outShapeLocation;

--- a/tfjs-backend-webgl/src/gpgpu_util.ts
+++ b/tfjs-backend-webgl/src/gpgpu_util.ts
@@ -19,7 +19,7 @@ import {env, PixelData, TypedArray} from '@tensorflow/tfjs-core';
 
 import {getGlslDifferences} from './glsl_version';
 import * as tex_util from './tex_util';
-import {TextureConfig} from './tex_util';
+import {Texture, TextureConfig} from './tex_util';
 import * as webgl_util from './webgl_util';
 
 export function createVertexShader(gl: WebGLRenderingContext): WebGLShader {
@@ -53,7 +53,7 @@ export function createIndexBuffer(gl: WebGLRenderingContext): WebGLBuffer {
 function createAndConfigureTexture(
     gl: WebGLRenderingContext, width: number, height: number,
     internalFormat: number, textureFormat: number,
-    textureType: number): WebGLTexture {
+    textureType: number): Texture {
   webgl_util.validateTextureSize(width, height);
   const texture = webgl_util.createTexture(gl);
 
@@ -80,7 +80,8 @@ function createAndConfigureTexture(
                   .texStorage2D(tex2d, 1, internalFormat, width, height));
   }
   webgl_util.callAndCheck(gl, () => gl.bindTexture(gl.TEXTURE_2D, null));
-  return texture;
+
+  return {texture, texShape: [height, width]};
 }
 
 export function getInternalFormatForFloat32MatrixTexture(
@@ -90,7 +91,7 @@ export function getInternalFormatForFloat32MatrixTexture(
 
 export function createFloat32MatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
-    textureConfig: TextureConfig): WebGLTexture {
+    textureConfig: TextureConfig): Texture {
   const [width, height] =
       tex_util.getUnpackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(
@@ -106,7 +107,7 @@ export function getInternalFormatForFloat16MatrixTexture(
 
 export function createFloat16MatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
-    textureConfig: TextureConfig): WebGLTexture {
+    textureConfig: TextureConfig): Texture {
   const [width, height] =
       tex_util.getUnpackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(
@@ -122,7 +123,7 @@ export function getInternalFormatForUnsignedBytesMatrixTexture(
 
 export function createUnsignedBytesMatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
-    textureConfig: TextureConfig): WebGLTexture {
+    textureConfig: TextureConfig): Texture {
   const [width, height] =
       tex_util.getUnpackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(
@@ -138,7 +139,7 @@ export function getInternalFormatForPackedMatrixTexture(
 
 export function createPackedMatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
-    textureConfig: TextureConfig): WebGLTexture {
+    textureConfig: TextureConfig): Texture {
   const [width, height] =
       tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(
@@ -153,7 +154,7 @@ export function getInternalFormatForFloat16PackedMatrixTexture(
 
 export function createFloat16PackedMatrixTexture(
     gl: WebGLRenderingContext, rows: number, columns: number,
-    textureConfig: TextureConfig): WebGLTexture {
+    textureConfig: TextureConfig): Texture {
   const [width, height] =
       tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(

--- a/tfjs-backend-webgl/src/gpgpu_util_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_util_test.ts
@@ -102,7 +102,7 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
     const textureConfig = tex_util.getTextureConfig(gpgpu.gl);
     const tex =
         gpgpu_util.createPackedMatrixTexture(gpgpu.gl, 32, 32, textureConfig);
-    gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
+    gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex.texture);
     expect(
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_S))
         .toEqual(gpgpu.gl.CLAMP_TO_EDGE);
@@ -110,7 +110,7 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_T))
         .toEqual(gpgpu.gl.CLAMP_TO_EDGE);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, null);
-    gpgpu.deleteMatrixTexture(tex);
+    gpgpu.deleteMatrixTexture(tex.texture);
     gpgpu.dispose();
   });
 
@@ -119,7 +119,7 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
     const textureConfig = tex_util.getTextureConfig(gpgpu.gl);
     const tex =
         gpgpu_util.createPackedMatrixTexture(gpgpu.gl, 32, 32, textureConfig);
-    gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
+    gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex.texture);
     expect(gpgpu.gl.getTexParameter(
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MIN_FILTER))
         .toEqual(gpgpu.gl.NEAREST);
@@ -127,7 +127,7 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MAG_FILTER))
         .toEqual(gpgpu.gl.NEAREST);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, null);
-    gpgpu.deleteMatrixTexture(tex);
+    gpgpu.deleteMatrixTexture(tex.texture);
     gpgpu.dispose();
   });
 });

--- a/tfjs-backend-webgl/src/gpgpu_util_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_util_test.ts
@@ -63,7 +63,8 @@ describeWithFlags('gpgpu_util createFloat32MatrixTexture', WEBGL_ENVS, () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = tex_util.getTextureConfig(gpgpu.gl);
     const tex =
-        gpgpu_util.createFloat32MatrixTexture(gpgpu.gl, 32, 32, textureConfig);
+        gpgpu_util.createFloat32MatrixTexture(gpgpu.gl, 32, 32, textureConfig)
+            .texture;
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_S))
@@ -80,7 +81,8 @@ describeWithFlags('gpgpu_util createFloat32MatrixTexture', WEBGL_ENVS, () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = tex_util.getTextureConfig(gpgpu.gl);
     const tex =
-        gpgpu_util.createFloat32MatrixTexture(gpgpu.gl, 32, 32, textureConfig);
+        gpgpu_util.createFloat32MatrixTexture(gpgpu.gl, 32, 32, textureConfig)
+            .texture;
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(gpgpu.gl.getTexParameter(
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MIN_FILTER))

--- a/tfjs-backend-webgl/src/tex_util.ts
+++ b/tfjs-backend-webgl/src/tex_util.ts
@@ -69,6 +69,10 @@ export enum PhysicalTextureType {
   PACKED_2X2_FLOAT16
 }
 
+export interface Texture {
+  texture: WebGLTexture;
+  texShape: [number, number];
+}
 export interface TextureData {
   // Required.
   shape: number[];
@@ -76,7 +80,7 @@ export interface TextureData {
 
   // Optional.
   values?: backend_util.BackendValues;
-  texture?: WebGLTexture;
+  texture?: Texture;
   // For complex numbers, the real and imaginary parts are stored as their own
   // individual tensorInfos, with a parent joining the two with the
   // complexTensors field. When this is defined, texture will be null.

--- a/tfjs-backend-webgl/src/texture_manager.ts
+++ b/tfjs-backend-webgl/src/texture_manager.ts
@@ -87,8 +87,8 @@ export class TextureManager {
   }
 
   releaseTexture(
-      texture: WebGLTexture, shape: [number, number],
-      logicalTexType: TextureUsage, isPacked: boolean): void {
+      texture: Texture, shape: [number, number], logicalTexType: TextureUsage,
+      isPacked: boolean): void {
     if (this.freeTextures == null) {
       // Already disposed.
       return;
@@ -106,7 +106,7 @@ export class TextureManager {
     const deleteTexThreshold = env().get('WEBGL_DELETE_TEXTURE_THRESHOLD');
     if (deleteTexThreshold !== -1 &&
         this._numBytesAllocated > deleteTexThreshold) {
-      this.gpgpu.deleteMatrixTexture(texture);
+      this.gpgpu.deleteMatrixTexture(texture.texture);
       this._numBytesAllocated -= texBytes;
     } else {
       this.freeTextures[shapeKey].push(texture);
@@ -164,12 +164,12 @@ export class TextureManager {
     }
     for (const texShape in this.freeTextures) {
       this.freeTextures[texShape].forEach(tex => {
-        this.gpgpu.deleteMatrixTexture(tex);
+        this.gpgpu.deleteMatrixTexture(tex.texture);
       });
     }
     for (const texShape in this.usedTextures) {
       this.usedTextures[texShape].forEach(tex => {
-        this.gpgpu.deleteMatrixTexture(tex);
+        this.gpgpu.deleteMatrixTexture(tex.texture);
       });
     }
     this.freeTextures = null;

--- a/tfjs-backend-webgl/src/texture_manager.ts
+++ b/tfjs-backend-webgl/src/texture_manager.ts
@@ -19,7 +19,7 @@ import {env} from '@tensorflow/tfjs-core';
 
 import {GPGPUContext} from './gpgpu_context';
 import {getInternalFormatForFloat16MatrixTexture, getInternalFormatForFloat16PackedMatrixTexture, getInternalFormatForFloat32MatrixTexture, getInternalFormatForPackedMatrixTexture, getInternalFormatForUnsignedBytesMatrixTexture} from './gpgpu_util';
-import {getPackedMatrixTextureShapeWidthHeight, getUnpackedMatrixTextureShapeWidthHeight, PhysicalTextureType, TextureConfig, TextureUsage} from './tex_util';
+import {getPackedMatrixTextureShapeWidthHeight, getUnpackedMatrixTextureShapeWidthHeight, PhysicalTextureType, Texture, TextureConfig, TextureUsage} from './tex_util';
 
 export class TextureManager {
   private numUsedTextures = 0;
@@ -27,15 +27,15 @@ export class TextureManager {
   private _numBytesAllocated = 0;
   private _numBytesFree = 0;  // How many bytes that have been allocated
                               // are available for reuse.
-  private freeTextures: {[shape: string]: WebGLTexture[]} = {};
+  private freeTextures: {[shape: string]: Texture[]} = {};
   private logEnabled = false;
-  private usedTextures: {[shape: string]: WebGLTexture[]} = {};
+  private usedTextures: {[shape: string]: Texture[]} = {};
 
   constructor(private gpgpu: GPGPUContext) {}
 
   acquireTexture(
       shapeRC: [number, number], usage: TextureUsage,
-      isPacked: boolean): WebGLTexture {
+      isPacked: boolean): Texture {
     const physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
 
     const shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
@@ -60,7 +60,7 @@ export class TextureManager {
       return newTexture;
     }
 
-    let newTexture: WebGLTexture;
+    let newTexture: Texture;
     if (physicalTexType === PhysicalTextureType.PACKED_2X2_FLOAT32) {
       newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
     } else if (physicalTexType === PhysicalTextureType.PACKED_2X2_FLOAT16) {


### PR DESCRIPTION
The texShape in texData may not be the actual texShape when the texture is created. This PR add a wrapper to the WebGLTexture type with our own defined Texture type, which contains WebGLTexture and a texShape, this texShape will be the actual texShape used when creating this texture. This PR prepares for a future change where we can return a texture to user to use directly, in which case user needs to know the actual texShape to be able to use it properly.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5949)
<!-- Reviewable:end -->
