### PR TITLE
[webgpu] Resolve timestamp when read

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -234,16 +234,25 @@ async function timeModelInference(model, input, numRuns = 1) {
  * @param predict The predict function to execute and time.
  * @param numRuns The number of rounds for `predict` to execute and time.
  */
+let setBatchSizes = null;
 async function timeInference(predict, numRuns = 1) {
   if (typeof predict !== 'function') {
     throw new Error(
         'The first parameter should be a function, while ' +
         `a(n) ${typeof predict} is found.`);
   }
+  if (setBatchSizes == null) {
+    // setBatchSizes = JSON.parse(await readFileAsync('batchSizes.json'));
+    console.log(JSON.stringify(setBatchSizes));
+  }
 
   const times = [];
   for (let i = 0; i < numRuns; i++) {
     const start = performance.now();
+    // tf.backend().setBatchSizes(
+    //  [15, 30, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90]);
+    // tf.backend().setBatchSizes([1, 5, 20, 35, 50, 65, 80, 95]);
+    if (setBatchSizes != null) tf.backend().setBatchSizes(setBatchSizes);
     const res = await predict();
     // The prediction can be tf.Tensor|tf.Tensor[]|{[name: string]: tf.Tensor}.
     const value = await downloadValuesFromTensorContainer(res);
@@ -263,7 +272,26 @@ async function timeInference(predict, numRuns = 1) {
     maxTime
 
   };
+  console.log('setBatch' + JSON.stringify(timeInfo));
   return timeInfo;
+}
+
+async function readFileAsync(url, method = 'GET') {
+  return new Promise(function(resolve, reject) {
+    let xhr = new XMLHttpRequest();
+    xhr.open(method, url);
+    xhr.onload = function() {
+      if (this.status >= 200 && this.status < 300) {
+        resolve(xhr.response);
+      } else {
+        reject({status: this.status, statusText: xhr.statusText});
+      }
+    };
+    xhr.onerror = function() {
+      reject({status: this.status, statusText: xhr.statusText});
+    };
+    xhr.send();
+  });
 }
 
 async function timeInferenceForTracing(predict, numRuns = 1) {
@@ -277,6 +305,14 @@ async function timeInferenceForTracing(predict, numRuns = 1) {
   const kernelTimes = [];
   for (let i = 0; i < numRuns; i++) {
     const start = performance.now();
+    console.timeStamp('timeInferenceForTracing');
+    // tf.backend().setBatchSizes(
+    //    [3, 5, 15, 30, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90]);
+    // tf.backend().setBatchSizes([1, 15, 30, 45, 60, 75, 90]);
+    // tf.backend().setBatchSizes([1, 15, 30, 45, 60, 75, 90]);
+    // tf.backend().setBatchSizes([3, 8, 20, 35, 50, 65, 80, 95]);
+    // tf.backend().setBatchSizes([1, 5, 20, 35, 50, 65, 80, 95]);  // best
+    if (setBatchSizes != null) tf.backend().setBatchSizes(setBatchSizes);
     const res = await predict();
     // The prediction can be tf.Tensor|tf.Tensor[]|{[name: string]: tf.Tensor}.
     const value = await downloadValuesFromTensorContainer(res);
@@ -520,7 +556,8 @@ const TUNABLE_FLAG_VALUE_RANGE_MAP = {
   CHECK_COMPUTATION_FOR_ERRORS: [true, false],
   KEEP_INTERMEDIATE_TENSORS: [true, false],
   WEBGL_USE_SHAPES_UNIFORMS: [true, false],
-  WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE: [1, 5, 10, 15, 20, 25, 30, 35, 40]
+  WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE:
+      [1, 5, 10, 15, 20, 25, 30, 35, 40, 86, 90, 100, 108, 178]
 };
 
 /**

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -92,7 +92,9 @@ limitations under the License.
     let urlState = null;
     let runTimes = 50;
     let profileTimes = 1;
+    let tracingRepeat = 10;
     let warmupTimes = 1;
+    let tracing = false;
     // Default do not run any task.
     let task = '';
     function getURLState(url) {
@@ -111,6 +113,12 @@ limitations under the License.
       }
       if (params.has('task')) {
         task = params.get('task');
+      }
+      if (params.has('tracing')) {
+        tracing = params.get('tracing') === 'true';
+      }
+      if (params.has('tracingrepeat')) {
+        tracingRepeat = Number(params.get('tracingrepeat'));
       }
       return params;
     }
@@ -590,6 +598,20 @@ limitations under the License.
       appendRow(timeTable, '', '');
     }
 
+    async function tracingPredictTime(repeat = 10) {
+      await showMsg(`Running tracing`);
+      tf.env().set('TRACING', true);
+      const tracingStart = performance.now();
+      let [timeInfo, kernelTimes] = await timeInferenceForTracing(() => predict(model), repeat);
+      console.log("predictbegin"+JSON.stringify(timeInfo)+ "predictend");
+      for (let item in kernelTimes) {
+        console.log('gpudatabegin' + JSON.stringify(kernelTimes[item]) + 'gpudataend');
+      }
+      appendRow(timeTable, `Tracing average ${repeat}`, printTime(timeInfo.averageTime));
+      tf.env().set('TRACING', false);
+      await showMsg(null);
+    }
+
     async function profileMemoryAndKernelTime() {
       if (state.numProfiles == 0) {
         return;
@@ -730,7 +752,11 @@ limitations under the License.
 
       await warmUpAndRecordTime();
       await measureAveragePredictTime();
-      await profileMemoryAndKernelTime();
+      if (tracing) {
+        await tracingPredictTime(tracingRepeat);
+      } else {
+        await profileMemoryAndKernelTime();
+      }
       urlState = null;
     }
 

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -46,7 +46,7 @@ const whereImpl = kernel_impls.whereImpl;
 
 export const EPSILON_FLOAT32 = 1e-7;
 export const EPSILON_FLOAT16 = 1e-4;
-
+type QueryResults = number|Array<{name: string; query: number[]}>;
 type KernelInfo = {
   name: string; query: Promise<number>;
 };
@@ -140,6 +140,7 @@ export class MathBackendWebGL extends KernelBackend {
   private gpgpuCreatedLocally: boolean;
   private numMBBeforeWarning: number;
   private warnedAboutMemory = false;
+  private webGLQueries: {name: string, query: WebGLQuery}[] = [];
 
   constructor(gpuResource?: GPGPUContext|HTMLCanvasElement|OffscreenCanvas) {
     super();
@@ -602,6 +603,21 @@ export class MathBackendWebGL extends KernelBackend {
     return timerQuery.endMs - timerQuery.startMs;
   }
 
+
+  async getKernelTimes(): Promise < number|{
+    name: string;
+    query: number[]}[] > {
+    const queryResults: QueryResults = [];
+    for(let i =0 ;i < this.webGLQueries.length; i ++) {
+      const kernelTime = await this.getQueryTime(this.webGLQueries[i].query);
+      queryResults[i] = {
+        name: this.webGLQueries[i].name,
+        query: [kernelTime, kernelTime]
+      };
+    }
+    return queryResults;
+  }
+
   private pendingDeletes = 0;
 
   /**
@@ -943,7 +959,8 @@ export class MathBackendWebGL extends KernelBackend {
       return gpgpu_math.compileProgram(
           this.gpgpu, program, inputsData, outputData);
     });
-    const shouldTimeProgram = this.activeTimers != null;
+    const tracing = env().getBool('TRACING');
+    const shouldTimeProgram = this.activeTimers != null || tracing;
     let query: WebGLQuery|CPUTimerQuery;
     if (shouldTimeProgram) {
       query = this.startTimer();
@@ -957,9 +974,13 @@ export class MathBackendWebGL extends KernelBackend {
     dataToDispose.forEach(info => this.disposeIntermediateTensorInfo(info));
 
     if (shouldTimeProgram) {
+      const name = program.constructor.name;
       query = this.endTimer(query);
-      this.activeTimers.push(
-          {name: program.constructor.name, query: this.getQueryTime(query)});
+      if (tracing) {
+        this.webGLQueries.push({name: name, query: query});
+      } else
+        this.activeTimers.push(
+            {name: name, query: this.getQueryTime(query)});
     }
 
     const glFlushThreshold = env().get('WEBGL_FLUSH_THRESHOLD');

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -143,6 +143,12 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   epsilon(): number {
     return this.floatPrecision() === 32 ? EPSILON_FLOAT32 : EPSILON_FLOAT16;
   }
+
+  /** Returns the smallest representable number.  */
+  async getKernelTimes(): Promise<any> {
+    return notYetImplemented('getKernelTimes');
+  }
+
   dispose(): void {
     return notYetImplemented('dispose');
   }

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -149,6 +149,11 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
     return notYetImplemented('getKernelTimes');
   }
 
+  setBatchSizes(batchSizes: number[]): void {
+    return notYetImplemented('getKernelTimes');
+  }
+
+
   dispose(): void {
     return notYetImplemented('dispose');
   }

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -35,6 +35,13 @@ ENV.registerFlag('DEBUG', () => false, debugValue => {
   }
 });
 
+/** Whether to enable tracing mode. */
+ENV.registerFlag('TRACING', () => false, tracingValue => {
+  if (tracingValue) {
+    console.warn('Tracing is ON. This has impacts on performance.');
+  }
+});
+
 /** Whether we are in a browser (as versus, say, node.js) environment. */
 ENV.registerFlag('IS_BROWSER', () => device_util.isBrowser());
 

--- a/tfjs-core/src/flags_test.ts
+++ b/tfjs-core/src/flags_test.ts
@@ -42,6 +42,30 @@ describe('DEBUG', () => {
   });
 });
 
+describe('TRACING', () => {
+  beforeEach(() => {
+    tf.env().reset();
+    spyOn(console, 'warn').and.callFake((msg: string) => {});
+  });
+  afterAll(() => tf.env().reset());
+
+  it('disabled by default', () => {
+    expect(tf.env().getBool('TRACING')).toBe(false);
+  });
+
+  it('warns when enabled', () => {
+    const consoleWarnSpy = console.warn as jasmine.Spy;
+    tf.env().set('TRACING', true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+    expect((consoleWarnSpy.calls.first().args[0] as string)
+               .startsWith('Tracing is ON. '))
+        .toBe(true);
+
+    expect(tf.env().getBool('TRACING')).toBe(true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+  });
+});
+
 // TODO (yassogba) figure out why this spy is not working / fix this test.
 describe('IS_BROWSER', () => {
   let isBrowser: boolean;


### PR DESCRIPTION
In the profile mode, timestamp will be resolved per op, the gpu burden is relatively heavy. This PR introduced a lightweight way to get timestamp,
resolve timestamp when read. This feature is guarded behind flag TRACING.

In addition to the resolve method difference, the time returned in profile mode is gpu execution time (milliseconds). The time returned by TRACING
is the start time and end time of gpu execution (nanoseconds).

For e2e, add tracing=true into the url will turn on tracing. For user application, set flag TRACING to true before predict.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6202)
<!-- Reviewable:end -->
