### PR TITLE
Implement http_sync IO handler and add it to loadGraphModelSync

### DIFF
--- a/tfjs-converter/src/executor/graph_model_test.ts
+++ b/tfjs-converter/src/executor/graph_model_test.ts
@@ -433,6 +433,15 @@ describe('loadGraphModelSync', () => {
     expect(errorMsg)
       .toMatch(/modelUrl in loadGraphModelSync\(\) cannot be null/);
   });
+
+  it('Pass a fetchFunc', async () => {
+    const fetchFunc = () => {};
+    spyOn(tfc.io, 'getLoadHandlers').and.returnValue([
+      CUSTOM_HTTP_MODEL_LOADER
+    ]);
+    await loadGraphModel(MODEL_URL, {fetchFunc});
+    expect(tfc.io.getLoadHandlers).toHaveBeenCalledWith(MODEL_URL, {fetchFunc});
+  });
 });
 
 describe('Model', () => {

--- a/tfjs-converter/yarn.lock
+++ b/tfjs-converter/yarn.lock
@@ -164,11 +164,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@tensorflow/tfjs-backend-cpu@link:../link-package/node_modules/@tensorflow/tfjs-backend-cpu":
+"@tensorflow/tfjs-backend-cpu@link:../link-package-core/node_modules/@tensorflow/tfjs-backend-cpu":
   version "0.0.0"
   uid ""
 
-"@tensorflow/tfjs-core@link:../link-package/node_modules/@tensorflow/tfjs-core":
+"@tensorflow/tfjs-core@link:../link-package-core/node_modules/@tensorflow/tfjs-core":
   version "0.0.0"
   uid ""
 
@@ -261,17 +261,12 @@
 "@types/seedrandom@2.4.27":
   version "2.4.27"
   resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
-  integrity sha512-YvMLqFak/7rt//lPBtEHv3M4sRNA+HGxrhFZ+DQs9K2IkYJbNwVIb8avtJfhDiuaUBX/AW0jnjv48FV8h3u9bQ==
+  integrity sha1-nbVjk33YaRX2kJK8QyWdL0hXjkE=
 
 "@types/webgl-ext@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
-
-"@webgpu/types@^0.1.16":
-  version "0.1.17"
-  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.17.tgz#91e8ec9fd6a1e63945ef12bff11394949ea1a583"
-  integrity sha512-M8INbXsMdkWtVsSHRPEiTXHe0S4gxMhYA/Kz4pNoUF9IXd3PHMi6/2n8EAsqkAEdna+aeCm2RmscWV0hsmIf0Q==
 
 ajv@~6.12.3:
   version "6.12.3"

--- a/tfjs-core/src/io/http_sync.ts
+++ b/tfjs-core/src/io/http_sync.ts
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {env} from '../environment';
+import {Platform} from '../platforms/platform';
+import {assert} from '../util';
+import {parseUrl} from './http';
+import {concatenateArrayBuffers, parseModelJson} from './io_utils';
+import {IOHandlerSync, LoadOptions, ModelArtifacts, ModelJSON, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
+
+type LoadOptionsSync = Omit<LoadOptions, 'weightUrlConverter'|'onProgress'> & {
+  weightUrlConverter?: (weightFileName: string) => string;
+};
+
+export class HTTPRequestSync implements IOHandlerSync {
+  protected readonly path: string;
+  protected readonly requestInit: RequestInit;
+
+  private readonly fetch: Function;
+  private readonly weightUrlConverter: (weightName: string) => string;
+
+  readonly DEFAULT_METHOD = 'POST';
+
+  static readonly URL_SCHEME_REGEX = /^https?:\/\//;
+
+  private readonly weightPathPrefix: string;
+
+  constructor(path: string, loadOptions?: LoadOptionsSync) {
+    if (loadOptions == null) {
+      loadOptions = {};
+    }
+    this.weightPathPrefix = loadOptions.weightPathPrefix;
+    this.weightUrlConverter = loadOptions.weightUrlConverter;
+
+    if (loadOptions.fetchFunc != null) {
+      assert(
+          typeof loadOptions.fetchFunc === 'function',
+          () => 'Must pass a function that matches the signature of ' +
+              '`fetch` (see ' +
+              'https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)');
+      this.fetch = loadOptions.fetchFunc;
+    } else {
+      this.fetch = env().platform.fetchSync;
+    }
+
+    assert(
+        path != null && path.length > 0,
+        () => 'URL path for http must not be null, undefined or ' +
+            'empty.');
+
+    if (Array.isArray(path)) {
+      assert(
+          path.length === 2,
+          () => 'URL paths for http must have a length of 2, ' +
+              `(actual length is ${path.length}).`);
+    }
+    this.path = path;
+
+    if (loadOptions.requestInit != null &&
+        loadOptions.requestInit.body != null) {
+      throw new Error(
+          'requestInit is expected to have no pre-existing body, but has one.');
+    }
+    this.requestInit = loadOptions.requestInit || {};
+  }
+
+  save(_modelArtifacts: ModelArtifacts): SaveResult {
+    throw new Error('http_sync does not support saving models. Use http instead.');
+  }
+
+  /**
+   * Load model artifacts via HTTP request(s).
+   *
+   * See the documentation to `tf.io.http` for details on the saved
+   * artifacts.
+   *
+   * @returns The loaded model artifacts (if loading succeeds).
+   */
+  load(): ModelArtifacts {
+    const modelConfigRequest = this.fetch(this.path, this.requestInit);
+
+    if (!modelConfigRequest.ok) {
+      throw new Error(
+          `Request to ${this.path} failed with status code ` +
+          `${modelConfigRequest.status}. Please verify this URL points to ` +
+          `the model JSON of the model to load.`);
+    }
+    let modelJSON: ModelJSON;
+    try {
+      modelJSON = modelConfigRequest.json();
+    } catch (e) {
+      let message = `Failed to parse model JSON of response from ${this.path}.`;
+      // TODO(nsthorat): Remove this after some time when we're comfortable that
+      // .pb files are mostly gone.
+      if (this.path.endsWith('.pb')) {
+        message += ' Your path contains a .pb file extension. ' +
+            'Support for .pb models have been removed in TensorFlow.js 1.0 ' +
+            'in favor of .json models. You can re-convert your Python ' +
+            'TensorFlow model using the TensorFlow.js 1.0 conversion scripts ' +
+            'or you can convert your.pb models with the \'pb2json\'' +
+            'NPM script in the tensorflow/tfjs-converter repository.';
+      } else {
+        message += ' Please make sure the server is serving valid ' +
+            'JSON for this request.';
+      }
+      throw new Error(message);
+    }
+
+    // We do not allow both modelTopology and weightsManifest to be missing.
+    const modelTopology = modelJSON.modelTopology;
+    const weightsManifest = modelJSON.weightsManifest;
+    if (modelTopology == null && weightsManifest == null) {
+      throw new Error(
+          `The JSON from HTTP path ${this.path} contains neither model ` +
+          `topology or manifest for weights.`);
+    }
+
+    const modelArtifacts = parseModelJson(modelJSON);
+    if (modelJSON.weightsManifest != null) {
+      const [weightSpecs, weightData] =
+        this.loadWeights(modelJSON.weightsManifest);
+      modelArtifacts.weightSpecs = weightSpecs;
+      modelArtifacts.weightData = weightData;
+
+    }
+    return modelArtifacts;
+  }
+
+  private loadWeights(weightsManifest: WeightsManifestConfig):
+      [WeightsManifestEntry[], ArrayBuffer] {
+    const weightPath = Array.isArray(this.path) ? this.path[1] : this.path;
+    const [prefix, suffix] = parseUrl(weightPath);
+    const pathPrefix = this.weightPathPrefix || prefix;
+
+    const weightSpecs = [];
+    for (const entry of weightsManifest) {
+      weightSpecs.push(...entry.weights);
+    }
+
+    const fetchURLs: string[] = [];
+    const urls: string[] = [];
+    for (const weightsGroup of weightsManifest) {
+      for (const path of weightsGroup.paths) {
+        if (this.weightUrlConverter != null) {
+          urls.push(this.weightUrlConverter(path));
+        } else {
+          fetchURLs.push(pathPrefix + path + suffix);
+        }
+      }
+    }
+
+    if (this.weightUrlConverter) {
+      fetchURLs.push(...urls);
+    }
+
+    const buffers = loadWeightsAsArrayBufferSync(
+      fetchURLs, this.fetch as Platform['fetchSync'], this.requestInit);
+    return [weightSpecs, concatenateArrayBuffers(buffers)];
+  }
+}
+
+export function httpSync(path: string, loadOptions?: LoadOptionsSync):
+IOHandlerSync {
+  return new HTTPRequestSync(path, loadOptions);
+}
+
+/**
+ * Synchronously reads binary weights data from a number of URLs.
+ *
+ * @param fetchURLs URLs to send the HTTP requests at, using synchronous
+ * `fetch` calls.
+ * @param requestOptions RequestInit (options) for the HTTP requests.
+ * @returns An Array of `ArrayBuffer`. The Array has the same
+ *   length as `fetchURLs`.
+ */
+function loadWeightsAsArrayBufferSync(
+  fetchURLs: string[], fetchFunction: Platform['fetchSync'],
+  requestOptions: RequestInit = {}): ArrayBuffer[] {
+  const responses = fetchURLs.map(
+      fetchURL =>
+      fetchFunction(fetchURL, requestOptions, {isBinary: true}));
+  return responses.map(response => response.arrayBuffer());
+}

--- a/tfjs-core/src/io/http_sync_test.ts
+++ b/tfjs-core/src/io/http_sync_test.ts
@@ -1,0 +1,527 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../index';
+import {BROWSER_ENVS, describeWithFlags} from '../jasmine_util';
+import {Platform} from '../platforms/platform';
+import {modelTopology1, trainingConfig1, TypedArrays} from './http_test';
+
+let fetchSpy: jasmine.Spy;
+
+export const fakeResponse =
+    (body: string|TypedArrays|ArrayBuffer, contentType: string, path: string) =>
+        ({
+          ok: true,
+          json() {
+            return JSON.parse(body as string);
+          },
+          arrayBuffer() {
+            const buf: ArrayBuffer = (body as TypedArrays).buffer ?
+                (body as TypedArrays).buffer :
+                body as ArrayBuffer;
+            return buf;
+          },
+          headers: {get: (key: string) => contentType},
+          url: path
+        });
+
+const setupFakeWeightFiles =
+    (fileBufferMap: {
+      [filename: string]: {
+        data: string|Float32Array|Int32Array|ArrayBuffer|Uint8Array|Uint16Array,
+        contentType: string
+      }
+    },
+     requestInits: {[key: string]: RequestInit}) => {
+       fetchSpy = spyOn(tf.env().platform, 'fetchSync')
+                     .and.callFake((path: string, init: RequestInit) => {
+                       if (fileBufferMap[path]) {
+                         requestInits[path] = init;
+                         return fakeResponse(
+                             fileBufferMap[path].data,
+                             fileBufferMap[path].contentType, path);
+                       } else {
+                         throw new Error('path not found');
+                       }
+                     });
+    };
+
+describeWithFlags('http-sync-load', BROWSER_ENVS, () => {
+  describe('JSON model', () => {
+    let requestInits: {[key: string]: {headers: {[key: string]: string}}};
+
+    beforeEach(() => {
+      requestInits = {};
+    });
+
+    it('1 group, 2 weights, 1 path', () => {
+      const weightManifest1: tf.io.WeightsManifestConfig = [{
+        paths: ['weightfile0'],
+        weights: [
+          {
+            name: 'dense/kernel',
+            shape: [3, 1],
+            dtype: 'float32',
+          },
+          {
+            name: 'dense/bias',
+            shape: [2],
+            dtype: 'float32',
+          }
+        ]
+      }];
+      const floatData = new Float32Array([1, 3, 3, 7, 4]);
+      setupFakeWeightFiles(
+          {
+            './model.json': {
+              data: JSON.stringify({
+                modelTopology: modelTopology1,
+                weightsManifest: weightManifest1,
+                format: 'tfjs-graph-model',
+                generatedBy: '1.15',
+                convertedBy: '1.3.1',
+                signature: null,
+                userDefinedMetadata: {},
+                modelInitializer: {}
+              }),
+              contentType: 'application/json'
+            },
+            './weightfile0':
+                {data: floatData, contentType: 'application/octet-stream'},
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync('./model.json');
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
+      expect(modelArtifacts.format).toEqual('tfjs-graph-model');
+      expect(modelArtifacts.generatedBy).toEqual('1.15');
+      expect(modelArtifacts.convertedBy).toEqual('1.3.1');
+      expect(modelArtifacts.userDefinedMetadata).toEqual({});
+      expect(modelArtifacts.modelInitializer).toEqual({});
+
+      expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
+      expect(Object.keys(requestInits).length).toEqual(2);
+      // Assert that fetch is invoked with `window` as the context.
+      expect(fetchSpy.calls.mostRecent().object).toEqual(window);
+    });
+
+    it('1 group, 2 weights, 1 path, with requestInit', () => {
+      const weightManifest1: tf.io.WeightsManifestConfig = [{
+        paths: ['weightfile0'],
+        weights: [
+          {
+            name: 'dense/kernel',
+            shape: [3, 1],
+            dtype: 'float32',
+          },
+          {
+            name: 'dense/bias',
+            shape: [2],
+            dtype: 'float32',
+          }
+        ]
+      }];
+      const floatData = new Float32Array([1, 3, 3, 7, 4]);
+      setupFakeWeightFiles(
+          {
+            './model.json': {
+              data: JSON.stringify({
+                modelTopology: modelTopology1,
+                weightsManifest: weightManifest1
+              }),
+              contentType: 'application/json'
+            },
+            './weightfile0':
+                {data: floatData, contentType: 'application/octet-stream'},
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync(
+          './model.json',
+          {requestInit: {headers: {'header_key_1': 'header_value_1'}}});
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
+      expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
+      expect(Object.keys(requestInits).length).toEqual(2);
+      expect(Object.keys(requestInits).length).toEqual(2);
+      expect(requestInits['./model.json'].headers['header_key_1'])
+          .toEqual('header_value_1');
+      expect(requestInits['./weightfile0'].headers['header_key_1'])
+          .toEqual('header_value_1');
+
+      expect(fetchSpy.calls.mostRecent().object).toEqual(window);
+    });
+
+    it('1 group, 2 weight, 2 paths', () => {
+      const weightManifest1: tf.io.WeightsManifestConfig = [{
+        paths: ['weightfile0', 'weightfile1'],
+        weights: [
+          {
+            name: 'dense/kernel',
+            shape: [3, 1],
+            dtype: 'float32',
+          },
+          {
+            name: 'dense/bias',
+            shape: [2],
+            dtype: 'float32',
+          }
+        ]
+      }];
+      const floatData1 = new Float32Array([1, 3, 3]);
+      const floatData2 = new Float32Array([7, 4]);
+      setupFakeWeightFiles(
+          {
+            './model.json': {
+              data: JSON.stringify({
+                modelTopology: modelTopology1,
+                weightsManifest: weightManifest1
+              }),
+              contentType: 'application/json'
+            },
+            './weightfile0':
+                {data: floatData1, contentType: 'application/octet-stream'},
+            './weightfile1':
+                {data: floatData2, contentType: 'application/octet-stream'}
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync('./model.json');
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
+      expect(new Float32Array(modelArtifacts.weightData))
+          .toEqual(new Float32Array([1, 3, 3, 7, 4]));
+    });
+
+    it('2 groups, 2 weight, 2 paths', () => {
+      const weightsManifest: tf.io.WeightsManifestConfig = [
+        {
+          paths: ['weightfile0'],
+          weights: [{
+            name: 'dense/kernel',
+            shape: [3, 1],
+            dtype: 'float32',
+          }]
+        },
+        {
+          paths: ['weightfile1'],
+          weights: [{
+            name: 'dense/bias',
+            shape: [2],
+            dtype: 'float32',
+          }],
+        }
+      ];
+      const floatData1 = new Float32Array([1, 3, 3]);
+      const floatData2 = new Float32Array([7, 4]);
+      setupFakeWeightFiles(
+          {
+            './model.json': {
+              data: JSON.stringify(
+                  {modelTopology: modelTopology1, weightsManifest}),
+              contentType: 'application/json'
+            },
+            './weightfile0':
+                {data: floatData1, contentType: 'application/octet-stream'},
+            './weightfile1':
+                {data: floatData2, contentType: 'application/octet-stream'}
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync('./model.json');
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs)
+          .toEqual(
+              weightsManifest[0].weights.concat(weightsManifest[1].weights));
+      expect(new Float32Array(modelArtifacts.weightData))
+          .toEqual(new Float32Array([1, 3, 3, 7, 4]));
+    });
+
+    it('2 groups, 2 weight, 2 paths, Int32 and Uint8 Data', () => {
+      const weightsManifest: tf.io.WeightsManifestConfig = [
+        {
+          paths: ['weightfile0'],
+          weights: [{
+            name: 'fooWeight',
+            shape: [3, 1],
+            dtype: 'int32',
+          }]
+        },
+        {
+          paths: ['weightfile1'],
+          weights: [{
+            name: 'barWeight',
+            shape: [2],
+            dtype: 'bool',
+          }],
+        }
+      ];
+      const floatData1 = new Int32Array([1, 3, 3]);
+      const floatData2 = new Uint8Array([7, 4]);
+      setupFakeWeightFiles(
+          {
+            'path1/model.json': {
+              data: JSON.stringify(
+                  {modelTopology: modelTopology1, weightsManifest}),
+              contentType: 'application/json'
+            },
+            'path1/weightfile0':
+                {data: floatData1, contentType: 'application/octet-stream'},
+            'path1/weightfile1':
+                {data: floatData2, contentType: 'application/octet-stream'}
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync('path1/model.json');
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs)
+          .toEqual(
+              weightsManifest[0].weights.concat(weightsManifest[1].weights));
+      expect(new Int32Array(modelArtifacts.weightData.slice(0, 12)))
+          .toEqual(new Int32Array([1, 3, 3]));
+      expect(new Uint8Array(modelArtifacts.weightData.slice(12, 14)))
+          .toEqual(new Uint8Array([7, 4]));
+    });
+
+    it('topology only', () => {
+      setupFakeWeightFiles(
+          {
+            './model.json': {
+              data: JSON.stringify({modelTopology: modelTopology1}),
+              contentType: 'application/json'
+            },
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync('./model.json');
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs).toBeUndefined();
+      expect(modelArtifacts.weightData).toBeUndefined();
+    });
+
+    it('weights only', () => {
+      const weightsManifest: tf.io.WeightsManifestConfig = [
+        {
+          paths: ['weightfile0'],
+          weights: [{
+            name: 'fooWeight',
+            shape: [3, 1],
+            dtype: 'int32',
+          }]
+        },
+        {
+          paths: ['weightfile1'],
+          weights: [{
+            name: 'barWeight',
+            shape: [2],
+            dtype: 'float32',
+          }],
+        }
+      ];
+      const floatData1 = new Int32Array([1, 3, 3]);
+      const floatData2 = new Float32Array([-7, -4]);
+      setupFakeWeightFiles(
+          {
+            'path1/model.json': {
+              data: JSON.stringify({weightsManifest}),
+              contentType: 'application/json'
+            },
+            'path1/weightfile0':
+                {data: floatData1, contentType: 'application/octet-stream'},
+            'path1/weightfile1':
+                {data: floatData2, contentType: 'application/octet-stream'}
+          },
+          requestInits);
+
+      const handler = tf.io.httpSync('path1/model.json');
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toBeUndefined();
+      expect(modelArtifacts.weightSpecs)
+          .toEqual(
+              weightsManifest[0].weights.concat(weightsManifest[1].weights));
+      expect(new Int32Array(modelArtifacts.weightData.slice(0, 12)))
+          .toEqual(new Int32Array([1, 3, 3]));
+      expect(new Float32Array(modelArtifacts.weightData.slice(12, 20)))
+          .toEqual(new Float32Array([-7, -4]));
+    });
+
+    it('Missing modelTopology and weightsManifest leads to error', () => {
+      setupFakeWeightFiles(
+          {
+            'path1/model.json':
+                {data: JSON.stringify({}), contentType: 'application/json'}
+          },
+          requestInits);
+      const handler = tf.io.httpSync('path1/model.json');
+      try {
+        handler.load();
+        fail('Loading from missing modelTopology and weightsManifest ' +
+          'succeeded unexpectedly.');
+      }
+      catch (err) {
+        expect(err.message)
+          .toMatch(/contains neither model topology or manifest/);
+      }
+    });
+
+    it('with fetch error leads to error', () => {
+      setupFakeWeightFiles(
+          {
+            'path1/model.json':
+                {data: JSON.stringify({}), contentType: 'text/html'}
+          },
+          requestInits);
+      const handler = tf.io.httpSync('path2/model.json');
+      try {
+        const data = handler.load();
+        expect(data).toBeDefined();
+        fail('Loading with fetch error succeeded unexpectedly.');
+      } catch (err) {
+        // This error is mocked in beforeEach
+        expect((err as Error).message).toEqual('path not found');
+      }
+    });
+    it('Provide WeightFileTranslateFunc', () => {
+      const weightManifest1: tf.io.WeightsManifestConfig = [{
+        paths: ['weightfile0'],
+        weights: [
+          {
+            name: 'dense/kernel',
+            shape: [3, 1],
+            dtype: 'float32',
+          },
+          {
+            name: 'dense/bias',
+            shape: [2],
+            dtype: 'float32',
+          }
+        ]
+      }];
+      const floatData = new Float32Array([1, 3, 3, 7, 4]);
+      setupFakeWeightFiles(
+          {
+            './model.json': {
+              data: JSON.stringify({
+                modelTopology: modelTopology1,
+                weightsManifest: weightManifest1
+              }),
+              contentType: 'application/json'
+            },
+            'auth_weightfile0':
+                {data: floatData, contentType: 'application/octet-stream'},
+          },
+          requestInits);
+      function prefixWeightUrlConverter(weightFile: string): string {
+        // Add 'auth_' prefix to the weight file url.
+        return 'auth_' + weightFile;
+      }
+
+      const handler = tf.io.httpSync('./model.json', {
+        requestInit: {headers: {'header_key_1': 'header_value_1'}},
+        weightUrlConverter: prefixWeightUrlConverter
+      });
+      const modelArtifacts = handler.load();
+      expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+      expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
+      expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
+      expect(Object.keys(requestInits).length).toEqual(2);
+      expect(Object.keys(requestInits).length).toEqual(2);
+      expect(requestInits['./model.json'].headers['header_key_1'])
+          .toEqual('header_value_1');
+      expect(requestInits['auth_weightfile0'].headers['header_key_1'])
+          .toEqual('header_value_1');
+
+      expect(fetchSpy.calls.mostRecent().object).toEqual(window);
+    });
+  });
+
+  it('Overriding BrowserHTTPRequest fetchFunc', () => {
+    const weightManifest1: tf.io.WeightsManifestConfig = [{
+      paths: ['weightfile0'],
+      weights: [
+        {
+          name: 'dense/kernel',
+          shape: [3, 1],
+          dtype: 'float32',
+        },
+        {
+          name: 'dense/bias',
+          shape: [2],
+          dtype: 'float32',
+        }
+      ]
+    }];
+    const floatData = new Float32Array([1, 3, 3, 7, 4]);
+
+    const fetchInputs: RequestInfo[] = [];
+    const fetchInits: RequestInit[] = [];
+    function customFetch(input: RequestInfo, init?: RequestInit):
+    ReturnType<Platform['fetchSync']> {
+      fetchInputs.push(input);
+      fetchInits.push(init);
+
+      if (input === './model.json') {
+        return {
+          json() {
+            return {
+              modelTopology: modelTopology1,
+              weightsManifest: weightManifest1,
+              trainingConfig: trainingConfig1
+            };
+          },
+          ok: true,
+          arrayBuffer() {throw new Error('not supported');}
+        };
+      } else if (input === './weightfile0') {
+        return {
+          arrayBuffer() {
+            return floatData;
+          },
+          json() {throw new Error('not supported');},
+          ok: true,
+        };
+      } else {
+        return {
+          ok: false,
+          json() {throw new Error('not supported');},
+          arrayBuffer() {throw new Error('not supported');},
+        };
+      }
+    }
+
+    const handler = tf.io.httpSync(
+        './model.json',
+        {requestInit: {credentials: 'include'}, fetchFunc: customFetch});
+    const modelArtifacts = handler.load();
+    expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+    expect(modelArtifacts.trainingConfig).toEqual(trainingConfig1);
+    expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
+    expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
+
+    expect(fetchInputs).toEqual(['./model.json', './weightfile0']);
+    expect(fetchInits.length).toEqual(2);
+    expect(fetchInits[0].credentials).toEqual('include');
+    expect(fetchInits[1].credentials).toEqual('include');
+  });
+});

--- a/tfjs-core/src/io/http_test.ts
+++ b/tfjs-core/src/io/http_test.ts
@@ -20,7 +20,7 @@ import {BROWSER_ENVS, CHROME_ENVS, describeWithFlags, NODE_ENVS} from '../jasmin
 import {HTTPRequest, httpRouter, parseUrl} from './http';
 
 // Test data.
-const modelTopology1: {} = {
+export const modelTopology1: {} = {
   'class_name': 'Sequential',
   'keras_version': '2.1.4',
   'config': [{
@@ -52,7 +52,7 @@ const modelTopology1: {} = {
   }],
   'backend': 'tensorflow'
 };
-const trainingConfig1: tf.io.TrainingConfig = {
+export const trainingConfig1: tf.io.TrainingConfig = {
   loss: 'categorical_crossentropy',
   metrics: ['accuracy'],
   optimizer_config: {class_name: 'SGD', config: {learningRate: 0.1}}
@@ -60,7 +60,7 @@ const trainingConfig1: tf.io.TrainingConfig = {
 
 let fetchSpy: jasmine.Spy;
 
-type TypedArrays = Float32Array|Int32Array|Uint8Array|Uint16Array;
+export type TypedArrays = Float32Array|Int32Array|Uint8Array|Uint16Array;
 const fakeResponse =
     (body: string|TypedArrays|ArrayBuffer, contentType: string, path: string) =>
         ({

--- a/tfjs-core/src/io/io.ts
+++ b/tfjs-core/src/io/io.ts
@@ -22,6 +22,7 @@ import './local_storage';
 
 import {browserFiles} from './browser_files';
 import {browserHTTPRequest, http, isHTTPScheme} from './http';
+import {httpSync} from './http_sync';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsForJSON, getModelArtifactsInfoForJSON} from './io_utils';
 import {fromMemory, fromMemorySync, withSaveHandler, withSaveHandlerSync} from './passthrough';
 import {getLoadHandlers, getSaveHandlers, registerLoadRouter, registerSaveRouter} from './router_registry';
@@ -42,6 +43,7 @@ export {
   getModelArtifactsInfoForJSON,
   getSaveHandlers,
   http,
+  httpSync,
   IOHandler,
   IOHandlerSync,
   isHTTPScheme,

--- a/tfjs-core/src/io/io_utils.ts
+++ b/tfjs-core/src/io/io_utils.ts
@@ -416,6 +416,25 @@ export async function getModelArtifactsForJSON(
     loadWeights: (weightsManifest: WeightsManifestConfig) => Promise<[
       /* weightSpecs */ WeightsManifestEntry[], /* weightData */ ArrayBuffer
     ]>): Promise<ModelArtifacts> {
+  const modelArtifacts = parseModelJson(modelJSON);
+
+  if (modelJSON.weightsManifest != null) {
+    const [weightSpecs, weightData] =
+        await loadWeights(modelJSON.weightsManifest);
+    modelArtifacts.weightSpecs = weightSpecs;
+    modelArtifacts.weightData = weightData;
+  }
+
+  return modelArtifacts;
+}
+
+/**
+ * Parse a JSON model file into `ModelArtifacts` without loading weights.
+ *
+ * @param modelJSON Object containing the parsed JSON of `model.json`
+ * @returns The `ModelArtifacts` without weights, as described by the JSON file.
+ */
+export function parseModelJson(modelJSON: ModelJSON): ModelArtifacts {
   const modelArtifacts: ModelArtifacts = {
     modelTopology: modelJSON.modelTopology,
     format: modelJSON.format,
@@ -425,12 +444,6 @@ export async function getModelArtifactsForJSON(
 
   if (modelJSON.trainingConfig != null) {
     modelArtifacts.trainingConfig = modelJSON.trainingConfig;
-  }
-  if (modelJSON.weightsManifest != null) {
-    const [weightSpecs, weightData] =
-        await loadWeights(modelJSON.weightsManifest);
-    modelArtifacts.weightSpecs = weightSpecs;
-    modelArtifacts.weightData = weightData;
   }
   if (modelJSON.signature != null) {
     modelArtifacts.signature = modelJSON.signature;

--- a/tfjs-core/src/platforms/platform.ts
+++ b/tfjs-core/src/platforms/platform.ts
@@ -33,6 +33,20 @@ export interface Platform {
       Promise<Response>;
 
   /**
+   * Makes a synchronous HTTP request.
+   * @param path The URL path to make a request to
+   * @param init The request init. See init here:
+   *     https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+   */
+  fetchSync(path: string, requestInits?: RequestInit,
+            options?: RequestDetails): {
+    ok: boolean,
+    arrayBuffer: () => ArrayBuffer,
+    // tslint:disable-next-line:no-any
+    json: () => any,
+  };
+
+  /**
    * Returns the current high-resolution time in milliseconds relative to an
    * arbitrary time in the past. It works across different platforms (node.js,
    * browsers).

--- a/tfjs-core/src/platforms/platform_node.ts
+++ b/tfjs-core/src/platforms/platform_node.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 import {env} from '../environment';
+import {RequestDetails} from '../io/types';
 import {Platform} from './platform';
 
 // We are wrapping this within an object so it can be stubbed by Jasmine.
@@ -59,6 +60,11 @@ export class PlatformNode implements Platform {
       systemFetch = getNodeFetch.importFetch();
     }
     return systemFetch(path, requestInits);
+  }
+
+  fetchSync(path: string, requestInits?: RequestInit, options?: RequestDetails):
+  ReturnType<Platform['fetchSync']> {
+    throw new Error('fetchSync is not implemented for node.');
   }
 
   now(): number {

--- a/tfjs/yarn.lock
+++ b/tfjs/yarn.lock
@@ -1035,6 +1035,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@webgpu/types@^0.1.16":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.17.tgz#91e8ec9fd6a1e63945ef12bff11394949ea1a583"
+  integrity sha512-M8INbXsMdkWtVsSHRPEiTXHe0S4gxMhYA/Kz4pNoUF9IXd3PHMi6/2n8EAsqkAEdna+aeCm2RmscWV0hsmIf0Q==
+
 accepts@~1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"


### PR DESCRIPTION
Implement the httpSync IO handler, which uses a synchronous xhr to load a model. It should only be used in a webworker because it blocks the event loop.

As part of implementing the httpSync IO handler, this PR also adds a fetchSync method to `platform.ts` which is used to perform the synchronous xhr. Only the Browser platform is supported right now.

Add httpSync as the default io handler for loadGraphModelSync when it is passed a url. This is currently hard-coded, and there is no registry for sync IO handlers.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6429)
<!-- Reviewable:end -->
