### PR TITLE
webgpu: storage variables shouldn't be structs

### DIFF
--- a/tfjs-backend-webgpu/src/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/argminmax_webgpu.ts
@@ -18,9 +18,8 @@
 import {backend_util} from '@tensorflow/tfjs-core';
 
 import {getMainHeaderAndGlobalIndexString} from './shader_preprocessor';
-import {computeDispatch, flatDispatchLayout} from './webgpu_util';
-
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ArgMinMaxProgram implements WebGPUProgram {
   outputShape: number[];
@@ -129,7 +128,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
 
         for (var k = i32(localId.x); k < Length && outputIndex < uniforms.size;
             k = k + i32(workGroupSizeX)) {
-          let candidate = f32(x.numbers[getInputIndex(coordInfo, k)]);
+          let candidate = f32(x[getInputIndex(coordInfo, k)]);
           if (!isnan(candidate) && candidate ${this.op} bestValue) {
             bestValue = candidate;
             bestIndex = k;

--- a/tfjs-backend-webgpu/src/binary_op_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/binary_op_shared_webgpu.ts
@@ -17,11 +17,10 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 
-import {getMainHeaderAndGlobalIndexString} from './shader_preprocessor';
-import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
-
+import {getMainHeaderAndGlobalIndexString} from './shader_preprocessor';
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class BinaryOpSharedProgram implements WebGPUProgram {
   outputShape: number[];
@@ -90,7 +89,7 @@ export class BinaryOpSharedProgram implements WebGPUProgram {
         this.lastDimensionSize}; localIndex = localIndex + ${
         this.workGroupSize[0]}) {
             sharedBuf[localIndex] = f32(${
-        this.useSharedMemoryWithB ? 'B' : 'A'}.numbers[localIndex]);
+        this.useSharedMemoryWithB ? 'B' : 'A'}[localIndex]);
           }
           workgroupBarrier();
 

--- a/tfjs-backend-webgpu/src/conv2d_mm_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv2d_mm_vec4_webgpu.ts
@@ -81,12 +81,13 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
       this.variableNames.push('leakyreluAlpha');
     }
 
-    this.tileAOuter = this.outputShape[1] === 1 ? 1 :
+    this.tileAOuter = this.outputShape[1] === 1 ?
+        1 :
         this.workGroupSize[1] * this.elementsPerThread[1];
     this.tileBOuter = this.workGroupSize[0] * this.elementsPerThread[0];
     this.tileInner = this.tileBOuter;
     [this.fitA, this.fitB] = this.getShapeFit();
-    this.shaderKey =`conv2DMMVec4_${this.activation}_${this.fitA}_${
+    this.shaderKey = `conv2DMMVec4_${this.activation}_${this.fitA}_${
         this.fitB}_${this.elementsPerThread}`;
   }
 
@@ -109,14 +110,14 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         index} = getIndexFromCoords4D(coord, uniforms.xShape);
     let divBy4Remainder${index} = flatIndex${index} % 4;
     let divBy4Index${index} = flatIndex${index} / 4;
-    let curData${index} = x.numbers[divBy4Index${index}];
+    let curData${index} = x[divBy4Index${index}];
     if (divBy4Remainder${index} == 0) {
       temp = curData${index};
     } else {
       // TODO: This could end up being a redundant load with another one in
       // the same shader invocation. Perhaps there's an opportunity for
       // optimization
-      let nextData${index} = x.numbers[divBy4Index${index} + 1];
+      let nextData${index} = x[divBy4Index${index} + 1];
       if (divBy4Remainder${index} == 1) {
         temp = vec4<f32>(curData${index}.yzw, nextData${index}.x);
       } else if (divBy4Remainder${index} == 2) {
@@ -129,8 +130,9 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
   }
 
   getUserCode(): string {
-    const matMulSource = makeMatMulPackedVec4Source(this.elementsPerThread,
-        this.tileAOuter, this.tileBOuter, this.tileInner);
+    const matMulSource = makeMatMulPackedVec4Source(
+        this.elementsPerThread, this.tileAOuter, this.tileBOuter,
+        this.tileInner);
 
     const remainder = this.convInfo.inChannels % 4;
     // Below code only applys to valid padding type.
@@ -138,7 +140,7 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         `// The bounds checking is always needed since we use it to pad zero for
           // the 'same' padding type.
           if (coordsInBounds4D(coord, uniforms.xShape)) {
-            resData = x.numbers[getIndexFromCoords4D(coord, uniforms.xShape) / 4];
+            resData = x[getIndexFromCoords4D(coord, uniforms.xShape) / 4];
           } else {
             resData = vec4<f32>(0.0); }` :
         `var temp = vec4<f32>(0.0);
