### PR TITLE
Decrease values in WebGL tests to fit into WebGL1's range

### DIFF
--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
@@ -234,8 +234,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], inShape);
        const w = tf.tensor4d(
            [-1, -1, -2, -2], [fSize, fSize, inputDepth, outputDepth]);
-       const alpha =
-           tf.tensor3d([0.0001, 0.001, 0.01, 0.1, 1, 10, 100, 1000], [2, 2, 2]);
+       const alpha = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
 
        const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
        const convInfo = backend_util.computeConv2DInfo(
@@ -255,7 +254,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        expect(result.shape).toEqual([1, 2, 2, 2]);
        expectArraysClose(
            tf.backend().readSync(result.dataId),
-           [-0.0011, -0.014, -0.17, -2, -11, -140, -1700, -20000]);
+           [-11, -28, -51, -80, -55, -84, -119, -160]);
      });
 });
 
@@ -430,8 +429,7 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
        const w = tf.tensor4d(
            [-1, -1, -1, -1, 1, 1, 1, 1, -2, -2, -2, -2, 0.5, 0.5, 0.5, 0.5],
            [fSize, fSize, inputDepth, outputDepth]);
-       const alpha =
-           tf.tensor3d([0.0001, 0.001, 0.01, 0.1, 1, 10, 100, 1000], [2, 2, 2]);
+       const alpha = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
 
        const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
        const convInfo = backend_util.computeConv2DInfo(
@@ -451,6 +449,6 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
        expect(result.shape).toEqual([1, 2, 2, 2]);
        expectArraysClose(
            tf.backend().readSync(result.dataId),
-           [-0.0012, -0.032, 2, -1.2, -12, -320, 2, -12000]);
+           [-12, -64, 2, -48, -60, -192, 2, -96]);
      });
 });

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl_test.ts
@@ -215,7 +215,6 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        });
 
        expect(result.shape).toEqual([1, 2, 2, 2]);
-       console.log(tf.backend().readSync(result.dataId));
        expectArraysClose(
            tf.backend().readSync(result.dataId),
            [-11, -14, -17, -20, -110, -140, -170, -200]);
@@ -236,7 +235,7 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        const w = tf.tensor4d(
            [-1, -1, -2, -2], [fSize, fSize, inputDepth, outputDepth]);
        const alpha =
-           tf.tensor3d([0.001, 0.01, 0.1, 1, 10, 100, 1000, 10000], [2, 2, 2]);
+           tf.tensor3d([0.0001, 0.001, 0.01, 0.1, 1, 10, 100, 1000], [2, 2, 2]);
 
        const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
        const convInfo = backend_util.computeConv2DInfo(
@@ -254,10 +253,9 @@ describeWithFlags('conv2dByMatMul', WEBGL_ENVS, () => {
        });
 
        expect(result.shape).toEqual([1, 2, 2, 2]);
-       console.log(tf.backend().readSync(result.dataId));
        expectArraysClose(
            tf.backend().readSync(result.dataId),
-           [-0.011, -0.14, -1.7, -20, -110, -1400, -17000, -200000]);
+           [-0.0011, -0.014, -0.17, -2, -11, -140, -1700, -20000]);
      });
 });
 
@@ -433,7 +431,7 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
            [-1, -1, -1, -1, 1, 1, 1, 1, -2, -2, -2, -2, 0.5, 0.5, 0.5, 0.5],
            [fSize, fSize, inputDepth, outputDepth]);
        const alpha =
-           tf.tensor3d([0.001, 0.01, 0.1, 1, 10, 100, 1000, 10000], [2, 2, 2]);
+           tf.tensor3d([0.0001, 0.001, 0.01, 0.1, 1, 10, 100, 1000], [2, 2, 2]);
 
        const $dataFormat = backend_util.convertConv2DDataFormat(dataFormat);
        const convInfo = backend_util.computeConv2DInfo(
@@ -453,6 +451,6 @@ describeWithFlags('conv2dWithIm2Row', WEBGL_ENVS, () => {
        expect(result.shape).toEqual([1, 2, 2, 2]);
        expectArraysClose(
            tf.backend().readSync(result.dataId),
-           [-0.012, -0.32, 2, -12, -120, -3200, 2, -120000]);
+           [-0.0012, -0.032, 2, -1.2, -12, -320, 2, -12000]);
      });
 });


### PR DESCRIPTION
Our nightly failed, because some expected test values are too large for `Mobile Safari 11.0 (iOS 11.2) WebGL/1`:
![image](https://user-images.githubusercontent.com/40653845/167028764-2d200eed-c2be-47ed-8309-c558c990dee2.png)
![image](https://user-images.githubusercontent.com/40653845/167028843-f348dd9f-940c-4fc5-9d92-59ef20d03ef4.png)

This PR tunes the values for the related tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6372)
<!-- Reviewable:end -->
