### PR TITLE
Disable fusedConv2d's NCHW bacth tests for node and WebGPU backends

### DIFF
--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -112,10 +112,11 @@ const TEST_FILTERS: TestFilter[] = [
     excludes: [
       'gradient x=[2,3,3,1] f=[2,2,1,1] s=1 p=0',  // conv2dDerInput not yet
                                                    // implemented
-      'backProp',  // Conv2DBackpropFilter not yet
-                   // implemented
+      'backProp',       // Conv2DBackpropFilter not yet
+                        // implemented
       'basic in NCHW',  // NCHW format is not yet supported
       'im2row in NCHW',
+      'batch in NCHW',
     ]
   },
   {

--- a/tfjs-node/src/run_tests.ts
+++ b/tfjs-node/src/run_tests.ts
@@ -107,6 +107,7 @@ const IGNORE_LIST: string[] = [
   'conv2dTranspose test-tensorflow {} gradient input=[1,3,3,1] f=[2,2,2,1] s=[1,1] p=explicit',
   'fused conv2d test-tensorflow {} basic in NCHW',
   'fused conv2d test-tensorflow {} im2row in NCHW',
+  'fused conv2d test-tensorflow {} batch in NCHW',
   'maxPoolWithArgmax',
   'rotate',
   // FIXME: unique NaN-handling is inconsistent between TFJS and TFPY


### PR DESCRIPTION
Currently, WebGPU, Node and WASM backends do not support NCHW format for fusedConv2d, while PR https://github.com/tensorflow/tfjs/pull/6423 added some NCHW tests in tfjs-core. WASM backend has already [disabled](https://github.com/tensorflow/tfjs/blob/6b012da29cc5db66ad48e9f2c22d77bbb016aec3/tfjs-backend-wasm/src/setup_test.ts#L123) these tests, so this PR aims to disable them for Node and WebGPU backends.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6425)
<!-- Reviewable:end -->
