### PR TITLE
[webgl]Allow constructor to take canvas.

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -750,3 +750,35 @@ describeWithFlags('WebGL backend has sync init', WEBGL_ENVS, () => {
     tf.removeBackend(customWebGLBackendName);
   });
 });
+
+describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
+  const customBackendName = 'custom-webgl';
+  let flag: boolean;
+
+  beforeAll(() => {
+    flag = tf.env().getBool('WEBGL_CPU_FORWARD');
+    const kernelFunc = tf.getKernel('Square', 'webgl').kernelFunc;
+    tf.registerKernel(
+        {kernelName: 'Square', backendName: customBackendName, kernelFunc});
+  });
+
+  afterAll(() => {
+    tf.env().set('WEBGL_CPU_FORWARD', flag);
+    tf.unregisterKernel('Square', customBackendName);
+  });
+
+  it('works.', () => {
+    const customCanvas = new OffscreenCanvas(300, 200);
+
+    const backend = new MathBackendWebGL(customCanvas);
+    tf.registerBackend(customBackendName, () => backend);
+    tf.setBackend(customBackendName);
+
+    const t = tf.square(2);
+    const data = t.dataSync();
+
+    expect(data).toEqual([4]);
+
+    tf.removeBackend(customBackendName);
+  })
+});

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -768,7 +768,9 @@ describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
   });
 
   it('works.', () => {
-    const customCanvas = new OffscreenCanvas(300, 200);
+    const customCanvas = document.createElement('canvas');
+    customCanvas.width = 300;
+    customCanvas.height = 200;
 
     const backend = new MathBackendWebGL(customCanvas);
     tf.registerBackend(customBackendName, () => backend);

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -780,5 +780,5 @@ describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
     expect(data).toEqual([4]);
 
     tf.removeBackend(customBackendName);
-  })
+  });
 });

--- a/tfjs-backend-webgl/src/backend_webgl_test.ts
+++ b/tfjs-backend-webgl/src/backend_webgl_test.ts
@@ -777,7 +777,7 @@ describeWithFlags('custom canvas ', WEBGL_ENVS, () => {
     const t = tf.square(2);
     const data = t.dataSync();
 
-    expect(data).toEqual([4]);
+    expectArraysEqual(data, [4]);
 
     tf.removeBackend(customBackendName);
   });

--- a/tfjs-backend-webgl/src/canvas_util.ts
+++ b/tfjs-backend-webgl/src/canvas_util.ts
@@ -36,9 +36,11 @@ export function setWebGLContext(
   contexts[webGLVersion] = gl;
 }
 
-export function getWebGLContext(webGLVersion: number): WebGLRenderingContext {
+export function getWebGLContext(
+    webGLVersion: number,
+    customCanvas?: HTMLCanvasElement|OffscreenCanvas): WebGLRenderingContext {
   if (!(webGLVersion in contexts)) {
-    const newCtx = getWebGLRenderingContext(webGLVersion);
+    const newCtx = getWebGLRenderingContext(webGLVersion, customCanvas);
     if (newCtx !== null) {
       contexts[webGLVersion] = newCtx;
     } else {
@@ -75,11 +77,14 @@ function createCanvas(webGLVersion: number) {
   }
 }
 
-function getWebGLRenderingContext(webGLVersion: number): WebGLRenderingContext {
+function getWebGLRenderingContext(
+    webGLVersion: number,
+    customCanvas?: HTMLCanvasElement|OffscreenCanvas): WebGLRenderingContext {
   if (webGLVersion !== 1 && webGLVersion !== 2) {
     throw new Error('Cannot get WebGL rendering context, WebGL is disabled.');
   }
-  const canvas = createCanvas(webGLVersion);
+  const canvas =
+      customCanvas == null ? createCanvas(webGLVersion) : customCanvas;
 
   canvas.addEventListener('webglcontextlost', (ev: Event) => {
     ev.preventDefault();

--- a/tfjs-backend-webgl/src/canvas_util_test.ts
+++ b/tfjs-backend-webgl/src/canvas_util_test.ts
@@ -38,11 +38,13 @@ describeWithFlags('canvas_util', BROWSER_ENVS, () => {
   });
 
   it('Returns a valid user defined canvas.', () => {
-    const customCanvas = new OffscreenCanvas(10, 10);
+    const customCanvas = document.createElement('canvas');
+    customCanvas.width = 10;
+    customCanvas.height = 10;
     const gl =
         getWebGLContext(tf.env().getNumber('WEBGL_VERSION'), customCanvas);
     expect(gl).not.toBeNull();
-    expect(gl.canvas as {} as OffscreenCanvas).toBe(customCanvas);
+    expect(gl.canvas).toBe(customCanvas);
   });
 });
 

--- a/tfjs-backend-webgl/src/canvas_util_test.ts
+++ b/tfjs-backend-webgl/src/canvas_util_test.ts
@@ -36,6 +36,14 @@ describeWithFlags('canvas_util', BROWSER_ENVS, () => {
     const gl = getWebGLContext(tf.env().getNumber('WEBGL_VERSION'));
     expect(gl.isContextLost()).toBe(false);
   });
+
+  it('Returns a valid user defined canvas.', () => {
+    const customCanvas = new OffscreenCanvas(10, 10);
+    const gl =
+        getWebGLContext(tf.env().getNumber('WEBGL_VERSION'), customCanvas);
+    expect(gl).not.toBeNull();
+    expect(gl.canvas as {} as OffscreenCanvas).toBe(customCanvas);
+  });
 });
 
 describeWithFlags('canvas_util webgl2', {flags: {WEBGL_VERSION: 2}}, () => {

--- a/tfjs-backend-webgl/src/canvas_util_test.ts
+++ b/tfjs-backend-webgl/src/canvas_util_test.ts
@@ -18,7 +18,7 @@ import * as tf from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {BROWSER_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
-import {getWebGLContext} from './canvas_util';
+import {clearWebGLContext, getWebGLContext} from './canvas_util';
 
 describeWithFlags('canvas_util', BROWSER_ENVS, () => {
   it('Returns a valid canvas', () => {
@@ -38,11 +38,15 @@ describeWithFlags('canvas_util', BROWSER_ENVS, () => {
   });
 
   it('Returns a valid user defined canvas.', () => {
+    const webGLVersion = tf.env().getNumber('WEBGL_VERSION');
+    clearWebGLContext(webGLVersion);
+
     const customCanvas = document.createElement('canvas');
     customCanvas.width = 10;
     customCanvas.height = 10;
-    const gl =
-        getWebGLContext(tf.env().getNumber('WEBGL_VERSION'), customCanvas);
+
+    const gl = getWebGLContext(webGLVersion, customCanvas);
+
     expect(gl).not.toBeNull();
     expect(gl.canvas).toBe(customCanvas);
   });


### PR DESCRIPTION
This feature allows users to use their own canvas, so that they have full control for downstream image processing. This feature can be used both in main thread and workers. When used in workers, user can pass an offscreenCanvas to worker. Note that, we recommend doing all the processing work (ML and image processing) in one context and one worker. Users should only render to canvas in the last step, which is lossy (canvas can only render uint8 data ranging from 0 - 255). We support keeping data on GPU (PR: https://github.com/tensorflow/tfjs/pull/5953), which means all the ML and image processing can happen on GPU without having to download data to CPU and re-upload. 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5983)
<!-- Reviewable:end -->
