### PR TITLE
[webgpu] Resolve timestamp when read

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -92,7 +92,9 @@ limitations under the License.
     let urlState = null;
     let runTimes = 50;
     let profileTimes = 1;
+    let tracingRepeat = 10;
     let warmupTimes = 1;
+    let tracing = false;
     // Default do not run any task.
     let task = '';
     function getURLState(url) {
@@ -111,6 +113,12 @@ limitations under the License.
       }
       if (params.has('task')) {
         task = params.get('task');
+      }
+      if (params.has('tracing')) {
+        tracing = params.get('tracing') === 'true';
+      }
+      if (params.has('tracingrepeat')) {
+        tracingRepeat = Number(params.get('tracingrepeat'));
       }
       return params;
     }
@@ -590,6 +598,20 @@ limitations under the License.
       appendRow(timeTable, '', '');
     }
 
+    async function tracingPredictTime(repeat = 10) {
+      await showMsg(`Running tracing`);
+      tf.env().set('TRACING', true);
+      const tracingStart = performance.now();
+      let [timeInfo, kernelTimes] = await timeInferenceForTracing(() => predict(model), repeat);
+      console.log("predictbegin"+JSON.stringify(timeInfo)+ "predictend");
+      for (let item in kernelTimes) {
+        console.log('gpudatabegin' + JSON.stringify(kernelTimes[item]) + 'gpudataend');
+      }
+      appendRow(timeTable, `Tracing average ${repeat}`, printTime(timeInfo.averageTime));
+      tf.env().set('TRACING', false);
+      await showMsg(null);
+    }
+
     async function profileMemoryAndKernelTime() {
       if (state.numProfiles == 0) {
         return;
@@ -730,7 +752,11 @@ limitations under the License.
 
       await warmUpAndRecordTime();
       await measureAveragePredictTime();
-      await profileMemoryAndKernelTime();
+      if (tracing) {
+        await tracingPredictTime(tracingRepeat);
+      } else {
+        await profileMemoryAndKernelTime();
+      }
       urlState = null;
     }
 

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -46,7 +46,7 @@ const whereImpl = kernel_impls.whereImpl;
 
 export const EPSILON_FLOAT32 = 1e-7;
 export const EPSILON_FLOAT16 = 1e-4;
-
+type QueryResults = number|Array<{name: string; query: number[]}>;
 type KernelInfo = {
   name: string; query: Promise<number>;
 };
@@ -140,6 +140,7 @@ export class MathBackendWebGL extends KernelBackend {
   private gpgpuCreatedLocally: boolean;
   private numMBBeforeWarning: number;
   private warnedAboutMemory = false;
+  private webGLQueries: {name: string, query: WebGLQuery}[] = [];
 
   constructor(gpuResource?: GPGPUContext|HTMLCanvasElement|OffscreenCanvas) {
     super();
@@ -602,6 +603,21 @@ export class MathBackendWebGL extends KernelBackend {
     return timerQuery.endMs - timerQuery.startMs;
   }
 
+
+  async getKernelTimes(): Promise < number|{
+    name: string;
+    query: number[]}[] > {
+    const queryResults: QueryResults = [];
+    for(let i =0 ;i < this.webGLQueries.length; i ++) {
+      const kernelTime = await this.getQueryTime(this.webGLQueries[i].query);
+      queryResults[i] = {
+        name: this.webGLQueries[i].name,
+        query: [kernelTime, kernelTime]
+      };
+    }
+    return queryResults;
+  }
+
   private pendingDeletes = 0;
 
   /**
@@ -943,7 +959,8 @@ export class MathBackendWebGL extends KernelBackend {
       return gpgpu_math.compileProgram(
           this.gpgpu, program, inputsData, outputData);
     });
-    const shouldTimeProgram = this.activeTimers != null;
+    const tracing = env().getBool('TRACING');
+    const shouldTimeProgram = this.activeTimers != null || tracing;
     let query: WebGLQuery|CPUTimerQuery;
     if (shouldTimeProgram) {
       query = this.startTimer();
@@ -957,9 +974,13 @@ export class MathBackendWebGL extends KernelBackend {
     dataToDispose.forEach(info => this.disposeIntermediateTensorInfo(info));
 
     if (shouldTimeProgram) {
+      const name = program.constructor.name;
       query = this.endTimer(query);
-      this.activeTimers.push(
-          {name: program.constructor.name, query: this.getQueryTime(query)});
+      if (tracing) {
+        this.webGLQueries.push({name: name, query: query});
+      } else
+        this.activeTimers.push(
+            {name: name, query: this.getQueryTime(query)});
     }
 
     const glFlushThreshold = env().get('WEBGL_FLUSH_THRESHOLD');

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -143,6 +143,17 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   epsilon(): number {
     return this.floatPrecision() === 32 ? EPSILON_FLOAT32 : EPSILON_FLOAT16;
   }
+
+  /** Returns the smallest representable number.  */
+  async getKernelTimes(): Promise<any> {
+    return notYetImplemented('getKernelTimes');
+  }
+
+  setBatchSizes(batchSizes: number[]): void {
+    return notYetImplemented('getKernelTimes');
+  }
+
+
   dispose(): void {
     return notYetImplemented('dispose');
   }

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -35,6 +35,13 @@ ENV.registerFlag('DEBUG', () => false, debugValue => {
   }
 });
 
+/** Whether to enable tracing mode. */
+ENV.registerFlag('TRACING', () => false, tracingValue => {
+  if (tracingValue) {
+    console.warn('Tracing is ON. This has impacts on performance.');
+  }
+});
+
 /** Whether we are in a browser (as versus, say, node.js) environment. */
 ENV.registerFlag('IS_BROWSER', () => device_util.isBrowser());
 

--- a/tfjs-core/src/flags_test.ts
+++ b/tfjs-core/src/flags_test.ts
@@ -42,6 +42,30 @@ describe('DEBUG', () => {
   });
 });
 
+describe('TRACING', () => {
+  beforeEach(() => {
+    tf.env().reset();
+    spyOn(console, 'warn').and.callFake((msg: string) => {});
+  });
+  afterAll(() => tf.env().reset());
+
+  it('disabled by default', () => {
+    expect(tf.env().getBool('TRACING')).toBe(false);
+  });
+
+  it('warns when enabled', () => {
+    const consoleWarnSpy = console.warn as jasmine.Spy;
+    tf.env().set('TRACING', true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+    expect((consoleWarnSpy.calls.first().args[0] as string)
+               .startsWith('Tracing is ON. '))
+        .toBe(true);
+
+    expect(tf.env().getBool('TRACING')).toBe(true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+  });
+});
+
 // TODO (yassogba) figure out why this spy is not working / fix this test.
 describe('IS_BROWSER', () => {
   let isBrowser: boolean;


### PR DESCRIPTION
In the profile mode, timestamp will be resolved per op, the gpu burden is relatively heavy. This PR introduced a lightweight way to get timestamp,
resolve timestamp when read. This feature is guarded behind flag TRACING.

In addition to the resolve method difference, the time returned in profile mode is gpu execution time (milliseconds). The time returned by TRACING
is the start time and end time of gpu execution (nanoseconds).

For e2e, add tracing=true into the url will turn on tracing. For user application, set flag TRACING to true before predict.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6322)
<!-- Reviewable:end -->