@@ -181,9 +183,9 @@ export class Conv2DMMVec4Program implements WebGPUProgram {
         `;
 
     const sampleB = this.fitB ?
-        `return W.numbers[row * uniforms.dimBOuter / 4 + col];` :
+        `return W[row * uniforms.dimBOuter / 4 + col];` :
         `if(coordsInBounds2D(vec2<i32>(row, col * 4), vec2<i32>(uniforms.dimInner, uniforms.dimBOuter))) {
-           return W.numbers[row * uniforms.dimBOuter / 4 + col];
+           return W[row * uniforms.dimBOuter / 4 + col];
          }
          return vec4<f32>(0.0);
         `;

--- a/tfjs-backend-webgpu/src/conv2d_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv2d_mm_webgpu.ts
@@ -17,11 +17,10 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d, tilesFitEvenlyIntoShape} from './webgpu_util';
 import {mapActivationToShaderProgram} from './activation_util';
-
 import {makeMatMulPackedSource} from './matmul_packed_webgpu';
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d, tilesFitEvenlyIntoShape} from './webgpu_util';
 
 export class Conv2DMMProgram implements WebGPUProgram {
   outputShape: number[];
@@ -117,7 +116,7 @@ export class Conv2DMMProgram implements WebGPUProgram {
     // The bounds checking is always needed since we use it to pad zero for the
     // 'same' padding type.
     if(coordsInBounds4D(coord, uniforms.xShape)) {
-      return x.numbers[getIndexFromCoords4D(coord, uniforms.xShape)];
+      return x[getIndexFromCoords4D(coord, uniforms.xShape)];
     }
     return 0.0;`;
 
@@ -130,9 +129,9 @@ export class Conv2DMMProgram implements WebGPUProgram {
     `;
 
     const sampleB = this.fitB ?
-        `return W.numbers[row * uniforms.dimBOuter + col];` :
+        `return W[row * uniforms.dimBOuter + col];` :
         `if(coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimInner, uniforms.dimBOuter))) {
-           return W.numbers[row * uniforms.dimBOuter + col];
+           return W[row * uniforms.dimBOuter + col];
 	 }
 	 return 0.0;
 	 `;
@@ -157,9 +156,8 @@ export class Conv2DMMProgram implements WebGPUProgram {
       applyActivationSnippet = `value = activation(value, outCoord);`;
     }
 
-    const addBiasSnippet = this.addBias ?
-        'value = value + getBiasByOutputCoords(outCoord);' :
-        '';
+    const addBiasSnippet =
+        this.addBias ? 'value = value + getBiasByOutputCoords(outCoord);' : '';
 
     const userCode = `
     ${activationSnippet}
@@ -182,7 +180,7 @@ export class Conv2DMMProgram implements WebGPUProgram {
           col);
       ${addBiasSnippet}
       ${applyActivationSnippet}
-      result.numbers[getIndexFromCoords4D(outCoord, uniforms.outShape)] = value;
+      result[getIndexFromCoords4D(outCoord, uniforms.outShape)] = value;
     }
     ${matMulSource}
   `;

--- a/tfjs-backend-webgpu/src/conv_backprop_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv_backprop_mm_webgpu.ts
@@ -17,10 +17,9 @@
 
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
-import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d} from './webgpu_util';
-
 import {makeMatMulPackedSource} from './matmul_packed_webgpu';
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d} from './webgpu_util';
 
 export class Conv2DDerInputMMProgram implements WebGPUProgram {
   outputShape: number[];
@@ -75,7 +74,7 @@ export class Conv2DDerInputMMProgram implements WebGPUProgram {
         i32(xR),
         i32(xC),
         col % uniforms.outBackprop[3]);
-    return x.numbers[getIndexFromCoords4D(coord, uniforms.xShape)];`;
+    return x[getIndexFromCoords4D(coord, uniforms.xShape)];`;
 
     const sampleA = `if (row < uniforms.dimAOuter && col < uniforms.dimInner) {
       ${readASnippet}
@@ -97,7 +96,7 @@ export class Conv2DDerInputMMProgram implements WebGPUProgram {
           coordX >= 0 && coordY >= 0) {
         let coord = vec4<i32>(coordX, coordY, col,
             row % uniforms.outBackprop[3]);
-        return W.numbers[getIndexFromCoords4D(coord, uniforms.wShape)];
+        return W[getIndexFromCoords4D(coord, uniforms.wShape)];
       }
       return 0.0;
     }
@@ -110,7 +109,7 @@ export class Conv2DDerInputMMProgram implements WebGPUProgram {
           row / uniforms.outShape[2],
           row % uniforms.outShape[2],
           col);
-      result.numbers[getIndexFromCoords4D(outCoord, uniforms.outShape)] = value;
+      result[getIndexFromCoords4D(outCoord, uniforms.outShape)] = value;
     }
 
     ${matMulSource}

