### PR TITLE
Fix Bazel karma ignoring custom browsers that don't use BrowserStack

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -86,8 +86,11 @@ module.exports = function(config) {
   let browser = 'TEMPLATE_browser';
   let extraConfig = {};
   const browserLauncher = CUSTOM_LAUNCHERS[browser];
-  if (browser && !browserLauncher) {
-    throw new Error(`Missing launcher for ${browser}`);
+  if (browser) {
+    if (!browserLauncher) {
+      throw new Error(`Missing launcher for ${browser}`);
+    }
+    extraConfig.browsers = [browser];
   }
   if (browserLauncher?.base === 'BrowserStack') {
     const username = process.env.BROWSERSTACK_USERNAME;
@@ -114,7 +117,6 @@ module.exports = function(config) {
       tunnelIdentifier:
       `tfjs_${Date.now()}_${Math.floor(Math.random() * 1000)}`
     };
-    extraConfig.browsers = [browser];
   }
 
   config.set({


### PR DESCRIPTION
#6504 broke Karma tests that run with custom browsers other than BrowserStack. This PR fixes it.

Tested by running `yarn test` in tfjs-backend-webgl, which uses Chrome Canary (although I'm on Linux, which doesn't have a Chrome Canary build, so I saw `No binary for ChromeCanary browser on your platform.`).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6515)
<!-- Reviewable:end -->
