### PR TITLE
[wasm] Make Bazel aware of pre.js and post.js input files

### DIFF
--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -53,12 +53,12 @@ cc_binary(
 cc_binary(
     name = "tfjs-backend-wasm-simd.js",
     srcs = ["backend.cc"] + KERNELS_WITH_KEEPALIVE,
-    copts = [
-        "-msimd128",
-    ],
     additional_linker_inputs = [
         "pre.js",
         "post.js",
+    ],
+    copts = [
+        "-msimd128",
     ],
     linkopts = BASE_LINKOPTS,
     deps = [
@@ -70,13 +70,13 @@ cc_binary(
 cc_binary(
     name = "tfjs-backend-wasm-threaded-simd.js",
     srcs = ["backend.cc"] + KERNELS_WITH_KEEPALIVE,
-    copts = [
-        "-msimd128",
-        "-pthread",
-    ],
     additional_linker_inputs = [
         "pre.js",
         "post.js",
+    ],
+    copts = [
+        "-msimd128",
+        "-pthread",
     ],
     linkopts = BASE_LINKOPTS + [
         "-s EXPORT_NAME=WasmBackendModuleThreadedSimd",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -22,8 +22,8 @@ BASE_LINKOPTS = [
     "-s MALLOC=emmalloc",
     # TODO(mattsoulanille): Mark these files as dependencies so Bazel rebuilds
     # when they change. github.com/emscripten-core/emsdk/issues/933
-    "--pre-js ./tfjs-backend-wasm/src/cc/pre.js",
-    "--post-js ./tfjs-backend-wasm/src/cc/post.js",
+    "--pre-js $(location :pre.js)",
+    "--post-js $(location :post.js)",
 ]
 
 # This build rule generates tfjs-backend-wasm.{js,wasm}.
@@ -37,6 +37,10 @@ BASE_LINKOPTS = [
 cc_binary(
     name = "tfjs-backend-wasm.js",
     srcs = ["backend.cc"] + KERNELS_WITH_KEEPALIVE,
+    additional_linker_inputs = [
+        "pre.js",
+        "post.js",
+    ],
     linkopts = BASE_LINKOPTS + [
         "-s EXPORT_NAME=WasmBackendModule",
     ],
@@ -52,6 +56,10 @@ cc_binary(
     copts = [
         "-msimd128",
     ],
+    additional_linker_inputs = [
+        "pre.js",
+        "post.js",
+    ],
     linkopts = BASE_LINKOPTS,
     deps = [
         ":all_kernels",
@@ -65,6 +73,10 @@ cc_binary(
     copts = [
         "-msimd128",
         "-pthread",
+    ],
+    additional_linker_inputs = [
+        "pre.js",
+        "post.js",
     ],
     linkopts = BASE_LINKOPTS + [
         "-s EXPORT_NAME=WasmBackendModuleThreadedSimd",

--- a/tfjs-backend-wasm/src/cc/BUILD
+++ b/tfjs-backend-wasm/src/cc/BUILD
@@ -20,8 +20,6 @@ BASE_LINKOPTS = [
     "-s EXPORTED_RUNTIME_METHODS='[\"cwrap\"]'",
     "-s MODULARIZE=1",
     "-s MALLOC=emmalloc",
-    # TODO(mattsoulanille): Mark these files as dependencies so Bazel rebuilds
-    # when they change. github.com/emscripten-core/emsdk/issues/933
     "--pre-js $(location :pre.js)",
     "--post-js $(location :post.js)",
 ]


### PR DESCRIPTION
pre.js and post.js are inputs to the wasm backend's emscripten compile, but they weren't declared as inputs in any BUILD file. This commit adds them following https://github.com/emscripten-core/emsdk/issues/933 .

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6535)
<!-- Reviewable:end -->
