### PR TITLE
Add 'leave_as_require' option to tfjs_bundle

### DIFF
--- a/tfjs-core/BUILD.bazel
+++ b/tfjs-core/BUILD.bazel
@@ -32,6 +32,9 @@ tfjs_bundle(
     entry_point = "//tfjs-core/src:index.ts",
     external = [
         "crypto",
+    ],
+    leave_as_require = [
+        "crypto",
         "node-fetch",
         "util",
     ],

--- a/tools/rollup_template.config.js
+++ b/tools/rollup_template.config.js
@@ -82,6 +82,12 @@ const useTerser = TEMPLATE_minify ? [
   })
 ] : [];
 
+const useCommonjs = TEMPLATE_transpile_cjs ? [
+  commonjs({
+    ignore: TEMPLATE_leave_as_require,
+  }),
+]: [];
+
 export default {
   output: {
     banner: preamble,
@@ -92,7 +98,7 @@ export default {
   external: TEMPLATE_external,
   plugins: [
     resolve({browser: true}),
-    commonjs(),
+    ...useCommonjs,
     sourcemaps(),
     ...useEs5,
     ...useTerser,

--- a/tools/rollup_template.config.js
+++ b/tools/rollup_template.config.js
@@ -82,12 +82,6 @@ const useTerser = TEMPLATE_minify ? [
   })
 ] : [];
 
-const useCommonjs = TEMPLATE_transpile_cjs ? [
-  commonjs({
-    ignore: TEMPLATE_leave_as_require,
-  }),
-]: [];
-
 export default {
   output: {
     banner: preamble,
@@ -98,7 +92,9 @@ export default {
   external: TEMPLATE_external,
   plugins: [
     resolve({browser: true}),
-    ...useCommonjs,
+    commonjs({
+      ignore: TEMPLATE_leave_as_require,
+    }),
     sourcemaps(),
     ...useEs5,
     ...useTerser,

--- a/tools/tfjs_bundle.bzl
+++ b/tools/tfjs_bundle.bzl
@@ -33,10 +33,6 @@ def _make_rollup_config_impl(ctx):
         ctx.attr.external + list(ctx.attr.globals.keys()),
     ))
 
-    # Transpile commonjs 'require' calls to es6 'import' statements if the
-    # output format is not commonjs. Otherwise, leave them as is.
-    transpile_cjs = ctx.attr.format != "cjs"
-
     ctx.actions.expand_template(
         template = ctx.file.template,
         output = ctx.outputs.config_file,
@@ -47,7 +43,6 @@ def _make_rollup_config_impl(ctx):
             "TEMPLATE_leave_as_require": str(ctx.attr.leave_as_require),
             "TEMPLATE_minify": "true" if ctx.attr.minify else "false",
             "TEMPLATE_stats": stats_file_path,
-            "TEMPLATE_transpile_cjs": "true" if transpile_cjs else "false",
         },
     )
     return [DefaultInfo(files = depset([output_file]))]
@@ -67,13 +62,6 @@ _make_rollup_config = rule(
 Keys from 'globals' are automatically added to this attribute, but additional external modules can be specified.
             """,
             mandatory = False,
-        ),
-        "format": attr.string(
-            mandatory = True,
-            doc = """The bundle format.
-
- Note that bundle format must also be specified in the 'rollup_bundle' rule. It is used here only to determine whether to include the 'commonjs' plugin.
-            """,
         ),
         "globals": attr.string_dict(
             default = {},
@@ -127,7 +115,6 @@ def tfjs_rollup_bundle(
         external = external,
         globals = globals,
         leave_as_require = leave_as_require,
-        format = format,
     )
 
     rollup_deps = deps + [


### PR DESCRIPTION
`@rollup/plugin-commonjs` rewrites 'require' calls to 'import' statements, but this is not always desirable. This commit adds the 'leave_as_require' option to 'tfjs_bundle', which allows specifying a list of modules to leave as 'require' calls.

This change does not disable `@rollup/plugin-commonjs` for cjs bundles even though it might not be required in some cases. The reason it is still enabled is because we still want to bundle commonjs modules for our node bundles. Without the plugin, they're left as `require()` calls, but with the plugin, their contents are included in the bundle.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6005)
<!-- Reviewable:end -->
