### PR TITLE
[webgpu] Use workPerThread for fromPixels

### DIFF
--- a/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
@@ -33,8 +33,10 @@ export class FromPixelsProgram implements WebGPUProgram {
   constructor(outputShape: number[], useImport = false) {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
+    this.workPerThread = this.outputShape[this.outputShape.length - 1];
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        [this.workPerThread, 1, 1]);
 
     this.useImport = useImport;
     this.shaderKey = `fromPixels_${this.useImport}`;


### PR DESCRIPTION
This will use a dispatch size and save more GPU resources.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6529)
<!-- Reviewable:end -->
