### PR TITLE
Fix Bazel linking of dependencies

### DIFF
--- a/scripts/cloudbuild_e2e_expected.yml
+++ b/scripts/cloudbuild_e2e_expected.yml
@@ -46,22 +46,13 @@ steps:
     secretEnv:
       - BROWSERSTACK_KEY
   - name: gcr.io/learnjs-174218/release
-    dir: link-package-core
-    entrypoint: yarn
-    id: yarn-link-package-core
-    args:
-      - install
-    waitFor:
-      - bazel-tests
-  - name: gcr.io/learnjs-174218/release
     dir: link-package
     entrypoint: yarn
     id: yarn-link-package
     args:
-      - install
+      - build
     waitFor:
       - bazel-tests
-      - yarn-link-package-core
   - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter
     entrypoint: yarn

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -51,22 +51,15 @@ steps:
   waitFor: ['yarn-common']
   secretEnv: ['BROWSERSTACK_KEY']
 
-# The following steps build the link packages, which are temporary packages
+# The following step builds the link packages, which are temporary packages
 # that help packages that don't build with Bazel load outputs from packages
 # that build with Bazel.
-- name: 'gcr.io/learnjs-174218/release'
-  dir: 'link-package-core'
-  entrypoint: 'yarn'
-  id: 'yarn-link-package-core'
-  args: ['install']
-  waitFor: ['bazel-tests']
-
 - name: 'gcr.io/learnjs-174218/release'
   dir: 'link-package'
   entrypoint: 'yarn'
   id: 'yarn-link-package'
-  args: ['install']
-  waitFor: ['bazel-tests', 'yarn-link-package-core']
+  args: ['build']
+  waitFor: ['bazel-tests']
 
 # General configuration
 secrets:

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -46,22 +46,13 @@ steps:
     secretEnv:
       - BROWSERSTACK_KEY
   - name: gcr.io/learnjs-174218/release
-    dir: link-package-core
-    entrypoint: yarn
-    id: yarn-link-package-core
-    args:
-      - install
-    waitFor:
-      - bazel-tests
-  - name: gcr.io/learnjs-174218/release
     dir: link-package
     entrypoint: yarn
     id: yarn-link-package
     args:
-      - install
+      - build
     waitFor:
       - bazel-tests
-      - yarn-link-package-core
   - name: gcr.io/learnjs-174218/release
     dir: tfjs-converter
     entrypoint: yarn

--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -45,7 +45,6 @@ tfjs_bundle(
     },
     umd_name = "tf",
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
     ],
 )
@@ -53,7 +52,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
     ],
     root = "src",

--- a/tfjs-backend-cpu/tfjs-backend-cpu_lib/BUILD.bazel
+++ b/tfjs-backend-cpu/tfjs-backend-cpu_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-backend-cpu_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-backend-cpu",
+    deps = [
+        "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
+    ],
+)

--- a/tfjs-backend-cpu/tfjs-backend-cpu_lib/index.ts
+++ b/tfjs-backend-cpu/tfjs-backend-cpu_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-backend-cpu/dist/index';

--- a/tfjs-backend-webgl/BUILD.bazel
+++ b/tfjs-backend-webgl/BUILD.bazel
@@ -36,7 +36,6 @@ tfjs_bundle(
     },
     umd_name = "tf",
     deps = [
-        "//tfjs-backend-webgl/src:tfjs-backend-webgl_lib",
         "//tfjs-backend-webgl/src:tfjs-backend-webgl_src_lib",
     ],
 )
@@ -44,7 +43,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-backend-webgl/src:tfjs-backend-webgl_lib",
         "//tfjs-backend-webgl/src:tfjs-backend-webgl_src_lib",
     ],
     root = "src",

--- a/tfjs-backend-webgl/src/BUILD.bazel
+++ b/tfjs-backend-webgl/src/BUILD.bazel
@@ -43,27 +43,18 @@ ts_library(
     name = "tfjs-backend-webgl_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + ["index.ts"],
+        exclude = TEST_SRCS,
     ),
     module_name = "@tensorflow/tfjs-backend-webgl/dist",
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@types/offscreencanvas",
         "@npm//@types/seedrandom",
         "@npm//@types/webgl-ext",
         "@npm//@types/webgl2",
-    ],
-)
-
-ts_library(
-    name = "tfjs-backend-webgl_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-backend-webgl",
-    deps = [
-        ":tfjs-backend-webgl_src_lib",
     ],
 )
 
