### PR TITLE
[node] Fix memory leak from string tensors

### DIFF
--- a/tfjs-node/binding/tfjs_backend.cc
+++ b/tfjs-node/binding/tfjs_backend.cc
@@ -23,6 +23,11 @@
 #include <set>
 #include <string>
 #include "napi_auto_ref.h"
+#include "tensorflow/c/eager/c_api.h"
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_tensor.h"
+#include "tensorflow/core/platform/ctstring_internal.h"
 #include "tf_auto_tensor.h"
 #include "tfe_auto_op.h"
 #include "utils.h"
@@ -781,6 +786,20 @@ void TFJSBackend::DeleteTensor(napi_env env, napi_value tensor_id_value) {
     return;
   }
 
+  TFE_TensorHandle *tensor_handle = tensor_entry->second;
+  if (TFE_TensorHandleDataType(tensor_handle) == TF_STRING) {
+    TF_AutoStatus tf_status;
+    TF_AutoTensor tensor(
+        TFE_TensorHandleResolve(tensor_handle, tf_status.status));
+    ENSURE_TF_OK(env, tf_status);
+    size_t num_elements = GetTensorNumElements(tensor.tensor);
+    TF_TString *data = reinterpret_cast<TF_TString *>(TF_TensorData(tensor.tensor));
+
+    // Deallocate each string
+    for (size_t i = 0; i < num_elements; i++) {
+      TF_TString_Dealloc(data + i);
+    }
+  };
   TFE_DeleteTensorHandle(tensor_entry->second);
   tfe_handle_map_.erase(tensor_entry);
 }


### PR DESCRIPTION
Fix a bug where string tensor handles are deleted without the underlying tstrings being deallocated.

Fixes #5242 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6371)
<!-- Reviewable:end -->
