### PR TITLE
Fix grep for browser tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,7 +39,7 @@ test --action_env=BROWSERSTACK_USERNAME --action_env=BROWSERSTACK_KEY
 
 # Platform specific DISPLAY environment variable for webgl
 test --enable_platform_specific_config
-test:linux --define DISPLAY=$DISPLAY
+test:linux --test_env=DISPLAY
 test:macos --define DISPLAY=true
 test:windows --define DISPLAY=true
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 # =============================================================================
 
+load("//tools:tfjs_web_test.bzl", "grep_flag")
 load(":python_packages.bzl", "PYTHON_PACKAGES")
 load(":python_toolchain.bzl", "configure_python_toolchains")
 
@@ -26,4 +27,10 @@ exports_files([
 
 configure_python_toolchains(
     platforms = PYTHON_PACKAGES,
+)
+
+grep_flag(
+    name = "grep",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
 )

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,10 +55,10 @@ unnecessarily rebuilding dependencies.
 
 Many TensorFlow.js packages use Karma to run tests in a browser. These tests can be configured by command-line options.
 
-To run a subset of tests on a specific browser:
+To run a subset of tests:
 
 ```bash
-$ yarn test --browsers=Chrome --grep='multinomial'
+$ yarn test --//:grep=multinomial
  
 > ...
 > Chrome 62.0.3202 (Mac OS X 10.12.6): Executed 28 of 1891 (skipped 1863) SUCCESS (6.914 secs / 0.634 secs)

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -22,6 +22,7 @@ const browserstackConfig = {
 };
 
 module.exports = function(config) {
+  console.log(`Running with arguments ${TEMPLATE_args.join(' ')}`);
   let browser = 'TEMPLATE_browser';
   let extraConfig = {};
   if (browser) {


### PR DESCRIPTION
Add the command line flag "--//:grep=test_to_grep_for" to support running only matching tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.