@@ -75,12 +66,12 @@ ts_library(
     srcs = glob(TEST_SRCS) + [":tests"],
     module_name = "@tensorflow/tfjs-backend-webgl/dist",
     deps = [
-        ":tfjs-backend-webgl_lib",
         ":tfjs-backend-webgl_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-backend-webgl/tfjs-backend-webgl_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )
 
@@ -98,7 +89,7 @@ esbuild(
     ],
     sources_content = True,
     deps = [
-        ":tfjs-backend-webgl_lib",
         ":tfjs-backend-webgl_test_lib",
+        "//tfjs-backend-webgl/tfjs-backend-webgl_lib",
     ],
 )

--- a/tfjs-backend-webgl/tfjs-backend-webgl_lib/BUILD.bazel
+++ b/tfjs-backend-webgl/tfjs-backend-webgl_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-backend-webgl_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-backend-webgl",
+    deps = [
+        "//tfjs-backend-webgl/src:tfjs-backend-webgl_src_lib",
+    ],
+)

--- a/tfjs-backend-webgl/tfjs-backend-webgl_lib/index.ts
+++ b/tfjs-backend-webgl/tfjs-backend-webgl_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-backend-webgl/dist/index';

--- a/tfjs-backend-webgpu/BUILD.bazel
+++ b/tfjs-backend-webgpu/BUILD.bazel
@@ -35,7 +35,6 @@ tfjs_bundle(
     },
     umd_name = "tf",
     deps = [
-        "//tfjs-backend-webgpu/src:tfjs-backend-webgpu_lib",
         "//tfjs-backend-webgpu/src:tfjs-backend-webgpu_src_lib",
     ],
 )
@@ -43,7 +42,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-backend-webgpu/src:tfjs-backend-webgpu_lib",
         "//tfjs-backend-webgpu/src:tfjs-backend-webgpu_src_lib",
     ],
     root = "src",

--- a/tfjs-backend-webgpu/src/BUILD.bazel
+++ b/tfjs-backend-webgpu/src/BUILD.bazel
@@ -43,26 +43,15 @@ ts_library(
     name = "tfjs-backend-webgpu_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + ["index.ts"],
+        exclude = TEST_SRCS,
     ),
     module_name = "@tensorflow/tfjs-backend-webgpu/dist",
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@webgpu/types",
-    ],
-)
-
-ts_library(
-    name = "tfjs-backend-webgpu_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-backend-webgpu",
-    deps = [
-        ":tfjs-backend-webgpu_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
-        "//tfjs-core/src:tfjs-core_src_lib",
     ],
 )
 
@@ -72,12 +61,12 @@ ts_library(
     srcs = glob(TEST_SRCS) + [":tests"],
     module_name = "@tensorflow/tfjs-backend-webgpu/dist",
     deps = [
-        ":tfjs-backend-webgpu_lib",
         ":tfjs-backend-webgpu_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-backend-webgpu/tfjs-backend-webgpu_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@webgpu/types",
     ],
 )
@@ -91,7 +80,7 @@ esbuild(
     ],
     sources_content = True,
     deps = [
-        ":tfjs-backend-webgpu_lib",
         ":tfjs-backend-webgpu_test_lib",
+        "//tfjs-backend-webgpu/tfjs-backend-webgpu_lib",
     ],
 )

--- a/tfjs-backend-webgpu/tfjs-backend-webgpu_lib/BUILD.bazel
+++ b/tfjs-backend-webgpu/tfjs-backend-webgpu_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-backend-webgpu_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-backend-webgpu",
+    deps = [
+        "//tfjs-backend-webgpu/src:tfjs-backend-webgpu_src_lib",
+    ],
+)

--- a/tfjs-backend-webgpu/tfjs-backend-webgpu_lib/index.ts
+++ b/tfjs-backend-webgpu/tfjs-backend-webgpu_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-backend-webgpu/dist/index';

--- a/tfjs-backend-webgpu/yarn.lock
+++ b/tfjs-backend-webgpu/yarn.lock
@@ -934,9 +934,11 @@
 
 "@tensorflow/tfjs-backend-cpu@link:../link-package-core/node_modules/@tensorflow/tfjs-backend-cpu":
   version "0.0.0"
+  uid ""
 
 "@tensorflow/tfjs-core@link:../link-package-core/node_modules/@tensorflow/tfjs-core":
   version "0.0.0"
