### PR TITLE
Fix release unit printing

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -218,8 +218,7 @@ export function $(cmd: string) {
   return result.stdout.trim();
 }
 
-export function printReleaseUnit(id: number) {
-  const releaseUnit = RELEASE_UNITS[id];
+export function printReleaseUnit(releaseUnit: ReleaseUnit, id: number) {
   console.log(chalk.green(`Release unit ${id}:`));
   console.log(` packages: ${
       chalk.blue(releaseUnit.phases.map(phase => phase.packages.join(', '))

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -47,7 +47,7 @@ async function main() {
   // released by this script. Packages in the alpha release unit need their
   // package.json dependencies rewritten.
   const releaseUnits = RELEASE_UNITS.filter(r => r !== ALPHA_RELEASE_UNIT);
-  releaseUnits.forEach((_, i) => printReleaseUnit(i));
+  releaseUnits.forEach((unit, index) => printReleaseUnit(unit, index));
   console.log();
 
   const releaseUnitStr =


### PR DESCRIPTION
Printing with release units was controlled by index, but that's not always accurate. Pass the actual release unit value to the print function instead.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6266)
<!-- Reviewable:end -->
