### PR TITLE
Handle IS_BROWSER and IS_NODE both being true

### DIFF
--- a/tfjs-core/src/environment.ts
+++ b/tfjs-core/src/environment.ts
@@ -60,7 +60,7 @@ export class Environment {
       if (!(env().getBool('IS_TEST') || env().getBool('PROD'))) {
         console.warn(
             `Platform ${this.platformName} has already been set. ` +
-            `Overwriting the platform with ${platform}.`);
+            `Overwriting the platform with ${platformName}.`);
       }
     }
     this.platformName = platformName;

--- a/tfjs-core/src/platforms/platform_node.ts
+++ b/tfjs-core/src/platforms/platform_node.ts
@@ -81,6 +81,6 @@ export class PlatformNode implements Platform {
   }
 }
 
-if (env().get('IS_NODE')) {
+if (env().get('IS_NODE') && !env().get('IS_BROWSER')) {
   env().setPlatform('node', new PlatformNode());
 }


### PR DESCRIPTION
Fixes #6030

In certain environments, IS_BROWSER and IS_NODE can both be true, which causes `setPlatform` to be called twice along with a warning message as soon as `import * as tf from '@tensorflow/tfjs'` is called. This PR addresses this by only setting the `node` platform if IS_BROWSER is explicitly false to avoid this scenario.

Alternatively, the change here could be done in the browser platform instead of the node platform. I'm not aware of any reasons to prefer one over the other, so I did it this way.

Finally, the warning that was logged out used to say `Overwriting the platform with [object Object]`, which is not particularly helpful. It will now log out the platform name, which should make debugging a legitimate platform issue easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6031)
<!-- Reviewable:end -->