--- a/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels_utils/from_pixels_webgpu.ts
@@ -16,10 +16,10 @@
  */
 
 import {util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString} from '../../shader_preprocessor';
 
-import {computeDispatch, flatDispatchLayout, WebGPULayout} from '../../webgpu_util';
+import {getMainHeaderAndGlobalIndexString} from '../../shader_preprocessor';
 import {WebGPUProgram} from '../../webgpu_program';
+import {computeDispatch, flatDispatchLayout, WebGPULayout} from '../../webgpu_util';
 
 export class FromPixelsProgram implements WebGPUProgram {
   outputShape: number[] = [0];
@@ -75,7 +75,7 @@ export class FromPixelsProgram implements WebGPUProgram {
           if (flatIndex < uniforms.size) {
             let coords = getCoordsFromIndex(flatIndexBase);
             let values = ${textureLoad};
-            result.numbers[flatIndex] = i32(floor(255.0 * values[i]));
+            result[flatIndex] = i32(floor(255.0 * values[i]));
           }
         }
       }

--- a/tfjs-backend-webgpu/src/matmul_packed_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_vec4_webgpu.ts
@@ -17,16 +17,16 @@
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
+import {mapActivationToShaderProgram} from './activation_util';
 import {getMainHeaderString} from './shader_preprocessor';
+import {WebGPUProgram} from './webgpu_program';
 import {computeDispatch, tilesFitEvenlyIntoShape} from './webgpu_util';
 
