### PR TITLE
Add hint willReadFrequently for canvas

### DIFF
--- a/tfjs-backend-webgl/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgl/src/kernels/FromPixels.ts
@@ -57,14 +57,16 @@ function fromPixels(args: {
 
   if (isImage || isVideo) {
     if (fromPixels2DContext == null) {
-      fromPixels2DContext = document.createElement('canvas').getContext('2d');
+      const willReadFrequently = env().getBool('CANVAS2D_WILL_READ_FREQUENTLY');
+      fromPixels2DContext = document.createElement('canvas').getContext(
+          '2d', {willReadFrequently});
     }
 
     fromPixels2DContext.canvas.width = width;
     fromPixels2DContext.canvas.height = height;
     fromPixels2DContext.drawImage(
-        pixels as HTMLVideoElement | HTMLImageElement | ImageBitmap,
-        0, 0, width, height);
+        pixels as HTMLVideoElement | HTMLImageElement | ImageBitmap, 0, 0,
+        width, height);
     pixels = fromPixels2DContext.canvas;
   }
 

--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -78,7 +78,9 @@ export function fromPixels(args: {
 
   if (isVideo || isImage) {
     if (fromPixels2DContext == null) {
-      fromPixels2DContext = document.createElement('canvas').getContext('2d');
+      const willReadFrequently = env().getBool('CANVAS2D_WILL_READ_FREQUENTLY');
+      fromPixels2DContext = document.createElement('canvas').getContext(
+          '2d', {willReadFrequently});
     }
     fromPixels2DContext.canvas.width = width;
     fromPixels2DContext.canvas.height = height;

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -79,3 +79,6 @@ ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);
 
 /** Experimental flag, whether enter compile only phase. */
 ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);
+
+/** Whether to enable canvas2d willReadFrequently. */
+ENV.registerFlag('CANVAS2D_WILL_READ_FREQUENTLY', () => false);

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -155,7 +155,11 @@ function fromPixels_(
               'Reason: OffscreenCanvas Context2D rendering is not supported.');
         }
       } else {
-        fromPixels2DContext = document.createElement('canvas').getContext('2d');
+        const willReadFrequently =
+            env().getBool('CANVAS2D_WILL_READ_FREQUENTLY');
+        fromPixels2DContext =
+            document.createElement('canvas').getContext(
+                '2d', {willReadFrequently}) as CanvasRenderingContext2D;
       }
     }
     fromPixels2DContext.canvas.width = width;


### PR DESCRIPTION
This change has performance impact on cpu and wasm backend. For
getImageData involved cases, set willReadFrequently to true may
improve performance, for example, for input image 125x125 to 513x513,
the measured time on getImageData is ~ 20ms when willReadFrequently: false, 
and 6~10 ms when willReadFrequently: true.

The root cause is, getImageData runs on different hardware (CPU, GPU).
See comments here: https://bugs.chromium.org/p/chromium/issues/detail?id=1239467

Use tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY', true) to turn on this feature.

Spec: https://github.com/fserb/canvas2D/blob/master/spec/will-read-frequently.md
Bug: https://github.com/tensorflow/tfjs/issues/4227, https://github.com/tensorflow/tfjs/issues/4218

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6471)
<!-- Reviewable:end -->