+  uid ""
 
 "@types/component-emitter@^1.2.10":
   version "1.2.10"
@@ -968,10 +970,20 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.0.0.tgz#9a6b6755a02fcd6baa088a767557709c79728f98"
   integrity sha512-yeQ81bQ46gOfj+AQLp5/x0Kylq6lz9d5a82Vo5JS63rDn1ctoItKcwrcKEM1wGsjqA4SrYkzzIHo8dbq8RhG5w==
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/node@*", "@types/node@>=10.0.0":
   version "16.4.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.12.tgz#961e3091f263e6345d2d84afab4e047a60b4b11b"
   integrity sha512-zxrTNFl9Z8boMJXs6ieqZP0wAhvkdzmHSxTlJabM16cf5G9xBc1uPRH5Bbv2omEDDiM8MzTfqTJXBf0Ba4xFWA==
+
+"@types/offscreencanvas@~2019.3.0":
+  version "2019.3.0"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz#3336428ec7e9180cf4566dfea5da04eb586a6553"
+  integrity sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -979,6 +991,16 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/seedrandom@2.4.27":
+  version "2.4.27"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
+  integrity sha1-nbVjk33YaRX2kJK8QyWdL0hXjkE=
+
+"@types/webgl-ext@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
+  integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
 "@webgpu/types@0.1.6":
   version "0.1.6"
@@ -2620,6 +2642,11 @@ log4js@^6.3.0:
     rfdc "^1.3.0"
     streamroller "^3.0.2"
 
+long@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 magic-string@^0.25.2, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -2751,6 +2778,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@~2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-releases@^1.1.73:
   version "1.1.73"
@@ -3263,6 +3297,11 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+seedrandom@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
+  integrity sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=
+
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -3582,6 +3621,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-node@~7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
@@ -3726,6 +3770,19 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/tfjs-converter/BUILD.bazel
+++ b/tfjs-converter/BUILD.bazel
@@ -30,7 +30,7 @@ nodejs_test(
     name = "tfjs-converter_test",
     data = [
         ":package_json",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-converter/metadata:kernels_to_ops",
         "//tfjs-converter/src:tfjs-converter_test_lib",
     ],
@@ -47,7 +47,7 @@ nodejs_test(
     data = [
         ":tsconfig.json",
         "//:tsconfig.json",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-converter/scripts:test_snippets_lib",
         "//tfjs-converter/src:all_srcs",
     ],
@@ -67,7 +67,6 @@ tfjs_bundle(
     },
     umd_name = "tf",
     deps = [
-        "//tfjs-converter/src:tfjs-converter_lib",
         "//tfjs-converter/src:tfjs-converter_src_lib",
     ],
 )
@@ -75,7 +74,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-converter/src:tfjs-converter_lib",
         "//tfjs-converter/src:tfjs-converter_src_lib",
     ],
     root = "src",

