### PR TITLE
Fix WebGL Conv2d (PReLU computation) for NCHW format

### DIFF
--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -87,7 +87,7 @@ export function conv2dByMatMul({
         preluActivationWeightsShape.length <= 1 ||
             preluActivationWeightsShape.length === 3,
         () => `WebGL conv2dByMatMul only supports scalar, 1-D Tensor or 3-D ` +
-            `Tensor PReLU activation weights but got the bias of ` +
+            `Tensor PReLU activation weights but got a tensor of ` +
             `rank-${preluActivationWeightsShape.length}.`);
 
     if (preluActivationWeightsShape.length === 1) {
@@ -100,26 +100,7 @@ export function conv2dByMatMul({
     } else if (preluActivationWeightsShape.length === 3) {
       // If PReLU's activation weights is NCHW format, then convert it to NHWC
       // format to be compatible with the following matmul computation.
-      if (!isChannelsLast) {
-        const preluActivationWeightsInNchwFormat = preluActivationWeights;
-        preluActivationWeights = transpose({
-          inputs: {x: preluActivationWeightsInNchwFormat},
-          backend,
-          attrs: {perm: [1, 2, 0]}
-        });
-        intermediates.push(preluActivationWeights);
-
-        util.assert(
-            (preluActivationWeightsShape[0] === 1 ||
-             preluActivationWeightsShape[0] === convInfo.outChannels) &&
-                (preluActivationWeightsShape[1] === 1 ||
-                 preluActivationWeightsShape[1] === convInfo.outHeight) &&
-                (preluActivationWeightsShape[2] === 1 ||
-                 preluActivationWeightsShape[2] === convInfo.outWidth),
-            () => `WebGL conv2dByMatMul PReLU activation weights ` +
-                `(${preluActivationWeightsShape}) is not compatible with ` +
-                `the output shape of the conv2d (${convInfo.outShape})`);
-      } else {
+      if (isChannelsLast) {
         util.assert(
             (preluActivationWeightsShape[0] === 1 ||
              preluActivationWeightsShape[0] === convInfo.outHeight) &&
@@ -130,6 +111,25 @@ export function conv2dByMatMul({
             () => `WebGL conv2dByMatMul PReLU activation weights ` +
                 `(${preluActivationWeightsShape}) is not compatible with ` +
                 `the output shape of the conv2d (${convInfo.outShape})`);
+      } else {
+        util.assert(
+            (preluActivationWeightsShape[0] === 1 ||
+             preluActivationWeightsShape[0] === convInfo.outChannels) &&
+                (preluActivationWeightsShape[1] === 1 ||
+                 preluActivationWeightsShape[1] === convInfo.outHeight) &&
+                (preluActivationWeightsShape[2] === 1 ||
+                 preluActivationWeightsShape[2] === convInfo.outWidth),
+            () => `WebGL conv2dByMatMul PReLU activation weights ` +
+                `(${preluActivationWeightsShape}) is not compatible with ` +
+                `the output shape of the conv2d (${convInfo.outShape})`);
+
+        const preluActivationWeightsInNchwFormat = preluActivationWeights;
+        preluActivationWeights = transpose({
+          inputs: {x: preluActivationWeightsInNchwFormat},
+          backend,
+          attrs: {perm: [1, 2, 0]}
+        });
+        intermediates.push(preluActivationWeights);
       }
     }
   }
@@ -324,7 +324,7 @@ export function conv2dWithIm2Row({
             preluActivationWeightsShape.length === 3,
         () =>
             `WebGL conv2dWithIm2Row only supports scalar, 1-D Tensor or 3-D ` +
-            `Tensor PReLU activation weights but got the bias of ` +
+            `Tensor PReLU activation weights but got a tensor of ` +
             `rank-${preluActivationWeightsShape.length}.`);
 
     if (preluActivationWeightsShape.length === 1) {
@@ -337,26 +337,7 @@ export function conv2dWithIm2Row({
     } else if (preluActivationWeightsShape.length === 3) {
       // If PReLU's activation weights is NCHW format, then convert it to NHWC
       // format to be compatible with the following matmul computation.
-      if (!isChannelsLast) {
-        const preluActivationWeightsInNchwFormat = preluActivationWeights;
-        preluActivationWeights = transpose({
-          inputs: {x: preluActivationWeightsInNchwFormat},
-          backend,
-          attrs: {perm: [1, 2, 0]}
-        });
-        intermediates.push(preluActivationWeights);
-
-        util.assert(
-            (preluActivationWeightsShape[0] === 1 ||
-             preluActivationWeightsShape[0] === convInfo.outChannels) &&
-                (preluActivationWeightsShape[1] === 1 ||
-                 preluActivationWeightsShape[1] === convInfo.outHeight) &&
-                (preluActivationWeightsShape[2] === 1 ||
-                 preluActivationWeightsShape[2] === convInfo.outWidth),
-            () => `WebGL conv2dWithIm2Row PReLU activation weights ` +
-                `(${preluActivationWeightsShape}) is not compatible with ` +
-                `the output shape of the conv2d (${convInfo.outShape})`);
-      } else {
+      if (isChannelsLast) {
         util.assert(
             (preluActivationWeightsShape[0] === 1 ||
              preluActivationWeightsShape[0] === convInfo.outHeight) &&
@@ -367,6 +348,25 @@ export function conv2dWithIm2Row({
             () => `WebGL conv2dWithIm2Row PReLU activation weights ` +
                 `(${preluActivationWeightsShape}) is not compatible with ` +
                 `the output shape of the conv2d (${convInfo.outShape})`);
+      } else {
+        util.assert(
+            (preluActivationWeightsShape[0] === 1 ||
+             preluActivationWeightsShape[0] === convInfo.outChannels) &&
+                (preluActivationWeightsShape[1] === 1 ||
+                 preluActivationWeightsShape[1] === convInfo.outHeight) &&
+                (preluActivationWeightsShape[2] === 1 ||
+                 preluActivationWeightsShape[2] === convInfo.outWidth),
+            () => `WebGL conv2dWithIm2Row PReLU activation weights ` +
+                `(${preluActivationWeightsShape}) is not compatible with ` +
+                `the output shape of the conv2d (${convInfo.outShape})`);
+
+        const preluActivationWeightsInNchwFormat = preluActivationWeights;
+        preluActivationWeights = transpose({
+          inputs: {x: preluActivationWeightsInNchwFormat},
+          backend,
+          attrs: {perm: [1, 2, 0]}
+        });
+        intermediates.push(preluActivationWeights);
       }
     }
   }

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -119,12 +119,12 @@ export function conv2dByMatMul({
         fitPreluActivationWeightsIntoNhwcFormat(
             preluActivationWeights, convInfo.outShape, isChannelsLast, backend);
 
-    if (preluActivationWeightsInNhwcFormat.dataId !=
+    if (preluActivationWeightsInNhwcFormat.dataId !==
         preluActivationWeights.dataId) {
       // preluActivationWeightsInNhwcFormat is a new tensor, temporarily
       // generated to be compatible with the following matmul computation.
       intermediates.push(preluActivationWeightsInNhwcFormat);
-      preluActivationWeights = preluActivationWeightsInNhwcFormat
+      preluActivationWeights = preluActivationWeightsInNhwcFormat;
     }
   }
 
@@ -314,12 +314,12 @@ export function conv2dWithIm2Row({
         fitPreluActivationWeightsIntoNhwcFormat(
             preluActivationWeights, convInfo.outShape, isChannelsLast, backend);
 
-    if (preluActivationWeightsInNhwcFormat.dataId !=
+    if (preluActivationWeightsInNhwcFormat.dataId !==
         preluActivationWeights.dataId) {
       // preluActivationWeightsInNhwcFormat is a new tensor, temporarily
       // generated to be compatible with the following matmul computation.
       intermediates.push(preluActivationWeightsInNhwcFormat);
-      preluActivationWeights = preluActivationWeightsInNhwcFormat
+      preluActivationWeights = preluActivationWeightsInNhwcFormat;
     }
   }
 

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -105,20 +105,32 @@ export function conv2dByMatMul({
         preluActivationWeights = transpose({
           inputs: {x: preluActivationWeightsInNchwFormat},
           backend,
-          attrs: {perm: [0, 3, 1, 2]}
+          attrs: {perm: [1, 2, 0]}
         });
-        intermediates.push(preluActivationWeightsInNchwFormat);
+        intermediates.push(preluActivationWeights);
+
+        util.assert(
+            (preluActivationWeightsShape[0] === 1 ||
+             preluActivationWeightsShape[0] === convInfo.outChannels) &&
+                (preluActivationWeightsShape[1] === 1 ||
+                 preluActivationWeightsShape[1] === convInfo.outHeight) &&
+                (preluActivationWeightsShape[2] === 1 ||
+                 preluActivationWeightsShape[2] === convInfo.outWidth),
+            () => `WebGL conv2dByMatMul PReLU activation weights ` +
+                `(${preluActivationWeightsShape}) is not compatible with ` +
+                `the output shape of the conv2d (${convInfo.outShape})`);
+      } else {
+        util.assert(
+            (preluActivationWeightsShape[0] === 1 ||
+             preluActivationWeightsShape[0] === convInfo.outHeight) &&
+                (preluActivationWeightsShape[1] === 1 ||
+                 preluActivationWeightsShape[1] === convInfo.outWidth) &&
+                (preluActivationWeightsShape[2] === 1 ||
+                 preluActivationWeightsShape[2] === convInfo.outChannels),
+            () => `WebGL conv2dByMatMul PReLU activation weights ` +
+                `(${preluActivationWeightsShape}) is not compatible with ` +
+                `the output shape of the conv2d (${convInfo.outShape})`);
       }
-      util.assert(
-          (preluActivationWeightsShape[0] === 1 ||
-           preluActivationWeightsShape[0] === convInfo.outHeight) &&
-              (preluActivationWeightsShape[1] === 1 ||
-               preluActivationWeightsShape[1] === convInfo.outWidth) &&
-              (preluActivationWeightsShape[2] === 1 ||
-               preluActivationWeightsShape[2] === convInfo.outChannels),
-          () => `WebGL conv2dByMatMul PReLU activation weights ` +
-              `(${preluActivationWeightsShape}) is not compatible with ` +
-              `the output shape of the conv2d (${convInfo.outShape})`);
     }
   }
 
@@ -330,20 +342,32 @@ export function conv2dWithIm2Row({
         preluActivationWeights = transpose({
           inputs: {x: preluActivationWeightsInNchwFormat},
           backend,
-          attrs: {perm: [0, 3, 1, 2]}
+          attrs: {perm: [1, 2, 0]}
         });
-        intermediates.push(preluActivationWeightsInNchwFormat);
+        intermediates.push(preluActivationWeights);
+
+        util.assert(
+            (preluActivationWeightsShape[0] === 1 ||
+             preluActivationWeightsShape[0] === convInfo.outChannels) &&
+                (preluActivationWeightsShape[1] === 1 ||
+                 preluActivationWeightsShape[1] === convInfo.outHeight) &&
+                (preluActivationWeightsShape[2] === 1 ||
+                 preluActivationWeightsShape[2] === convInfo.outWidth),
+            () => `WebGL conv2dWithIm2Row PReLU activation weights ` +
+                `(${preluActivationWeightsShape}) is not compatible with ` +
+                `the output shape of the conv2d (${convInfo.outShape})`);
+      } else {
+        util.assert(
+            (preluActivationWeightsShape[0] === 1 ||
+             preluActivationWeightsShape[0] === convInfo.outHeight) &&
+                (preluActivationWeightsShape[1] === 1 ||
+                 preluActivationWeightsShape[1] === convInfo.outWidth) &&
+                (preluActivationWeightsShape[2] === 1 ||
+                 preluActivationWeightsShape[2] === convInfo.outChannels),
+            () => `WebGL conv2dWithIm2Row PReLU activation weights ` +
+                `(${preluActivationWeightsShape}) is not compatible with ` +
+                `the output shape of the conv2d (${convInfo.outShape})`);
       }
-      util.assert(
-          (preluActivationWeightsShape[0] === 1 ||
-           preluActivationWeightsShape[0] === convInfo.outHeight) &&
-              (preluActivationWeightsShape[1] === 1 ||
-               preluActivationWeightsShape[1] === convInfo.outWidth) &&
-              (preluActivationWeightsShape[2] === 1 ||
-               preluActivationWeightsShape[2] === convInfo.outChannels),
-          () => `WebGL conv2dWithIm2Row PReLU activation weights ` +
-              `(${preluActivationWeightsShape}) is not compatible with ` +
-              `the output shape of the conv2d (${convInfo.outShape})`);
     }
   }
 

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, broadcast_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
-import {assertAndGetBroadcastShape} from '../../../tfjs-core/src/ops/broadcast_util';
+// import {assertAndGetBroadcastShape} from
+// '../../../tfjs-core/src/ops/broadcast_util';
 import {MathBackendWebGL} from '../backend_webgl';
 import {Im2ColPackedProgram} from '../im2col_packed_gpu';
 import {mapActivationToShaderProgram} from '../kernel_utils/kernel_funcs_utils';
@@ -60,7 +61,7 @@ function fitPreluActivationWeightsIntoNhwcFormat(
             `(${outputChannels}).`);
   } else if (alphaShape.length === 3) {
     try {
-      assertAndGetBroadcastShape(alphaShape, outputShape);
+      broadcast_util.assertAndGetBroadcastShape(alphaShape, outputShape);
     } catch (e) {
       const errMsg = `WebGL conv2d PReLU activation weights (${alphaShape}) ` +
           `is not compatible with the output shape of the conv2d ` +

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
@@ -124,7 +124,6 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        const w = tf.tensor4d(
            [-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
        const alpha = tf.scalar(10);
-       //  const alpha = tf.tensor3d([10, 10], [2, 1, 1]);
 
        const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
        const convInfo = backend_util.computeConv2DInfo(
@@ -303,4 +302,157 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
         tf.backend().readSync(result.dataId),
         [91, 55, 64, 37, 92, 56, 65, 38, 91, 55, 64, 37, 92, 56, 65, 38]);
   });
+
+  it('Should work for NCHW format when having a scalar PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 2;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 'same';
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, -1, -1, -1, 1, 1, 1, 1, -2, -2, -2, -2, 0.5, 0.5, 0.5, 0.5],
+           [fSize, fSize, inputDepth, outputDepth]);
+       const alpha = tf.scalar(10);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dWithIm2Row({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-120, -320, 2, -120, -120, -320, 2, -120]);
+     });
+
+  it('Should work for NCHW format when having a 1-D PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 2;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 'same';
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, -1, -1, -1, 1, 1, 1, 1, -2, -2, -2, -2, 0.5, 0.5, 0.5, 0.5],
+           [fSize, fSize, inputDepth, outputDepth]);
+       const alpha = tf.tensor1d([1, 10]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dWithIm2Row({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-12, -32, 2, -12, -120, -320, 2, -120]);
+     });
+
+  it('Should work for NCHW format when having a 3-D PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 2;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 'same';
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, -1, -1, -1, 1, 1, 1, 1, -2, -2, -2, -2, 0.5, 0.5, 0.5, 0.5],
+           [fSize, fSize, inputDepth, outputDepth]);
+       const alpha = tf.tensor3d([1, 10], [2, 1, 1]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dWithIm2Row({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-12, -32, 2, -12, -120, -320, 2, -120]);
+     });
+
+  it('Should work for NCHW format when having a full 3-D PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 2;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 'same';
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, -1, -1, -1, 1, 1, 1, 1, -2, -2, -2, -2, 0.5, 0.5, 0.5, 0.5],
+           [fSize, fSize, inputDepth, outputDepth]);
+       const alpha =
+           tf.tensor3d([0.001, 0.01, 0.1, 1, 10, 100, 1000, 10000], [2, 2, 2]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dWithIm2Row({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-0.012, -0.32, 2, -12, -120, -3200, 2, -120000]);
+     });
 });

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
@@ -109,7 +109,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        ]);
      });
 
