### PR TITLE
Add hint willReadFrequently for canvas

### DIFF
--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -79,3 +79,6 @@ ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);
 
 /** Experimental flag, whether enter compile only phase. */
 ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);
+
+/** Whether to enable canvas2d willReadFrequently. */
+ENV.registerFlag('CANVAS2D_WILL_READ_FREQUENTLY', () => false);

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -157,9 +157,9 @@ function fromPixels_(
       } else {
         const willReadFrequently =
             env().getBool('CANVAS2D_WILL_READ_FREQUENTLY');
-        const options = willReadFrequently ? {willReadFrequently} : {};
-        fromPixels2DContext = document.createElement('canvas').getContext(
-                                  '2d', options) as CanvasRenderingContext2D;
+        fromPixels2DContext =
+            document.createElement('canvas').getContext(
+                '2d', {willReadFrequently}) as CanvasRenderingContext2D;
       }
     }
     fromPixels2DContext.canvas.width = width;

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -157,9 +157,9 @@ function fromPixels_(
       } else {
         const willReadFrequently =
             env().getBool('CANVAS2D_WILL_READ_FREQUENTLY');
-        fromPixels2DContext =
-            document.createElement('canvas').getContext(
-                '2d', {willReadFrequently}) as CanvasRenderingContext2D;
+        const options = willReadFrequently ? {willReadFrequently} : {};
+        fromPixels2DContext = document.createElement('canvas').getContext(
+                                  '2d', options) as CanvasRenderingContext2D;
       }
     }
     fromPixels2DContext.canvas.width = width;

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -155,7 +155,11 @@ function fromPixels_(
               'Reason: OffscreenCanvas Context2D rendering is not supported.');
         }
       } else {
-        fromPixels2DContext = document.createElement('canvas').getContext('2d');
+        const willReadFrequently =
+            env().getBool('CANVAS2D_WILL_READ_FREQUENTLY');
+        fromPixels2DContext =
+            document.createElement('canvas').getContext(
+                '2d', {willReadFrequently}) as CanvasRenderingContext2D;
       }
     }
     fromPixels2DContext.canvas.width = width;


### PR DESCRIPTION
Add hint willReadFrequently for canvas

This change has performance impact on cpu and wasm backend. For
getImageData involved cases, set willReadFrequently to true may
improve performance, for example, for input image 125x125 to 513x513,
the measured time on getImageData is ~ 20ms when willReadFrequently: false, 
and 6~10 ms when willReadFrequently: true.

The root cause is, getImageData runs on different hardware (CPU, GPU).
See comments here: https://bugs.chromium.org/p/chromium/issues/detail?id=1239467

Use tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY', true) to turn on this feature.

Spec: https://github.com/fserb/canvas2D/blob/master/spec/will-read-frequently.md
Bug: https://github.com/tensorflow/tfjs/issues/4227, https://github.com/tensorflow/tfjs/issues/4218

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6445)
<!-- Reviewable:end -->
