### PR TITLE
Add '--bazel_patch_module_resolver' to 'tfjs-converter_test'

### DIFF
--- a/tfjs-converter/BUILD.bazel
+++ b/tfjs-converter/BUILD.bazel
@@ -37,6 +37,10 @@ nodejs_test(
     entry_point = "//tfjs-converter/src:run_tests.ts",
     link_workspace_root = True,
     tags = ["ci"],
+    # This fixes a race condition between this test and test_snippets_test where
+    # the wrong runfiles will be linked to node_modules/@tensorflow/tfjs-converter/dist.
+    # TODO(mattSoulanille): Assess whether we should apply this to all nodejs_test targets.
+    templated_args = ["--bazel_patch_module_resolver"],
 )
 
 # Defined here because chdir must be a subdirectory of the directory the rule is


### PR DESCRIPTION
Fix a race condition between `tfjs-converter_test` and `test_snippets_test` where a different directory will be linked to `node_modules/@tensorflow/tfjs-converter/dist` depending on which one runs first. 

If `//tfjs-converter:test_snippets_test` runs first, it links `node_modules/@tensorflow/tfjs-converter/dist` to `..../bazel-out/k8-fastbuild/bin/tfjs-converter/test_snippets_test.sh.runfiles/tfjs/tfjs-converter/src`, which is missing the spy ops file. On the other hand, if `//tfjs-converter:tfjs-converter_test` runs first, it links `node_modules/@tensorflow/tfjs-converter/dist` to `..../bazel-out/k8-fastbuild/bin/tfjs-converter/tfjs-converter_test.sh.runfiles/tfjs/tfjs-converter/src` instead, which has the spy_ops file.

The solution seems to be to add `templated_args = ["--bazel_patch_module_resolver"]` to the converter test's `nodejs_test` rule. I think this makes it use sources from `dist/tfjs-converter` instead of `node_modules`.

The failure is most easily reproduced by the following command, which is now fixed at this PR.
```sh
bazel clean
bazel test //tfjs-converter:tests --nocache_test_results
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6593)
<!-- Reviewable:end -->
