### PR TITLE
[webgpu] remove bad browser check

### DIFF
--- a/tfjs-backend-webgpu/src/index.ts
+++ b/tfjs-backend-webgpu/src/index.ts
@@ -24,7 +24,7 @@ import {WebGPUBackend} from './backend_webgpu';
 import * as webgpu from './webgpu';
 import {isWebGPUSupported} from './webgpu_util';
 
-if (device_util.isBrowser() && isWebGPUSupported()) {
+if (isWebGPUSupported()) {
   registerBackend('webgpu', async () => {
     // Remove it once we figure out how to correctly read the tensor data
     // before the tensor is disposed in profiling mode.

--- a/tfjs-backend-webgpu/src/index.ts
+++ b/tfjs-backend-webgpu/src/index.ts
@@ -18,7 +18,7 @@
 import './flags_webgpu';
 import './register_all_kernels';
 
-import {device_util, env, registerBackend} from '@tensorflow/tfjs-core';
+import {env, registerBackend} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from './backend_webgpu';
 import * as webgpu from './webgpu';

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -170,7 +170,7 @@ export function ArrayBufferToTypedArray(data: ArrayBuffer, dtype: DataType) {
 export function isWebGPUSupported(): boolean {
   return ((typeof window !== 'undefined') ||
     //@ts-ignore
-    (typeof WorkerGlobalScope !== 'undefined')) && navigator.gpu
+    (typeof WorkerGlobalScope !== 'undefined')) && navigator.gpu;
 }
 
 export interface WebGPULayout {

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -170,7 +170,7 @@ export function ArrayBufferToTypedArray(data: ArrayBuffer, dtype: DataType) {
 export function isWebGPUSupported(): boolean {
   return ((typeof window !== 'undefined') ||
     //@ts-ignore
-    (typeof WorkerGlobalScope !== 'undefined')) && navigator.gpu;
+    (typeof WorkerGlobalScope !== 'undefined')) && !!navigator.gpu;
 }
 
 export interface WebGPULayout {

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -168,10 +168,9 @@ export function ArrayBufferToTypedArray(data: ArrayBuffer, dtype: DataType) {
 }
 
 export function isWebGPUSupported(): boolean {
-  if (!navigator.gpu) {
-    return false;
-  }
-  return true;
+  return ((typeof window !== 'undefined') ||
+    //@ts-ignore
+    (typeof WorkerGlobalScope !== 'undefined')) && navigator.gpu
 }
 
 export interface WebGPULayout {


### PR DESCRIPTION
This browser check is wrong, but also unecessary as `navigator.gpu` is also being checked. This will unblock the usage of the webgpu backend in deno.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6108)
<!-- Reviewable:end -->