--- a/tfjs-converter/scripts/BUILD.bazel
+++ b/tfjs-converter/scripts/BUILD.bazel
@@ -15,7 +15,7 @@ ts_library(
         "test_snippets.ts",
     ],
     deps = [
-        "//tfjs-converter/src:tfjs-converter_src_lib",
+        "//tfjs-converter/tfjs-converter_lib",
         "//tfjs-core/scripts/test_snippets:test_snippets_util_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/tfjs-core_lib",

--- a/tfjs-converter/scripts/BUILD.bazel
+++ b/tfjs-converter/scripts/BUILD.bazel
@@ -15,10 +15,10 @@ ts_library(
         "test_snippets.ts",
     ],
     deps = [
-        "//tfjs-converter/src:tfjs-converter_lib",
+        "//tfjs-converter/src:tfjs-converter_src_lib",
         "//tfjs-core/scripts/test_snippets:test_snippets_util_lib",
-        "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )
 

--- a/tfjs-converter/scripts/test_snippets.ts
+++ b/tfjs-converter/scripts/test_snippets.ts
@@ -24,7 +24,7 @@ import * as tfc from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/dist/scripts/test_snippets/util';
 
-import * as tfconv from '../src/index';
+import * as tfconv from '@tensorflow/tfjs-converter';
 
 const tf = {
   ...tfconv,

--- a/tfjs-converter/src/BUILD.bazel
+++ b/tfjs-converter/src/BUILD.bazel
@@ -41,23 +41,14 @@ ts_library(
     name = "tfjs-converter_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + ["index.ts"],
+        exclude = TEST_SRCS,
     ) + [":ops_ts_files"],
     module_name = "@tensorflow/tfjs-converter/dist",
     deps = [
-        "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@types/seedrandom",
         "@npm//seedrandom",
-    ],
-)
-
-ts_library(
-    name = "tfjs-converter_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-converter",
-    deps = [
-        ":tfjs-converter_src_lib",
     ],
 )
 
@@ -67,11 +58,11 @@ ts_library(
     srcs = glob(TEST_SRCS),
     module_name = "@tensorflow/tfjs-converter/dist",
     deps = [
-        ":tfjs-converter_lib",
         ":tfjs-converter_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-converter/tfjs-converter_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@types/jasmine",
         "@npm//ajv",
         "@npm//jasmine",

--- a/tfjs-converter/tfjs-converter_lib/BUILD.bazel
+++ b/tfjs-converter/tfjs-converter_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-converter_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-converter",
+    deps = [
+        "//tfjs-converter/src:tfjs-converter_src_lib",
+    ],
+)

--- a/tfjs-converter/tfjs-converter_lib/index.ts
+++ b/tfjs-converter/tfjs-converter_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-converter/dist/index';

--- a/tfjs-core/BUILD.bazel
+++ b/tfjs-core/BUILD.bazel
@@ -40,14 +40,13 @@ tfjs_bundle(
     ],
     umd_name = "tf",
     deps = [
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-core/src:tfjs-core_src_lib",
     ],
 )
 
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
     ],
@@ -131,7 +130,7 @@ nodejs_test(
     data = [
         ":tsconfig.json",
         "//:tsconfig.json",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/scripts/test_snippets:test_snippets_lib",
         "//tfjs-core/src:all_srcs",
     ],
@@ -143,12 +142,12 @@ nodejs_test(
 nodejs_test(
     name = "tfjs-core_node_test",
     data = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:setup_test_lib",
         "//tfjs-core/src:test_node_lib",
-        "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
     entry_point = "//tfjs-core/src:test_node.ts",
     link_workspace_root = True,
@@ -158,7 +157,7 @@ nodejs_test(
 nodejs_test(
     name = "tfjs-core_async_backends_test",
     data = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
     ],
     entry_point = "//tfjs-core/src:test_async_backends.ts",

--- a/tfjs-core/scripts/test_snippets/BUILD.bazel
+++ b/tfjs-core/scripts/test_snippets/BUILD.bazel
@@ -23,9 +23,9 @@ ts_library(
     module_name = "@tensorflow/tfjs-core/dist/scripts/test_snippets",
     deps = [
         ":test_snippets_util_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )

--- a/tfjs-core/scripts/test_snippets/test_snippets.ts
+++ b/tfjs-core/scripts/test_snippets/test_snippets.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import * as tf from '../../src/index';
+import * as tf from '@tensorflow/tfjs-core';
 import '../../src/public/chained_ops/register_all_chained_ops';
 import '../../src/register_all_gradients';
 import '@tensorflow/tfjs-backend-cpu';

--- a/tfjs-core/src/BUILD.bazel
+++ b/tfjs-core/src/BUILD.bazel
@@ -68,24 +68,12 @@ ts_library(
     name = "tfjs-core_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + TEST_ENTRYPOINTS + ["index.ts"],
+        exclude = TEST_SRCS + TEST_ENTRYPOINTS,
     ),
     module_name = "@tensorflow/tfjs-core/dist",
     deps = [
         "@npm//@types",
         "@npm//seedrandom",
-    ],
-)
-
-# Compiles the `index.ts` entrypoint of tfjs-core separately from the rest of
-# the sources in order to use the `@tensorflow/tfjs-core` module name instead
-# of `@tensorflow/tfjs-core/dist`,
-ts_library(
-    name = "tfjs-core_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-core",
-    deps = [
-        ":tfjs-core_src_lib",
     ],
 )
 
@@ -102,8 +90,8 @@ ts_library(
     # npm package (for other downstream packages' tests).
     module_name = "@tensorflow/tfjs-core/dist",
     deps = [
-        ":tfjs-core_lib",
         ":tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )
 
@@ -115,7 +103,7 @@ ts_library(
     deps = [
         ":tfjs-core_src_lib",
         ":tfjs-core_test_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
     ],
 )
 
@@ -129,7 +117,7 @@ ts_library(
         # so it is not listed here (it is listed in the nodejs_test, instead).
         ":tfjs-core_src_lib",
         ":tfjs-core_test_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
     ],
 )
 
@@ -148,9 +136,9 @@ esbuild(
     sources_content = True,
     deps = [
         ":setup_test_lib",
-        ":tfjs-core_lib",
         ":tfjs-core_test_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )
 
@@ -161,7 +149,7 @@ ts_library(
     ],
     deps = [
         ":tfjs-core_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
     ],
 )
 
@@ -182,9 +170,9 @@ ts_library(
         "worker_test.ts",
     ],
     deps = [
-        ":tfjs-core_lib",
         ":tfjs-core_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )
 
@@ -218,9 +206,9 @@ ts_library(
         "ops/from_pixels_worker_test.ts",
     ],
     deps = [
-        ":tfjs-core_lib",
         ":tfjs-core_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-core/tfjs-core_lib",
     ],
 )
 

--- a/tfjs-core/tfjs-core_lib/BUILD.bazel
+++ b/tfjs-core/tfjs-core_lib/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC. All Rights Reserved.
+# Copyright 2022 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,36 +17,11 @@ load("//tools:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
-TEST_SRCS = [
-    "**/*_test.ts",
-    "run_tests.ts",
-]
-
 ts_library(
-    name = "tfjs-backend-cpu_src_lib",
-    srcs = glob(
-        ["**/*.ts"],
-        exclude = TEST_SRCS,
-    ),
-    module_name = "@tensorflow/tfjs-backend-cpu/dist",
+    name = "tfjs-core_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-core",
     deps = [
-        "//tfjs-core/tfjs-core_lib",
-        "@npm//@types/seedrandom",
-        "@npm//seedrandom",
-    ],
-)
-
-ts_library(
-    name = "tfjs-backend-cpu_test_lib",
-    testonly = True,
-    srcs = glob(TEST_SRCS),
-    module_name = "@tensorflow/tfjs-backend-cpu/dist",
-    deps = [
-        ":tfjs-backend-cpu_src_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
-        "//tfjs-core/src:tfjs-core_test_lib",
-        "//tfjs-core/tfjs-core_lib",
-        "@npm//@types/jasmine",
-        "@npm//jasmine",
     ],
 )

--- a/tfjs-core/tfjs-core_lib/index.ts
+++ b/tfjs-core/tfjs-core_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-core/dist/index';

--- a/tfjs-data/BUILD.bazel
+++ b/tfjs-data/BUILD.bazel
@@ -30,7 +30,7 @@ exports_files([
 nodejs_test(
     name = "tfjs-data_test",
     data = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-data/src:tfjs-data_test_lib",
     ],
     entry_point = "//tfjs-data/src:test_node.ts",
@@ -45,7 +45,7 @@ nodejs_test(
     data = [
         ":tsconfig.json",
         "//:tsconfig.json",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-data/scripts:test_snippets_lib",
         "//tfjs-data/src:all_srcs",
     ],
@@ -79,7 +79,6 @@ tfjs_bundle(
     },
     umd_name = "tf",
     deps = [
-        "//tfjs-data/src:tfjs-data_lib",
         "//tfjs-data/src:tfjs-data_src_lib",
     ],
 )
@@ -87,7 +86,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-data/src:tfjs-data_lib",
         "//tfjs-data/src:tfjs-data_src_lib",
     ],
     root = "src",

--- a/tfjs-data/scripts/BUILD.bazel
+++ b/tfjs-data/scripts/BUILD.bazel
@@ -13,7 +13,7 @@ ts_library(
         "//tfjs-core/scripts/test_snippets:test_snippets_util_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/tfjs-core_lib",
-        "//tfjs-data/src:tfjs-data_src_lib",
+        "//tfjs-data/tfjs-data_lib",
         "//tfjs-layers/tfjs-layers_lib",
     ],
 )

--- a/tfjs-data/scripts/BUILD.bazel
+++ b/tfjs-data/scripts/BUILD.bazel
@@ -9,11 +9,11 @@ ts_library(
         "test_snippets.ts",
     ],
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/scripts/test_snippets:test_snippets_util_lib",
-        "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
-        "//tfjs-data/src:tfjs-data_lib",
-        "//tfjs-layers/src:tfjs-layers_lib",
+        "//tfjs-core/tfjs-core_lib",
+        "//tfjs-data/src:tfjs-data_src_lib",
+        "//tfjs-layers/tfjs-layers_lib",
     ],
 )

--- a/tfjs-data/scripts/test_snippets.ts
+++ b/tfjs-data/scripts/test_snippets.ts
@@ -24,7 +24,7 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/dist/scripts/test_snippets/util';
 import * as tfl from '@tensorflow/tfjs-layers';
 
-import * as tfd from '../src/index';
+import * as tfd from '@tensorflow/tfjs-data';
 
 const tf = {
   data: {...tfd},

--- a/tfjs-data/src/BUILD.bazel
+++ b/tfjs-data/src/BUILD.bazel
@@ -49,30 +49,16 @@ ts_library(
     name = "tfjs-data_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + ["index.ts"],
+        exclude = TEST_SRCS,
     ),
     module_name = "@tensorflow/tfjs-data/dist",
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@types/seedrandom",
         "@npm//seedrandom",
-    ],
-)
-
-# Compiles the `index.ts` entrypoint of tfjs-data separately from the rest of
-# the sources in order to use the `@tensorflow/tfjs-data` module name instead
-# of `@tensorflow/tfjs-data/dist`,
-ts_library(
-    name = "tfjs-data_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-data",
-    deps = [
-        ":tfjs-data_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
-        "//tfjs-core/src:tfjs-core_src_lib",
     ],
 )
 
@@ -84,13 +70,13 @@ ts_library(
     srcs = glob(TEST_SRCS) + [":tests"],
     module_name = "@tensorflow/tfjs-data/dist",
     deps = [
-        ":tfjs-data_lib",
         ":tfjs-data_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-backend-webgl/src:tfjs-backend-webgl_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-backend-webgl/tfjs-backend-webgl_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "//tfjs-core/tfjs-core_lib",
+        "//tfjs-data/tfjs-data_lib",
         "@npm//@types/jasmine",
         "@npm//jasmine",
     ],
@@ -113,7 +99,7 @@ esbuild(
     ],
     sources_content = True,
     deps = [
-        ":tfjs-data_lib",
         ":tfjs-data_test_lib",
+        "//tfjs-data/tfjs-data_lib",
     ],
 )

--- a/tfjs-data/tfjs-data_lib/BUILD.bazel
+++ b/tfjs-data/tfjs-data_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-data_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-data",
+    deps = [
+        "//tfjs-data/src:tfjs-data_src_lib",
+    ],
+)

--- a/tfjs-data/tfjs-data_lib/index.ts
+++ b/tfjs-data/tfjs-data_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-data/dist/index';

--- a/tfjs-layers/BUILD.bazel
+++ b/tfjs-layers/BUILD.bazel
@@ -35,7 +35,7 @@ nodejs_test(
     data = [
         ":tsconfig.json",
         "//:tsconfig.json",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-layers/scripts:test_snippets_lib",
         "//tfjs-layers/src:all_srcs",
     ],
@@ -94,7 +94,6 @@ tfjs_bundle(
     },
     umd_name = "tf",
     deps = [
-        "//tfjs-layers/src:tfjs-layers_lib",
         "//tfjs-layers/src:tfjs-layers_src_lib",
     ],
 )
@@ -102,7 +101,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-layers/src:tfjs-layers_lib",
         "//tfjs-layers/src:tfjs-layers_src_lib",
     ],
     root = "src",

--- a/tfjs-layers/scripts/BUILD.bazel
+++ b/tfjs-layers/scripts/BUILD.bazel
@@ -13,6 +13,6 @@ ts_library(
         "//tfjs-core/scripts/test_snippets:test_snippets_util_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/tfjs-core_lib",
-        "//tfjs-layers/src:tfjs-layers_src_lib",
+        "//tfjs-layers/tfjs-layers_lib",
     ],
 )

--- a/tfjs-layers/scripts/BUILD.bazel
+++ b/tfjs-layers/scripts/BUILD.bazel
@@ -9,10 +9,10 @@ ts_library(
         "test_snippets.ts",
     ],
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/scripts/test_snippets:test_snippets_util_lib",
-        "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
-        "//tfjs-layers/src:tfjs-layers_lib",
+        "//tfjs-core/tfjs-core_lib",
+        "//tfjs-layers/src:tfjs-layers_src_lib",
     ],
 )

