### PR TITLE
Limit concurrent tests with --local_test_jobs instead of --jobs

### DIFF
--- a/scripts/run_bazel_ci_tests.sh
+++ b/scripts/run_bazel_ci_tests.sh
@@ -25,4 +25,4 @@ else
   TARGETS=`./node_modules/.bin/bazel query --output label 'attr("tags", "ci", ...)'`
 fi
 
-yarn bazel test --config=ci --flaky_test_attempts=3 --test_output=all --jobs=25 $TARGETS
+yarn bazel test --config=ci --flaky_test_attempts=3 --test_output=all --local_test_jobs=25 $TARGETS


### PR DESCRIPTION
This should allow CI to use its full 32 cores for building without going over the BrowserStack limit of 25.

[Docs](https://docs.bazel.build/versions/main/command-line-reference.html#flag--local_test_jobs)

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6508)
<!-- Reviewable:end -->
