### PR TITLE
[core] Add a synchronous I/O handler

### DIFF
--- a/tfjs-core/src/io/io.ts
+++ b/tfjs-core/src/io/io.ts
@@ -23,7 +23,7 @@ import './local_storage';
 import {browserFiles} from './browser_files';
 import {browserHTTPRequest, http, isHTTPScheme} from './http';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsForJSON, getModelArtifactsInfoForJSON} from './io_utils';
-import {fromMemory, withSaveHandler} from './passthrough';
+import {fromMemory, fromMemorySync, withSaveHandler, withSaveHandlerSync} from './passthrough';
 import {getLoadHandlers, getSaveHandlers, registerLoadRouter, registerSaveRouter} from './router_registry';
 import {IOHandler, LoadHandler, LoadOptions, ModelArtifacts, ModelArtifactsInfo, ModelJSON, ModelStoreManager, OnProgressCallback, RequestDetails, SaveConfig, SaveHandler, SaveResult, TrainingConfig, WeightGroup, WeightsManifestConfig, WeightsManifestEntry} from './types';
 import {loadWeights, weightsLoaderFactory} from './weights_loader';
@@ -36,6 +36,7 @@ export {
   decodeWeights,
   encodeWeights,
   fromMemory,
+  fromMemorySync,
   getLoadHandlers,
   getModelArtifactsForJSON,
   getModelArtifactsInfoForJSON,
@@ -62,5 +63,6 @@ export {
   weightsLoaderFactory,
   WeightsManifestConfig,
   WeightsManifestEntry,
-  withSaveHandler
+  withSaveHandler,
+  withSaveHandlerSync,
 };

--- a/tfjs-core/src/io/passthrough.ts
+++ b/tfjs-core/src/io/passthrough.ts
@@ -67,9 +67,9 @@ class PassthroughAsync implements IOHandler {
  * @param modelArtifacts a object containing model topology (i.e., parsed from
  *   the JSON format).
  * @param weightSpecs An array of `WeightsManifestEntry` objects describing the
- *   names, shapes, types, and quantization of the weight data.
+ *   names, shapes, types, and quantization of the weight data. Optional.
  * @param weightData A single `ArrayBuffer` containing the weight data,
- *   concatenated in the order described by the weightSpecs.
+ *   concatenated in the order described by the weightSpecs. Optional.
  * @param trainingConfig Model training configuration. Optional.
  *
  * @returns A passthrough `IOHandler` that simply loads the provided data.
@@ -96,9 +96,9 @@ export function fromMemory(
  * @param modelArtifacts a object containing model topology (i.e., parsed from
  *   the JSON format).
  * @param weightSpecs An array of `WeightsManifestEntry` objects describing the
- *   names, shapes, types, and quantization of the weight data.
+ *   names, shapes, types, and quantization of the weight data. Optional.
  * @param weightData A single `ArrayBuffer` containing the weight data,
- *   concatenated in the order described by the weightSpecs.
+ *   concatenated in the order described by the weightSpecs. Optional.
  * @param trainingConfig Model training configuration. Optional.
  *
  * @returns A passthrough `IOHandlerSync` that simply loads the provided data.

--- a/tfjs-core/src/io/passthrough.ts
+++ b/tfjs-core/src/io/passthrough.ts
@@ -19,23 +19,37 @@
  * IOHandlers that pass through the in-memory ModelArtifacts format.
  */
 
-import {IOHandler, ModelArtifacts, SaveResult, TrainingConfig, WeightsManifestEntry} from './types';
+import {IOHandler, IOHandlerSync, LoadHandler, ModelArtifacts, SaveHandler, SaveResult, TrainingConfig, WeightsManifestEntry} from './types';
 
-class PassthroughLoader implements IOHandler {
+class PassthroughLoader implements IOHandlerSync {
   constructor(private readonly modelArtifacts?: ModelArtifacts) {}
 
-  async load(): Promise<ModelArtifacts> {
+  load(): ModelArtifacts {
     return this.modelArtifacts;
   }
 }
 
-class PassthroughSaver implements IOHandler {
+class PassthroughSaver<R extends SaveResult | Promise<SaveResult>> {
   constructor(
-      private readonly saveHandler:
-          (artifacts: ModelArtifacts) => Promise<SaveResult>) {}
+    private readonly saveHandler: (artifacts: ModelArtifacts) => R) {}
 
-  async save(modelArtifacts: ModelArtifacts) {
+  save(modelArtifacts: ModelArtifacts): R {
     return this.saveHandler(modelArtifacts);
+  }
+}
+
+class PassthroughAsync implements IOHandler {
+  load?: LoadHandler;
+  save?: SaveHandler;
+
+  constructor(handler: IOHandlerSync) {
+    if (handler.load) {
+      this.load = () => Promise.resolve(handler.load());
+    }
+    if (handler.save) {
+      this.save = (modelArtifacts: ModelArtifacts) =>
+        Promise.resolve(handler.save(modelArtifacts));
+    }
   }
 }
 
@@ -63,6 +77,35 @@ class PassthroughSaver implements IOHandler {
 export function fromMemory(
     modelArtifacts: {}|ModelArtifacts, weightSpecs?: WeightsManifestEntry[],
     weightData?: ArrayBuffer, trainingConfig?: TrainingConfig): IOHandler {
+
+  const args = arguments as unknown as Parameters<typeof fromMemory>;
+  return new PassthroughAsync(fromMemorySync(...args));
+}
+
+/**
+ * Creates an IOHandler that loads model artifacts from memory.
+ *
+ * When used in conjunction with `tf.loadLayersModel`, an instance of
+ * `tf.LayersModel` (Keras-style) can be constructed from the loaded artifacts.
+ *
+ * ```js
+ * const model = await tf.loadLayersModel(tf.io.fromMemory(
+ *     modelTopology, weightSpecs, weightData));
+ * ```
+ *
+ * @param modelArtifacts a object containing model topology (i.e., parsed from
+ *   the JSON format).
+ * @param weightSpecs An array of `WeightsManifestEntry` objects describing the
+ *   names, shapes, types, and quantization of the weight data.
+ * @param weightData A single `ArrayBuffer` containing the weight data,
+ *   concatenated in the order described by the weightSpecs.
+ * @param trainingConfig Model training configuration. Optional.
+ *
+ * @returns A passthrough `IOHandlerSync` that simply loads the provided data.
+ */
+export function fromMemorySync(
+    modelArtifacts: {}|ModelArtifacts, weightSpecs?: WeightsManifestEntry[],
+    weightData?: ArrayBuffer, trainingConfig?: TrainingConfig): IOHandlerSync {
   if (arguments.length === 1) {
     const isModelArtifacts =
         (modelArtifacts as ModelArtifacts).modelTopology != null ||
@@ -109,10 +152,30 @@ export function fromMemory(
  * ```
  *
  * @param saveHandler A function that accepts a `ModelArtifacts` and returns a
- *     `SaveResult`.
+ *     promise that resolves to a `SaveResult`.
  */
 export function withSaveHandler(
     saveHandler: (artifacts: ModelArtifacts) =>
         Promise<SaveResult>): IOHandler {
   return new PassthroughSaver(saveHandler);
+}
+
+/**
+ * Creates an IOHandlerSync that passes saved model artifacts to a callback.
+ *
+ * ```js
+ * function handleSave(artifacts) {
+ *   // ... do something with the artifacts ...
+ *   return {modelArtifactsInfo: {...}, ...};
+ * }
+ *
+ * const saveResult = model.save(tf.io.withSaveHandler(handleSave));
+ * ```
+ *
+ * @param saveHandler A function that accepts a `ModelArtifacts` and returns a
+ *     `SaveResult`.
+ */
+export function withSaveHandlerSync(
+    saveHandler: (artifacts: ModelArtifacts) => SaveResult): IOHandlerSync {
+  return new PassthroughSaver<SaveResult>(saveHandler);
 }

--- a/tfjs-core/src/io/types.ts
+++ b/tfjs-core/src/io/types.ts
@@ -387,6 +387,13 @@ export interface IOHandler {
   load?: LoadHandler;
 }
 
+export type Syncify<T> = T extends (...args: infer Args) => Promise<infer R>
+  ? (...args: Args) => R : never;
+
+export type IOHandlerSync = {
+  [K in keyof IOHandler]: Syncify<IOHandler[K]>
+};
+
 /**
  * An interface for the manager of a model store.
  *

--- a/tfjs-core/src/io/types.ts
+++ b/tfjs-core/src/io/types.ts
@@ -387,7 +387,7 @@ export interface IOHandler {
   load?: LoadHandler;
 }
 
-export type Syncify<T> = T extends (...args: infer Args) => Promise<infer R>
+type Syncify<T> = T extends (...args: infer Args) => Promise<infer R>
   ? (...args: Args) => R : never;
 
 export type IOHandlerSync = {

--- a/tfjs-core/src/io/types.ts
+++ b/tfjs-core/src/io/types.ts
@@ -387,8 +387,9 @@ export interface IOHandler {
   load?: LoadHandler;
 }
 
-type Syncify<T> = T extends (...args: infer Args) => Promise<infer R>
-  ? (...args: Args) => R : never;
+type PromiseFunction = (...args: unknown[]) => Promise<unknown>;
+type Syncify<T extends PromiseFunction> = T extends (...args: infer Args)
+  => Promise<infer R> ? (...args: Args) => R : never;
 
 export type IOHandlerSync = {
   [K in keyof IOHandler]: Syncify<IOHandler[K]>


### PR DESCRIPTION
Add IOHandlerSync, which has the same interface as IOHandler but returns values instead of promises. Add fromMemorySync, the synchronous version of fromMemory, and withSaveHandlerSync, the synchronous version of withSavehandler.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6417)
<!-- Reviewable:end -->
