### PR TITLE
Build link package with remote cache access in CI

### DIFF
--- a/link-package/build_deps.ts
+++ b/link-package/build_deps.ts
@@ -91,8 +91,8 @@ async function main() {
       bazelArgs.push(...targets);
       spawnSync('yarn', bazelArgs, {stdio:'inherit'});
     }
-
   }
+
   const tfjsDir = `${__dirname}/node_modules/@tensorflow`;
   rimraf.sync(tfjsDir);
   fs.mkdirSync(tfjsDir, {recursive: true});

--- a/link-package/build_deps.ts
+++ b/link-package/build_deps.ts
@@ -39,6 +39,12 @@ parser.add_argument('--all', {
   help: 'Build all packages',
 });
 
+parser.add_argument('--bazel_options', {
+  type: String,
+  default: '',
+  help: 'Options to pass to Bazel',
+});
+
 /**
  * Build bazel dependencies for the packages specified by the repeated argument
  * tfjs_package.
@@ -64,7 +70,8 @@ async function main() {
 
   if (targets.length > 0) {
     if (process.platform === 'win32') {
-      const child = exec(`yarn bazel build --color=yes ${targets.join(' ')}`);
+      const child = exec('yarn bazel build --color=yes '
+        + `${args.bazel_options} ${targets.join(' ')}`);
       await new Promise((resolve, reject) => {
         child.stdout.pipe(process.stdout);
         child.stderr.pipe(process.stderr);
@@ -77,7 +84,12 @@ async function main() {
       });
     } else {
       // Use spawnSync intead of exec for prettier printing.
-      spawnSync('yarn', ['bazel', 'build', ...targets], {stdio:'inherit'});
+      const bazelArgs = ['bazel', 'build'];
+      if (args.bazel_options) {
+        bazelArgs.push(args.bazel_options);
+      }
+      bazelArgs.push(...targets);
+      spawnSync('yarn', bazelArgs, {stdio:'inherit'});
     }
 
   }

--- a/scripts/cloudbuild_e2e_expected.yml
+++ b/scripts/cloudbuild_e2e_expected.yml
@@ -59,6 +59,7 @@ steps:
     id: yarn-link-package-build
     args:
       - build
+      - '--bazel_options=--config=ci'
     waitFor:
       - yarn-link-package
   - name: gcr.io/learnjs-174218/release

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -65,7 +65,7 @@ steps:
   dir: 'link-package'
   entrypoint: 'yarn'
   id: 'yarn-link-package-build'
-  args: ['build']
+  args: ['build', "--bazel_options='--config=remote'"]
   waitFor: ['yarn-link-package']
 
 # General configuration

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -65,7 +65,7 @@ steps:
   dir: 'link-package'
   entrypoint: 'yarn'
   id: 'yarn-link-package-build'
-  args: ['build', "--bazel_options='--config=remote'"]
+  args: ['build', '--bazel_options=--config=ci']
   waitFor: ['yarn-link-package']
 
 # General configuration

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -59,6 +59,7 @@ steps:
     id: yarn-link-package-build
     args:
       - build
+      - '--bazel_options=--config=ci'
     waitFor:
       - yarn-link-package
   - name: gcr.io/learnjs-174218/release


### PR DESCRIPTION
Use the Bazel remote cache when building the link package in CI. This prevents it from rebuilding everything that the bazel tests built. To see that this is working, check the yarn-link-package-build step in this PR's CI run for `53 remote cache hit`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6511)
<!-- Reviewable:end -->
