### PR TITLE
Add tslib, which es5 bundling depends on

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "terser": "^5.7.0",
     "ts-morph": "^11.0.3",
     "ts-node": "~8.8.2",
+    "tslib": "^2.4.0",
     "tslint": "^6.1.3",
     "tslint-no-circular-imports": "~0.7.0",
     "typescript": "3.5.3"

--- a/tools/tfjs_bundle.bzl
+++ b/tools/tfjs_bundle.bzl
@@ -124,6 +124,7 @@ def tfjs_rollup_bundle(
         "@npm//rollup-plugin-terser",
         "@npm//rollup-plugin-visualizer",
         "@npm//typescript",
+        "@npm//tslib",  # downlevel_to_es5_plugin uses importHelpers.
         "@//tools:downlevel_to_es5_plugin",
         "@//tools:make_rollup_config",
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,6 +2514,11 @@ tslib@^1.13.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslint-no-circular-imports@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/tslint-no-circular-imports/-/tslint-no-circular-imports-0.7.0.tgz#9df0a15654d66b172e0b7843eed073fa5ae99b5f"


### PR DESCRIPTION
tslib was formerly included by chance since typescript depends on it. With this change, we explicitly depend on it and add it as a dependency to the tfjs_bundle Bazel rule. Rollup uses the es5 downleveling plugin, which uses tslib for bundle size optimization.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6536)
<!-- Reviewable:end -->