-import {mapActivationToShaderProgram} from './activation_util';
-import {WebGPUProgram} from './webgpu_program';
-
-export function makeMatMulPackedVec4Source(workPerThread: number[],
-    tileAOuter: number, tileBOuter: number, tileInner: number): string {
+export function makeMatMulPackedVec4Source(
+    workPerThread: number[], tileAOuter: number, tileBOuter: number,
+    tileInner: number): string {
   util.assert(
-    tileInner % 4 === 0 && workPerThread[0] === 4,
+      tileInner % 4 === 0 && workPerThread[0] === 4,
       () => 'tileInner must be divisible by 4. And ColPerThread must be 4');
   return `
   var<workgroup> mm_Asub : array<array<vec4<f32>, ${
@@ -44,7 +44,7 @@ export function makeMatMulPackedVec4Source(workPerThread: number[],
     let tileCol = i32(localId.x);
 
     let globalRow = ${
-        tileAOuter === 1 ? '0' : 'i32(globalId.y) * RowPerThread'};
+      tileAOuter === 1 ? '0' : 'i32(globalId.y) * RowPerThread'};
     let globalCol = i32(globalId.x);
     let numTiles = (uniforms.dimInner - 1) / TileInner + 1;
 
@@ -115,9 +115,9 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
   addBias: boolean;
   activation: backend_util.Activation;
   hasPreluActivationWeights: boolean;
-  tileAOuter:number;
-  tileBOuter:number;
-  tileInner:number;
+  tileAOuter: number;
+  tileBOuter: number;
+  tileInner: number;
   fitA: boolean;
   fitB: boolean;
 
@@ -148,7 +148,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
       this.variableNames.push('preluActivationWeights');
     }
 
-    this.tileAOuter = outputShape[1] === 1 ? 1 :
+    this.tileAOuter = outputShape[1] === 1 ?
+        1 :
         this.workGroupSize[1] * this.elementsPerThread[1];
     this.tileBOuter = this.workGroupSize[0] * this.elementsPerThread[0];
     this.tileInner = this.tileBOuter;
@@ -160,8 +161,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
 
     [this.fitA, this.fitB] = this.getShapeFit();
 
-    this.shaderKey = `matMulPackedVec4_${this.activation}_${
-        this.fitA}_${this.fitB}_${this.elementsPerThread}`;
+    this.shaderKey = `matMulPackedVec4_${this.activation}_${this.fitA}_${
+        this.fitB}_${this.elementsPerThread}`;
   }
 
   getShapeFit(): boolean[] {
@@ -179,16 +180,16 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
 
   getUserCode(): string {
     const sampleA = this.fitA ?
-        `return A.numbers[batch * batchASize + row * uniforms.dimInner / 4 + col]` :
+        `return A[batch * batchASize + row * uniforms.dimInner / 4 + col]` :
         `if (coordsInBounds2D(vec2<i32>(row, col * 4), vec2<i32>(uniforms.dimAOuter, uniforms.dimInner))) {
-            return A.numbers[batch * batchASize + row * uniforms.dimInner / 4 + col];
+            return A[batch * batchASize + row * uniforms.dimInner / 4 + col];
         }
         return vec4<f32>(0.0)`;
 
     const sampleB = this.fitB ?
-        `return B.numbers[batch * batchBSize + row * uniforms.dimBOuter / 4 + col]` :
+        `return B[batch * batchBSize + row * uniforms.dimBOuter / 4 + col]` :
         `if(coordsInBounds2D(vec2<i32>(row, col * 4), vec2<i32>(uniforms.dimInner, uniforms.dimBOuter))) {
-             return B.numbers[batch * batchBSize + row * uniforms.dimBOuter / 4 + col];
+             return B[batch * batchBSize + row * uniforms.dimBOuter / 4 + col];
         }
         return vec4<f32>(0.0)`;
 
@@ -211,9 +212,8 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
 
       applyActivationSnippet = 'value = activation(value, outCoord);';
     }
-    const addBiasSnippet = this.addBias ?
-        'value = value + getBiasByOutputCoords(outCoord);' :
-        '';
+    const addBiasSnippet =
+        this.addBias ? 'value = value + getBiasByOutputCoords(outCoord);' : '';
 
     const userCode = `
       ${activationSnippet}
@@ -240,8 +240,10 @@ export class MatMulPackedVec4Program implements WebGPUProgram {
           setOutputAtCoords(outCoord[0], outCoord[1], outCoord[2], value);
         }
       }
-      ${makeMatMulPackedVec4Source(this.elementsPerThread,
-          this.tileAOuter, this.tileBOuter, this.tileInner)}
+      ${
+        makeMatMulPackedVec4Source(
+            this.elementsPerThread, this.tileAOuter, this.tileBOuter,
+            this.tileInner)}
     `;
 
     return userCode;

--- a/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
@@ -17,11 +17,10 @@
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
-import {getMainHeaderString} from './shader_preprocessor';
-import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from './webgpu_util';
-
 import {mapActivationToShaderProgram} from './activation_util';
+import {getMainHeaderString} from './shader_preprocessor';
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, computeWorkGroupSizeForMatMul, tilesFitEvenlyIntoShape} from './webgpu_util';
 
 export function makeMatMulPackedSource(
     workPerThread: number[], workGroupSize: [number, number, number]): string {
@@ -271,16 +270,16 @@ export class MatMulPackedProgram implements WebGPUProgram {
 
     if (this.transposeA === false) {
       sampleA = this.fitA ?
-          `return A.numbers[batch * batchASize + row * uniforms.dimInner + col];` :
+          `return A[batch * batchASize + row * uniforms.dimInner + col];` :
           `if(coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimAOuter, uniforms.dimInner))) {
-             return A.numbers[batch * batchASize + row * uniforms.dimInner + col];
+             return A[batch * batchASize + row * uniforms.dimInner + col];
            }
            return 0.0;`;
     } else {
       sampleA = this.fitA ?
-          `return A.numbers[batch * batchASize + col * uniforms.dimAOuter + row];` :
+          `return A[batch * batchASize + col * uniforms.dimAOuter + row];` :
           `if(coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimAOuter, uniforms.dimInner))) {
-             return A.numbers[batch* batchASize + col * uniforms.dimAOuter + row];
+             return A[batch* batchASize + col * uniforms.dimAOuter + row];
            }
            return 0.0;`;
     }
@@ -288,16 +287,16 @@ export class MatMulPackedProgram implements WebGPUProgram {
     let sampleB;
     if (this.transposeB === false) {
       sampleB = this.fitB ?
-          `return B.numbers[batch * batchBSize + row * uniforms.dimBOuter + col];` :
+          `return B[batch * batchBSize + row * uniforms.dimBOuter + col];` :
           `if(coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimInner, uniforms.dimBOuter))) {
-             return B.numbers[batch * batchBSize + row * uniforms.dimBOuter + col];
+             return B[batch * batchBSize + row * uniforms.dimBOuter + col];
            }
            return 0.0;`;
     } else {
       sampleB = this.fitB ?
-          `return B.numbers[batch * batchBSize + col * uniforms.dimInner + row];` :
+          `return B[batch * batchBSize + col * uniforms.dimInner + row];` :
           `if(coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimInner, uniforms.dimBOuter))) {
-             return B.numbers[batch * batchBSize + col * uniforms.dimInner + row];
+             return B[batch * batchBSize + col * uniforms.dimInner + row];
            }
            return 0.0;`;
     }
@@ -322,9 +321,8 @@ export class MatMulPackedProgram implements WebGPUProgram {
       applyActivationSnippet = 'value = activation(value, outCoord);';
     }
 
-    const addBiasSnippet = this.addBias ?
-        'value = value + getBiasByOutputCoords(outCoord);' :
-        '';
+    const addBiasSnippet =
+        this.addBias ? 'value = value + getBiasByOutputCoords(outCoord);' : '';
 
     const userCode = `
       ${activationSnippet}

