### PR TITLE
[tfjs-converter] fix the regex version for py2

### DIFF
--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -100,6 +100,7 @@ py_wheel(
         "six>=1.12.0,<2",
         "tensorflow-hub>=0.7.0,<0.10",
         "regex<2022.1.18",
+        "grpcio==1.39.0",
     ],
     strip_path_prefixes = [
         "tfjs-converter/python",

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -99,6 +99,7 @@ py_wheel(
         "protobuf==3.17.3",
         "six>=1.12.0,<2",
         "tensorflow-hub>=0.7.0,<0.10",
+        "regex<2022.1.18",
     ],
     strip_path_prefixes = [
         "tfjs-converter/python",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,6 +1,7 @@
 tensorflow>=2.1.0,<3
 protobuf==3.17.3; python_version < "3"
 regex<2022.1.18; python_version < "3"
+grpcio==1.39.0; python_version < "3"
 numpy~=1.19.2
 six>=1.12.0,<2
 tensorflow-hub>=0.7.0,<0.10; python_version < "3"

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,5 +1,6 @@
 tensorflow>=2.1.0,<3
 protobuf==3.17.3; python_version < "3"
+regex<2022.1.18; python_version < "3"
 numpy~=1.19.2
 six>=1.12.0,<2
 tensorflow-hub>=0.7.0,<0.10; python_version < "3"


### PR DESCRIPTION
regex pip has stopped support for py2 after 2022-1-18 build, we will need to fix the version for regex to earlier version for py2.
This fixes the failing nightly build.
Also locked grpcio==1.39.0 for py2, which will significant improve nightly converter test speed (55mins => 33mins)
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6038)
<!-- Reviewable:end -->
