### PR TITLE
Add string_decoder to tfjs-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rollup-plugin-visualizer": "~3.3.2",
     "seedrandom": "^3.0.5",
     "shelljs": "~0.8.5",
+    "string_decoder": "^1.3.0",
     "terser": "^5.7.0",
     "ts-morph": "^11.0.3",
     "ts-node": "~8.8.2",

--- a/tfjs-data/package.json
+++ b/tfjs-data/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@types/node-fetch": "^2.1.2",
-    "node-fetch": "~2.6.1"
+    "node-fetch": "~2.6.1",
+    "string_decoder": "^1.3.0"
   },
   "browser": {
     "fs": false,

--- a/tfjs-data/src/BUILD.bazel
+++ b/tfjs-data/src/BUILD.bazel
@@ -59,6 +59,7 @@ ts_library(
         "//tfjs-core/src:tfjs-core_src_lib",
         "@npm//@types/seedrandom",
         "@npm//seedrandom",
+        "@npm//string_decoder",
     ],
 )
 

--- a/tfjs-data/yarn.lock
+++ b/tfjs-data/yarn.lock
@@ -70,6 +70,18 @@ node-fetch@~2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,7 +2188,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.1.0:
+safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2389,6 +2389,13 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"


### PR DESCRIPTION
string_decoder is used by [tfjs-data/src/util/deep_map.ts:261](https://github.com/tensorflow/tfjs/blob/master/tfjs-data/src/util/deep_map.ts#L261), so it should be included in the package.json and Bazel build rule for tfjs-data.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6538)
<!-- Reviewable:end -->
