### PR TITLE
NOP-change core only-not fore review

### DIFF
--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -79,3 +79,6 @@ ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);
 
 /** Experimental flag, whether enter compile only phase. */
 ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);
+
+/** Whether to enable canvas2d willReadFrequently. */
+ENV.registerFlag('CANVAS2D_WILL_READ_FREQUENTLY', () => false);


### PR DESCRIPTION
This change has performance impact on cpu and wasm backend. For
getImageData involved cases, set willReadFrequently to true may
improve performance, for example, for input image 125x125 to 513x513,
the time on getImageData is ~20ms when willReadFrequently: false, and
6~10 ms when willReadFrequently: true.

The root cause is, getImageData runs on different hardware (CPU, GPU).
See comments here: https://bugs.chromium.org/p/chromium/issues/detail?id=1239467

Use tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY', true) to turn this feature.

Spec: https://github.com/fserb/canvas2D/blob/master/spec/will-read-frequently.md

Bug: https://github.com/tensorflow/tfjs/issues/4227, https://github.com/tensorflow/tfjs/issues/4218

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.