### PR TITLE
webgpu: Fix bank conflicts

### DIFF
--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -31,7 +31,7 @@ ENV.registerFlag('WEBGPU_CPU_FORWARD', () => true);
 /**
  * Thread register block size for matmul kernel.
  */
-ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 4);
+ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 2);
 
 /**
  * Whether to use conv2d_naive which directly implement the conv2d logic rather

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -31,7 +31,7 @@ ENV.registerFlag('WEBGPU_CPU_FORWARD', () => true);
 /**
  * Thread register block size for matmul kernel.
  */
-ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 2);
+ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 4);
 
 /**
  * Whether to use conv2d_naive which directly implement the conv2d logic rather

--- a/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
@@ -40,11 +40,7 @@ export function makeMatMulPackedSource(
       numWorkgroups = NumWorkgroups;
       let localRow = i32(localId.y);
       let localCol = i32(localId.x);
-      let tileRow = localRow * ${workPerThread[1]};
-      let tileCol = localCol * ${workPerThread[0]};
 
-      let globalRow = i32(globalId.y) * ${workPerThread[1]};
-      let globalCol = i32(globalId.x) * ${workPerThread[0]};
       let newGlobalRow = i32(workgroupId.y) * ${tileAOuter};
       let newGlobalCol = i32(workgroupId.x) * ${tileBOuter};
 

--- a/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
@@ -199,6 +199,7 @@ export class MatMulPackedProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = {x: [2], y: [1], z: [0]};
     const dimInner = transposeA ? aShape[1] : aShape[2];
+    workPerThread = 2;
     this.workGroupSize =
         computeWorkGroupSizeForMatMul(outputShape[1], dimInner, outputShape[2]);
     if (outputShape[1] === 1 || outputShape[2] === 1) {

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -98,7 +98,7 @@ export function computeWorkGroupSizeForMatMul(
     return [1, 32, 1];
   }
 
-  return [16, 16, 1];
+  return [8, 8, 1];
 }
 
 export function computeWorkPerThreadForConv2d(

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -98,7 +98,7 @@ export function computeWorkGroupSizeForMatMul(
     return [1, 32, 1];
   }
 
-  return [8, 8, 1];
+  return [16, 16, 1];
 }
 
 export function computeWorkPerThreadForConv2d(
@@ -148,8 +148,9 @@ export function ArrayBufferToTypedArray(data: ArrayBuffer, dtype: DataType) {
 
 export function isWebGPUSupported(): boolean {
   return ((typeof window !== 'undefined') ||
-    //@ts-ignore
-    (typeof WorkerGlobalScope !== 'undefined')) && !!navigator.gpu;
+          //@ts-ignore
+          (typeof WorkerGlobalScope !== 'undefined')) &&
+      !!navigator.gpu;
 }
 
 export interface WebGPULayout {


### PR DESCRIPTION
This PR fixed the shared memory bank conflicts issue on MatMulPackedProgram. Previously, it used interleaved loads, which resulted the bank conflict. This PR uses sequential accessing to resolve it.
Before:
```
shared[2*localId.x] = global[2*localId.x];
shared[2*localId.x + 1] = global[2*localId.x + 1];
```
After:
```
shared[localId.x] = global[localId.x];
shared[localId.x+ workGroupSizeX] = global[localId.x+ workGroupSizeX];
```

With this change, Conv2DDerInputMMProgram/Conv2DMMProgram/MatMulPackedProgram get about >20% improvement. For example, the total time of Conv2DBackpropInput in hand_detector becomes 7.46ms from 11.26ms. The total time Conv2D in AutoML Image becomes 4.05ms from 5.61ms.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6152)
<!-- Reviewable:end -->
