### PR TITLE
Fix Bazel not using the WORKSPACE node version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,22 +41,23 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.6.1/rules_nodejs-4.6.1.tar.gz"],
 )
 
+# Set up node version to use. Must come before rules_nodejs_dependencies()
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+
+node_repositories(
+    node_version = "16.13.2",
+    package_json = ["//:package.json"],
+)
+
 # Install rules_nodejs dependencies.
 load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
 
 rules_nodejs_dependencies()
 
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
-
 yarn_install(
     name = "npm",
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
-)
-
-node_repositories(
-    node_version = "16.13.2",
-    package_json = ["//:package.json"],
 )
 
 # Fetch transitive Bazel dependencies of karma_web_test


### PR DESCRIPTION
Bazel was using the default rules_nodejs node version instead of the version specified in the WORKSPACE file because the order of rules was wrong.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6335)
<!-- Reviewable:end -->
