### PR TITLE
[wasm] Cache wasm files when running Karma tests

### DIFF
--- a/tfjs-backend-wasm/src/BUILD.bazel
+++ b/tfjs-backend-wasm/src/BUILD.bazel
@@ -22,6 +22,7 @@ package(default_visibility = ["//visibility:public"])
 TEST_SRCS = [
     "**/*_test.ts",
     "test_node.ts",
+    "test_util.ts",
 ]
 
 TEST_ENTRYPOINTS = [

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -359,8 +359,12 @@ export async function init(): Promise<{wasm: BackendWasmModule}> {
       wasm = wasmFactory(factoryConfig);
     }
 
-    // The WASM module has been successfully created by the factory.
-    // Any error will be caught by the onAbort callback defined above.
+    // The `wasm` promise will resolve to the WASM module created by
+    // the factory, but it might have had errors during creation. Most
+    // errors are caught by the onAbort callback defined above.
+    // However, some errors, such as those occurring from a
+    // failed fetch, result in this promise being rejected. These are
+    // caught and re-rejected below.
     wasm.then((module) => {
       initialized = true;
       initAborted = false;
@@ -384,7 +388,7 @@ export async function init(): Promise<{wasm: BackendWasmModule}> {
       };
 
       resolve({wasm: module});
-    });
+    }).catch(reject);
   });
 }
 

--- a/tfjs-backend-wasm/src/index_test.ts
+++ b/tfjs-backend-wasm/src/index_test.ts
@@ -22,8 +22,7 @@ import {ALL_ENVS, BROWSER_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/d
 
 import {init, resetWasmPath} from './backend_wasm';
 import {BackendWasm, setWasmPath, setWasmPaths} from './index';
-
-const VALID_PREFIX = '/base/tfjs/tfjs-backend-wasm/wasm-out/';
+import {VALID_PREFIX, setupCachedWasmPaths} from './test_util';
 
 /**
  * Tests specific to the wasm backend. The name of these tests must start with
@@ -79,9 +78,8 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
     spyOn(console, 'log');
   });
 
-  afterEach(() => {
-    resetWasmPath();
-    setWasmPaths(VALID_PREFIX);
+  afterEach(async () => {
+    await setupCachedWasmPaths();
     removeBackend('wasm-test');
   });
 
@@ -100,6 +98,7 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
   it('backend init fails when setWasmPaths is called with ' +
          'an invalid prefix',
      async () => {
+       resetWasmPath();
        setWasmPaths('invalid/prefix/');
        let wasmPath: string;
        const realFetch = fetch;
@@ -114,6 +113,7 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
   it('backend init fails when setWasmPaths is called with ' +
          'an invalid fileMap',
      async () => {
+       resetWasmPath();
        setWasmPaths({
          'tfjs-backend-wasm.wasm': 'invalid/path',
          'tfjs-backend-wasm-simd.wasm': 'invalid/path',
@@ -154,6 +154,7 @@ describeWithFlags('wasm init', BROWSER_ENVS, () => {
 
     it('backend init works when the path is valid', async () => {
       const usePlatformFetch = true;
+      resetWasmPath();
       setWasmPaths(VALID_PREFIX, usePlatformFetch);
       let wasmPath: string;
       fetchSpy.and.callFake((path: string) => {

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -16,21 +16,16 @@
  */
 
 // Import core for side effects (e.g. flag registration)
-import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-core';
 // tslint:disable-next-line:no-imports-from-dist
 import '@tensorflow/tfjs-core/dist/public/chained_ops/register_all_chained_ops';
 // tslint:disable-next-line: no-imports-from-dist
 import '@tensorflow/tfjs-core/dist/register_all_gradients';
 // Register the wasm backend.
-import * as wasmBackend from './index';
+import './index';
 // tslint:disable-next-line: no-imports-from-dist
 import {setTestEnvs, setupTestFilters, TestFilter} from '@tensorflow/tfjs-core/dist/jasmine_util';
-
-// Bazel's karma_web_test does not support setting proxies for loaded files,
-// so set the wasm path to where it serves them.
-if (tf.device_util.isBrowser()) {
-  wasmBackend.setWasmPaths('/base/tfjs/tfjs-backend-wasm/wasm-out/');
-}
+import {setupCachedWasmPaths} from './test_util';
 
 setTestEnvs([{name: 'test-wasm', backendName: 'wasm', isDataSync: true}]);
 
@@ -413,6 +408,8 @@ const customInclude = (testName: string) => {
   return false;
 };
 setupTestFilters(TEST_FILTERS, customInclude);
+
+beforeAll(setupCachedWasmPaths);
 
 // Import and run all the tests from core.
 // tslint:disable-next-line:no-imports-from-dist

--- a/tfjs-backend-wasm/src/test_util.ts
+++ b/tfjs-backend-wasm/src/test_util.ts
@@ -1,0 +1,40 @@
+import * as tf from '@tensorflow/tfjs-core';
+import {resetWasmPath} from './backend_wasm';
+import {setWasmPaths} from './index';
+
+export const VALID_PREFIX = '/base/tfjs/tfjs-backend-wasm/wasm-out/';
+
+async function cacheUrl(url: string): Promise<string> {
+  const blob = await (await fetch(url)).blob();
+  return URL.createObjectURL(blob);
+}
+
+let cachedUrlsPromises: Array<Promise<readonly [
+  'tfjs-backend-wasm.wasm'
+    | 'tfjs-backend-wasm-simd.wasm'
+    | 'tfjs-backend-wasm-threaded-simd.wasm', string]>>;
+
+if (tf.device_util.isBrowser()) {
+  cachedUrlsPromises = ([
+    'tfjs-backend-wasm.wasm',
+    'tfjs-backend-wasm-simd.wasm',
+    'tfjs-backend-wasm-threaded-simd.wasm',
+  ] as const).map(async name => {
+    return [name, await cacheUrl(VALID_PREFIX + name)] as const;
+  });
+}
+
+/**
+ * Set the wasm paths to the blob URLs that were loaded above. This is useful
+ * for Karma tests because it prevents Karma from loading the same WASM files
+ * every time the backend is reset (each `describe` block). This saves ~200MB
+ * of network and should reduce flakiness due to network slowness / instability.
+ */
+export async function setupCachedWasmPaths() {
+  resetWasmPath();
+  if (tf.device_util.isBrowser()) {
+    const cachedUrlsList = await Promise.all(cachedUrlsPromises);
+    const cachedUrls = Object.fromEntries(cachedUrlsList);
+    setWasmPaths(cachedUrls);
+  }
+}

--- a/tfjs-backend-wasm/src/test_util.ts
+++ b/tfjs-backend-wasm/src/test_util.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import * as tf from '@tensorflow/tfjs-core';
 import {resetWasmPath} from './backend_wasm';
 import {setWasmPaths} from './index';


### PR DESCRIPTION
Cache wasm files as blobs when running Karma tests. This prevents the browser from re-fetching the wasm files every time the wasm backend is reset (every `describe` block). This should reduce the number of flaky test failures due to failing to fetch the wasm files. It also removes 200MB of requests when running Karma tests.

Fix error handling when `fetch()` fails to download the wasm file.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6613)
<!-- Reviewable:end -->
