### PR TITLE
Add TensorListResize op

### DIFF
--- a/tfjs-converter/docs/supported_ops.md
+++ b/tfjs-converter/docs/supported_ops.md
@@ -100,6 +100,7 @@
 |TensorListFromTensor|TensorListFromTensor|
 |TensorListGather|TensorListGather|
 |TensorListGetItem|TensorListGetItem|
+|TensorListLength|TensorListLength|
 |TensorListPopBack|TensorListPopBack|
 |TensorListPushBack|TensorListPushBack|
 |TensorListReserve|TensorListReserve|

--- a/tfjs-converter/docs/supported_ops.md
+++ b/tfjs-converter/docs/supported_ops.md
@@ -104,6 +104,7 @@
 |TensorListPopBack|TensorListPopBack|
 |TensorListPushBack|TensorListPushBack|
 |TensorListReserve|TensorListReserve|
+|TensorListResize|TensorListResize|
 |TensorListScatter|TensorListScatter|
 |TensorListScatterV2|TensorListScatterV2|
 |TensorListSetItem|TensorListSetItem|

--- a/tfjs-converter/python/tensorflowjs/op_list/control.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/control.json
@@ -821,5 +821,21 @@
         "type": "tensor"
       }
     ]
+  },
+  {
+    "tfOpName": "TensorListResize",
+    "category": "control",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "tensorListId",
+        "type": "tensor"
+      },
+      {
+        "start": 1,
+        "name": "size",
+        "type": "number"
+      }
+    ]
   }
 ]

--- a/tfjs-converter/python/tensorflowjs/op_list/control.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/control.json
@@ -810,5 +810,16 @@
         "type": "dtype"
       }
     ]
+  },
+  {
+    "tfOpName": "TensorListLength",
+    "category": "control",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "tensorListId",
+        "type": "tensor"
+      }
+    ]
   }
 ]

--- a/tfjs-converter/src/executor/tensor_list.ts
+++ b/tfjs-converter/src/executor/tensor_list.ts
@@ -184,7 +184,14 @@ export class TensorList {
       throw new Error(`TensorListResize input size ${
           size} is greater maxNumElement ${this.maxNumElements}.`);
     }