--- a/tfjs-backend-webgpu/src/matmul_reduce.ts
+++ b/tfjs-backend-webgpu/src/matmul_reduce.ts
@@ -17,11 +17,10 @@
 
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
-import {getMainHeaderString} from './shader_preprocessor';
-import {computeDispatch} from './webgpu_util';
-
 import {mapActivationToShaderProgram} from './activation_util';
+import {getMainHeaderString} from './shader_preprocessor';
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch} from './webgpu_util';
 
 export function makeMatMulReduceSource(): string {
   return `
@@ -104,20 +103,18 @@ export class MatMulReduceProgram implements WebGPUProgram {
   getUserCode(): string {
     let sampleA;
     if (this.transposeA === false) {
-      sampleA =
-          `return A.numbers[batch * batchASize + row * uniforms.dimInner + col];`;
+      sampleA = `return A[batch * batchASize + row * uniforms.dimInner + col];`;
     } else {
       sampleA =
-          `return A.numbers[batch * batchASize + col * uniforms.dimAOuter + row];`;
+          `return A[batch * batchASize + col * uniforms.dimAOuter + row];`;
     }
 
     let sampleB;
     if (this.transposeB === false) {
       sampleB =
-          `return B.numbers[batch * batchBSize + row * uniforms.dimBOuter + col];`;
+          `return B[batch * batchBSize + row * uniforms.dimBOuter + col];`;
     } else {
-      sampleB =
-          `return B.numbers[batch * batchBSize + col * uniforms.dimInner + row];`;
+      sampleB = `return B[batch * batchBSize + col * uniforms.dimInner + row];`;
     }
 
     let activationSnippet = '', applyActivationSnippet = '';
@@ -140,9 +137,8 @@ export class MatMulReduceProgram implements WebGPUProgram {
       applyActivationSnippet = 'value = activation(value, outCoord);';
     }
 
-    const addBiasSnippet = this.addBias ?
-        'value = value + getBiasByOutputCoords(outCoord);' :
-        '';
+    const addBiasSnippet =
+        this.addBias ? 'value = value + getBiasByOutputCoords(outCoord);' : '';
 
     const userCode = `
       ${activationSnippet}

--- a/tfjs-backend-webgpu/src/matmul_small_output_size_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_small_output_size_webgpu.ts
@@ -16,8 +16,9 @@
  */
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
-import {getMainHeaderString} from './shader_preprocessor';
+
 import {mapActivationToShaderProgram} from './activation_util';
+import {getMainHeaderString} from './shader_preprocessor';
 import {WebGPUProgram} from './webgpu_program';
 
 export function makeMatMulSmallOutputSizeSource(
@@ -164,13 +165,13 @@ export class MatMulSmallOutputSizeProgram implements WebGPUProgram {
   getUserCode(): string {
     const sampleA =
         `if (coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimAOuter, uniforms.dimInner))) {
-          return A.numbers[batch * batchASize + row * uniforms.dimInner + col];
+          return A[batch * batchASize + row * uniforms.dimInner + col];
         }
         return 0.0;`;
 
     const sampleB =
         `if (coordsInBounds2D(vec2<i32>(row, col), vec2<i32>(uniforms.dimInner, uniforms.dimBOuter))) {
-           return B.numbers[batch * batchBSize + row * uniforms.dimBOuter + col];
+           return B[batch * batchBSize + row * uniforms.dimBOuter + col];
          }
          return 0.0;`;
 
@@ -193,9 +194,8 @@ export class MatMulSmallOutputSizeProgram implements WebGPUProgram {
       applyActivationSnippet = 'value = activation(value, outCoord);';
     }
 
-    const addBiasSnippet = this.addBias ?
-        'value = value + getBiasByOutputCoords(outCoord);' :
-        '';
+    const addBiasSnippet =
+        this.addBias ? 'value = value + getBiasByOutputCoords(outCoord);' : '';
 
     const userCode = `
       ${activationSnippet}

--- a/tfjs-backend-webgpu/src/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/reduce_webgpu.ts
@@ -61,7 +61,7 @@ export class ReduceProgram implements WebGPUProgram {
          } else if (!isnan(bestValue) && candidate ${
           this.reduceType === 'min' ? '<' : '>'} bestValue)
            {  bestValue = candidate; }`;
-      initValue = 'f32(x.numbers[offset])';
+      initValue = 'f32(x[offset])';
     } else if (this.reduceType === 'sum' || this.reduceType === 'mean') {
       reduceOp = ' bestValue = bestValue + candidate; ';
     } else if (this.reduceType === 'prod') {
@@ -100,7 +100,7 @@ export class ReduceProgram implements WebGPUProgram {
          let WorkPerThread = DIV_CEIL(u32(Length), workGroupSizeX);
          for (var k = i32(localId.x); k < Length && outputIndex < uniforms.size;
              k = k + i32(workGroupSizeX)) {
-           let candidate = f32(x.numbers[offset + k]);
+           let candidate = f32(x[offset + k]);
            ${reduceOp}
          }
          xBestValues[localId.x] = bestValue;

--- a/tfjs-backend-webgpu/src/scatter_optimized_webgpu.ts
+++ b/tfjs-backend-webgpu/src/scatter_optimized_webgpu.ts
@@ -18,9 +18,8 @@
 import {DataType} from '@tensorflow/tfjs-core';
 
 import {getCoordsDataType, getMainHeaderAndGlobalIndexString} from './shader_preprocessor';
-import {computeDispatch, flatDispatchLayout} from './webgpu_util';
-
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ScatterOptimizedProgram implements WebGPUProgram {
   variableNames = ['updates', 'indices'];
@@ -94,14 +93,14 @@ export class ScatterOptimizedProgram implements WebGPUProgram {
     // atomicAdd only supports uint/int type. For float, we use
     // atomicCompareExchangeWeak to simulate.
     const atomicAddSnippet = this.type === 'int32' ?
-        `atomicAdd(&(result.numbers[flatIndex]), i32(updateValue));` :
+        `atomicAdd(&(result[flatIndex]), i32(updateValue));` :
         `
-     var assumed = atomicLoad(&(result.numbers[flatIndex]));
+     var assumed = atomicLoad(&(result[flatIndex]));
      var success = 0;
      for (; success == 0;) {
        let new = bitcast<f32>(assumed) + updateValue;
        let newI32 = bitcast<i32>(new);
-       let resValue = atomicCompareExchangeWeak(&(result.numbers[flatIndex]), assumed, newI32);
+       let resValue = atomicCompareExchangeWeak(&(result[flatIndex]), assumed, newI32);
        assumed = resValue[0];
        success = resValue[1];
      }

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -93,7 +93,6 @@ export function getMainHeaderAndGlobalIndexString(): string {
 export function makeShader(
     inputInfo: InputInfo[], outputData: {dtype: DataType, shape: number[]},
     program: ProgramParams, isFromPixel = false): string {
-
   const prefixSnippets: string[] = [];
   prefixSnippets.push(`
     let workGroupSizeX = ${program.workGroupSize[0]}u;
@@ -124,9 +123,6 @@ export function makeShader(
 
   if (isFromPixel === true) {
     prefixSnippets.push(`
-      struct Matrix0 {
-        numbers: array<${mapToWgslTypes(outputData.dtype, program.isVec4)}>;
-      };
       struct Uniform {
         size            : i32;
         numChannels     : i32;
@@ -134,7 +130,8 @@ export function makeShader(
         dispatchSize    : vec3<u32>;
       };
 
-      @group(0) @binding(0) var<storage, write> result : Matrix0;
+      @group(0) @binding(0) var<storage, write> result: array<${
+        mapToWgslTypes(outputData.dtype, program.isVec4)}>;
       @group(0) @binding(2) var<uniform> uniforms: Uniform;
     `);
     return [
@@ -170,34 +167,25 @@ export function makeShader(
   // Output buffer.
   if (program.atomic) {
     prefixSnippets.push(`
-    struct Matrix0 {
-        numbers: array<atomic<i32>>;
-    };
-
-    @group(0) @binding(0) var<storage, read_write> result : Matrix0;
+    @group(0) @binding(0) var<storage, read_write> result: array<atomic<i32>>;
   `);
   } else {
     prefixSnippets.push(`
-    struct Matrix0 {
-        numbers: array<${mapToWgslTypes(outputData.dtype, program.isVec4)}>;
-    };
-
-    @group(0) @binding(0) var<storage, write> result : Matrix0;
+    @group(0) @binding(0) var<storage, write> result: array<${
+        mapToWgslTypes(outputData.dtype, program.isVec4)}>;
   `);
   }
   program.variableNames.forEach((x, i) => {
     prefixSnippets.push(`
-    struct Matrix${1 + i} {
-      numbers: array<${mapToWgslTypes(inputInfo[i].dtype, program.isVec4)}>;
-    };
-    @group(0) @binding(${1 + i}) var<storage, read> ${x} : Matrix${1 + i};
+    @group(0) @binding(${1 + i}) var<storage, read> ${x}: array<${
+        mapToWgslTypes(inputInfo[i].dtype, program.isVec4)}>;
     `);
   });
 
   if (uniformDeclaration !== '') {
     prefixSnippets.push(`
     @group(0) @binding(${
-        1 + program.variableNames.length}) var<uniform> uniforms : Uniforms;
+        1 + program.variableNames.length}) var<uniform> uniforms: Uniforms;
     `);
   }
 
@@ -205,27 +193,24 @@ export function makeShader(
       getOutputCoordsSnippet(outputData.shape, program.dispatchLayout);
 
   const sources = [
-    commonSnippet,
-    prefixSnippets.join('\n'),
-    getCoordsFromIndexSnippet(outputData.shape),
-    coordsSnippet,
+    commonSnippet, prefixSnippets.join('\n'),
+    getCoordsFromIndexSnippet(outputData.shape), coordsSnippet,
     getOutputIndexFromCoordsSnippet(outputData.shape.length)
   ];
   if (!program.atomic) {
-    sources.push(setOutputSnippet(
-        outputData.shape, outputData.dtype, program.isVec4));
+    sources.push(
+        setOutputSnippet(outputData.shape, outputData.dtype, program.isVec4));
   }
   if (dispatchLayoutRank === outputData.shape.length) {
     // Input snippet is only meaningful when the output isn't getting
     // implicitly reshaped (like it does in conv2d_matmul).
-    const inputSnippet =
-        inputInfo
-            .map(
-                x => getInputSnippet(
-                    x, outputData.shape, program.isVec4,
-                    program.dispatchLayout.x.length ===
-                        outputData.shape.length))
-            .join('\n');
+    const inputSnippet = inputInfo
+                             .map(
+                                 x => getInputSnippet(
+                                     x, outputData.shape, program.isVec4,
+                                     program.dispatchLayout.x.length ===
+                                         outputData.shape.length))
+                             .join('\n');
     sources.push(inputSnippet);
   }
 
@@ -330,17 +315,17 @@ function setOutputSnippet(
   let snippet;
   if (isVec4) {
     snippet = `fn setOutputAtIndex(flatIndex : i32, value : vec4<f32>) {
-      result.numbers[flatIndex] = ${wgslType}(value);
+      result[flatIndex] = ${wgslType}(value);
     }
     fn setOutputAtIndexI32(flatIndex : i32, value : vec4<i32>) {
-      result.numbers[flatIndex] = ${wgslType}(value);
+      result[flatIndex] = ${wgslType}(value);
     }`;
   } else {
     snippet = `fn setOutputAtIndex(flatIndex : i32, value : f32) {
-      result.numbers[flatIndex] = ${wgslType}(value);
+      result[flatIndex] = ${wgslType}(value);
     }
     fn setOutputAtIndexI32(flatIndex : i32, value : i32) {
-      result.numbers[flatIndex] = ${wgslType}(value);
+      result[flatIndex] = ${wgslType}(value);
     }`;
   }
   if (outRank >= 2) {
@@ -362,11 +347,13 @@ function setOutputSnippet(
     `;
     } else {
       snippet += `
-      fn setOutputAtCoords(${dims.map(d => `${d} : i32`).join(', ')}, value : f32) {
+      fn setOutputAtCoords(${
+          dims.map(d => `${d} : i32`).join(', ')}, value : f32) {
         let flatIndex = getOutputIndexFromCoords(${type}(${dims.join(', ')}));
         setOutputAtIndex(flatIndex, value);
       }
-      fn setOutputAtCoordsI32(${dims.map(d => `${d} : i32`).join(', ')}, value : i32) {
+      fn setOutputAtCoordsI32(${
+          dims.map(d => `${d} : i32`).join(', ')}, value : i32) {
         let flatIndex = getOutputIndexFromCoords(${type}(${dims.join(', ')}));
         setOutputAtIndexI32(flatIndex, value);
       }
@@ -404,14 +391,14 @@ function getInputAtCoordsSnippet(
     if (isVec4) {
       return `
         fn ${funcName}() -> vec4<f32> {
-          return vec4<f32>(${texName}.numbers[0]);
+          return vec4<f32>(${texName}[0]);
         }
       `;
     }
 
     return `
       fn ${funcName}() ->f32 {
-        return f32(${texName}.numbers[0]);
+        return f32(${texName}[0]);
       }
     `;
   }
@@ -426,7 +413,7 @@ function getInputAtCoordsSnippet(
   if (isVec4) {
     return `
       fn ${funcName}(${inputs}) -> vec4<f32> {
-        return vec4<f32>(${texName}.numbers[getIndexFromCoords${rankStr}(${type}(${
+        return vec4<f32>(${texName}[getIndexFromCoords${rankStr}(${type}(${
         dims.join(',')}),
           ${shapeStr}) / 4]);
       }
@@ -435,7 +422,7 @@ function getInputAtCoordsSnippet(
 
   return `
     fn ${funcName}(${inputs}) -> f32 {
-      return f32(${texName}.numbers[getIndexFromCoords${rankStr}(${type}(${
+      return f32(${texName}[getIndexFromCoords${rankStr}(${type}(${
       dims.join(',')}),
         ${shapeStr})]);
     }
@@ -461,22 +448,22 @@ export function getInputByOutputSnippet(
     if (isVec4) {
       return `
         fn ${funcName}Index(globalIndex : i32) -> vec4<f32> {
-          return vec4<f32>(${texName}.numbers[globalIndex]);
+          return vec4<f32>(${texName}[globalIndex]);
         }
 
         fn ${funcName}Coords(coords : ${type}) -> vec4<f32> {
-          return vec4<f32>(${texName}.numbers[${
+          return vec4<f32>(${texName}[${
           outRank > 1 ? 'getOutputIndexFromCoords(coords)' : 'coords'} / 4]);
         }
         `;
     } else {
       return `
       fn ${funcName}Index(globalIndex : i32) -> f32 {
-        return f32(${texName}.numbers[globalIndex]);
+        return f32(${texName}[globalIndex]);
       }
 
       fn ${funcName}Coords(coords : ${type}) -> f32 {
-        return f32(${texName}.numbers[${
+        return f32(${texName}[${
           outRank > 1 ? 'getOutputIndexFromCoords(coords)' : 'coords'}]);
       }
       `;
@@ -541,14 +528,14 @@ export function getInputByOutputSnippet(
       fn ${funcName}Index(globalIndex : i32) -> vec4<f32> {
         var coords = getCoordsFromIndex(globalIndex);
         ${coordsSnippet}
-        return ${texName}.numbers[getIndexFromCoords${rankStr}(${
+        return ${texName}[getIndexFromCoords${rankStr}(${
         unpackedCoordsSnippet}, ${shapeStr}) / 4];
       }
 
       fn ${funcName}Coords(coordsIn : ${type}) -> vec4<f32> {
         var coords = coordsIn;
         ${coordsSnippet}
-        return ${texName}.numbers[getIndexFromCoords${rankStr}(${
+        return ${texName}[getIndexFromCoords${rankStr}(${
         unpackedCoordsSnippet}, ${shapeStr}) / 4];
       }
     `;
@@ -558,14 +545,14 @@ export function getInputByOutputSnippet(
     fn ${funcName}Index(globalIndex : i32) -> f32 {
       var coords = getCoordsFromIndex(globalIndex);
       ${coordsSnippet}
-      return f32(${texName}.numbers[getIndexFromCoords${rankStr}(${
+      return f32(${texName}[getIndexFromCoords${rankStr}(${
       unpackedCoordsSnippet}, ${shapeStr})]);
     }
 
     fn ${funcName}Coords(coordsIn : ${type}) -> f32 {
       var coords = coordsIn;
       ${coordsSnippet}
-      return f32(${texName}.numbers[getIndexFromCoords${rankStr}(${
+      return f32(${texName}[getIndexFromCoords${rankStr}(${
       unpackedCoordsSnippet}, ${shapeStr})]);
     }
   `;

--- a/tfjs-backend-webgpu/src/transpose_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transpose_shared_webgpu.ts
@@ -16,9 +16,8 @@
  */
 
 import {getWorkGroupSizeString} from './shader_preprocessor';
-import {computeDispatch} from './webgpu_util';
-
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch} from './webgpu_util';
 
 export class TransposeSharedProgram implements WebGPUProgram {
   variableNames = ['A'];
@@ -55,8 +54,7 @@ export class TransposeSharedProgram implements WebGPUProgram {
         let width = uniforms.outShape[0];
         let height = uniforms.outShape[1];
         if (x < width && y < height) {
-          tile[localId.y][localId.x] =
-              A.numbers[y * width + x];
+          tile[localId.y][localId.x] = A[y * width + x];
         }
         workgroupBarrier();
 

--- a/tfjs-backend-webgpu/src/transpose_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transpose_webgpu.ts
@@ -16,9 +16,8 @@
  */
 
 import {getCoordsDataType, getMainHeaderAndGlobalIndexString} from './shader_preprocessor';
-import {computeDispatch, flatDispatchLayout} from './webgpu_util';
-
 import {WebGPUProgram} from './webgpu_program';
+import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class TransposeProgram implements WebGPUProgram {
   variableNames = ['A'];
@@ -57,7 +56,7 @@ export class TransposeProgram implements WebGPUProgram {
           let flatIndex = index * ${this.workPerThread} + i;
           if(flatIndex < uniforms.size) {
             let resRC = getCoordsFromIndex(flatIndex);
-            setOutputAtIndex(flatIndex, A.numbers[getIndexFromCoords${
+            setOutputAtIndex(flatIndex, A[getIndexFromCoords${
         this.outputShape.length}D(
               ${dtype}(${switched}), uniforms.aShape)]);
           }


### PR DESCRIPTION
webgpu spec removes the restriction that store type for
buffer must be structure, and this patch removes the
unnecessary structures.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6274)
<!-- Reviewable:end -->
