### PR TITLE
Use sorted feedDict names as part of the cache key

### DIFF
--- a/tfjs-layers/src/engine/executor.ts
+++ b/tfjs-layers/src/engine/executor.ts
@@ -271,7 +271,7 @@ export function execute(
 
   // Check cache.
   const fetchAndFeedKey =
-      outputNames.join(',') + '|' + feedDict.names().join(',');
+      outputNames.join(',') + '|' + feedDict.names().sort().join(',');
   let sorted: SymbolicTensor[] = cachedSorted.get(fetchAndFeedKey);
   let recipientCounts: {[fetchName: string]: number};
   if (sorted == null) {


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.