### PR TITLE
[tfjs-converter] fix python nightly test

### DIFF
--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -48,6 +48,7 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     requires = [
+        "protobuf==3.20.0",
         "tensorflow>=2.1.0,<3",
         "six>=1.12.0,<2",
         "tensorflow-hub>=0.7.0,<0.13",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,3 +1,4 @@
+protobuf==3.20.0
 tensorflow>=2.1.0,<3
 numpy~=1.19.2
 six>=1.12.0,<2


### PR DESCRIPTION
The python pip deps resolver is not stable, I am fixing the protobuf version to 3.20.0 to avoid conflicts.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6612)
<!-- Reviewable:end -->
