### PR TITLE
Compute WebGL conv2d's NCHW output without transposing to NHWC

### DIFF
--- a/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgl/src/kernels/Conv2D_impl.ts
@@ -297,7 +297,6 @@ export function conv2dWithIm2Row({
     preluActivationWeights = preluActivationWeightsInNhwcFormat;
   }
 
-
   const xSqueezed =
       reshape({inputs: {x}, backend, attrs: {shape: x.shape.slice(1)}});
   const w2Row = reshape({


### PR DESCRIPTION
Currently, to compute NCHW `conv2d/fusedConv2d` in WebGL backend,  both `conv2dByMatMul` and `conv2dWithIm2Row` do:
1. transpose inputs (x, bias and activation weights) from NCHW to NHWC
2. compute `conv2d/fusedConv2d` with the transposed inputs, as if computing NHWC.
3. transpose the output in NHWC format to NCHW back.

Transposing the inputs and outputs back and forth between NHWC and NCHW is an overhead which could be avoided. This PR optimizes `conv2dByMatMul` and `conv2dWithIm2Row` for NCHW by computing the NCHW output directly without transposing, utilizing the rule: `Transpose(A x B) = Transpose(B) x Transpose(A)` (https://github.com/tensorflow/tfjs/pull/6430).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6453)
<!-- Reviewable:end -->
