### PR TITLE
[webgpu] Migrate sparseToDense to the atomic-based kernel

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/ScatterNd.ts
+++ b/tfjs-backend-webgpu/src/kernels/ScatterNd.ts
@@ -47,6 +47,8 @@ export function scatterNd(args: {
       {inputs: {x: updates}, backend, attrs: {shape: [numUpdates, sliceSize]}});
 
   const type = flattenX.dtype;
+  const zero =
+      backend.makeTensorInfo([], type, util.makeZerosTypedArray(1, type));
   const output =
       fill({backend, attrs: {shape: flattenShape, value: 0, dtype: type}});
   const size = util.sizeFromShape(flattenX.shape);
@@ -58,12 +60,13 @@ export function scatterNd(args: {
       flattenX.shape, sliceRank, flattenIndices.shape.length,
       flattenX.shape.length, strides, flattenShape, type);
   const res = backend.runWebGPUProgram(
-      program, [flattenX, flattenIndices], type, uniformData, output);
+      program, [flattenX, flattenIndices, zero], type, uniformData, output);
 
   const reshaped = reshape({inputs: {x: res}, backend, attrs: {shape}});
 
   backend.disposeData(flattenIndices.dataId);
   backend.disposeData(flattenX.dataId);
+  backend.disposeData(zero.dataId);
   backend.disposeData(res.dataId);
 
   return reshaped;

--- a/tfjs-backend-webgpu/src/scatter_optimized_webgpu.ts
+++ b/tfjs-backend-webgpu/src/scatter_optimized_webgpu.ts
@@ -16,11 +16,11 @@
  */
 
 import {DataType} from '@tensorflow/tfjs-core';
-import {getCoordsDataType, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getMainHeaderAndGlobalIndexString, mapToWgslTypes, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ScatterOptimizedProgram implements WebGPUProgram {
-  variableNames = ['updates', 'indices'];
+  variableNames = ['updates', 'indices', 'originalSparseValue'];
   uniforms: string;
   outputShape: number[];
   shaderKey: string;
@@ -64,45 +64,33 @@ export class ScatterOptimizedProgram implements WebGPUProgram {
     const strideString = this.sliceDimGreaterThanOne ? 'uniforms.strides[j]' :
                                                        'uniforms.strides';
 
-    let updatesString = '';
     let outCoordsString = '';
     let getUpdatesCoordsFromFlatIndex = '';
-    if (this.updatesRank === 1) {
-      updatesString = 'coords[0]';
+    if (this.dispatchLayout.x.length === 1) {
       outCoordsString = 'flattenedIndex';
       getUpdatesCoordsFromFlatIndex = `
       fn getUpdatesCoordsFromFlatIndex(index : i32) -> i32 {
         return index;
       }
       `;
-    } else if (this.updatesRank === 2) {
-      updatesString = 'coords[0], coords[1]';
+    } else if (this.dispatchLayout.x.length === 2) {
       outCoordsString = 'vec2<i32>(flattenedIndex, coords[1])';
       getUpdatesCoordsFromFlatIndex = `
       fn getUpdatesCoordsFromFlatIndex(index : i32) -> vec2<i32> {
-        let d0 = index / uniforms.updatesShape[1];
-        let d1 = index - d0 * uniforms.updatesShape[1];
+        // N.B. |updates| could be a scalar tensor, conceptually representing a
+        // 2D tensor with all values equal to that. By design, its size must be
+        // the same as |outShape[1]| in one dimension, and |indicesShape[0]|
+        // gives the other.
+        let sliceSize = uniforms.outShape[1];
+        let d0 = index / sliceSize;
+        let d1 = index - d0 * sliceSize;
         return vec2<i32>(d0, d1);
       }
       `;
     }
-    const updatesSnippet = `getUpdates(${updatesString})`;
-
-    // atomicAdd only supports uint/int type. For float, we use
-    // atomicCompareExchangeWeak to simulate.
-    const atomicAddSnippet = this.type === 'int32' ?
-        `atomicAdd(&(result[flatIndex]), i32(updateValue));` :
-        `
-     var oldValue = atomicLoad(&(result[flatIndex]));
-     var exchanged = false;
-     for (; !exchanged;) {
-       let newValueF32 = bitcast<f32>(oldValue) + updateValue;
-       let newValue = bitcast<i32>(newValueF32);
-       let res = atomicCompareExchangeWeak(&(result[flatIndex]), oldValue, newValue);
-       oldValue = res.old_value;
-       exchanged = res.exchanged;
-     }
-     `;
+    const updatesString =
+        Array.from({length: this.updatesRank}, (_, idx) => `coords[${idx}]`);
+    const updatesSnippet = `getUpdates(${updatesString.join(', ')})`;
 
     const userCode = `
     ${getUpdatesCoordsFromFlatIndex}
@@ -116,10 +104,27 @@ export class ScatterOptimizedProgram implements WebGPUProgram {
             let indexInside = i32(round(${indicesSnippet}));
             flattenedIndex = flattenedIndex + indexInside * ${strideString};
           }
-          let updateValue = ${updatesSnippet};
+          let updateValue =
+              ${mapToWgslTypes(this.type, false)}(${updatesSnippet});
           let flatIndex = getOutputIndexFromCoords(${outCoordsString});
 
-         ${atomicAddSnippet}
+          var oldBits = bitcast<i32>(
+              ${mapToWgslTypes(this.type, false)}(getOriginalSparseValue()));
+          var newBits = bitcast<i32>(updateValue);
+          loop {
+            let info =
+                atomicCompareExchangeWeak(&result[flatIndex], oldBits, newBits);
+            if (info.exchanged) {
+              break;
+            }
+            oldBits = info.old_value;
+            let oldValue =
+                bitcast<${mapToWgslTypes(this.type, false)}>(oldBits);
+            let newValue = select(updateValue + oldValue,
+                                  updateValue,
+                                  f32(oldValue) == getOriginalSparseValue());
+            newBits = bitcast<i32>(newValue);
+          }
         }
       }`;
     return userCode;

--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -367,7 +367,7 @@ const commonSnippet = `
 type InputInfo = {
   dtype: DataType; shape: number[]; name: string;
 };
-type WGSLDataType = 'f32'|'i32'|'vec4<f32>'|'vec4<i32>'|'vec4<bool>';
+export type WGSLDataType = 'f32'|'i32'|'vec4<f32>'|'vec4<i32>'|'vec4<bool>';
 
 /**
  * Derives logical coordinates from a flat index. Performs integer division
@@ -754,7 +754,7 @@ function isFlatDispatch(program: WebGPUProgram): boolean {
   return program.dispatch[1] === 1 && program.dispatch[2] === 1;
 }
 
-function mapToWgslTypes(type: DataType, isVec4: boolean): WGSLDataType|
+export function mapToWgslTypes(type: DataType, isVec4: boolean): WGSLDataType|
     DataType {
   if (type === 'float32') {
     return isVec4 ? 'vec4<f32>' : 'f32';


### PR DESCRIPTION
PERF

The sparseToDense op takes an optional default value. Unlike scatterNd, the output cannot be initialized with fill(), since the default value is a scalar tensor (which could be the result of a previous op) than a scalar number. The (horrible!) workaround here is to broadcast the value with tile().

The other challenge is if the kernel should discard the original value at index or accumulate on that. The magic is performed by splitting the op into two "scatter" steps: 1) replace the default value with 0 or add 0 to 0, and 2) add the input sparse values to 0 or whatever. This avoids a bitmap for recording whether the output element at index has been updated by another invocation.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6525)
<!-- Reviewable:end -->
