### PR TITLE
[webgpu] Resolve timestamp when read

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -234,23 +234,49 @@ async function timeModelInference(model, input, numRuns = 1) {
  * @param predict The predict function to execute and time.
  * @param numRuns The number of rounds for `predict` to execute and time.
  */
-async function timeInference(predict, numRuns = 1) {
+let setBatchSizes = null;
+async function timeInference(predict, numRuns = 1, traceFlag = false) {
   if (typeof predict !== 'function') {
     throw new Error(
         'The first parameter should be a function, while ' +
         `a(n) ${typeof predict} is found.`);
   }
+  if (setBatchSizes == null) {
+    // setBatchSizes = JSON.parse(await readFileAsync('batchSizes.json'));
+    console.log(JSON.stringify(setBatchSizes));
+  }
+
+  const trace = tf.getBackend() === 'webgpu' && traceFlag;
+  if (trace) {
+    tf.env().set('TRACE', true);
+  }
 
   const times = [];
+  const kernelTimes = [];
   for (let i = 0; i < numRuns; i++) {
     const start = performance.now();
+    // tf.backend().setBatchSizes(
+    //  [15, 30, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90]);
+    // tf.backend().setBatchSizes([1, 5, 20, 35, 50, 65, 80, 95]);
+    if (setBatchSizes != null) tf.backend().setBatchSizes(setBatchSizes);
+    if (trace) {
+      console.timeStamp('predict');
+      tf.env().set('TRACE', true);
+    }
     const res = await predict();
     // The prediction can be tf.Tensor|tf.Tensor[]|{[name: string]: tf.Tensor}.
     const value = await downloadValuesFromTensorContainer(res);
-    const elapsedTime = performance.now() - start;
 
+    const elapsedTime = performance.now() - start;
+    if (trace) {
+      const kernelTime = await tf.backend().getKernelTimes();
+      kernelTimes.push(kernelTime);
+    }
     tf.dispose(res);
     times.push(elapsedTime);
+  }
+  if (trace) {
+    tf.env().set('TRACE', false);
   }
 
   const averageTime = times.reduce((acc, curr) => acc + curr, 0) / times.length;
@@ -263,7 +289,33 @@ async function timeInference(predict, numRuns = 1) {
     maxTime
 
   };
+  console.log('setBatch' + JSON.stringify(timeInfo));
+  if (trace) {
+    console.log('predictbegin' + JSON.stringify(timeInfo) + 'predictend');
+    for (let item in kernelTimes) {
+      console.log(
+          'gpudatabegin' + JSON.stringify(kernelTimes[item]) + 'gpudataend');
+    }
+  }
   return timeInfo;
+}
+
+async function readFileAsync(url, method = 'GET') {
+  return new Promise(function(resolve, reject) {
+    let xhr = new XMLHttpRequest();
+    xhr.open(method, url);
+    xhr.onload = function() {
+      if (this.status >= 200 && this.status < 300) {
+        resolve(xhr.response);
+      } else {
+        reject({status: this.status, statusText: xhr.statusText});
+      }
+    };
+    xhr.onerror = function() {
+      reject({status: this.status, statusText: xhr.statusText});
+    };
+    xhr.send();
+  });
 }
 
 /**
@@ -419,6 +471,8 @@ async function profileInference(predict, isTflite = false, numProfiles = 1) {
         const res = await predict();
         await downloadValuesFromTensorContainer(res);
         tf.dispose(res);
+        // Add below to clean query Index.
+        if (tf.getBackend() === 'webgpu') await tf.backend().getKernelTimes();
       });
       kernelInfos.push(kernelInfo);
     }
@@ -486,7 +540,8 @@ const TUNABLE_FLAG_VALUE_RANGE_MAP = {
   CHECK_COMPUTATION_FOR_ERRORS: [true, false],
   KEEP_INTERMEDIATE_TENSORS: [true, false],
   WEBGL_USE_SHAPES_UNIFORMS: [true, false],
-  WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE: [1, 5, 10, 15, 20, 25, 30, 35, 40]
+  WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE:
+      [1, 5, 10, 15, 20, 25, 30, 35, 40, 86, 90, 100, 108, 178]
 };
 
 /**

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -92,6 +92,7 @@ limitations under the License.
     let urlState = null;
     let runTimes = 50;
     let profileTimes = 1;
+    let trace = false;
     let warmupTimes = 1;
     // Default do not run any task.
     let task = '';
@@ -111,6 +112,9 @@ limitations under the License.
       }
       if (params.has('task')) {
         task = params.get('task');
+      }
+      if (params.has('trace')) {
+        trace = params.get('trace') === 'true';
       }
       return params;
     }
@@ -558,7 +562,7 @@ limitations under the License.
         .setAttribute('d', `M${data.map((d, i) => `${i * xIncrement},${chartHeight - ((d - yMin) / (yMax - yMin)) * chartHeight}`).join('L')} `);
     }
 
-    async function measureAveragePredictTime() {
+    async function measureAveragePredictTime(trace) {
       if (state.numRuns == 0) {
         return;
       }
@@ -577,7 +581,7 @@ limitations under the License.
           tf.dispose(input);
         }
       } else {
-        timeInfo = await timeInference(() => predict(model), numRuns);
+        timeInfo = await timeInference(() => predict(model), numRuns, trace);
       }
 
       const forceInferenceTrendYMinToZero = true;
@@ -729,7 +733,7 @@ limitations under the License.
       await showBenchmarkingParameters();
 
       await warmUpAndRecordTime();
-      await measureAveragePredictTime();
+      await measureAveragePredictTime(trace);
       await profileMemoryAndKernelTime();
       urlState = null;
     }

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -143,6 +143,18 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   epsilon(): number {
     return this.floatPrecision() === 32 ? EPSILON_FLOAT32 : EPSILON_FLOAT16;
   }
+
+  /** Returns the kernel times.  */
+  async getKernelTimes():
+      Promise<number|Array<{name: string; query: number[]}>> {
+    return notYetImplemented('getKernelTimes');
+  }
+
+  /** Sets batch size.  */
+  setBatchSizes(batchSizes: number[]): void {
+    return notYetImplemented('setBatchSizes');
+  }
+
   dispose(): void {
     return notYetImplemented('dispose');
   }

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -35,6 +35,13 @@ ENV.registerFlag('DEBUG', () => false, debugValue => {
   }
 });
 
+/** Whether to enable trace mode. */
+ENV.registerFlag('TRACE', () => false, traceValue => {
+  if (traceValue) {
+    console.warn('Trace is ON. This has impacts on performance.');
+  }
+});
+
 /** Whether we are in a browser (as versus, say, node.js) environment. */
 ENV.registerFlag('IS_BROWSER', () => device_util.isBrowser());
 

--- a/tfjs-core/src/flags_test.ts
+++ b/tfjs-core/src/flags_test.ts
@@ -42,6 +42,30 @@ describe('DEBUG', () => {
   });
 });
 
