### PR TITLE
Add TensorListLength op

### DIFF
--- a/tfjs-converter/docs/supported_ops.md
+++ b/tfjs-converter/docs/supported_ops.md
@@ -100,6 +100,7 @@
 |TensorListFromTensor|TensorListFromTensor|
 |TensorListGather|TensorListGather|
 |TensorListGetItem|TensorListGetItem|
+|TensorListLength|TensorListLength|
 |TensorListPopBack|TensorListPopBack|
 |TensorListPushBack|TensorListPushBack|
 |TensorListReserve|TensorListReserve|

--- a/tfjs-converter/python/tensorflowjs/op_list/control.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/control.json
@@ -810,5 +810,16 @@
         "type": "dtype"
       }
     ]
+  },
+  {
+    "tfOpName": "TensorListLength",
+    "category": "control",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "tensorListId",
+        "type": "tensor"
+      }
+    ]
   }
 ]

--- a/tfjs-converter/src/metadata_test.ts
+++ b/tfjs-converter/src/metadata_test.ts
@@ -60,6 +60,7 @@ describe('kernel2op metadata file', () => {
       'TensorListFromTensor',
       'TensorListGather',
       'TensorListGetItem',
+      'TensorListLength',
       'TensorListPopBack',
       'TensorListPushBack',
       'TensorListReserve',

--- a/tfjs-converter/src/operations/executors/control_executor.ts
+++ b/tfjs-converter/src/operations/executors/control_executor.ts
@@ -366,6 +366,12 @@ export const executeOp: InternalOpAsyncExecutor = async(
       context.addTensorList(tensorList);
       return [tensorList.idTensor];
     }
+    case 'TensorListLength': {
+      const idTensor =
+          getParamValue('tensorListId', node, tensorMap, context) as Tensor;
+      const tensorList = context.getTensorList(idTensor.id);
+      return [scalar(tensorList.size(), 'int32')];
+    }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);
   }

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -1007,7 +1007,7 @@ describe('control', () => {
         const size = await executeOp(node, {input2}, context);
         expect(size.length).toEqual(1);
         expect(size[0].shape).toEqual([]);
-        test_util.expectArraysClose(size[0].dataSync(), new Int32Array([2]));
+        test_util.expectArraysClose(size[0].dataSync(), new Array([2]));
       });
 
       it('should match json def', () => {

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -993,5 +993,29 @@ describe('control', () => {
         expect(validateParam(node, control.json)).toBeTruthy();
       });
     });
+
+    describe('TensorListLength', () => {
+      it('should get the size of tensorList', async () => {
+        const input4 = tensor1d([0, 0, 0], 'int32');
+        const input5 = tensor1d([1, 1, 1], 'int32');
+        const tensorList = new TensorList([input4, input5], [3], 'int32', 5);
+        context.addTensorList(tensorList);
+        node.op = 'TensorListLength';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+        node.inputNames = ['input2'];
+        const input2 = [tensorList.idTensor];
+        const size = await executeOp(node, {input2}, context);
+        expect(size.length).toEqual(1);
+        expect(size[0].shape).toEqual([]);
+        test_util.expectArraysClose(size[0].dataSync(), new Int32Array([2]));
+      });
+
+      it('should match json def', () => {
+        node.op = 'TensorListLength';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+
+        expect(validateParam(node, control.json)).toBeTruthy();
+      });
+    });
   });
 });

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -1007,7 +1007,7 @@ describe('control', () => {
         const size = await executeOp(node, {input2}, context);
         expect(size.length).toEqual(1);
         expect(size[0].shape).toEqual([]);
-        test_util.expectArraysClose(size[0].dataSync(), new Array([2]));
+        test_util.expectArraysClose(size[0].dataSync(), [2]);
       });
 
       it('should match json def', () => {


### PR DESCRIPTION
Add `TensorListLength` op, as mentioned in [Issue](https://github.com/tensorflow/tfjs/issues/6077).

Here is the corresponding TensorListLength op in TensorFlow:
https://www.tensorflow.org/api_docs/python/tf/raw_ops/TensorListLength?hl=vi

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6282)
<!-- Reviewable:end -->
