### PR TITLE
Fix publish-npm.ts for packages with no dependencies

### DIFF
--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -96,11 +96,13 @@ async function main() {
     // Check the package.json for 'link:' and 'file:' dependencies.
     const packageJson = JSON.parse(fs.readFileSync('package.json')
         .toString('utf8')) as {dependencies: Record<string, string>};
-    for (let [dep, depVersion] of Object.entries(packageJson.dependencies)) {
-      const start = depVersion.slice(0,5);
-      if (start === 'link:' || start === 'file:') {
-        throw new Error(`${pkg} has a '${start}' dependency on ${dep}. `
-                       + 'Refusing to publish.');
+    if (packageJson.dependencies) {
+      for (let [dep, depVersion] of Object.entries(packageJson.dependencies)) {
+        const start = depVersion.slice(0,5);
+        if (start === 'link:' || start === 'file:') {
+          throw new Error(`${pkg} has a '${start}' dependency on ${dep}. `
+                          + 'Refusing to publish.');
+        }
       }
     }
 


### PR DESCRIPTION
Do not try to check `dependencies` of a package.json file if the package.json file has no `dependencies`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6258)
<!-- Reviewable:end -->
