### PR TITLE
[converter] Remove executeAsync() warning when running a sync model

### DIFF
--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -499,11 +499,6 @@ export class GraphExecutor implements FunctionExecutor {
           outputNodeNames, intermediateTensorConsumerCount, usedNodes);
       await Promise.all(promises);
     }
-    if (dynamicNode == null && !isFunctionExecution) {
-      console.warn(
-          `This model execution did not contain any nodes with control flow ` +
-          `or dynamic output shapes. You can use model.execute() instead.`);
-    }
     const missingOutputs =
         outputNodes
             .filter(

--- a/tfjs-converter/src/executor/graph_model_test.ts
+++ b/tfjs-converter/src/executor/graph_model_test.ts
@@ -835,26 +835,6 @@ describe('Model', () => {
 });
 
 describe('Graph execution gives actionable errors', () => {
-  it('executeAsync warns when there are no dynamic ops', async () => {
-    const customLoader: tfc.io.IOHandler = {
-      load: async () => ({
-        modelTopology: SIMPLE_MODEL,
-        weightSpecs: weightsManifest,
-        weightData: new Int32Array([5]).buffer,
-      })
-    };
-    const model = await loadGraphModel(customLoader);
-    spyOn(console, 'warn');
-    const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
-    await model.executeAsync(input);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn)
-        .toHaveBeenCalledWith(
-            'This model execution did not contain any nodes with control ' +
-            'flow or dynamic output shapes. You can use model.execute() ' +
-            'instead.');
-  });
-
   it('executeAsync does not warn when there are dynamic ops', async () => {
     const customLoader: tfc.io.IOHandler = {
       load: async () => ({
@@ -868,35 +848,6 @@ describe('Graph execution gives actionable errors', () => {
     const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
     await model.executeAsync(input);
     expect(console.warn).toHaveBeenCalledTimes(0);
-  });
-
-  it('executeAsync warns when the subgraph has no dynamic ops', async () => {
-    const graphDef: tensorflow.IGraphDef = {
-      node: [
-        {name: 'input', op: 'Placeholder'},
-        {name: 'intermediate', op: 'Enter', input: ['input']},
-        {name: 'intermediate2', op: 'Sqrt', input: ['intermediate']},
-        {name: 'output', op: 'Square', input: ['intermediate2']},
-      ],
-      versions: {producer: 1.0, minConsumer: 3}
-    };
-    const customLoader: tfc.io.IOHandler = {
-      load: async () => ({
-        modelTopology: graphDef,
-        weightSpecs: weightsManifest,
-        weightData: new Int32Array([5]).buffer,
-      })
-    };
-    const model = await loadGraphModel(customLoader);
-    spyOn(console, 'warn');
-    const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
-    await model.executeAsync({'intermediate2': input});
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn)
-        .toHaveBeenCalledWith(
-            'This model execution did not contain any nodes with control ' +
-            'flow or dynamic output shapes. You can use model.execute() ' +
-            'instead.');
   });
 
   it('executeAsync works when the subgraph has no unknown ops', async () => {


### PR DESCRIPTION
Do not warn the user when they run a synchronous model with model.executeAsync(), which should be allowed for both types of models. Users can check if their model has async ops by trying to run it with model.execute(), which will throw an error if it contains async ops. This is a better experience because users who need synchronous execution will try this anyway, and users who don't can just use model.executeAsync() without seeing warning messages.

fixes #6249

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.