### PR TITLE
Fix CPU fusedConv2d (bias add) for NCHW format 

### DIFF
--- a/tfjs-backend-cpu/src/kernels/FusedConv2D.ts
+++ b/tfjs-backend-cpu/src/kernels/FusedConv2D.ts
@@ -21,6 +21,7 @@ import {MathBackendCPU} from '../backend_cpu';
 import {applyActivation} from '../utils/fused_utils';
 import {add} from './Add';
 import {conv2D} from './Conv2D';
+import {reshape} from './Reshape';
 
 export function fusedConv2D(args: {
   inputs: FusedConv2DInputs,
@@ -47,7 +48,20 @@ export function fusedConv2D(args: {
 
   if (bias) {
     const resultOld = result;
-    result = add({inputs: {a: result, b: bias}, backend}) as TensorInfo;
+    if (dataFormat === 'NCHW' && bias.shape.length === 1 &&
+        bias.shape[0] !== 1) {
+      const reshapedBias = reshape({
+                             inputs: {x: bias},
+                             backend,
+                             attrs: {shape: [bias.shape[0], 1, 1]}
+                           }) as TensorInfo;
+      result =
+          add({inputs: {a: result, b: reshapedBias}, backend}) as TensorInfo;
+      backend.disposeIntermediateTensorInfo(reshapedBias);
+      console.log('tested');
+    } else {
+      result = add({inputs: {a: result, b: bias}, backend}) as TensorInfo;
+    }
     backend.disposeIntermediateTensorInfo(resultOld);
   }
 

--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -103,19 +103,6 @@ export function conv2dByMatMul({
   let out: TensorInfo;
   const intermediates: TensorInfo[] = [];
 
-  if (bias != null) {
-    // Bias could be a 1-D tensor or a scalar.
-    util.assert(
-        bias.shape.length <= 1,
-        () => `WebGL conv2dByMatMul only supports 1-D Tensor bias but got ` +
-            `the bias of rank-${bias.shape.length}.`);
-    util.assert(
-        bias.shape.length === 0 || bias.shape[0] === convInfo.outChannels,
-        () => `WebGL conv2dByMatMul bias shape (${bias.shape}) is not ` +
-            `compatible with the number of output channels ` +
-            `(${convInfo.outChannels})`);
-  }
-
   if (preluActivationWeights != null) {
     const preluActivationWeightsInNhwcFormat =
         fitPreluActivationWeightsIntoNhwcFormat(
@@ -299,19 +286,6 @@ export function conv2dWithIm2Row({
   const transposeB = false;
 
   const intermediates: TensorInfo[] = [];
-
-  if (bias != null) {
-    // Bias could be a 1-D tensor or a scalar.
-    util.assert(
-        bias.shape.length <= 1,
-        () => `WebGL conv2dWithIm2Row only supports 1-D Tensor bias but got ` +
-            `the bias of rank-${bias.shape.length}.`);
-    util.assert(
-        bias.shape.length === 0 || bias.shape[0] === convInfo.outChannels,
-        () => `WebGL conv2dWithIm2Row bias shape (${bias.shape}) is not ` +
-            `compatible with the number of output channels ` +
-            `(${convInfo.outChannels})`);
-  }
 
   if (preluActivationWeights != null) {
     const preluActivationWeightsInNhwcFormat =


### PR DESCRIPTION
For NCHW format, if fusedConv2d has a 1-D bias, CPU-backend does not apply it to the channel dimension, while currently 
 just applying it to the last dimension.

This PR does:
1. For CPU-backend, properly reshape bias to align with the NCHW format to compute fusedConv2d
2. Moves the bias's shape check from WebGL-backend to tfjs-core, because this checking is general for all backends.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.