--- a/tfjs-layers/scripts/test_snippets.ts
+++ b/tfjs-layers/scripts/test_snippets.ts
@@ -24,7 +24,7 @@ import * as tfc from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {parseAndEvaluateSnippets} from '@tensorflow/tfjs-core/dist/scripts/test_snippets/util';
 
-import * as tfl from '../src/index';
+import * as tfl from '@tensorflow/tfjs-layers';
 
 const tf = {
   ...tfl,

--- a/tfjs-layers/src/BUILD.bazel
+++ b/tfjs-layers/src/BUILD.bazel
@@ -49,30 +49,16 @@ ts_library(
     name = "tfjs-layers_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + ["index.ts"],
+        exclude = TEST_SRCS,
     ),
     module_name = "@tensorflow/tfjs-layers/dist",
     deps = [
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@types/seedrandom",
         "@npm//seedrandom",
-    ],
-)
-
-# Compiles the `index.ts` entrypoint of tfjs-layers separately from the rest of
-# the sources in order to use the `@tensorflow/tfjs-layers` module name instead
-# of `@tensorflow/tfjs-layers/dist`,
-ts_library(
-    name = "tfjs-layers_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-layers",
-    deps = [
-        ":tfjs-layers_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
-        "//tfjs-core/src:tfjs-core_src_lib",
     ],
 )
 
