### PR TITLE
[wasm] Fix threaded worker blob syntax error

### DIFF
--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -292,7 +292,10 @@ export async function init(): Promise<{wasm: BackendWasmModule}> {
      */
     factoryConfig.locateFile = (path, prefix) => {
       if (path.endsWith('.worker.js')) {
-        const response = wasmWorkerContents;
+        // Escape '\n' because Blob will turn it into a newline.
+        // There should be a setting for this, but 'endings: "native"' does
+        // not seem to work.
+        const response = (wasmWorkerContents as string).replace(/\n/g, '\\n');
         const blob = new Blob([response], {type: 'application/javascript'});
         return URL.createObjectURL(blob);
       }


### PR DESCRIPTION
JS's `Blob` replaces "\n" with a newline character. In the threaded worker bundle, there's a "\n" in `if(ENVIRONMENT_IS_NODE){fs.writeSync(2,text+"\n")`. When it is replaced with a newline, it splits a string across multiple lines, which is not valid JavaScript.

This change prevents Blob from doing that replacement by escaping the "\n" character as "\\n".

fixes #6203

This was not caught by presubmits because they do not run threaded tests. I'll fix this in another PR.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6214)
<!-- Reviewable:end -->
