### PR TITLE
Fix find_packages_with_diff.js not checking all packages

### DIFF
--- a/scripts/find_packages_with_diff.js
+++ b/scripts/find_packages_with_diff.js
@@ -32,14 +32,9 @@ let branchName = process.env['BRANCH_NAME'];
 let baseBranch = process.env['BASE_BRANCH'];
 
 
-const allPackages = readdirSync('.').filter(f => {
-  if (f === 'node_modules' || f === '.git' || f === 'clone' ||
-      !statSync(f).isDirectory()) {
-    return false;
-  }
-  const directoryContents = readdirSync(join('.', f));
-  return directoryContents.includes('cloudbuild.yml');
-});
+const packageDependencies = JSON.parse(readFileSync(
+    join(__dirname, 'package_dependencies.json'), 'utf8'));
+const allPackages = Object.keys(packageDependencies);
 
 
 function findPackagesWithDiff() {

--- a/scripts/find_packages_with_diff.js
+++ b/scripts/find_packages_with_diff.js
@@ -56,6 +56,7 @@ function findPackagesWithDiff() {
 
   console.log();  // Break up the console for readability.
 
+  const originalPath = process.cwd();
   shell.cd(CLONE_PATH);
 
   // If we cannot check out the commit then this PR is coming from a fork.
@@ -75,7 +76,7 @@ function findPackagesWithDiff() {
   } else {
     console.log(`PR is going to diff against branch ${baseBranch}.`);
   }
-  shell.cd('..');
+  shell.cd(originalPath);
   console.log();  // Break up the console for readability.
 
   let triggerAllBuilds = false;

--- a/scripts/find_packages_with_diff.js
+++ b/scripts/find_packages_with_diff.js
@@ -16,7 +16,7 @@
 
 const {exec} = require('./test-util');
 const shell = require('shelljs');
-const {readdirSync, statSync, readFileSync} = require('fs');
+const {readFileSync} = require('fs');
 const {join} = require('path');
 
 

--- a/scripts/find_packages_with_diff.js
+++ b/scripts/find_packages_with_diff.js
@@ -16,7 +16,7 @@
 
 const {exec} = require('./test-util');
 const shell = require('shelljs');
-const {readdirSync, statSync} = require('fs');
+const {readdirSync, statSync, readFileSync} = require('fs');
 const {join} = require('path');
 
 
@@ -26,7 +26,7 @@ const filesAllowlistToTriggerBuild = [
   'scripts/generate_cloudbuild.js'
 ];
 
-const CLONE_PATH = 'clone';
+const CLONE_PATH = '/tmp/tfjs-diff-clone';
 let commitSha = process.env['COMMIT_SHA'];
 let branchName = process.env['BRANCH_NAME'];
 let baseBranch = process.env['BASE_BRANCH'];
@@ -115,7 +115,7 @@ function findPackagesWithDiff() {
 function diff(fileOrDirName) {
   const diffCmd = `diff -rq --exclude='settings.json' ` +
       `${CLONE_PATH}/${fileOrDirName} ` +
-      `${fileOrDirName}`;
+      `${join(__dirname, '../', fileOrDirName)}`;
   return exec(diffCmd, {silent: true}, true).stdout.trim();
 }
 


### PR DESCRIPTION
Use `package_dependencies.json` to find packages instead of scanning for directories containing `cloudbuild.yml` files. Set the clone path to be in `/tmp` by default.

Fixes #6426

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6427)
<!-- Reviewable:end -->
