### PR TITLE
Upgrade release docker node to 16

### DIFF
--- a/dockers/release-docker/Dockerfile
+++ b/dockers/release-docker/Dockerfile
@@ -1,5 +1,4 @@
-# Official emsdk docker: https://hub.docker.com/r/emscripten/emsdk
-FROM debian:10-slim
+FROM node:lts-buster
 
 # Install cloud-sdk
 ARG CLOUD_SDK_VERSION=355.0.0
@@ -21,16 +20,12 @@ RUN apt-get update -qqy && apt-get install -qqy \
         git \
         gnupg \
         file \
-        nodejs \
-        yarnpkg \
-        npm \
         wget \
         unzip \
         libssl-dev \
         libffi-dev \
         zlib1g-dev \
         procps && \
-    ln -s /usr/bin/yarnpkg /usr/bin/yarn && \
     ln -s /usr/bin/pip3 /usr/bin/pip && \
     pip3 install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
@@ -51,3 +46,5 @@ RUN pip3 install virtualenv
 
 # Install absl
 RUN pip3 install absl-py
+
+ENTRYPOINT /bin/bash

--- a/dockers/release-docker/Dockerfile
+++ b/dockers/release-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-buster
+FROM node:16.13.2-buster-slim
 
 # Install cloud-sdk
 ARG CLOUD_SDK_VERSION=355.0.0

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -231,8 +231,9 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
   });
 });
 
-describeWithFlags('wasm pre.js', BROWSER_ENVS, () => {
-  it('works if process variable is undefined', async () => {
+describe('wasm pre.js', () => {
+  // Temporarily disabled due to node 16 incompatability
+  xit('works if process variable is undefined', async () => {
     tf.engine().reset();
 
     const savedProcess = process;

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -233,25 +233,25 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
 
 describe('wasm pre.js', () => {
   // Temporarily disabled due to node 16 incompatability
-  xit('works if process variable is undefined', async () => {
-    tf.engine().reset();
+  // it('works if process variable is undefined', async () => {
+  //   tf.engine().reset();
 
-    const savedProcess = process;
-    // This test is not perfect since checks like `if (process)` will not throw
-    // errors if process is set to undefined, however, process can not be
-    // `delete`d due to strict mode.
+  //   const savedProcess = process;
+  //   // This test is not perfect since checks like `if (process)` will not
+  //   // throw errors if process is set to undefined, however, process can not
+  //   // be `delete`d due to strict mode.
 
-    process = undefined;
+  //   process = undefined;
 
-    try {
-      await tf.setBackend('wasm');
-    } catch (e) {
-      fail(e);
-    } finally {
-      process = savedProcess;
-    }
+  //   try {
+  //     await tf.setBackend('wasm');
+  //   } catch (e) {
+  //     fail(e);
+  //   } finally {
+  //     process = savedProcess;
+  //   }
 
-    tf.engine().disposeVariables();
-    tf.engine().reset();
-  });
+  //   tf.engine().disposeVariables();
+  //   tf.engine().reset();
+  // });
 });

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -231,7 +231,7 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
   });
 });
 
-describe('wasm pre.js', () => {
+describeWithFlags('wasm pre.js', BROWSER_ENVS, () => {
   it('works if process variable is undefined', async () => {
     tf.engine().reset();
 


### PR DESCRIPTION
Base the release docker off of the Debian (buster) node 16 image instead of the base Debian image.

CI presubmit runs for this PR are meaningless (they don't use the new image), so I will post nightly runs with the new image.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6076)
<!-- Reviewable:end -->
