### PR TITLE
Fix bufferSync return type

### DIFF
--- a/tfjs-backend-cpu/src/kernels/AvgPool3DGrad.ts
+++ b/tfjs-backend-cpu/src/kernels/AvgPool3DGrad.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {AvgPool3DGrad, AvgPool3DGradAttrs, AvgPool3DGradInputs, backend_util, buffer, KernelConfig, KernelFunc, TensorInfo} from '@tensorflow/tfjs-core';
+import {AvgPool3DGrad, AvgPool3DGradAttrs, AvgPool3DGradInputs, backend_util, buffer, KernelConfig, KernelFunc, Rank, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 import {assertNotComplex} from '../cpu_util';
@@ -54,7 +54,7 @@ export function avgPool3DGrad(args: {
 
   const avgMultiplier = 1 / (filterDepth * filterHeight * filterWidth);
 
-  const dyBuf = backend.bufferSync(dy);
+  const dyBuf = backend.bufferSync<Rank, 'float32'>(dy);
 
   for (let batch = 0; batch < convInfo.batchSize; ++batch) {
     for (let channel = 0; channel < convInfo.inChannels; ++channel) {

--- a/tfjs-backend-cpu/src/kernels/DenseBincount.ts
+++ b/tfjs-backend-cpu/src/kernels/DenseBincount.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {DenseBincount, DenseBincountAttrs, DenseBincountInputs, KernelConfig, KernelFunc, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
+import {DenseBincount, DenseBincountAttrs, DenseBincountInputs, KernelConfig, KernelFunc, Rank, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 import {bincountImpl, bincountReduceImpl} from './Bincount_impl';
@@ -38,8 +38,8 @@ export function denseBincount(args: {
 
     return backend.makeTensorInfo([size], weights.dtype, outVals);
   } else if (x.shape.length === 2) {
-    const xBuf = backend.bufferSync(x);
-    const weightsBuf = backend.bufferSync(weights);
+    const xBuf = backend.bufferSync<Rank, 'float32'>(x);
+    const weightsBuf = backend.bufferSync<Rank, 'float32'>(weights);
 
     const outBuf = bincountReduceImpl(xBuf, weightsBuf, size, binaryOutput);
 

--- a/tfjs-backend-cpu/src/kernels/GatherNd.ts
+++ b/tfjs-backend-cpu/src/kernels/GatherNd.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, GatherNd, GatherNdInputs, KernelConfig, KernelFunc, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+import {backend_util, GatherNd, GatherNdInputs, KernelConfig, KernelFunc, Rank, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 
@@ -38,7 +38,7 @@ export function gatherNd(
   }
 
   const indicesData = backend.data.get(indices.dataId).values as TypedArray;
-  const paramsBuf = backend.bufferSync(params);
+  const paramsBuf = backend.bufferSync<Rank, 'float32'>(params);
   const outBuf = gatherNdImpl(
       indicesData, paramsBuf, params.dtype, numSlices, sliceRank, sliceSize,
       strides, params.shape, paramsSize);

--- a/tfjs-backend-cpu/src/kernels/MaxPool3DGrad.ts
+++ b/tfjs-backend-cpu/src/kernels/MaxPool3DGrad.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, buffer, KernelConfig, KernelFunc, MaxPool3DGrad, MaxPool3DGradAttrs, MaxPool3DGradInputs, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, buffer, KernelConfig, KernelFunc, MaxPool3DGrad, MaxPool3DGradAttrs, MaxPool3DGradInputs, Rank, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 import {assertNotComplex} from '../cpu_util';
@@ -52,7 +52,7 @@ export function maxPool3DGrad(args: {
   const padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
   const dx = buffer(input.shape, 'float32');
 
-  const dyBuf = backend.bufferSync(dy);
+  const dyBuf = backend.bufferSync<Rank, 'float32'>(dy);
 
   for (let batch = 0; batch < convInfo.batchSize; ++batch) {
     for (let channel = 0; channel < convInfo.inChannels; ++channel) {

--- a/tfjs-backend-cpu/src/kernels/ScatterNd.ts
+++ b/tfjs-backend-cpu/src/kernels/ScatterNd.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, KernelConfig, KernelFunc, ScatterNd, ScatterNdAttrs, ScatterNdInputs, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, KernelConfig, KernelFunc, Rank, ScatterNd, ScatterNdAttrs, ScatterNdInputs, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 import {scatterImpl} from './Scatter_impl';
@@ -33,8 +33,8 @@ export function scatterNd(args: {
       backend_util.calculateShapes(updates, indices, shape);
   const sumDupeIndices = true;
 
-  const indicesBuf = backend.bufferSync(indices);
-  const updatesBuf = backend.bufferSync(updates);
+  const indicesBuf = backend.bufferSync<Rank, 'float32'>(indices);
+  const updatesBuf = backend.bufferSync<Rank, 'float32'>(updates);
 
   const outBuf = scatterImpl(
       indicesBuf, updatesBuf, shape, outputSize, sliceSize, numUpdates,

--- a/tfjs-backend-cpu/src/kernels/SparseToDense.ts
+++ b/tfjs-backend-cpu/src/kernels/SparseToDense.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, KernelConfig, KernelFunc, SparseToDense, SparseToDenseAttrs, SparseToDenseInputs, TensorInfo} from '@tensorflow/tfjs-core';
+import {backend_util, KernelConfig, KernelFunc, Rank, SparseToDense, SparseToDenseAttrs, SparseToDenseInputs, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 import {scatterImpl} from './Scatter_impl';
@@ -33,8 +33,8 @@ export function sparseToDense(args: {
       backend_util.calculateShapes(sparseValues, sparseIndices, outputShape);
   const sumDupeIndices = false;
 
-  const indicesBuf = backend.bufferSync(sparseIndices);
-  const updatesBuf = backend.bufferSync(sparseValues);
+  const indicesBuf = backend.bufferSync<Rank, 'float32'>(sparseIndices);
+  const updatesBuf = backend.bufferSync<Rank, 'float32'>(sparseValues);
   const $defaultValue =
       backend.data.get(defaultValue.dataId).values[0] as number;
 

--- a/tfjs-backend-cpu/src/kernels/StridedSlice.ts
+++ b/tfjs-backend-cpu/src/kernels/StridedSlice.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc, slice_util, StridedSlice, StridedSliceAttrs, StridedSliceInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, Rank, slice_util, StridedSlice, StridedSliceAttrs, StridedSliceInputs, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {MathBackendCPU} from '../backend_cpu';
 import {assertNotComplex} from '../cpu_util';
@@ -77,7 +77,7 @@ export function stridedSlice(args: {
         reshape({inputs: {x: sliced}, backend, attrs: {shape: finalShape}});
     backend.disposeIntermediateTensorInfo(sliced);
   } else {
-    const xBuf = backend.bufferSync(x);
+    const xBuf = backend.bufferSync<Rank, 'float32'>(x);
     const outBuf = stridedSliceImpl(finalShapeSparse, xBuf, $strides, $begin);
 
     result = backend.makeTensorInfo(finalShape, outBuf.dtype, outBuf.values);

--- a/tfjs-backend-webgl/src/kernels/DenseBincount.ts
+++ b/tfjs-backend-webgl/src/kernels/DenseBincount.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {DenseBincount, DenseBincountAttrs, DenseBincountInputs, KernelConfig, KernelFunc, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
+import {DenseBincount, DenseBincountAttrs, DenseBincountInputs, KernelConfig, KernelFunc, Rank, TensorInfo, TypedArray} from '@tensorflow/tfjs-core';
 
 import {MathBackendWebGL} from '../backend_webgl';
 import {bincountImplCPU, bincountReduceImplCPU} from '../kernel_utils/shared';
@@ -38,8 +38,8 @@ export function denseBincount(args: {
 
     return backend.makeTensorInfo([size], weights.dtype, outVals);
   } else if (x.shape.length === 2) {
-    const xBuf = backend.bufferSync(x);
-    const weightsBuf = backend.bufferSync(weights);
+    const xBuf = backend.bufferSync<Rank, 'float32'>(x);
+    const weightsBuf = backend.bufferSync<Rank, 'float32'>(weights);
 
     const outBuf = bincountReduceImplCPU(xBuf, weightsBuf, size, binaryOutput);
 

--- a/tfjs-backend-webgl/src/kernels/GatherNd.ts
+++ b/tfjs-backend-webgl/src/kernels/GatherNd.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, GatherNd, GatherNdInputs, KernelConfig, KernelFunc, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+import {backend_util, GatherNd, GatherNdInputs, KernelConfig, KernelFunc, Rank, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {MathBackendWebGL} from '../backend_webgl';
 import {GatherNDProgram} from '../gather_nd_gpu';
@@ -46,7 +46,7 @@ export function gatherNd(
   if (backend.shouldExecuteOnCPU([params, indices]) ||
       params.dtype === 'string') {
     const indicesData = backend.readSync(indices.dataId) as TypedArray;
-    const paramsBuf = backend.bufferSync(params);
+    const paramsBuf = backend.bufferSync<Rank, 'float32'>(params);
     const outValue = gatherNdImplCPU(
         indicesData, paramsBuf, params.dtype, numSlices, sliceRank, sliceSize,
         strides, params.shape, paramsSize);

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -530,17 +530,18 @@ export class WebGPUBackend extends KernelBackend {
 
   bufferSync<R extends Rank>(t: TensorInfo): TensorBuffer<R> {
     const data = this.readSync(t.dataId);
-    let decodedData = data as DataValues;
     if (t.dtype === 'string') {
       try {
         // Decode the bytes into string.
-        decodedData = (data as Uint8Array[]).map(d => util.decodeString(d));
+        const strings = (data as Uint8Array[]).map(d => util.decodeString(d));
+        return buffer(t.shape as ShapeMap[R], t.dtype, strings) as
+            TensorBuffer<R, D>;
       } catch {
         throw new Error('Failed to decode encoded string bytes into utf-8');
       }
     }
-    return buffer(t.shape as ShapeMap[R], t.dtype, decodedData) as
-        TensorBuffer<R>;
+    return buffer(t.shape as ShapeMap[R], t.dtype, data as TypedArray) as
+        TensorBuffer<R, D>;
   }
 
   async time(f: () => void): Promise<WebGPUTimingInfo> {

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -17,7 +17,7 @@
 
 import './flags_webgpu';
 
-import {backend_util, buffer, DataStorage, DataToGPUWebGPUOption, DataType, DataValues, engine, env, GPUData, KernelBackend, Rank, RecursiveArray, ShapeMap, TensorBuffer, TensorInfo, TimingInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+import {backend_util, buffer, DataStorage, DataToGPUWebGPUOption, DataType, engine, env, GPUData, KernelBackend, Rank, RecursiveArray, ShapeMap, TensorBuffer, TensorInfo, TimingInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {BufferManager} from './buffer_manager';
 import {TextureManager} from './texture_manager';
@@ -528,7 +528,8 @@ export class WebGPUBackend extends KernelBackend {
     return {tensorRef, buffer: resBuffer, bufSize: bufferSize};
   }
 
-  bufferSync<R extends Rank>(t: TensorInfo): TensorBuffer<R> {
+  bufferSync<R extends Rank, D extends DataType>(t: TensorInfo):
+      TensorBuffer<R, D> {
     const data = this.readSync(t.dataId);
     if (t.dtype === 'string') {
       try {
@@ -750,20 +751,20 @@ export class WebGPUBackend extends KernelBackend {
     bindGroupLayoutEntries.push({
       binding: 0,
       visibility: GPUShaderStage.COMPUTE,
-      buffer: {type: 'storage' as const }
+      buffer: {type: 'storage' as const}
     });
     // Input buffer binding layout. Depends on variableNames length.
     for (let i = 0; i < inputEntrySize; i++) {
       bindGroupLayoutEntries.push({
         binding: i + 1,
         visibility: GPUShaderStage.COMPUTE,
-        buffer: {type: 'read-only-storage' as const }
+        buffer: {type: 'read-only-storage' as const}
       });
     }
     bindGroupLayoutEntries.push({
       binding: inputEntrySize + 1,
       visibility: GPUShaderStage.COMPUTE,
-      buffer: {type: 'uniform' as const }
+      buffer: {type: 'uniform' as const}
     });
     const bindGroupLayout =
         this.device.createBindGroupLayout({entries: bindGroupLayoutEntries});
@@ -922,7 +923,7 @@ export class WebGPUBackend extends KernelBackend {
     bindGroupLayoutEntries.push({
       binding: 0,
       visibility: GPUShaderStage.COMPUTE,
-      buffer: {type: 'storage' as const }
+      buffer: {type: 'storage' as const}
     });
     // Input texture binding layout.
     if (useImport) {

--- a/tfjs-backend-webgpu/src/kernels/GatherNd.ts
+++ b/tfjs-backend-webgpu/src/kernels/GatherNd.ts
@@ -15,12 +15,12 @@
  * =============================================================================
  */
 
-import {backend_util, GatherNd, GatherNdInputs, KernelConfig, KernelFunc, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+import {backend_util, GatherNd, GatherNdInputs, KernelConfig, KernelFunc, Rank, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
+import {GatherNDProgram} from '../gather_nd_webgpu';
 import {gatherNdImplCPU} from '../kernel_utils/shared';
 
-import {GatherNDProgram} from '../gather_nd_webgpu';
 import {reshape} from './Reshape';
 
 export function gatherNd(
@@ -45,7 +45,7 @@ export function gatherNd(
   if (backend.shouldExecuteOnCPU([params, indices]) ||
       params.dtype === 'string') {
     const indicesData = backend.readSync(indices.dataId) as TypedArray;
-    const paramsBuf = backend.bufferSync(params);
+    const paramsBuf = backend.bufferSync<Rank, 'float32'>(params);
     const outValue = gatherNdImplCPU(
         indicesData, paramsBuf, params.dtype, numSlices, sliceRank, sliceSize,
         strides, params.shape, paramsSize);


### PR DESCRIPTION
The existing bufferSync always returned a float template type which throws away the type, so users of the function always assume they are working with a number array which is incorrect for string types.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6362)
<!-- Reviewable:end -->
