### PR TITLE
Gathernd range check

### DIFF
--- a/tfjs-backend-webgl/src/gather_nd_gpu.ts
+++ b/tfjs-backend-webgl/src/gather_nd_gpu.ts
@@ -22,21 +22,28 @@ export class GatherNDProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
   constructor(
-      private sliceDim: number, private strides: number[], shape: number[]) {
+      private sliceDim: number, private strides: number[], shape: number[],
+      private paramsShape: number[]) {
     this.outputShape = shape;
     const stridesType = getCoordsDataType(strides.length);
     const dtype = getCoordsDataType(shape.length);
     const strideString = this.sliceDim > 1 ? 'strides[j]' : 'strides';
+    const paramsShapeType = getCoordsDataType(paramsShape.length);
+    const paramsShapeString = paramsShape.length > 1 ? 'paramsShape[j]' : 'paramsShape';
     this.userCode = `
         ${stridesType} strides = ${stridesType}(${this.strides});
+        ${paramsShapeType} paramsShape = ${paramsShapeType}(${this.paramsShape});
          void main() {
           ${dtype} coords = getOutputCoords();
           int flattenIndex = 0;
+          bool out_of_bounds = false;
           for (int j = 0; j < ${this.sliceDim}; j++) {
             int index = round(getIndices(coords[0], j));
+            out_of_bounds = out_of_bounds || index < 0;
+            out_of_bounds = out_of_bounds || index > ${paramsShapeString};
             flattenIndex += index * ${strideString};
           }
-          setOutput(getX(flattenIndex, coords[1]));
+          setOutput(out_of_bounds ? 0.0 : getX(flattenIndex, coords[1]));
         }
       `;
   }