@@ -84,13 +70,13 @@ ts_library(
     srcs = glob(TEST_SRCS) + [":tests"],
     module_name = "@tensorflow/tfjs-layers/dist",
     deps = [
-        ":tfjs-layers_lib",
         ":tfjs-layers_src_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-backend-webgl/src:tfjs-backend-webgl_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-backend-webgl/tfjs-backend-webgl_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "//tfjs-core/tfjs-core_lib",
+        "//tfjs-layers/tfjs-layers_lib",
         "@npm//@types/jasmine",
         "@npm//jasmine",
     ],
@@ -111,8 +97,8 @@ esbuild(
     ],
     sources_content = True,
     deps = [
-        ":tfjs-layers_lib",
         ":tfjs-layers_test_lib",
         "//tfjs-layers:package_json",
+        "//tfjs-layers/tfjs-layers_lib",
     ],
 )

--- a/tfjs-layers/tfjs-layers_lib/BUILD.bazel
+++ b/tfjs-layers/tfjs-layers_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-layers_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-layers",
+    deps = [
+        "//tfjs-layers/src:tfjs-layers_src_lib",
+    ],
+)

--- a/tfjs-layers/tfjs-layers_lib/index.ts
+++ b/tfjs-layers/tfjs-layers_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-layers/dist/index';

