### PR TITLE
Update e2e dependencies in a release PR

### DIFF
--- a/scripts/release-tfjs.ts
+++ b/scripts/release-tfjs.ts
@@ -27,7 +27,7 @@ import * as argparse from 'argparse';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import * as shell from 'shelljs';
-import {TMP_DIR, $, question, makeReleaseDir, createPR, TFJS_RELEASE_UNIT, updateTFJSDependencyVersions, ALPHA_RELEASE_UNIT, getMinorUpdateVersion, getPatchUpdateVersion} from './release-util';
+import {TMP_DIR, $, question, makeReleaseDir, createPR, TFJS_RELEASE_UNIT, updateTFJSDependencyVersions, ALPHA_RELEASE_UNIT, getMinorUpdateVersion, getPatchUpdateVersion, E2E_PHASE} from './release-util';
 
 const parser = new argparse.ArgumentParser();
 
@@ -89,7 +89,9 @@ async function main() {
   $(`git push origin ${releaseBranch}`);
 
   // Update versions in package.json files.
-  const phases = [...TFJS_RELEASE_UNIT.phases, ...ALPHA_RELEASE_UNIT.phases];
+  const phases = [
+    ...TFJS_RELEASE_UNIT.phases, ...ALPHA_RELEASE_UNIT.phases, E2E_PHASE
+  ];
   for (const phase of phases) {
     for (const packageName of phase.packages) {
       shell.cd(packageName);

--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -130,6 +130,16 @@ export const WEBSITE_PHASE: Phase = {
   title: 'Update website to latest dependencies.'
 };
 
+// Note that e2e is not actually published. As a result, this phase is not
+// included in any release unit, however, it is used for updating dependencies.
+export const E2E_PHASE: Phase = {
+  packages: ['e2e'],
+  deps: [
+    'tfjs', 'tfjs-backend-cpu', 'tfjs-backend-wasm', 'tfjs-backend-webgl',
+    'tfjs-converter', 'tfjs-core', 'tfjs-data', 'tfjs-layers', 'tfjs-node'
+  ],
+}
+
 export const TFJS_RELEASE_UNIT: ReleaseUnit = {
   name: 'tfjs',
   phases: [


### PR DESCRIPTION
Update e2e dependencies to the versions that are released when releasing the tfjs monorepo. This fixes a failure in release tests where e2e tries to install 'link:' dependencies.

[Link to 3.15.0 verdaccio test after this PR](https://pantheon.corp.google.com/cloud-build/builds/66d69999-ab57-4d3c-a735-0bdfdcaa672f;step=0?project=learnjs-174218).

Add a '--local' option to the release-tfjs script to prevent creating a release PR. This is just for development and makes it easier to see the output of the script.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6254)
<!-- Reviewable:end -->