--- a/tfjs-backend-webgl/src/gather_nd_gpu.ts
+++ b/tfjs-backend-webgl/src/gather_nd_gpu.ts
@@ -40,7 +40,7 @@ export class GatherNDProgram implements GPGPUProgram {
           for (int j = 0; j < ${this.sliceDim}; j++) {
             int index = round(getIndices(coords[0], j));
             out_of_bounds = out_of_bounds || index < 0;
-            out_of_bounds = out_of_bounds || index > ${paramsShapeString};
+            out_of_bounds = out_of_bounds || index >= ${paramsShapeString};
             flattenIndex += index * ${strideString};
           }
           setOutput(out_of_bounds ? 0.0 : getX(flattenIndex, coords[1]));

--- a/tfjs-backend-webgl/src/kernels/GatherNd.ts
+++ b/tfjs-backend-webgl/src/kernels/GatherNd.ts
@@ -54,7 +54,7 @@ export function gatherNd(
     return backend.makeTensorInfo(resultShape, params.dtype, outValue.values);
   }
   const program =
-      new GatherNDProgram(sliceRank, strides, [numSlices, sliceSize]);
+      new GatherNDProgram(sliceRank, strides, [numSlices, sliceSize], params.shape);
   const res = backend.runWebGLProgram(
       program, [flattenX, flattenIndices], flattenX.dtype);
 

--- a/tfjs-backend-webgl/src/webgl_ops_test.ts
+++ b/tfjs-backend-webgl/src/webgl_ops_test.ts
@@ -887,31 +887,30 @@ describeWithFlags('gather debug', WEBGL_ENVS, () => {
 
 describeWithFlags('gatherNd', WEBGL_ENVS, () => {
   it('works for out of bounds indices', async () => {
-    const x = tf.tensor1d([1, 2, 3, 4], 'int32');
-    const ind = tf.tensor2d([-2, -1, 0, 1, 2, 3, 4, 5], [8, 1], 'int32');
+    const x = tf.tensor1d([1, 2], 'int32');
+    const ind = tf.tensor2d([-1, 0, 1, 2], [4, 1], 'int32');
     const g = tf.gatherND(x, ind);
-    expectArraysEqual(await g.data(), [0, 0, 1, 2, 3, 4, 0, 0]);
+    expectArraysEqual(await g.data(), [0, 1, 2, 0]);
   });
 
   it('works for out of bounds indices 2d', async () => {
-    const x = tf.tensor2d([...Array(9).keys()].map(e => e + 1), [3, 3], 'int32');
+    const x = tf.tensor2d([...Array(4).keys()].map(e => e + 1), [2, 2], 'int32');
     let indices = [];
-    for (let y = -1; y != 4; y+=1) {
-      for (let x = -1; x != 4; x+=1) {
+    for (let y = -1; y != 3; y+=1) {
+      for (let x = -1; x != 3; x+=1) {
         indices.push(y);
         indices.push(x);
       }
     }
-    const ind = tf.tensor2d(indices, [25, 2], 'int32');
+    const ind = tf.tensor2d(indices, [16, 2], 'int32');
     const g = tf.gatherND(x, ind);
     let g_expected = [
-      0, 0, 0, 0, 0,
-      0, 1, 2, 3, 0,
-      0, 4, 5, 6, 0,
-      0, 7, 8, 9, 0,
-      0, 0, 0, 0, 0
+      0, 0, 0, 0,
+      0, 1, 2, 0,
+      0, 3, 4, 0,
+      0, 0, 0, 0
     ];
-    expect(g.shape).toEqual([25]);
+    expect(g.shape).toEqual([16]);
     expectArraysEqual(await g.data(), g_expected);
   });
 

--- a/tfjs-backend-webgl/src/webgl_ops_test.ts
+++ b/tfjs-backend-webgl/src/webgl_ops_test.ts
@@ -883,3 +883,60 @@ describeWithFlags('gather debug', WEBGL_ENVS, () => {
         .toThrowError(/GatherV2: the index value -1 is not in \[0, 1\]/);
   });
 });
+
+
+describeWithFlags('gatherNd', WEBGL_ENVS, () => {
+  it('works for out of bounds indices', async () => {
+    const x = tf.tensor1d([1, 2, 3, 4], 'int32');
+    const ind = tf.tensor2d([-2, -1, 0, 1, 2, 3, 4, 5], [8, 1], 'int32');
+    const g = tf.gatherND(x, ind);
+    expectArraysEqual(await g.data(), [0, 0, 1, 2, 3, 4, 0, 0]);
+  });
+
+  it('works for out of bounds indices 2d', async () => {
+    const x = tf.tensor2d([...Array(9).keys()].map(e => e + 1), [3, 3], 'int32');
+    let indices = [];
+    for (let y = -1; y != 4; y+=1) {
+      for (let x = -1; x != 4; x+=1) {
+        indices.push(y);
+        indices.push(x);
+      }
+    }
+    const ind = tf.tensor2d(indices, [25, 2], 'int32');
+    const g = tf.gatherND(x, ind);
+    let g_expected = [
+      0, 0, 0, 0, 0,
+      0, 1, 2, 3, 0,
+      0, 4, 5, 6, 0,
+      0, 7, 8, 9, 0,
+      0, 0, 0, 0, 0
+    ];
+    expect(g.shape).toEqual([25]);
+    expectArraysEqual(await g.data(), g_expected);
+  });
+
+  it('works for out of bounds indices 3d', async () => {
+    const x = tf.tensor3d([...Array(8).keys()].map(e => e + 1), [2, 2, 2], 'int32');
+    let indices = [];
+    for (let z = -1; z != 3; z+=1) {
+      for (let y = -1; y != 3; y+=1) {
+        for (let x = -1; x != 3; x+=1) {
+          indices.push(z);
+          indices.push(y);
+          indices.push(x);
+        }
+      }
+    }
+    const ind = tf.tensor2d(indices, [64, 3], 'int32');
+    const g = tf.gatherND(x, ind);
+    const g_expected = [
+      0, 0, 0, 0,   0, 0, 0, 0,   0, 0, 0, 0,   0, 0, 0, 0,
+      0, 0, 0, 0,   0, 1, 2, 0,   0, 3, 4, 0,   0, 0, 0, 0,
+      0, 0, 0, 0,   0, 5, 6, 0,   0, 7, 8, 0,   0, 0, 0, 0,
+      0, 0, 0, 0,   0, 0, 0, 0,   0, 0, 0, 0,   0, 0, 0, 0,
+    ];
+    expectArraysEqual(await g.data(), g_expected);
+  });
+
+});
+


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

`tf.gatherNd` using webgl backend does not yield 0 values for out of bounds indices as written in the [docs](https://js.tensorflow.org/api/latest/#gatherND) and in Tensorflow (python).  See [here](https://github.com/hrbigelow/tfjs-tests).

This pull request is adding a range check and some unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6463)
<!-- Reviewable:end -->
