### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -279,7 +279,7 @@ export async function updateDependency(
 
       let relaxedVersionPrefix = '';
       if (version.startsWith('~') || version.startsWith('^')) {
-        relaxedVersionPrefix = version.substr(0, 1);
+        relaxedVersionPrefix = version.slice(0, 1);
       }
       const depVersionLatest = relaxedVersionPrefix + depsLatestVersion[j];
 
@@ -337,7 +337,7 @@ export function updateTFJSDependencyVersions(
 
     let relaxedVersionPrefix = '';
     if (version.startsWith('~') || version.startsWith('^')) {
-      relaxedVersionPrefix = version.substr(0, 1);
+      relaxedVersionPrefix = version.slice(0, 1);
     }
     const versionLatest = relaxedVersionPrefix + newVersion;
 

--- a/scripts/tag-version.js
+++ b/scripts/tag-version.js
@@ -22,7 +22,7 @@ const fs = require('fs');
 
 let dirName = process.argv[2];
 if (dirName.endsWith('/')) {
-  dirName = dirName.substr(0, dirName.length - 1);
+  dirName = dirName.slice(0, -1);
 }
 const packageJsonFile = dirName + '/package.json';
 if (!fs.existsSync(packageJsonFile)) {

--- a/tfjs-converter/src/operations/operation_mapper.ts
+++ b/tfjs-converter/src/operations/operation_mapper.ts
@@ -191,7 +191,7 @@ export class OperationMapper {
       category: mapper.category,
       inputNames:
           (node.input ||
-           []).map(input => input.startsWith('^') ? input.substr(1) : input),
+           []).map(input => input.startsWith('^') ? input.slice(1) : input),
       inputs: [],
       children: [],
       inputParams: {},

--- a/tfjs-data/src/sources/file_data_source.ts
+++ b/tfjs-data/src/sources/file_data_source.ts
@@ -46,7 +46,7 @@ export class FileDataSource extends DataSource {
     if (isLocalPath(this.input) && env().get('IS_NODE')) {
       // tslint:disable-next-line:no-require-imports
       const fs = require('fs');
-      this.input = fs.readFileSync((this.input as string).substr(7));
+      this.input = fs.readFileSync((this.input as string).slice(7));
     }
     // TODO(kangyizhang): Add LocalFileChunkIterator to split local streaming
     // with file in browser.

--- a/tfjs-data/src/util/source_util.ts
+++ b/tfjs-data/src/util/source_util.ts
@@ -20,5 +20,5 @@
 // input.
 // tslint:disable-next-line:no-any
 export function isLocalPath(source: any): boolean {
-  return (typeof source === 'string') && source.substr(0, 7) === 'file://';
+  return (typeof source === 'string') && source.slice(0, 7) === 'file://';
 }

--- a/tfjs-layers/src/engine/topology.ts
+++ b/tfjs-layers/src/engine/topology.ts
@@ -1232,7 +1232,7 @@ export abstract class Layer extends serialization.Serializable {
         // TODO(cais): Restore the following and use `providedWeights`, instead
         // of `weights` in the error message, once the deeplearn.js bug is
         // fixed: https://github.com/PAIR-code/deeplearnjs/issues/498 const
-        // providedWeights = JSON.stringify(weights).substr(0, 50);
+        // providedWeights = JSON.stringify(weights).slice(0, 50);
         throw new ValueError(
             `You called setWeights(weights) on layer "${this.name}" ` +
             `with a weight list of length ${weights.length}, ` +

--- a/tfjs-node/scripts/deps-stage.js
+++ b/tfjs-node/scripts/deps-stage.js
@@ -40,7 +40,7 @@ if (os.platform() !== 'win32') {
 
 // Some windows machines contain a trailing " char:
 if (targetDir != undefined && targetDir.endsWith('"')) {
-  targetDir = targetDir.substr(0, targetDir.length - 1);
+  targetDir = targetDir.slice(0, -1);
 }
 
 // Setup dest binary paths:


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6255)
<!-- Reviewable:end -->
