### PR TITLE
Replace expo-permissions with Camera permissions.

### DIFF
--- a/tfjs-react-native/integration_rn59/components/webcam/webcam_demo.tsx
+++ b/tfjs-react-native/integration_rn59/components/webcam/webcam_demo.tsx
@@ -17,7 +17,6 @@
 
 import React from 'react';
 import { ActivityIndicator, StyleSheet, View, Image, Text, TouchableHighlight } from 'react-native';
-import * as Permissions from 'expo-permissions';
 import { Camera } from 'expo-camera';
 import {StyleTranfer} from './style_transfer';
 import {base64ImageToTensor, tensorToImageUrl, resizeImage, toDataUri} from './image_utils';
@@ -54,7 +53,7 @@ export class WebcamDemo extends React.Component<ScreenProps,ScreenState> {
 
   async componentDidMount() {
     await this.styler.init();
-    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    const { status } = await Camera.requestCameraPermissionsAsync();
     this.setState({
       hasCameraPermission: status === 'granted',
       isLoading: false


### PR DESCRIPTION
Remove deprecated expo-permissions in favour of Camera.requestCameraPermissionsAsync()

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.