### PR TITLE
Modularize rollup templates so they can be more easily reused

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/node": "^12.7.5",
     "@types/node-fetch": "~2.1.2",
     "@types/offscreencanvas": "~2019.3.0",
+    "@types/rollup-plugin-visualizer": "^4.2.1",
     "@types/seedrandom": "^2.4.28",
     "@types/shelljs": "^0.8.7",
     "@types/webgl-ext": "0.0.30",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -64,3 +64,34 @@ nodejs_binary(
     ],
     entry_point = "make_version_test_file.ts",
 )
+
+ts_library(
+    name = "downlevel_to_es5_plugin",
+    srcs = [
+        "downlevel_to_es5_plugin.ts",
+    ],
+    module_name = "downlevel_to_es5_plugin",
+    deps = [
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+ts_library(
+    name = "make_rollup_config",
+    srcs = [
+        "make_rollup_config.ts",
+    ],
+    module_name = "make_rollup_config",
+    deps = [
+        ":downlevel_to_es5_plugin",
+        "@npm//@rollup/plugin-commonjs",
+        "@npm//@rollup/plugin-node-resolve",
+        "@npm//@types/node",
+        "@npm//@types/rollup-plugin-visualizer",
+        "@npm//rollup-plugin-sourcemaps",
+        "@npm//rollup-plugin-terser",
+        "@npm//rollup-plugin-visualizer",
+        "@npm//typescript",
+    ],
+)

--- a/tools/downlevel_to_es5_plugin.ts
+++ b/tools/downlevel_to_es5_plugin.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as ts from 'typescript';
+import * as path from 'path';
+
+
+// Transform that is enabled for es5 bundling. It transforms existing ES2015
+// prodmode output to ESM5 so that the resulting bundles are using ES5 format.
+// Inspired by Angular's ng_package ES5 transform:
+// https://github.com/angular/angular/blob/a92a89b0eb127a59d7e071502b5850e57618ec2d/packages/bazel/src/ng_package/rollup.config.js#L150-L170
+export const downlevelToEs5Plugin = {
+  name: 'downlevel-to-es5',
+  transform: (code: string, filePath: string) => {
+    const compilerOptions = {
+      target: ts.ScriptTarget.ES5,
+      module: ts.ModuleKind.ES2015,
+      allowJs: true,
+      sourceMap: true,
+      downlevelIteration: true,
+      importHelpers: true,
+      mapRoot: path.dirname(filePath),
+    };
+    const {outputText, sourceMapText}
+          = ts.transpileModule(code, {compilerOptions});
+    return {
+      code: outputText,
+      map: JSON.parse(sourceMapText),
+    };
+  },
+};

--- a/tools/make_rollup_config.ts
+++ b/tools/make_rollup_config.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as commonjs_import from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import * as sourcemaps_import from 'rollup-plugin-sourcemaps';
+import * as visualizer from 'rollup-plugin-visualizer';
+import {terser as terserPlugin} from 'rollup-plugin-terser';
+import {downlevelToEs5Plugin} from 'downlevel_to_es5_plugin/downlevel_to_es5_plugin';
+
+// These workarounds would not be necessary with esModuleInterop = true,
+// but we likely can't set that.
+const commonjs = commonjs_import as unknown as typeof commonjs_import.default;
+const sourcemaps =
+  sourcemaps_import as unknown as typeof sourcemaps_import.default;
+
+const preamble = `/**
+ * @license
+ * Copyright ${(new Date).getFullYear()} Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */`;
+
+// Without `compress: {typeofs: false}`, the terser plugin will turn
+// `typeof _scriptDir == "undefined"` into `_scriptDir === void 0` in minified
+// JS file which will cause "_scriptDir is undefined" error in web worker's
+// inline script.
+//
+// For more context, see tfjs-backend-wasm/scripts/patch-threaded-simd-module.js
+
+export function makeRollupConfig({
+  globals = {},
+  external = [],
+  leave_as_require = [],
+  plugins = [],
+  terser = false,
+  es5 = false,
+  vis_filename,
+}: {
+  globals?: {[name: string]: string},
+  external?: string[],
+  leave_as_require?: string[],
+  plugins?: unknown[],
+  terser?: boolean,
+  es5?: boolean,
+  vis_filename?: string,
+}) {
+  const vis = vis_filename ? [visualizer({
+    sourcemap: true,
+    filename: vis_filename,
+    template: 'sunburst',
+  })] : [];
+
+  const useTerser = terser ? [
+    terserPlugin({
+      output: {preamble, comments: false},
+      compress: {typeofs: false},
+    })
+  ] : [];
+
+  const useEs5 = es5 ? [downlevelToEs5Plugin] : [];
+
+  return {
+    output: {
+      banner: preamble,
+      freeze: false, // For tests that spyOn imports
+      extend: true, // For imports that extend the global 'tf' variable
+      globals,
+    },
+    external,
+    plugins: [
+      resolve({browser: true}),
+      commonjs({
+        ignore: leave_as_require,
+      }),
+      sourcemaps(),
+      ...plugins,
+      ...useEs5,
+      ...useTerser,
+      ...vis,
+    ],
+    onwarn: function (warning: {code: string, message: string}) {
+      if (warning.code === 'THIS_IS_UNDEFINED') {
+        return;
+      }
+      console.warn(warning.message);
+    }
+  }
+}

--- a/tools/rollup_template.config.js
+++ b/tools/rollup_template.config.js
@@ -15,99 +15,13 @@
  * =============================================================================
  */
 
-import commonjs from '@rollup/plugin-commonjs';
-import resolve from '@rollup/plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
-import {terser} from 'rollup-plugin-terser';
-import visualizer from 'rollup-plugin-visualizer';
-import * as ts from 'typescript';
-import path from 'path';
+import {makeRollupConfig} from 'make_rollup_config/make_rollup_config';
 
-
-const preamble = `/**
- * @license
- * Copyright ${(new Date).getFullYear()} Google LLC. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * =============================================================================
- */`;
-
-
-// Transform that is enabled for es5 bundling. It transforms existing ES2015
-// prodmode output to ESM5 so that the resulting bundles are using ES5 format.
-// Inspired by Angular's ng_package ES5 transform:
-// https://github.com/angular/angular/blob/a92a89b0eb127a59d7e071502b5850e57618ec2d/packages/bazel/src/ng_package/rollup.config.js#L150-L170
-const downlevelToEs5Plugin = {
-  name: 'downlevel-to-es5',
-  transform: (code, filePath) => {
-    const compilerOptions = {
-      target: ts.ScriptTarget.ES5,
-      module: ts.ModuleKind.ES2015,
-      allowJs: true,
-      sourceMap: true,
-      downlevelIteration: true,
-      importHelpers: true,
-      mapRoot: path.dirname(filePath),
-    };
-    const {outputText, sourceMapText}
-          = ts.transpileModule(code, {compilerOptions});
-    return {
-      code: outputText,
-      map: JSON.parse(sourceMapText),
-    };
-  },
-};
-
-const useEs5 = TEMPLATE_es5 ? [downlevelToEs5Plugin] : [];
-
-// Without `compress: {typeofs: false}`, the terser plugin will turn
-// `typeof _scriptDir == "undefined"` into `_scriptDir === void 0` in minified
-// JS file which will cause "_scriptDir is undefined" error in web worker's
-// inline script.
-//
-// For more context, see tfjs-backend-wasm/scripts/patch-threaded-simd-module.js
-const useTerser = TEMPLATE_minify ? [
-  terser({
-    output: {preamble, comments: false},
-    compress: {typeofs: false},
-  })
-] : [];
-
-export default {
-  output: {
-    banner: preamble,
-    freeze: false, // For tests that spyOn imports
-    extend: true, // For imports that extend the global 'tf' variable
-    globals: TEMPLATE_globals,
-  },
+export default makeRollupConfig({
+  globals: TEMPLATE_globals,
   external: TEMPLATE_external,
-  plugins: [
-    resolve({browser: true}),
-    commonjs({
-      ignore: TEMPLATE_leave_as_require,
-    }),
-    sourcemaps(),
-    ...useEs5,
-    ...useTerser,
-    visualizer({
-      sourcemap: true,
-      filename: 'TEMPLATE_stats',
-      template: 'sunburst',
-    }),
-  ],
-  onwarn: function (warning) {
-    if (warning.code === 'THIS_IS_UNDEFINED') {
-      return;
-    }
-    console.warn(warning.message);
-  }
-}
+  leave_as_require: TEMPLATE_leave_as_require,
+  terser: TEMPLATE_minify,
+  es5: TEMPLATE_es5,
+  vis_filename: 'TEMPLATE_stats',
+});

--- a/tools/tfjs_bundle.bzl
+++ b/tools/tfjs_bundle.bzl
@@ -124,6 +124,8 @@ def tfjs_rollup_bundle(
         "@npm//rollup-plugin-terser",
         "@npm//rollup-plugin-visualizer",
         "@npm//typescript",
+        "@//tools:downlevel_to_es5_plugin",
+        "@//tools:make_rollup_config",
     ]
 
     rollup_args = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,6 +354,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/rollup-plugin-visualizer@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/rollup-plugin-visualizer/-/rollup-plugin-visualizer-4.2.1.tgz#84b317bcb218b4e35dd9f529f2e379e373935a27"
+  integrity sha512-Fk4y0EgmsSbvbayYhtSI9+cGvgw1rcQ9RlbExkQt4ivXRdiEwFKuRpxNuJCr0JktXIvOPUuPR7GSmtyZu0dujQ==
+  dependencies:
+    "@types/node" "*"
+    rollup "^2.42.3"
+
 "@types/seedrandom@^2.4.28":
   version "2.4.30"
   resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.30.tgz#d2efe425869b84163c2d56e779dddadb9372cbfa"
@@ -2148,6 +2156,13 @@ rollup-plugin-visualizer@~3.3.2:
     pupa "^2.0.0"
     source-map "^0.7.3"
     yargs "^15.0.0"
+
+rollup@^2.42.3:
+  version "2.75.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.6.tgz#ac4dc8600f95942a0180f61c7c9d6200e374b439"
+  integrity sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rollup@^2.46.0:
   version "2.56.2"


### PR DESCRIPTION
Create tools/make_rollup_config.ts, which exports a function to create a tfjs rollup configuration. All tools/rollup_template.config.js does is import and call that function.

Move the custom es5 downleveling plugin to its own file.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.