-  it('Should work for NCHW format when having a scalar PReLU actiavation weight',
+  it('Should work for NCHW format when PReLU actiavation weights is a scalar ',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -146,7 +146,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
            [-110, -140, -170, -200, 3.5, 5, 6.5, 8]);
      });
 
-  it('Should work for NCHW format when having a 1-D PReLU actiavation weight',
+  it('Should work for NCHW format when having a 1-D PReLU actiavation weights',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -183,7 +183,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
            [-110, -140, -170, -200, 3.5, 5, 6.5, 8]);
      });
 
-  it('Should work for NCHW format when having a 3-D PReLU actiavation weight',
+  it('Should work for NCHW format when having a 3-D PReLU actiavation weights',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -221,7 +221,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
            [-11, -14, -17, -20, -110, -140, -170, -200]);
      });
 
-  it('Should work for NCHW format when having a full 3-D PReLU actiavation weight',
+  it('Should work for NCHW format when having a full 3-D PReLU actiavation weights',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -303,7 +303,7 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
         [91, 55, 64, 37, 92, 56, 65, 38, 91, 55, 64, 37, 92, 56, 65, 38]);
   });
 
-  it('Should work for NCHW format when having a scalar PReLU actiavation weight',
+  it('Should work for NCHW format when PReLU actiavation weights is a scalar',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -341,7 +341,7 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
            [-120, -320, 2, -120, -120, -320, 2, -120]);
      });
 
