### PR TITLE
[wasm] Remove unused pre.js and post.js test

### DIFF
--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -235,28 +235,3 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
         .toThrowError(/The WASM backend was already initialized. Make sure/);
   });
 });
-
-// describe('wasm pre.js', () => {
-  // Temporarily disabled due to node 16 incompatability
-  // it('works if process variable is undefined', async () => {
-  //   tf.engine().reset();
-
-  //   const savedProcess = process;
-  //   // This test is not perfect since checks like `if (process)` will not
-  //   // throw errors if process is set to undefined, however, process can not
-  //   // be `delete`d due to strict mode.
-
-  //   process = undefined;
-
-  //   try {
-  //     await tf.setBackend('wasm');
-  //   } catch (e) {
-  //     fail(e);
-  //   } finally {
-  //     process = savedProcess;
-  //   }
-
-  //   tf.engine().disposeVariables();
-  //   tf.engine().reset();
-  // });
-// });


### PR DESCRIPTION
The pre.js and post.js test has been disabled for some time now, and will likely not work since it requires deleting the `process` variable. This PR removes it.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6588)
<!-- Reviewable:end -->
