### PR TITLE
[core] Restore makeTensorFromDataId

### DIFF
--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -824,6 +824,20 @@ export class Engine implements TensorTracker, DataMover {
   }
 
   /**
+   * Internal method used by backends. Makes a new tensor
+   * that is a wrapper around an existing data id. It doesn't create
+   * a new data id, only increments the ref count used in memory tracking.
+   * @deprecated
+   */
+  makeTensorFromDataId(
+    dataId: DataId, shape: number[], dtype: DataType,
+    backend?: KernelBackend): Tensor {
+    dtype = dtype || 'float32';
+    const tensorInfo: TensorInfo = {dataId, shape, dtype};
+    return this.makeTensorFromTensorInfo(tensorInfo, backend);
+  }
+
+  /**
    * Internal method used by backends. Makes a new tensor that is a wrapper
    * around an existing data id in TensorInfo. It doesn't create a new data id,
    * only increments the ref count used in memory tracking.

--- a/tfjs-core/src/engine_test.ts
+++ b/tfjs-core/src/engine_test.ts
@@ -368,6 +368,12 @@ describeWithFlags('memory', ALL_ENVS, () => {
         '(2 bytes per character)';
     expect(mem.reasons.indexOf(expectedReason) >= 0).toBe(true);
   });
+
+  it('makeTensorFromDataId creates a tensor', () => {
+    const tensor = ENGINE.makeTensorFromDataId({}, [3], 'float32');
+    expect(tensor).toBeDefined();
+    expect(tensor.shape).toEqual([3]);
+  });
 });
 
 describeWithFlags('profile', ALL_ENVS, () => {


### PR DESCRIPTION
`makeTensorFromDataId` was [removed](https://github.com/tensorflow/tfjs/pull/6355/files#diff-a157689219de3bc0a158633178e4773fa3fda524fe7561f26f75ce20cdae9ffbL832-R833) by #6355 but it should have been deprecated instead. This PR adds it back as a deprecated function.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6432)
<!-- Reviewable:end -->
