### PR TITLE
[webgl]Donot use cache context if use custom canvas

### DIFF
--- a/tfjs-backend-webgl/src/canvas_util.ts
+++ b/tfjs-backend-webgl/src/canvas_util.ts
@@ -39,7 +39,7 @@ export function setWebGLContext(
 export function getWebGLContext(
     webGLVersion: number,
     customCanvas?: HTMLCanvasElement|OffscreenCanvas): WebGLRenderingContext {
-  if (!(webGLVersion in contexts)) {
+  if (!(webGLVersion in contexts) || customCanvas != null) {
     const newCtx = getWebGLRenderingContext(webGLVersion, customCanvas);
     if (newCtx !== null) {
       contexts[webGLVersion] = newCtx;

--- a/tfjs-backend-webgl/src/canvas_util_test.ts
+++ b/tfjs-backend-webgl/src/canvas_util_test.ts
@@ -39,7 +39,6 @@ describeWithFlags('canvas_util', BROWSER_ENVS, () => {
 
   it('Returns a valid user defined canvas.', () => {
     const webGLVersion = tf.env().getNumber('WEBGL_VERSION');
-    clearWebGLContext(webGLVersion);
 
     const customCanvas = document.createElement('canvas');
     customCanvas.width = 10;

--- a/tfjs-backend-webgl/src/canvas_util_test.ts
+++ b/tfjs-backend-webgl/src/canvas_util_test.ts
@@ -18,7 +18,7 @@ import * as tf from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {BROWSER_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
-import {clearWebGLContext, getWebGLContext} from './canvas_util';
+import {getWebGLContext} from './canvas_util';
 
 describeWithFlags('canvas_util', BROWSER_ENVS, () => {
   it('Returns a valid canvas', () => {


### PR DESCRIPTION
User needs to clear the default gl context (generated as a side effect when webgl backend is imported) to use their own canvas. From user feedback, it seems that they expect no caching when custom canvas is passed. This is also the behavior of passing in custom context. This change allows users to directly use their custom canvas without having to clear gl context first.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6100)
<!-- Reviewable:end -->