-  it('Should work for NCHW format when having a 1-D PReLU actiavation weight',
+  it('Should work for NCHW format when having a 1-D PReLU actiavation weights',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -379,7 +379,7 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
            [-12, -32, 2, -12, -120, -320, 2, -120]);
      });
 
-  it('Should work for NCHW format when having a 3-D PReLU actiavation weight',
+  it('Should work for NCHW format when having a 3-D PReLU actiavation weights',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
@@ -417,7 +417,7 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
            [-12, -32, 2, -12, -120, -320, 2, -120]);
      });
 
-  it('Should work for NCHW format when having a full 3-D PReLU actiavation weight',
+  it('Should work for NCHW format when having a full 3-D PReLU actiavation weights',
      async () => {
        const inputDepth = 2;
        const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
@@ -108,6 +108,158 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
          10, 19, 28, 37, 11, 20, 29, 38, 10, 19, 28, 37, 11, 20, 29, 38
        ]);
      });
+
+  it('Should work for NCHW format when having a scalar PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 1;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 0;
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
+       const alpha = tf.scalar(10);
+       //  const alpha = tf.tensor3d([10, 10], [2, 1, 1]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dByMatMul({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-110, -140, -170, -200, 3.5, 5, 6.5, 8]);
+     });
+
+  it('Should work for NCHW format when having a 1-D PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 1;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 0;
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
+       const alpha = tf.tensor1d([10, 100]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dByMatMul({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-110, -140, -170, -200, 3.5, 5, 6.5, 8]);
+     });
+
+  it('Should work for NCHW format when having a 3-D PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 1;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 0;
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, -1, -2, -2], [fSize, fSize, inputDepth, outputDepth]);
+       const alpha = tf.tensor3d([1, 10], [2, 1, 1]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dByMatMul({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       console.log(tf.backend().readSync(result.dataId));
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-11, -14, -17, -20, -110, -140, -170, -200]);
+     });
+
+  it('Should work for NCHW format when having a full 3-D PReLU actiavation weight',
+     async () => {
+       const inputDepth = 2;
+       const inShape: [number, number, number, number] = [1, inputDepth, 2, 2];
+       const outputDepth = 2;
+       const fSize = 1;
+       const dataFormat = 'NCHW';
+       const dilation = 1;
+       const pad = 0;
+       const stride = 1;
+
+       const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
+       const w = tf.tensor4d(
+           [-1, -1, -2, -2], [fSize, fSize, inputDepth, outputDepth]);
+       const alpha =
+           tf.tensor3d([0.001, 0.01, 0.1, 1, 10, 100, 1000, 10000], [2, 2, 2]);
+
+       const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
+       const convInfo = backend_util.computeConv2DInfo(
+           x.shape as [number, number, number, number],
+           w.shape as [number, number, number, number], stride, dilation, pad,
+           undefined /* roundingMode */, false /* depthwise */, $dataFormat);
+
+       const result = conv2dByMatMul({
+         x,
+         filter: w,
+         convInfo,
+         backend: tf.backend() as MathBackendWebGL,
+         activation: 'prelu',
+         preluActivationWeights: alpha
+       });
+
+       expect(result.shape).toEqual([1, 2, 2, 2]);
+       console.log(tf.backend().readSync(result.dataId));
+       expectArraysClose(
+           tf.backend().readSync(result.dataId),
+           [-0.011, -0.14, -1.7, -20, -110, -1400, -17000, -200000]);
+     });
 });
 
 describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {


### PR DESCRIPTION
For https://github.com/tensorflow/tfjs/issues/6354, this PR does:
1. Add asserts to check compatibility of the shape of the PReLU weights.
2. Transpose PReLU's weights properly to compute fusedConv2d.

Specifically, according to TensorFlow, in the `fusedConv2d` (`conv2d` + `biasAdd` + `activation`), the PReLU's weights should have the compatible shape with the output of the `conv2d`. Then, if the data format is `NCHW`, the shape of the PReLU's weights should be compatible with `[channel, height, weight]`. However, the original codes do not consider the data format for the PReLU weights.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6365)
<!-- Reviewable:end -->