+describe('TRACE', () => {
+  beforeEach(() => {
+    tf.env().reset();
+    spyOn(console, 'warn').and.callFake((msg: string) => {});
+  });
+  afterAll(() => tf.env().reset());
+
+  it('disabled by default', () => {
+    expect(tf.env().getBool('TRACE')).toBe(false);
+  });
+
+  it('warns when enabled', () => {
+    const consoleWarnSpy = console.warn as jasmine.Spy;
+    tf.env().set('TRACE', true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+    expect((consoleWarnSpy.calls.first().args[0] as string)
+               .startsWith('Trace is ON. '))
+        .toBe(true);
+
+    expect(tf.env().getBool('TRACE')).toBe(true);
+    expect(consoleWarnSpy.calls.count()).toBe(1);
+  });
+});
+
 // TODO (yassogba) figure out why this spy is not working / fix this test.
 describe('IS_BROWSER', () => {
   let isBrowser: boolean;


### PR DESCRIPTION
In the profile mode, timestamp will be resolved per op, the gpu burden is relatively heavy. This PR introduced a lightweight way to get timestamp, resolve timestamp when read. This feature is guarded behind flag TRACE.

In addition to the resolve method difference, the time returned in profile mode is gpu execution time (milliseconds). The time returned by TRACE is the start time and end time of gpu execution (nanoseconds).

For e2e, add trace=true into the url will turn on trace. For user application, set flag TRACE to true before predict.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6401)
<!-- Reviewable:end -->
