### PR TITLE
[cpu] GatherV2 return zero if out of bounds when forwarding from webgl

### DIFF
--- a/tfjs-backend-cpu/src/kernels/GatherV2_impl.ts
+++ b/tfjs-backend-cpu/src/kernels/GatherV2_impl.ts
@@ -31,7 +31,10 @@ export function gatherV2Impl<R extends Rank, D extends DataType>(
     originalLoc[2] = indicesBuf.values[indicesIndex] as number;
 
     const originalIndex = xBuf.locToIndex(originalLoc);
-    outBuf.values[i] = xBuf.values[originalIndex];
+
+    if (0 <= originalIndex && originalIndex < xBuf.values.length) {
+      outBuf.values[i] = xBuf.values[originalIndex];
+    } // Else, index is out of bounds, so leave the default zero val in outBuf.
   }
 
   return outBuf as TensorBuffer<R, D>;


### PR DESCRIPTION
WebGL sometimes forwards to the CPU implementation of kernels. In #5984, the bounds check for GatherV2 was removed in favor of filling the out of bounds areas with zeroes, but the CPU implementation did not do this and filled with NaNs instead. This PR makes the CPU implementation of GatherV2 fill with zeroes. The CPU backend still checks for out of bounds before running its GatherV2 implementation.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/5994)
<!-- Reviewable:end -->
