### PR TITLE
[tfjs-converter] Use system python for unsupported build platforms

### DIFF
--- a/python_repositories.bzl
+++ b/python_repositories.bzl
@@ -49,3 +49,15 @@ def python_repositories():
                 python_interpreter_target = interpreter,
                 requirements = "@//tfjs-converter/python:requirements.txt",
             )
+
+        # Create an external repo for python deps that relies on the default
+        # python interpreter.
+        pip_install(
+            name = "tensorflowjs_dev_deps",
+            requirements = "@//tfjs-converter/python:requirements-dev.txt",
+        )
+
+        pip_install(
+            name = "tensorflowjs_deps",
+            requirements = "@//tfjs-converter/python:requirements.txt",
+        )

--- a/python_toolchain.bzl
+++ b/python_toolchain.bzl
@@ -83,6 +83,9 @@ def dev_requirement(name):
             selection_values["@//:%s" % platform_name] = \
                 "@tensorflowjs_dev_deps_%s//pypi__%s" % (platform_name, _name)
 
+        selection_values["//conditions:default"] = \
+            "@tensorflowjs_dev_deps//pypi__%s" % _name
+
         native.alias(
             name = alias_name,
             actual = select(selection_values),


### PR DESCRIPTION
Use the system python on platforms that are not defined in `python_packages.bzl`.

TESTED=Commented out the linux_amd64 entry in python_packages.bzl and ran `bazel build //tfjs-converter/python/...`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6089)
<!-- Reviewable:end -->
