### PR TITLE
[webgpu] Use GPUComputePassEncoder.end() instead of endPass()

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "buildifier-ci": "./scripts/buildifier-ci.sh"
   },
   "dependencies": {
-    "@webgpu/types": "0.1.6",
+    "@webgpu/types": "0.1.13",
     "node-fetch": "^2.6.7"
   },
   "resolutions": {

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -158,10 +158,7 @@ export class WebGPUBackend extends KernelBackend {
       this.dummyCanvas.width = 1;
       this.dummyCanvas.height = 1;
 
-      // TODO: @webgpu/types 0.1.6 version has a bug to support both old
-      // rendring context type and webgpu context type. Use any to bypass this.
-      // tslint:disable-next-line:no-any
-      this.dummyContext = this.dummyCanvas.getContext('webgpu') as any;
+      this.dummyContext = this.dummyCanvas.getContext('webgpu');
       this.dummyContext.configure({
         device,
         format: 'bgra8unorm',
@@ -364,7 +361,7 @@ export class WebGPUBackend extends KernelBackend {
 
   ensureComputePassEnded() {
     if (this.currentComputePass) {
-      this.currentComputePass.endPass();
+      this.currentComputePass.end();
       this.currentComputePass = null;
     }
   }
@@ -795,7 +792,7 @@ export class WebGPUBackend extends KernelBackend {
     const pass = this.getComputePass();
     if (shouldTimeProgram) {
       if (this.supportTimeQuery) {
-        pass.writeTimestamp(this.querySet, 0);
+        (pass as any).writeTimestamp(this.querySet, 0);
       }
     }
     pass.setPipeline(pipeline);
@@ -804,7 +801,7 @@ export class WebGPUBackend extends KernelBackend {
         program.dispatch[0], program.dispatch[1], program.dispatch[2]);
     if (shouldTimeProgram) {
       if (this.supportTimeQuery) {
-        pass.writeTimestamp(this.querySet, 1);
+        (pass as any).writeTimestamp(this.querySet, 1);
       }
     }
     this.dispatchNumberInEncoder++;
@@ -863,20 +860,20 @@ export class WebGPUBackend extends KernelBackend {
       ],
     });
     this.ensureCommandEncoderReady();
-    const passEncoder = this.getComputePass();
+    const pass = this.getComputePass();
     const shouldTimeProgram = this.activeTimers != null;
     if (shouldTimeProgram) {
       if (this.supportTimeQuery) {
-        passEncoder.writeTimestamp(this.querySet, 0);
+        (pass as any).writeTimestamp(this.querySet, 0);
       }
     }
-    passEncoder.setPipeline(program.pipeline);
-    passEncoder.setBindGroup(0, bindGroup);
-    passEncoder.dispatch(
+    pass.setPipeline(program.pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatch(
         program.dispatch[0], program.dispatch[1], program.dispatch[2]);
     if (shouldTimeProgram) {
       if (this.supportTimeQuery) {
-        passEncoder.writeTimestamp(this.querySet, 1);
+        (pass as any).writeTimestamp(this.querySet, 1);
       }
     }
     this.commandQueueOwnedIds.add(outputId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,10 +367,10 @@
   resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.6.tgz#1ea2db791362bd8521548d664dbd3c5311cdf4b6"
   integrity sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==
 
-"@webgpu/types@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.6.tgz#91c89d950449fa0d2c7802de3a6b3c3a9054f392"
-  integrity sha512-5c3ZxNmGwVhTo8nW0b0iEaSVLTx89D056c7JzbzC2f9J+qebRM+U9rH52q9Z/HwZbZQTUAYX5UGp0c4BNv61Ew==
+"@webgpu/types@0.1.13":
+  version "0.1.13"
+  resolved "https://registry.npmmirror.com/@webgpu/types/-/types-0.1.13.tgz#afb6ac170884b29bc8f05e68fac74835b92acb9f"
+  integrity sha512-SAq8FRONvMANQi/eXw5ArKfSvih6am/EC+5y7+du2xf1VyprtKn4ylUPKGW4T6ZkDogtH3xZgGE+J/cx601L5w==
 
 "@xmldom/xmldom@^0.7.3":
   version "0.7.5"


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6310)
<!-- Reviewable:end -->
