### PR TITLE
Unify the name and order of kernel files and kernel configs

### DIFF
--- a/tfjs-backend-cpu/src/kernels/ClipByValue.ts
+++ b/tfjs-backend-cpu/src/kernels/ClipByValue.ts
@@ -19,7 +19,7 @@ import {ClipByValue, ClipByValueAttrs, KernelConfig} from '@tensorflow/tfjs-core
 
 import {unaryKernelFunc} from '../utils/unary_utils';
 
-export const clip = unaryKernelFunc(ClipByValue, (xi, attrs) => {
+export const clipByValue = unaryKernelFunc(ClipByValue, (xi, attrs) => {
   const clipAttrs = attrs as {} as ClipByValueAttrs;
   if (xi > clipAttrs.clipValueMax) {
     return clipAttrs.clipValueMax;
@@ -27,8 +27,8 @@ export const clip = unaryKernelFunc(ClipByValue, (xi, attrs) => {
   return xi < clipAttrs.clipValueMin ? clipAttrs.clipValueMin : xi;
 });
 
-export const clipConfig: KernelConfig = {
+export const clipByValueConfig: KernelConfig = {
   kernelName: ClipByValue,
   backendName: 'cpu',
-  kernelFunc: clip,
+  kernelFunc: clipByValue,
 };

--- a/tfjs-backend-cpu/src/kernels/Dilation2D.ts
+++ b/tfjs-backend-cpu/src/kernels/Dilation2D.ts
@@ -19,7 +19,7 @@ import {backend_util, Dilation2D, Dilation2DAttrs, Dilation2DInputs, KernelConfi
 
 import {MathBackendCPU} from '../backend_cpu';
 
-export const dilation2dConfig: KernelConfig = {
+export const dilation2DConfig: KernelConfig = {
   kernelName: Dilation2D,
   backendName: 'cpu',
   kernelFunc: ({inputs, backend, attrs}) => {

--- a/tfjs-backend-cpu/src/kernels/Dilation2DBackpropFilter.ts
+++ b/tfjs-backend-cpu/src/kernels/Dilation2DBackpropFilter.ts
@@ -20,7 +20,7 @@ import {KernelConfig} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 
-export const dilation2dBackpropFilterConfig: KernelConfig = {
+export const dilation2DBackpropFilterConfig: KernelConfig = {
   kernelName: Dilation2DBackpropFilter,
   backendName: 'cpu',
   kernelFunc: ({inputs, backend, attrs}) => {

--- a/tfjs-backend-cpu/src/kernels/Dilation2DBackpropInput.ts
+++ b/tfjs-backend-cpu/src/kernels/Dilation2DBackpropInput.ts
@@ -20,7 +20,7 @@ import {KernelConfig} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 
-export const dilation2dBackpropInputConfig: KernelConfig = {
+export const dilation2DBackpropInputConfig: KernelConfig = {
   kernelName: Dilation2DBackpropInput,
   backendName: 'cpu',
   kernelFunc: ({inputs, backend, attrs}) => {

--- a/tfjs-backend-cpu/src/kernels/LRN.ts
+++ b/tfjs-backend-cpu/src/kernels/LRN.ts
@@ -20,7 +20,7 @@ import {KernelConfig, KernelFunc, LRN, LRNAttrs, LRNInputs, TensorInfo, TypedArr
 import {MathBackendCPU} from '../backend_cpu';
 import {assertNotComplex} from '../cpu_util';
 
-export function lRN(
+export function lrn(
     args: {inputs: LRNInputs, backend: MathBackendCPU, attrs: LRNAttrs}):
     TensorInfo {
   const {inputs, backend, attrs} = args;
@@ -59,8 +59,9 @@ export function lRN(
   return backend.makeTensorInfo(x.shape, x.dtype, result);
 }
 
-export const lRNConfig: KernelConfig = {
+// tslint:disable-next-line: variable-name
+export const LRNConfig: KernelConfig = {
   kernelName: LRN,
   backendName: 'cpu',
-  kernelFunc: lRN as {} as KernelFunc
+  kernelFunc: lrn as {} as KernelFunc
 };

--- a/tfjs-backend-cpu/src/kernels/LRN.ts
+++ b/tfjs-backend-cpu/src/kernels/LRN.ts
@@ -20,7 +20,7 @@ import {KernelConfig, KernelFunc, LRN, LRNAttrs, LRNInputs, TensorInfo, TypedArr
 import {MathBackendCPU} from '../backend_cpu';
 import {assertNotComplex} from '../cpu_util';
 
-export function lrn(
+export function lRN(
     args: {inputs: LRNInputs, backend: MathBackendCPU, attrs: LRNAttrs}):
     TensorInfo {
   const {inputs, backend, attrs} = args;
@@ -63,5 +63,5 @@ export function lrn(
 export const LRNConfig: KernelConfig = {
   kernelName: LRN,
   backendName: 'cpu',
-  kernelFunc: lrn as {} as KernelFunc
+  kernelFunc: lRN as {} as KernelFunc
 };

--- a/tfjs-backend-cpu/src/kernels/LRNGrad.ts
+++ b/tfjs-backend-cpu/src/kernels/LRNGrad.ts
@@ -65,7 +65,8 @@ export function lRNGrad(
   return backend.makeTensorInfo(dy.shape, x.dtype, result);
 }
 
-export const lRNGradConfig: KernelConfig = {
+// tslint:disable-next-line: variable-name
+export const LRNGradConfig: KernelConfig = {
   kernelName: LRNGrad,
   backendName: 'cpu',
   kernelFunc: lRNGrad as {} as KernelFunc

--- a/tfjs-backend-cpu/src/register_all_kernels.ts
+++ b/tfjs-backend-cpu/src/register_all_kernels.ts
@@ -45,7 +45,7 @@ import {bincountConfig} from './kernels/Bincount';
 import {broadcastArgsConfig} from './kernels/BroadcastArgs';
 import {castConfig} from './kernels/Cast';
 import {ceilConfig} from './kernels/Ceil';
-import {clipConfig} from './kernels/Clip';
+import {clipByValueConfig} from './kernels/ClipByValue';
 import {complexConfig} from './kernels/Complex';
 import {complexAbsConfig} from './kernels/ComplexAbs';
 import {concatConfig} from './kernels/Concat';
@@ -65,9 +65,9 @@ import {depthwiseConv2dNativeConfig} from './kernels/DepthwiseConv2dNative';
 import {depthwiseConv2dNativeBackpropFilterConfig} from './kernels/DepthwiseConv2dNativeBackpropFilter';
 import {depthwiseConv2dNativeBackpropInputConfig} from './kernels/DepthwiseConv2dNativeBackpropInput';
 import {diagConfig} from './kernels/Diag';
-import {dilation2dConfig} from './kernels/Dilation2D';
-import {dilation2dBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
-import {dilation2dBackpropInputConfig} from './kernels/Dilation2DBackpropInput';
+import {dilation2DConfig} from './kernels/Dilation2D';
+import {dilation2DBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
+import {dilation2DBackpropInputConfig} from './kernels/Dilation2DBackpropInput';
 import {einsumConfig} from './kernels/Einsum';
 import {eluConfig} from './kernels/Elu';
 import {eluGradConfig} from './kernels/EluGrad';
@@ -102,8 +102,8 @@ import {log1pConfig} from './kernels/Log1p';
 import {logicalAndConfig} from './kernels/LogicalAnd';
 import {logicalNotConfig} from './kernels/LogicalNot';
 import {logicalOrConfig} from './kernels/LogicalOr';
-import {lRNConfig} from './kernels/LRN';
-import {lRNGradConfig} from './kernels/LRNGrad';
+import {LRNConfig} from './kernels/LRN';
+import {LRNGradConfig} from './kernels/LRNGrad';
 import {maxConfig} from './kernels/Max';
 import {maximumConfig} from './kernels/Maximum';
 import {maxPoolConfig} from './kernels/MaxPool';
@@ -211,16 +211,16 @@ const kernelConfigs: KernelConfig[] = [
   broadcastArgsConfig,
   castConfig,
   ceilConfig,
-  clipConfig,
+  clipByValueConfig,
   complexConfig,
   complexAbsConfig,
   concatConfig,
+  conv2DConfig,
   conv2DBackpropFilterConfig,
   conv2DBackpropInputConfig,
-  conv2DConfig,
+  conv3DConfig,
   conv3DBackpropFilterV2Config,
   conv3DBackpropInputV2Config,
-  conv3DConfig,
   cosConfig,
   coshConfig,
   cropAndResizeConfig,
@@ -231,10 +231,9 @@ const kernelConfigs: KernelConfig[] = [
   depthwiseConv2dNativeBackpropFilterConfig,
   depthwiseConv2dNativeBackpropInputConfig,
   diagConfig,
-  dilation2dConfig,
-  dilation2dBackpropInputConfig,
-  dilation2dBackpropFilterConfig,
-  realDivConfig,
+  dilation2DConfig,
+  dilation2DBackpropFilterConfig,
+  dilation2DBackpropInputConfig,
   einsumConfig,
   eluConfig,
   eluGradConfig,
@@ -269,15 +268,15 @@ const kernelConfigs: KernelConfig[] = [
   logicalAndConfig,
   logicalNotConfig,
   logicalOrConfig,
-  lRNConfig,
-  lRNGradConfig,
+  LRNConfig,
+  LRNGradConfig,
+  maxConfig,
   maximumConfig,
   maxPoolConfig,
   maxPool3DConfig,
   maxPool3DGradConfig,
   maxPoolGradConfig,
   maxPoolWithArgmaxConfig,
-  maxConfig,
   meanConfig,
   minConfig,
   minimumConfig,
@@ -299,6 +298,7 @@ const kernelConfigs: KernelConfig[] = [
   prodConfig,
   rangeConfig,
   realConfig,
+  realDivConfig,
   reciprocalConfig,
   reluConfig,
   relu6Config,
@@ -342,8 +342,8 @@ const kernelConfigs: KernelConfig[] = [
   tanhConfig,
   tileConfig,
   topKConfig,
-  transposeConfig,
   transformConfig,
+  transposeConfig,
   uniqueConfig,
   unpackConfig,
   unsortedSegmentSumConfig,

--- a/tfjs-backend-wasm/src/kernels/_FusedMatMul.ts
+++ b/tfjs-backend-wasm/src/kernels/_FusedMatMul.ts
@@ -103,7 +103,7 @@ function fusedBatchMatMul(args: {
   return out;
 }
 
-export const fusedMatMulConfig: KernelConfig = {
+export const _fusedMatMulConfig: KernelConfig = {
   kernelName: _FusedMatMul,
   backendName: 'wasm',
   setupFunc: setup,

--- a/tfjs-backend-wasm/src/register_all_kernels.ts
+++ b/tfjs-backend-wasm/src/register_all_kernels.ts
@@ -19,7 +19,7 @@
 // the contents of this file and import only the kernels that are needed.
 import {KernelConfig, registerKernel} from '@tensorflow/tfjs-core';
 
-import {fusedMatMulConfig} from './kernels/_FusedMatMul';
+import {_fusedMatMulConfig} from './kernels/_FusedMatMul';
 import {absConfig} from './kernels/Abs';
 import {addConfig} from './kernels/Add';
 import {addNConfig} from './kernels/AddN';
@@ -122,6 +122,7 @@ import {zerosLikeConfig} from './kernels/ZerosLike';
 
 // List all kernel configs here
 const kernelConfigs: KernelConfig[] = [
+  _fusedMatMulConfig,
   absConfig,
   addConfig,
   addNConfig,
@@ -151,7 +152,6 @@ const kernelConfigs: KernelConfig[] = [
   flipLeftRightConfig,
   floorConfig,
   floorDivConfig,
-  fusedMatMulConfig,
   fusedBatchNormConfig,
   fusedConv2DConfig,
   fusedDepthwiseConv2DConfig,
@@ -193,8 +193,8 @@ const kernelConfigs: KernelConfig[] = [
   resizeBilinearConfig,
   reverseConfig,
   rotateWithOffsetConfig,
-  rsqrtConfig,
   roundConfig,
+  rsqrtConfig,
   scatterNdConfig,
   selectConfig,
   sigmoidConfig,

--- a/tfjs-backend-webgl/src/kernels/AvgPool3DGrad.ts
+++ b/tfjs-backend-webgl/src/kernels/AvgPool3DGrad.ts
@@ -37,7 +37,7 @@ export function avgPool3DGrad(args: {
   return backend.runWebGLProgram(avgPoolBackpropProgram, [dy], x.dtype);
 }
 
-export const avgPoolGrad3DConfig: KernelConfig = {
+export const avgPool3DGradConfig: KernelConfig = {
   kernelName: AvgPool3DGrad,
   backendName: 'webgl',
   kernelFunc: avgPool3DGrad as {} as KernelFunc

--- a/tfjs-backend-webgl/src/kernels/MaxPool3DGrad.ts
+++ b/tfjs-backend-webgl/src/kernels/MaxPool3DGrad.ts
@@ -46,7 +46,7 @@ export function maxPool3DGrad(args: {
   return result;
 }
 
-export const maxPoolGrad3DConfig: KernelConfig = {
+export const maxPool3DGradConfig: KernelConfig = {
   kernelName: MaxPool3DGrad,
   backendName: 'webgl',
   kernelFunc: maxPool3DGrad as {} as KernelFunc

--- a/tfjs-backend-webgl/src/register_all_kernels.ts
+++ b/tfjs-backend-webgl/src/register_all_kernels.ts
@@ -33,7 +33,7 @@ import {atan2Config} from './kernels/Atan2';
 import {atanhConfig} from './kernels/Atanh';
 import {avgPoolConfig} from './kernels/AvgPool';
 import {avgPool3DConfig} from './kernels/AvgPool3D';
-import {avgPoolGrad3DConfig} from './kernels/AvgPool3DGrad';
+import {avgPool3DGradConfig} from './kernels/AvgPool3DGrad';
 import {avgPoolGradConfig} from './kernels/AvgPoolGrad';
 import {batchMatMulConfig} from './kernels/BatchMatMul';
 import {batchNormConfig} from './kernels/BatchNorm';
@@ -104,7 +104,7 @@ import {maxConfig} from './kernels/Max';
 import {maximumConfig} from './kernels/Maximum';
 import {maxPoolConfig} from './kernels/MaxPool';
 import {maxPool3DConfig} from './kernels/MaxPool3D';
-import {maxPoolGrad3DConfig} from './kernels/MaxPool3DGrad';
+import {maxPool3DGradConfig} from './kernels/MaxPool3DGrad';
 import {maxPoolGradConfig} from './kernels/MaxPoolGrad';
 import {maxPoolWithArgmaxConfig} from './kernels/MaxPoolWithArgmax';
 import {meanConfig} from './kernels/Mean';
@@ -181,8 +181,6 @@ import {zerosLikeConfig} from './kernels/ZerosLike';
 
 // List all kernel configs here
 const kernelConfigs: KernelConfig[] = [
-  LRNConfig,
-  LRNGradConfig,
   _fusedMatMulConfig,
   absConfig,
   acosConfig,
@@ -195,12 +193,12 @@ const kernelConfigs: KernelConfig[] = [
   argMinConfig,
   asinConfig,
   asinhConfig,
-  atan2Config,
   atanConfig,
+  atan2Config,
   atanhConfig,
-  avgPool3DConfig,
   avgPoolConfig,
-  avgPoolGrad3DConfig,
+  avgPool3DConfig,
+  avgPool3DGradConfig,
   avgPoolGradConfig,
   batchMatMulConfig,
   batchNormConfig,
@@ -210,24 +208,24 @@ const kernelConfigs: KernelConfig[] = [
   castConfig,
   ceilConfig,
   clipByValueConfig,
-  complexAbsConfig,
   complexConfig,
+  complexAbsConfig,
   concatConfig,
+  conv2DConfig,
   conv2DBackpropFilterConfig,
   conv2DBackpropInputConfig,
-  conv2DConfig,
+  conv3DConfig,
   conv3DBackpropFilterV2Config,
   conv3DBackpropInputConfig,
-  conv3DConfig,
   cosConfig,
   coshConfig,
   cropAndResizeConfig,
   cumsumConfig,
   denseBincountConfig,
   depthToSpaceConfig,
+  depthwiseConv2dNativeConfig,
   depthwiseConv2dNativeBackpropFilterConfig,
   depthwiseConv2dNativeBackpropInputConfig,
-  depthwiseConv2dNativeConfig,
   diagConfig,
   dilation2DConfig,
   einsumConfig,
@@ -260,18 +258,20 @@ const kernelConfigs: KernelConfig[] = [
   lessConfig,
   lessEqualConfig,
   linSpaceConfig,
-  log1pConfig,
   logConfig,
+  log1pConfig,
   logicalAndConfig,
   logicalNotConfig,
   logicalOrConfig,
+  LRNConfig,
+  LRNGradConfig,
   maxConfig,
-  maxPool3DConfig,
+  maximumConfig,
   maxPoolConfig,
-  maxPoolGrad3DConfig,
+  maxPool3DConfig,
+  maxPool3DGradConfig,
   maxPoolGradConfig,
   maxPoolWithArgmaxConfig,
-  maximumConfig,
   meanConfig,
   minConfig,
   minimumConfig,
@@ -295,8 +295,8 @@ const kernelConfigs: KernelConfig[] = [
   realConfig,
   realDivConfig,
   reciprocalConfig,
-  relu6Config,
   reluConfig,
+  relu6Config,
   reshapeConfig,
   resizeBilinearConfig,
   resizeBilinearGradConfig,

--- a/tfjs-backend-webgpu/src/register_all_kernels.ts
+++ b/tfjs-backend-webgpu/src/register_all_kernels.ts
@@ -57,6 +57,7 @@ import {greaterConfig} from './kernels/Greater';
 import {greaterEqualConfig} from './kernels/GreaterEqual';
 import {identityConfig} from './kernels/Identity';
 import {imagConfig} from './kernels/Imag';
+import {leakyReluConfig} from './kernels/LeakyRelu';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
 import {logConfig} from './kernels/Log';
@@ -85,7 +86,6 @@ import {realConfig} from './kernels/Real';
 import {realDivConfig} from './kernels/RealDiv';
 import {reluConfig} from './kernels/Relu';
 import {relu6Config} from './kernels/Relu6';
-import {leakyReluConfig} from './kernels/LeakyRelu';
 import {reshapeConfig} from './kernels/Reshape';
 import {resizeBilinearConfig} from './kernels/ResizeBilinear';
 import {resizeNearestNeighborConfig} from './kernels/ResizeNearestNeighbor';
@@ -142,8 +142,8 @@ const kernelConfigs: KernelConfig[] = [
   einsumConfig,
   eluConfig,
   equalConfig,
-  expandDimsConfig,
   expConfig,
+  expandDimsConfig,
   expm1Config,
   fillConfig,
   flipLeftRightConfig,
@@ -159,6 +159,7 @@ const kernelConfigs: KernelConfig[] = [
   greaterEqualConfig,
   identityConfig,
   imagConfig,
+  leakyReluConfig,
   lessConfig,
   lessEqualConfig,
   logConfig,
@@ -179,15 +180,14 @@ const kernelConfigs: KernelConfig[] = [
   onesLikeConfig,
   packConfig,
   padV2Config,
+  powConfig,
   preluConfig,
   prodConfig,
-  powConfig,
   rangeConfig,
   realConfig,
   realDivConfig,
   reluConfig,
   relu6Config,
-  leakyReluConfig,
   reshapeConfig,
   resizeBilinearConfig,
   resizeNearestNeighborConfig,
@@ -203,8 +203,8 @@ const kernelConfigs: KernelConfig[] = [
   stringNGramsConfig,
   softmaxConfig,
   spaceToBatchNDConfig,
-  splitVConfig,
   sparseToDenseConfig,
+  splitVConfig,
   sqrtConfig,
   squareConfig,
   squaredDifferenceConfig,


### PR DESCRIPTION
Unified kernel file names can be helpful to find related kernels
easier. A proper order of kernel configs can be useful to list all the
supported kernels for a specific backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5969)
<!-- Reviewable:end -->
