### PR TITLE
Print karma jasmine seed to terminal and in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
+    "karma-jasmine-order-reporter": "^1.1.0",
     "karma-requirejs": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.8",
     "long": "4.0.0",

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -17,7 +17,6 @@
 
 const browserstackConfig = {
   hostname: 'bs-local.com',
-  reporters: ['dots'],
   port: 9876,
 };
 
@@ -124,11 +123,15 @@ module.exports = function(config) {
   }
 
   config.set({
-    reporters: ['kjhtml'],
+    reporters: [
+      'kjhtml',
+      'jasmine-order',
+    ],
     frameworks: ['jasmine'],
     plugins: [
       require('karma-jasmine'),
       require('karma-jasmine-html-reporter'),
+      require('karma-jasmine-order-reporter'),
     ],
     captureTimeout: 3e5,
     reportSlowerThan: 500,

--- a/tools/tfjs_web_test.bzl
+++ b/tools/tfjs_web_test.bzl
@@ -26,6 +26,7 @@ PEER_DEPS = [
     # specified. They are manually spefied here so we can append
     # extra dependencies.
     "@npm//karma-jasmine-html-reporter",
+    "@npm//karma-jasmine-order-reporter",
 ]
 
 GrepProvider = provider(fields = ["grep"])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,6 +1543,11 @@ karma-jasmine-html-reporter@^2.0.0:
   resolved "https://registry.yarnpkg.com/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.0.0.tgz#76c26ce40e217dc36a630fbcd7b31c3462948bf2"
   integrity sha512-SB8HNNiazAHXM1vGEzf8/tSyEhkfxuDdhYdPBX2Mwgzt0OuF2gicApQ+uvXLID/gXyJQgvrM9+1/2SxZFUUDIA==
 
+karma-jasmine-order-reporter@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/karma-jasmine-order-reporter/-/karma-jasmine-order-reporter-1.1.0.tgz#3bd4cfd9e5ae53cc0d972905b811a479c127d0a8"
+  integrity sha512-mzC6WfOg7y5kCf7K4W+nB5NHea1ogcDjRpepFLLRjbi4lx08wQG+6EY2zd+mC2ANIvb6+ux2d9mFVtZ3MIwTYg==
+
 karma-jasmine@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-5.1.0.tgz#3af4558a6502fa16856a0f346ec2193d4b884b2f"


### PR DESCRIPTION
Print the seed used for Jasmine test order to the terminal when running Karma tests. This also appears in CI logs.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6609)
<!-- Reviewable:end -->