-    this.tensors.length = size;
+
+    const destTensorList: TensorList = new TensorList(
+        [], this.elementShape, this.elementDtype, this.maxNumElements);
+    destTensorList.tensors.length = size;
+    for (let i = 0; i < Math.min(this.tensors.length, size); ++i) {
+      destTensorList.tensors[i] = this.tensors[i];
+    }
+    return destTensorList;
   }
 
   /**

--- a/tfjs-converter/src/metadata_test.ts
+++ b/tfjs-converter/src/metadata_test.ts
@@ -60,6 +60,7 @@ describe('kernel2op metadata file', () => {
       'TensorListFromTensor',
       'TensorListGather',
       'TensorListGetItem',
+      'TensorListLength',
       'TensorListPopBack',
       'TensorListPushBack',
       'TensorListReserve',

--- a/tfjs-converter/src/metadata_test.ts
+++ b/tfjs-converter/src/metadata_test.ts
@@ -64,6 +64,7 @@ describe('kernel2op metadata file', () => {
       'TensorListPopBack',
       'TensorListPushBack',
       'TensorListReserve',
+      'TensorListResize',
       'TensorListScatter',
       'TensorListScatterV2',
       'TensorListSetItem',

--- a/tfjs-converter/src/operations/executors/control_executor.ts
+++ b/tfjs-converter/src/operations/executors/control_executor.ts
@@ -366,6 +366,12 @@ export const executeOp: InternalOpAsyncExecutor = async(
       context.addTensorList(tensorList);
       return [tensorList.idTensor];
     }
+    case 'TensorListLength': {
+      const idTensor =
+          getParamValue('tensorListId', node, tensorMap, context) as Tensor;
+      const tensorList = context.getTensorList(idTensor.id);
+      return [scalar(tensorList.size(), 'int32')];
+    }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);
   }

--- a/tfjs-converter/src/operations/executors/control_executor.ts
+++ b/tfjs-converter/src/operations/executors/control_executor.ts
@@ -372,6 +372,15 @@ export const executeOp: InternalOpAsyncExecutor = async(
       const tensorList = context.getTensorList(idTensor.id);
       return [scalar(tensorList.size(), 'int32')];
     }
+    case 'TensorListResize': {
+      const idTensor =
+          getParamValue('tensorListId', node, tensorMap, context) as Tensor;
+      const size = getParamValue('size', node, tensorMap, context) as number;
+
+      const tensorList = context.getTensorList(idTensor.id);
+      tensorList.resize(size);
+      return [tensorList.idTensor];
+    }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);
   }

--- a/tfjs-converter/src/operations/executors/control_executor.ts
+++ b/tfjs-converter/src/operations/executors/control_executor.ts
@@ -377,9 +377,10 @@ export const executeOp: InternalOpAsyncExecutor = async(
           getParamValue('tensorListId', node, tensorMap, context) as Tensor;
       const size = getParamValue('size', node, tensorMap, context) as number;
 
-      const tensorList = context.getTensorList(idTensor.id);
-      tensorList.resize(size);
-      return [tensorList.idTensor];
+      const srcTensorList = context.getTensorList(idTensor.id);
+      const destTensorList = srcTensorList.resize(size);
+      context.addTensorList(destTensorList);
+      return [destTensorList.idTensor];
     }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -1017,5 +1017,45 @@ describe('control', () => {
         expect(validateParam(node, control.json)).toBeTruthy();
       });
     });
+
+    describe('TensorListResize', () => {
+      it('should match the size when reducing the size', async () => {
+        const input4 = tensor1d([0, 0, 0], 'int32');
+        const input5 = tensor1d([1, 1, 1], 'int32');
+        const tensorList = new TensorList([input4, input5], [3], 'int32', 5);
+        context.addTensorList(tensorList);
+        node.op = 'TensorListResize';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+        node.inputParams['size'] = createNumberAttrFromIndex(1);
+        node.inputNames = ['input2', 'input3'];
+        const input2 = [tensorList.idTensor];
+        const input3 = [scalar(1)];
+        await executeOp(node, {input2, input3}, context);
+        expect(tensorList.size()).toEqual(1);
+      });
+
+      it('should match the size when increasing the size', async () => {
+        const input4 = tensor1d([0, 0, 0], 'int32');
+        const input5 = tensor1d([1, 1, 1], 'int32');
+        const tensorList = new TensorList([input4, input5], [3], 'int32', 5);
+        context.addTensorList(tensorList);
+        node.op = 'TensorListResize';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+        node.inputParams['size'] = createNumberAttrFromIndex(1);
+        node.inputNames = ['input2', 'input3'];
+        const input2 = [tensorList.idTensor];
+        const input3 = [scalar(3)];
+        await executeOp(node, {input2, input3}, context);
+        expect(tensorList.size()).toEqual(3);
+      });
+
+      it('should match json def', () => {
+        node.op = 'TensorListResize';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+        node.inputParams['size'] = createNumberAttrFromIndex(1);
+
+        expect(validateParam(node, control.json)).toBeTruthy();
+      });
+    });
   });
 });

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -1030,23 +1030,27 @@ describe('control', () => {
         node.inputNames = ['input2', 'input3'];
         const input2 = [tensorList.idTensor];
         const input3 = [scalar(1)];
-        await executeOp(node, {input2, input3}, context);
-        expect(tensorList.size()).toEqual(1);
+        const tensorListId =
+            (await executeOp(node, {input2, input3}, context))[0];
+        const destTensorList = context.getTensorList(tensorListId.id);
+        expect(destTensorList.size()).toEqual(1);
       });
 
       it('should match the size when increasing the size', async () => {
         const input4 = tensor1d([0, 0, 0], 'int32');
         const input5 = tensor1d([1, 1, 1], 'int32');
-        const tensorList = new TensorList([input4, input5], [3], 'int32', 5);
-        context.addTensorList(tensorList);
+        const srcTensorList = new TensorList([input4, input5], [3], 'int32', 5);
+        context.addTensorList(srcTensorList);
         node.op = 'TensorListResize';
         node.inputParams['tensorListId'] = createTensorAttr(0);
         node.inputParams['size'] = createNumberAttrFromIndex(1);
         node.inputNames = ['input2', 'input3'];
-        const input2 = [tensorList.idTensor];
+        const input2 = [srcTensorList.idTensor];
         const input3 = [scalar(3)];
-        await executeOp(node, {input2, input3}, context);
-        expect(tensorList.size()).toEqual(3);
+        const destTensorListId =
+            (await executeOp(node, {input2, input3}, context))[0];
+        const destTensorList = context.getTensorList(destTensorListId.id);
+        expect(destTensorList.size()).toEqual(3);
       });
 
       it('should match json def', () => {

--- a/tfjs-converter/src/operations/executors/control_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/control_executor_test.ts
@@ -993,5 +993,29 @@ describe('control', () => {
         expect(validateParam(node, control.json)).toBeTruthy();
       });
     });
+
+    describe('TensorListLength', () => {
+      it('should get the size of tensorList', async () => {
+        const input4 = tensor1d([0, 0, 0], 'int32');
+        const input5 = tensor1d([1, 1, 1], 'int32');
+        const tensorList = new TensorList([input4, input5], [3], 'int32', 5);
+        context.addTensorList(tensorList);
+        node.op = 'TensorListLength';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+        node.inputNames = ['input2'];
+        const input2 = [tensorList.idTensor];
+        const size = await executeOp(node, {input2}, context);
+        expect(size.length).toEqual(1);
+        expect(size[0].shape).toEqual([]);
+        test_util.expectArraysClose(size[0].dataSync(), new Int32Array([2]));
+      });
+
+      it('should match json def', () => {
+        node.op = 'TensorListLength';
+        node.inputParams['tensorListId'] = createTensorAttr(0);
+
+        expect(validateParam(node, control.json)).toBeTruthy();
+      });
+    });
   });
 });


### PR DESCRIPTION
Add `TensorListResize` op, as mentioned in [Issue](https://github.com/tensorflow/tfjs/issues/6077), and update the `resize` method of TensorList.

Here is the corresponding TensorListResize op in TensorFlow:
https://www.tensorflow.org/api_docs/python/tf/raw_ops/TensorListResize

The original `resize` method of TensorList is in-place, while the TensorFlow's implementation is out-place, and currently there are no reference to the `resize` method in tfjs code base, so updated the implementation to the out-place way.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6283)
<!-- Reviewable:end -->
