### PR TITLE
Use N1_HIGHCPU_32 in cloudbuild-release.yml

### DIFF
--- a/cloudbuild-release.yml
+++ b/cloudbuild-release.yml
@@ -19,5 +19,5 @@ substitutions:
   _RELEASE: ''
 options:
   logStreamingOption: 'STREAM_ON'
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'N1_HIGHCPU_32'
   substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
Fixes a case where building all layers packages in parallel uses all the system memory.

This was necessary in https://github.com/tensorflow/tfjs/pull/6330

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6336)
<!-- Reviewable:end -->
