### PR TITLE
Use a more simple type construction for IOHandlerSync

### DIFF
--- a/tfjs-core/src/io/types.ts
+++ b/tfjs-core/src/io/types.ts
@@ -387,12 +387,26 @@ export interface IOHandler {
   load?: LoadHandler;
 }
 
-type PromiseFunction = (...args: unknown[]) => Promise<unknown>;
-type Syncify<T extends PromiseFunction> = T extends (...args: infer Args)
-  => Promise<infer R> ? (...args: Args) => R : never;
+/**
+ * Type definition for handlers of synchronous loading operations.
+ */
+export type LoadHandlerSync = () => ModelArtifacts;
 
+/**
+ * Type definition for handlers of synchronous saving operations.
+ */
+export type SaveHandlerSync = (modelArtifact: ModelArtifacts) => SaveResult;
+
+/**
+ * Interface for a synchronous model import/export handler.
+ *
+ * The `save` and `load` handlers are both optional, in order to allow handlers
+ * that support only saving or loading.
+ */
+// tslint:disable-next-line:interface-name
 export type IOHandlerSync = {
-  [K in keyof IOHandler]: Syncify<IOHandler[K]>
+  save?: SaveHandlerSync;
+  load?: LoadHandlerSync;
 };
 
 /**


### PR DESCRIPTION
There's likely a breaking change from ts3.5.3 to ts4.x that causes the Syncify type to work correctly in ts3.5.3 but fail in ts4.x. Until we switch to ts4, (or perhaps forever), replace the type with an equivalent but simpler construction.

See comment in #3875

Before this change, compiling a ts4 downstream project results in this error:
```
node_modules/@tensorflow/tfjs-core/dist/io/types.d.ts:337:37 - error TS2344: Type 'IOHandler[K]' does not satisfy the constraint 'PromiseFunction'.
  Type 'SaveHandler | LoadHandler | undefined' is not assignable to type 'PromiseFunction'.
    Type 'undefined' is not assignable to type 'PromiseFunction'.

337     [K in keyof IOHandler]: Syncify<IOHandler[K]>;
                                        ~~~~~~~~~~~~


Found 1 error in node_modules/@tensorflow/tfjs-core/dist/io/types.d.ts:337
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6481)
<!-- Reviewable:end -->
