### PR TITLE
Add WebGPU to the release script

### DIFF
--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -25,7 +25,7 @@
 import * as argparse from 'argparse';
 import chalk from 'chalk';
 import * as shell from 'shelljs';
-import {RELEASE_UNITS, question, $, printReleaseUnit, printPhase, getReleaseBranch, checkoutReleaseBranch} from './release-util';
+import {RELEASE_UNITS, question, $, printReleaseUnit, printPhase, getReleaseBranch, checkoutReleaseBranch, ALPHA_RELEASE_UNIT, TFJS_RELEASE_UNIT} from './release-util';
 import * as fs from 'fs';
 
 const TMP_DIR = '/tmp/tfjs-publish';
@@ -56,7 +56,8 @@ async function main() {
   console.log(chalk.blue(`Using release unit ${releaseUnitInt}`));
   console.log();
 
-  const {name, phases} = RELEASE_UNITS[releaseUnitInt];
+  const releaseUnit = RELEASE_UNITS[releaseUnitInt];
+  const {name, phases} = releaseUnit;
 
   phases.forEach((_, i) => printPhase(phases, i));
   console.log();
@@ -70,7 +71,13 @@ async function main() {
   console.log(chalk.blue(`Using phase ${phaseInt}`));
   console.log();
 
-  let releaseBranch = await getReleaseBranch(name);
+  let releaseBranch: string;
+  if (releaseUnit === ALPHA_RELEASE_UNIT) {
+    // Alpha release unit is published with the tfjs release unit.
+    releaseBranch = await getReleaseBranch(TFJS_RELEASE_UNIT.name);
+  } else {
+    releaseBranch = await getReleaseBranch(name);
+  }
   console.log();
 
   checkoutReleaseBranch(releaseBranch, args.git_protocol, TMP_DIR);

--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -140,7 +140,7 @@ export const TFJS_RELEASE_UNIT: ReleaseUnit = {
 
 // TODO(mattsoulanille): Move WEBGPU_PHASE to TFJS_RELEASE_UNIT when webgpu
 // is out of alpha.
-// Alpha packages that use monorepo dependencies at the latest version but are
+// Alpha packages use monorepo dependencies at the latest version but are
 // not yet released at the same version number as the monorepo packages.
 // Use this for packages that will be a part of the monorepo in the future.
 // The release script will ask for a new version for each phase, and it will

--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -95,6 +95,11 @@ export const WASM_PHASE: Phase = {
   deps: ['tfjs-core', 'tfjs-backend-cpu']
 };
 
+export const WEBGPU_PHASE: Phase = {
+  packages: ['tfjs-backend-webgpu'],
+  deps: ['tfjs-core', 'tfjs-backend-cpu'],
+};
+
 export const VIS_PHASE: Phase = {
   packages: ['tfjs-vis']
 };
@@ -133,6 +138,13 @@ export const TFJS_RELEASE_UNIT: ReleaseUnit = {
   ]
 };
 
+// TODO(mattsoulanille): Move WEBGPU_PHASE to TFJS_RELEASE_UNIT when webgpu
+// is out of alpha.
+export const WEBGPU_RELEASE_UNIT: ReleaseUnit = {
+  name: 'tfjs',
+  phases: [WEBGPU_PHASE],
+};
+
 export const VIS_RELEASE_UNIT: ReleaseUnit = {
   name: 'vis',
   phases: [VIS_PHASE]
@@ -160,8 +172,9 @@ export const WEBSITE_RELEASE_UNIT: ReleaseUnit = {
 };
 
 export const RELEASE_UNITS: ReleaseUnit[] = [
-  TFJS_RELEASE_UNIT, VIS_RELEASE_UNIT, REACT_NATIVE_RELEASE_UNIT,
-  TFLITE_RELEASE_UNIT, AUTOML_RELEASE_UNIT, WEBSITE_RELEASE_UNIT
+  TFJS_RELEASE_UNIT, WEBGPU_RELEASE_UNIT, VIS_RELEASE_UNIT,
+  REACT_NATIVE_RELEASE_UNIT, TFLITE_RELEASE_UNIT, AUTOML_RELEASE_UNIT,
+  WEBSITE_RELEASE_UNIT,
 ];
 
 export const TMP_DIR = '/tmp/tfjs-release';

--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -146,7 +146,7 @@ export const TFJS_RELEASE_UNIT: ReleaseUnit = {
 // The release script will ask for a new version for each phase, and it will
 // replace 'link' dependencies with the new monorepo version.
 export const ALPHA_RELEASE_UNIT: ReleaseUnit = {
-  name: 'alpha monorepo packages',
+  name: 'alpha-monorepo-packages',
   phases: [WEBGPU_PHASE],
 };
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -30,7 +30,7 @@ import * as argparse from 'argparse';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import * as shell from 'shelljs';
-import {RELEASE_UNITS, WEBSITE_RELEASE_UNIT, TMP_DIR, $, question, printReleaseUnit, printPhase, makeReleaseDir, updateDependency, prepareReleaseBuild, createPR} from './release-util';
+import {RELEASE_UNITS, WEBSITE_RELEASE_UNIT, TMP_DIR, $, question, printReleaseUnit, printPhase, makeReleaseDir, updateDependency, prepareReleaseBuild, createPR, getPatchUpdateVersion} from './release-util';
 import {releaseWebsite} from './release-website';
 
 const parser = new argparse.ArgumentParser();
@@ -39,21 +39,6 @@ parser.addArgument('--git-protocol', {
   action: 'storeTrue',
   help: 'Use the git protocal rather than the http protocol when cloning repos.'
 });
-
-// Computes the default updated version (does a patch version update).
-function getPatchUpdateVersion(version: string): string {
-  const versionSplit = version.split('.');
-
-  // For alpha or beta version string (e.g. "0.0.1-alpha.5"), increase the
-  // number after alpha/beta.
-  if (versionSplit[2].includes('alpha') || versionSplit[2].includes('beta')) {
-    return [
-      versionSplit[0], versionSplit[1], versionSplit[2], +versionSplit[3] + 1
-    ].join('.');
-  }
-
-  return [versionSplit[0], versionSplit[1], +versionSplit[2] + 1].join('.');
-}
 
 async function main() {
   const args = parser.parseArgs();

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -30,7 +30,7 @@ import * as argparse from 'argparse';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import * as shell from 'shelljs';
-import {RELEASE_UNITS, WEBSITE_RELEASE_UNIT, TMP_DIR, $, question, printReleaseUnit, printPhase, makeReleaseDir, updateDependency, prepareReleaseBuild, createPR, getPatchUpdateVersion} from './release-util';
+import {RELEASE_UNITS, WEBSITE_RELEASE_UNIT, TMP_DIR, $, question, printReleaseUnit, printPhase, makeReleaseDir, updateDependency, prepareReleaseBuild, createPR, getPatchUpdateVersion, ALPHA_RELEASE_UNIT} from './release-util';
 import {releaseWebsite} from './release-website';
 
 const parser = new argparse.ArgumentParser();
@@ -43,20 +43,24 @@ parser.addArgument('--git-protocol', {
 async function main() {
   const args = parser.parseArgs();
 
-  RELEASE_UNITS.forEach((_, i) => printReleaseUnit(i));
+  // The alpha release unit is released with the monorepo and should not be
+  // released by this script. Packages in the alpha release unit need their
+  // package.json dependencies rewritten.
+  const releaseUnits = RELEASE_UNITS.filter(r => r !== ALPHA_RELEASE_UNIT);
+  releaseUnits.forEach((_, i) => printReleaseUnit(i));
   console.log();
 
   const releaseUnitStr =
       await question('Which release unit (leave empty for 0): ');
   const releaseUnitInt = +releaseUnitStr;
-  if (releaseUnitInt < 0 || releaseUnitInt >= RELEASE_UNITS.length) {
+  if (releaseUnitInt < 0 || releaseUnitInt >= releaseUnits.length) {
     console.log(chalk.red(`Invalid release unit: ${releaseUnitStr}`));
     process.exit(1);
   }
   console.log(chalk.blue(`Using release unit ${releaseUnitInt}`));
   console.log();
 
-  const releaseUnit = RELEASE_UNITS[releaseUnitInt];
+  const releaseUnit = releaseUnits[releaseUnitInt];
   const {name, phases} = releaseUnit;
 
   phases.forEach((_, i) => printPhase(phases, i));

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
Allow alpha packages that are part of the monorepo to be published alongside the monorepo with a different version number than the monorepo's version number. Add WebGPU as an alpha package.

Running `yarn release-tfjs` produces the following output. Since tfjs-backend-webgpu is an alpha package, the release script asks the user what version it should have.
```
New version for monorepo (leave empty for 3.15.0): 
> example_release
New version for alpha package tfjs-backend-webgpu (leave empty for 0.0.1-alpha.9): 
> example_webgpu_release
Commit of release candidate (the last successful nightly build): 
> c513dc30a5cd1820d6c05b4f42ec322b5a038517
```
This produces the following PR: #6208.

Alpha packages can be added to the ALPHA_RELEASE_UNIT in release-util.ts.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6209)
<!-- Reviewable:end -->
