### PR TITLE
Fix iOS and macOS Safari CI Failures

### DIFF
--- a/BAZEL_MIGRATION.md
+++ b/BAZEL_MIGRATION.md
@@ -210,7 +210,7 @@ tfjs_web_test(
         "bs_chrome_mac",
         "bs_firefox_mac",
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ],

--- a/e2e/karma.conf.js
+++ b/e2e/karma.conf.js
@@ -169,7 +169,7 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'High Sierra'
       },
-      bs_ios_11: {
+      bs_ios_12: {
         base: 'BrowserStack',
         device: 'iPhone X',
         os: 'iOS',

--- a/e2e/script_tag_tests/tfjs-core-cpu/karma.conf.js
+++ b/e2e/script_tag_tests/tfjs-core-cpu/karma.conf.js
@@ -97,7 +97,7 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'High Sierra'
       },
-      bs_ios_11: {
+      bs_ios_12: {
         base: 'BrowserStack',
         device: 'iPhone X',
         os: 'iOS',

--- a/e2e/script_tag_tests/tfjs/karma.conf.js
+++ b/e2e/script_tag_tests/tfjs/karma.conf.js
@@ -89,7 +89,7 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'High Sierra'
       },
-      bs_ios_11: {
+      bs_ios_12: {
         base: 'BrowserStack',
         device: 'iPhone X',
         os: 'iOS',

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -60,7 +60,7 @@ fi
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
 
-  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_11 --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_12 --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
 
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac --tags '$TAGS'"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS'"

--- a/tfjs-automl/karma.conf.js
+++ b/tfjs-automl/karma.conf.js
@@ -106,7 +106,7 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'High Sierra'
       },
-      bs_ios_11: {
+      bs_ios_12: {
         base: 'BrowserStack',
         device: 'iPhone X',
         os: 'iOS',

--- a/tfjs-backend-wasm/BUILD.bazel
+++ b/tfjs-backend-wasm/BUILD.bazel
@@ -153,7 +153,7 @@ tfjs_web_test(
         "bs_chrome_mac",
         "bs_firefox_mac",
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
         # TODO(mattsoulanille): Fix clipByValue on Android.
         # "bs_android_9",
         "win_10_chrome",

--- a/tfjs-backend-wasm/scripts/test-ci.sh
+++ b/tfjs-backend-wasm/scripts/test-ci.sh
@@ -17,7 +17,7 @@ if [ "$NIGHTLY" = true ]; then
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=win_10_chrome"
-  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_11"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_12"
 else
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac"
 fi

--- a/tfjs-backend-webgl/BUILD.bazel
+++ b/tfjs-backend-webgl/BUILD.bazel
@@ -126,7 +126,7 @@ tfjs_web_test(
     ],
     browsers = [
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
     ],
     headless = False,
     static_files = STATIC_FILES,

--- a/tfjs-backend-webgl/scripts/test-ci.sh
+++ b/tfjs-backend-webgl/scripts/test-ci.sh
@@ -17,7 +17,7 @@
 set -e
 
 if [ "$NIGHTLY" = true ]; then
-  node ../scripts/run_flaky.js "yarn run-browserstack --browsers='bs_safari_mac,bs_ios_11' --testEnv webgl1"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers='bs_safari_mac,bs_ios_12' --testEnv webgl1"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers='bs_firefox_mac,bs_chrome_mac'"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers='win_10_chrome,bs_android_9' --testEnv webgl2"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{"\""WEBGL_PACK"\"": false}'"

--- a/tfjs-core/BUILD.bazel
+++ b/tfjs-core/BUILD.bazel
@@ -113,7 +113,7 @@ tfjs_web_test(
         "bs_chrome_mac",
         "bs_firefox_mac",
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ],

--- a/tfjs-core/src/BUILD.bazel
+++ b/tfjs-core/src/BUILD.bazel
@@ -202,7 +202,7 @@ tfjs_web_test(
         "bs_chrome_mac",
         "bs_firefox_mac",
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ],
@@ -238,7 +238,7 @@ tfjs_web_test(
         "bs_chrome_mac",
         # Omit Firefox since it does not support offscreen canvas.
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ],

--- a/tfjs-core/src/BUILD.bazel
+++ b/tfjs-core/src/BUILD.bazel
@@ -202,7 +202,10 @@ tfjs_web_test(
         "bs_chrome_mac",
         "bs_firefox_mac",
         "bs_safari_mac",
-        "bs_ios_12",
+        # Temporarily disabled because BrowserStack does not support loading
+        # absolute paths in iOS, which is required for loading the worker.
+        # https://www.browserstack.com/question/39573
+        # "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ],
@@ -238,7 +241,10 @@ tfjs_web_test(
         "bs_chrome_mac",
         # Omit Firefox since it does not support offscreen canvas.
         "bs_safari_mac",
-        "bs_ios_12",
+        # Temporarily disabled because BrowserStack does not support loading
+        # absolute paths in iOS, which is required for loading the worker.
+        # https://www.browserstack.com/question/39573
+        # "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ],

--- a/tfjs-core/src/ops/from_pixels_async_test.ts
+++ b/tfjs-core/src/ops/from_pixels_async_test.ts
@@ -242,7 +242,7 @@ describeWithFlags(
         const data = await res.data();
         expect(data.length).toEqual(90 * 160 * 3);
         document.body.removeChild(video);
-      });
+      }, 30_000 /* 30 seconds */);
 
       it('canvas and image match', async () => {
         const img = new Image();

--- a/tfjs-core/src/ops/from_pixels_test.ts
+++ b/tfjs-core/src/ops/from_pixels_test.ts
@@ -231,7 +231,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     const data = await res.data();
     expect(data.length).toEqual(90 * 160 * 3);
     document.body.removeChild(video);
-  });
+  }, 30_000 /* 30 seconds */);
 
   it('fromPixels for HTMLVideoElement throws without loadeddata', async () => {
     const video = document.createElement('video');

--- a/tfjs-core/src/test_async_backends.ts
+++ b/tfjs-core/src/test_async_backends.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * @license
  * Copyright 2019 Google LLC. All Rights Reserved.

--- a/tfjs-layers/BUILD.bazel
+++ b/tfjs-layers/BUILD.bazel
@@ -74,7 +74,7 @@ tfjs_web_test(
     ],
     browsers = [
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
     ],
     headless = False,
     static_files = [

--- a/tfjs-vis/karma.conf.js
+++ b/tfjs-vis/karma.conf.js
@@ -100,7 +100,7 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'High Sierra'
       },
-      bs_ios_11: {
+      bs_ios_12: {
         base: 'BrowserStack',
         device: 'iPhone X',
         os: 'iOS',

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -45,11 +45,11 @@ const CUSTOM_LAUNCHERS = {
     os: 'OS X',
     os_version: 'High Sierra'
   },
-  bs_ios_11: {
+  bs_ios_12: {
     base: 'BrowserStack',
-    device: 'iPhone X',
+    device: 'iPhone XS',
     os: 'ios',
-    os_version: '11.0',
+    os_version: '12.3',
     real_mobile: true
   },
   bs_android_9: {

--- a/tools/tfjs_web_test.bzl
+++ b/tools/tfjs_web_test.bzl
@@ -89,7 +89,7 @@ def tfjs_web_test(name, ci = True, args = [], **kwargs):
         "bs_chrome_mac",
         "bs_firefox_mac",
         "bs_safari_mac",
-        "bs_ios_11",
+        "bs_ios_12",
         "bs_android_9",
         "win_10_chrome",
     ])


### PR DESCRIPTION
Update iOS from 11 to 12.3. 

Remove `#/usr/bin/env node` from test_async_backends.ts

Disable iOS worker tests, which need to load absolute URLs [(unsupported in BrowserStack right now)](https://www.browserstack.com/question/39573).

Fixes #6598 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6608)
<!-- Reviewable:end -->
