### PR TITLE
[tfjs-data] Use '!IS_BROWSER' instead of 'IS_NODE' for detecting browser

### DIFF
--- a/tfjs-data/src/iterators/microphone_iterator.ts
+++ b/tfjs-data/src/iterators/microphone_iterator.ts
@@ -77,7 +77,7 @@ export class MicrophoneIterator extends LazyIterator<TensorContainer> {
 
   // Construct a MicrophoneIterator and start the audio stream.
   static async create(microphoneConfig: MicrophoneConfig = {}) {
-    if (env().get('IS_NODE')) {
+    if (!env().get('IS_BROWSER')) {
       throw new Error(
           'microphone API is only supported in browser environment.');
     }

--- a/tfjs-data/src/iterators/webcam_iterator.ts
+++ b/tfjs-data/src/iterators/webcam_iterator.ts
@@ -67,7 +67,7 @@ export class WebcamIterator extends LazyIterator<Tensor3D> {
   // Construct a WebcamIterator and start it's video stream.
   static async create(
       webcamVideoElement?: HTMLVideoElement, webcamConfig: WebcamConfig = {}) {
-    if (env().get('IS_NODE')) {
+    if (!env().get('IS_BROWSER')) {
       throw new Error(
           'tf.data.webcam is only supported in browser environment.');
     }


### PR DESCRIPTION
Make webcam and microphone iterators check the IS_BROWSER flag instead of the IS_NODE flag when checking environment compatability. This is more accurate because some browsers, like Electron, look like node but still have all the browser features required for webcams and microphones.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6240)
<!-- Reviewable:end -->