--- a/tfjs-tflite/BUILD.bazel
+++ b/tfjs-tflite/BUILD.bazel
@@ -35,7 +35,6 @@ tfjs_bundle(
     },
     umd_name = "tflite",
     deps = [
-        "//tfjs-tflite/src:tfjs-tflite_lib",
         "//tfjs-tflite/src:tfjs-tflite_src_lib",
         "//tfjs-tflite/src:tflite_web_api_client_js",
         "//tfjs-tflite/wasm:wasm_files",
@@ -46,7 +45,6 @@ tfjs_bundle(
 copy_ts_library_to_dist(
     name = "copy_src_to_dist",
     srcs = [
-        "//tfjs-tflite/src:tfjs-tflite_lib",
         "//tfjs-tflite/src:tfjs-tflite_src_lib",
     ],
     root = "src",

--- a/tfjs-tflite/src/BUILD.bazel
+++ b/tfjs-tflite/src/BUILD.bazel
@@ -27,22 +27,13 @@ ts_library(
     name = "tfjs-tflite_src_lib",
     srcs = glob(
         ["**/*.ts"],
-        exclude = TEST_SRCS + ["index.ts"],
+        exclude = TEST_SRCS,
     ),
     module_name = "@tensorflow/tfjs-tflite/dist",
     deps = [
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-core/tfjs-core_lib",
         "@npm//@types/seedrandom",
         "@npm//seedrandom",
-    ],
-)
-
-ts_library(
-    name = "tfjs-tflite_lib",
-    srcs = ["index.ts"],
-    module_name = "@tensorflow/tfjs-tflite",
-    deps = [
-        ":tfjs-tflite_src_lib",
     ],
 )
 
@@ -58,9 +49,9 @@ ts_library(
     srcs = glob(TEST_SRCS),
     module_name = "@tensorflow/tfjs-tflite/dist",
     deps = [
-        ":tfjs-tflite_lib",
         ":tfjs-tflite_src_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        "//tfjs-core/tfjs-core_lib",
+        "//tfjs-tflite/tfjs-tflite_lib",
     ],
 )
 
@@ -75,9 +66,11 @@ esbuild(
     ],
     sources_content = True,
     deps = [
-        ":tfjs-tflite_lib",
         ":tfjs-tflite_test_lib",
-        "//tfjs-backend-cpu/src:tfjs-backend-cpu_lib",
-        "//tfjs-core/src:tfjs-core_lib",
+        ":tflite_web_api_client_js",
+        "//tfjs-backend-cpu/tfjs-backend-cpu_lib",
+        "//tfjs-core/tfjs-core_lib",
+        "//tfjs-tflite/tfjs-tflite_lib",
+        "//tfjs-tflite/wasm:wasm_files",
     ],
 )

--- a/tfjs-tflite/tfjs-tflite_lib/BUILD.bazel
+++ b/tfjs-tflite/tfjs-tflite_lib/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "tfjs-tflite_lib",
+    srcs = ["index.ts"],
+    module_name = "@tensorflow/tfjs-tflite",
+    deps = [
+        "//tfjs-tflite/src:tfjs-tflite_src_lib",
+    ],
+)

--- a/tfjs-tflite/tfjs-tflite_lib/index.ts
+++ b/tfjs-tflite/tfjs-tflite_lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// This index.ts file is used by Bazel as an entrypoint to this package instead
+// of the index.ts in '../src'. The reason for this is that we want this package
+// to be importable by the same name as it has in npm. Normally, this is handled
+// by the 'main' entry in the package.json file, but ts_library has no concept
+// of package.json files. Instead, we set 'module_name' (and 'package_name') to
+// this package's name on npm to achieve the same effect.
+
+// The reason we need a separate index.ts file to do this is because of how
+// rules_nodejs's linker works. If we didn't use a separate index.ts and
+// instead set the 'module_name' of '../src/index.ts', then the linker's output
+// (viewable in the root node_modules directory after yarn build) would look
+// like this:
+//
+// @tensorflow/this-package-name/
+//   index.js
+//   foo.js
+//   bar.js
+//   dist -> . (symbolic link to current directory)
+//
+// This causes bundling issues for packages that import the main 'index.ts' file
+// and additional files from 'dist/' because rollup has been instructed to treat
+// symlinks as real files (a requirement to make it run in Bazel), so you can
+// easily end up with multiple copies of 'foo.js' if it is imported manually
+// from '@tensorflow/this-package-name/dist/foo' and if the 'index.ts' file also
+// imports it.
+//
+// There isn't really anything the linker can do to avoid this structure, since
+// since 'index.js' must be importable as @tensorflow/this-package-name and the
+// linker can't rewrite the import statements in index.js.
+//
+// So why the extra directory? Why not put the index.ts file in '../'? Again,
+// this is related to how the linker works. The linker symlinks the bazel output
+// directory containing the ts_library's output to a directory in node_modules.
+// This output directory contains the outputs of other rules as well, including
+// the rules that copy files to the 'dist' directory for publishing. When one
+// of these other rules that writes to 'dist' is run, it overwrites the 'dist'
+// symlink created by the linker.
+//
+// Putting the entrypoint in its own directory allows the linker to link
+// ts_library targets with module_name (and package_name) set to
+// '@tensorflow/this-package-name/dist' without having the 'dist' symlink
+// overwritten. With this approach, the output struture looks like this:
+//
+// @tensorflow/this-package-name/
+//   index.js (from this directory's index.ts)
+//   dist/
+//     index.js (from ../src/index.ts)
+//     foo.js
+//     bar.js
+//
+
+export * from '@tensorflow/tfjs-tflite/dist/index';


### PR DESCRIPTION
Create a new Bazel-only entrypoint for each Bazel package (in e.g. tfjs-core/tfjs-core_lib/index.ts) that allows the rules_nodejs linker to properly create symlinks in the root node_modules directory to Bazel's output in dist/bin/.

Before this change, packages were linked like this:
```
@tensorflow/tfjs-core/
  index.js
  foo.js
  bar.js
  dist -> . (a symlink to this directory)
```
This format confused bundlers. After this change, packages no longer have a circular symlink:
```
@tensorflow/tfjs-core/
  index.js (Bazel's index.js entrypoint. Just exports * from dist/index)
  dist/
    index.js (tfjs-core's entrypoint)
    foo.js
    bar.js
```
For more details on how this is done and why it is necessary, see `tfjs-core/tfjs-core_lib/index.ts`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6105)
<!-- Reviewable:end -->
