### PR TITLE
[converter] Fix fusedMatMul bug.

### DIFF
--- a/tfjs-converter/python/tensorflowjs/op_list/convolution.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/convolution.json
@@ -394,7 +394,8 @@
       {
         "tfName": "leakyrelu_alpha",
         "name": "leakyreluAlpha",
-        "type": "number"
+        "type": "number",
+        "defaultValue": 0.2
       }
     ]
   },

--- a/tfjs-converter/python/tensorflowjs/op_list/matrices.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/matrices.json
@@ -51,6 +51,12 @@
         "defaultValue": false
       },
       {
+        "tfName": "leakyrelu_alpha",
+        "name": "leakyreluAlpha",
+        "type": "number",
+        "defaultValue": 0.2
+      },
+      {
         "tfName": "T",
         "name": "dtype",
         "type": "dtype",

--- a/tfjs-converter/src/operations/executors/matrices_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/matrices_executor_test.ts
@@ -18,12 +18,13 @@
 import {Tensor} from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import * as tfOps from '@tensorflow/tfjs-core/dist/ops/ops_for_converter';
+import * as matrices from '../op_list/matrices';
 
 import {ExecutionContext} from '../../executor/execution_context';
 import {Node} from '../types';
 
 import {executeOp} from './matrices_executor';
-import {createBoolAttr, createNumberAttr, createNumericArrayAttr, createStrArrayAttr, createStrAttr, createTensorAttr, createTensorsAttr} from './test_helper';
+import {createBoolAttr, createNumberAttr, createNumericArrayAttr, createStrArrayAttr, createStrAttr, createTensorAttr, createTensorsAttr, validateParam} from './test_helper';
 
 describe('matrices', () => {
   let node: Node;
@@ -129,6 +130,18 @@ describe('matrices', () => {
           preluActivationWeights: undefined,
           leakyreluAlpha: 0.3
         });
+      });
+      it('should match json def.', () => {
+        node.op = '_FusedMatMul';
+
+        node.attrParams['fusedOps'] =
+          createStrArrayAttr(['biasadd', 'leakyrelu']);
+        node.attrParams['numArgs'] = createNumberAttr(1);
+        node.attrParams.transposeA = createBoolAttr(true);
+        node.attrParams.transposeB = createBoolAttr(false);
+        node.attrParams.leakyreluAlpha = createNumberAttr(0.3);
+
+        expect(validateParam(node, matrices.json)).toBeTruthy();
       });
     });
     describe('BatchMatMul', () => {

--- a/tfjs-core/src/ops/fused/fused_mat_mul_test.ts
+++ b/tfjs-core/src/ops/fused/fused_mat_mul_test.ts
@@ -111,6 +111,26 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     expectArraysClose(await c.data(), [0, 8, -0.9000000357627869, 20]);
   });
 
+  it('fused A x B with leakyrelu not provided.', async () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+    const transposeA = false;
+    const transposeB = false;
+
+    const c = tf.fused.matMul({
+      a,
+      b,
+      transposeA,
+      transposeB,
+      bias: null,
+      activation: 'leakyrelu'
+    });
+
+    expect(c.shape).toEqual([2, 2]);
+    // leakyRelu should use default alpha=0.2.
+    expectArraysClose(await c.data(), [0, 8, -0.6000000238418579, 20]);
+  });
+
   it('fused A x B with sigmoid', async () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);

--- a/tfjs-core/src/ops/fused/mat_mul.ts
+++ b/tfjs-core/src/ops/fused/mat_mul.ts
@@ -63,7 +63,7 @@ function fusedMatMul_({
   bias,
   activation = 'linear',
   preluActivationWeights,
-  leakyreluAlpha,
+  leakyreluAlpha = 0.2,
 }: {
   a: Tensor|TensorLike,
   b: Tensor|TensorLike,


### PR DESCRIPTION
Fix a bug in fusedMatMul, leakyRelu's alpha value was not mapped, which cause NaN when the op is called. This PR adds the mapping and adds a test to capture this. The test failed before the fix and passed after the fix.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6455)
<!-- Reviewable:end -->
