### PR TITLE
Update to wording for starting values of indices

### DIFF
--- a/tfjs-core/src/ops/one_hot.ts
+++ b/tfjs-core/src/ops/one_hot.ts
@@ -29,13 +29,16 @@ import {op} from './operation';
  * Creates a one-hot `tf.Tensor`. The locations represented by `indices` take
  * value `onValue` (defaults to 1), while all other locations take value
  * `offValue` (defaults to 0). If `indices` is rank `R`, the output has rank
- * `R+1` with the last axis of size `depth`.
+ * `R+1` with the last axis of size `depth`. 
+ * `indices` used to encode prediction class must start from 0. For example,
+ *  if you have 3 classes of data, class 1 should be encoded as 0, class 2
+ *  should be 1, and class 3 should be 2. 
  *
  * ```js
  * tf.oneHot(tf.tensor1d([0, 1], 'int32'), 3).print();
  * ```
  *
- * @param indices `tf.Tensor` of indices with dtype `int32`.
+ * @param indices `tf.Tensor` of indices with dtype `int32`. Indices must start from 0.
  * @param depth The depth of the one hot dimension.
  * @param onValue A number used to fill in the output when the index matches
  * the location.

--- a/tfjs-core/src/ops/one_hot.ts
+++ b/tfjs-core/src/ops/one_hot.ts
@@ -38,7 +38,8 @@ import {op} from './operation';
  * tf.oneHot(tf.tensor1d([0, 1], 'int32'), 3).print();
  * ```
  *
- * @param indices `tf.Tensor` of indices with dtype `int32`. Indices must start from 0.
+ * @param indices `tf.Tensor` of indices with dtype `int32`. Indices must 
+ * start from 0.
  * @param depth The depth of the one hot dimension.
  * @param onValue A number used to fill in the output when the index matches
  * the location.


### PR DESCRIPTION
To avoid confusion. User's should be aware that indices must start from 0 when encoding their class data.
User can not use indices that start from say 1.

So if you have 2 classes of data, Class 1, and Class 2:

[1,2,1,2] is not valid.

Indices must be encoded as:

[0,1,0,1]

For class 1 (0) and class 2 (1) respectively for 1 hot to work as expected.

This is not obvious or expected in current documentation.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6018)
<!-- Reviewable:end -->
