### PR TITLE
DRAFT: measure the esplased time of reading kernel output

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -418,15 +418,19 @@ function aggregateKernelTime(kernels) {
   kernels.forEach(kernel => {
     const oldAggregatedKernelTime = aggregatedKernelTime[kernel.name];
     if (oldAggregatedKernelTime == null) {
-      aggregatedKernelTime[kernel.name] = kernel.kernelTimeMs;
-    } else {
       aggregatedKernelTime[kernel.name] =
-          oldAggregatedKernelTime + kernel.kernelTimeMs;
+          [kernel.kernelTimeMs, kernel.readOutputTimeMs];
+    } else {
+      aggregatedKernelTime[kernel.name] = [
+        oldAggregatedKernelTime[0] + kernel.kernelTimeMs,
+        oldAggregatedKernelTime[1] + kernel.readOutputTimeMs,
+      ];
     }
   });
 
   return Object.entries(aggregatedKernelTime)
-      .map(([name, timeMs]) => ({name, timeMs}))
+      .map(([name,
+             [timeMs, readOutputTimeMs]]) => ({name, timeMs, readOutputTimeMs}))
       .sort((a, b) => b.timeMs - a.timeMs);
 }
 

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -81,6 +81,7 @@ limitations under the License.
         <tr>
           <th>Type</th>
           <th>Time(ms)</th>
+          <th>ReadOutputTime(ms)</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -332,7 +333,7 @@ limitations under the License.
     async function setupKernelTable() {
       kernelsTableHead.innerText = '';
       kernelTable.innerHTML = '';
-      const rows = ['<b>Kernel</b>', '<b>Time(ms)</b>'];
+      const rows = ['<b>Kernel</b>', '<b>Time(ms)</b>', '<b>ReadOutputTime(ms)</b>'];
       if (state.kernelTiming === 'individual') {
         rows.push('<b>Inputs</b>', '<b>Output</b>');
         if (state.backend === 'webgl') {
@@ -649,7 +650,7 @@ limitations under the License.
               inputInfo += `input${index}: ${inputShape.length}D[${inputShape}]`;
             }
           });
-          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2),
+          appendRow(tbody, nameSpan, kernel.kernelTimeMs.toFixed(2), kernel.readOutputTimeMs.toFixed(2),
                     inputInfo || '-',
                     kernel.outputShapes.length !== 0 ? kernel.outputShapes : '-',
                     kernel.extraInfo || '-');
@@ -659,7 +660,7 @@ limitations under the License.
           const nameSpan = document.createElement('span');
           nameSpan.setAttribute('title', r.name);
           nameSpan.textContent = r.name;
-          appendRow(tbody, nameSpan, r.timeMs.toFixed(2));
+          appendRow(tbody, nameSpan, r.timeMs.toFixed(2), r.readOutputTimeMs.toFixed(2));
         });
       }
     }

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -59,6 +59,7 @@ type KernelInfo = {
   totalTensorsSnapshot: number;
   inputShapes: number[][];
   outputShapes: number[][];
+  readOutputTimeMs: number;
   kernelTimeMs: number | {error: string} | Promise<number|{error: string}>;
   extraInfo: string | Promise<string>;
 };
@@ -734,6 +735,7 @@ export class Engine implements TensorTracker, DataMover {
         inputShapes: Object.keys(inputs).map(
             key => inputs[key] != null ? inputs[key].shape : null),
         outputShapes: outputs.map(item => item.shape),
+        readOutputTimeMs: kernelProfile.readOutputTimeMs,
         kernelTimeMs: kernelProfile.timeMs,
         extraInfo: kernelProfile.extraInfo
       });

--- a/tfjs-core/src/engine_test.ts
+++ b/tfjs-core/src/engine_test.ts
@@ -406,6 +406,7 @@ describeWithFlags('profile', ALL_ENVS, () => {
       'totalTensorsSnapshot': 2,
       'inputShapes': [[3]],
       'outputShapes': [[3]],
+      'readOutputTimeMs': profile.kernels[0].readOutputTimeMs,
       'kernelTimeMs': profile.kernels[0].kernelTimeMs,
       'extraInfo': profile.kernels[0].extraInfo
     });
@@ -418,6 +419,7 @@ describeWithFlags('profile', ALL_ENVS, () => {
       'totalTensorsSnapshot': 2,
       'inputShapes': [[3]],
       'outputShapes': [[3]],
+      'readOutputTimeMs': profile.kernels[1].readOutputTimeMs,
       'kernelTimeMs': profile.kernels[1].kernelTimeMs,
       'extraInfo': profile.kernels[1].extraInfo
     });
@@ -447,6 +449,7 @@ describeWithFlags('profile', ALL_ENVS, () => {
       'totalTensorsSnapshot': 2,
       'inputShapes': [[3]],
       'outputShapes': [[3]],
+      'readOutputTimeMs': profile.kernels[0].readOutputTimeMs,
       'kernelTimeMs': profile.kernels[0].kernelTimeMs,
       'extraInfo': profile.kernels[0].extraInfo
     });
@@ -478,6 +481,7 @@ describeWithFlags('profile', ALL_ENVS, () => {
       'totalTensorsSnapshot': 2,
       'inputShapes': [[3]],
       'outputShapes': [[3]],
+      'readOutputTimeMs': profile.kernels[0].readOutputTimeMs,
       'kernelTimeMs': profile.kernels[0].kernelTimeMs,
       'extraInfo': profile.kernels[0].extraInfo
     });


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.