### PR TITLE
Fix wasm nightly e2e regression tests

### DIFF
--- a/e2e/integration_tests/convert_predict.ts
+++ b/e2e/integration_tests/convert_predict.ts
@@ -38,7 +38,7 @@ import {createInputTensors} from './test_util';
 
 const DATA_URL = 'convert_predict_data';
 
-describeWithFlags(`${REGRESSION} convert_predict`, ALL_ENVS, () => {
+describeWithFlags(`${REGRESSION} convert_predict`, ALL_ENVS, (env) => {
   let originalTimeout: number;
 
   beforeAll(() => {
@@ -55,7 +55,11 @@ describeWithFlags(`${REGRESSION} convert_predict`, ALL_ENVS, () => {
   for (const modelType in CONVERT_PREDICT_MODELS) {
     const models =
         (CONVERT_PREDICT_MODELS as {[key: string]: string[]})[modelType];
-    models.forEach(model => {
+    for (const model of models) {
+      if (env.backendName === 'wasm' && model.includes('complex')) {
+        // WASM does not support complex
+        continue;
+      }
       it(`${model}.`, async () => {
         let inputsNames: string[];
         let inputsData: tfc.TypedArray[];
@@ -146,6 +150,6 @@ describeWithFlags(`${REGRESSION} convert_predict`, ALL_ENVS, () => {
           ys.forEach(tensor => tensor.dispose());
         }
       });
-    });
+    }
   }
 });

--- a/e2e/integration_tests/grad_layers_test.ts
+++ b/e2e/integration_tests/grad_layers_test.ts
@@ -30,7 +30,7 @@ import {SMOKE} from './constants';
 // TODO(#6518): Test against wasm as well.
 const NOT_WASM: Constraints = {
   predicate: testEnv => testEnv.backendName !== 'wasm',
-}
+};
 
 /**
  *  Tests that tf.grad works for layers models.

--- a/e2e/integration_tests/metadata.ts
+++ b/e2e/integration_tests/metadata.ts
@@ -16,11 +16,13 @@
  */
 import * as tfconverter from '@tensorflow/tfjs-converter';
 import {KARMA_SERVER, REGRESSION} from './constants';
+import * as tfc from '@tensorflow/tfjs-core';
 
 const DATA_URL = 'metadata';
 
 describe(`${REGRESSION} Metadata`, () => {
   it('can load metadata.', async () => {
+    await tfc.ready();
     const model = await tfconverter.loadGraphModel(
         `${KARMA_SERVER}/${DATA_URL}/model.json`);
     const metadata = {metadata1: {a: 1}, metadata2: {label1: 0, label2: 1}};


### PR DESCRIPTION
Fix metadata test not waiting for tf to be ready. Skip the wasm backend when testing complex models because wasm does not support complex ops.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6541)
<!-- Reviewable:end -->
