### PR TITLE
webgpu: Optimize FromPixelsProgram

### DIFF
--- a/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
@@ -48,15 +48,13 @@ export class FromPixelsProgram implements WebGPUProgram {
         this.importVideo ? 'texture_external' : 'texture_2d<f32>';
     return `
       @binding(1) @group(0) var src: ${textureType};
-
       ${getMainHeaderAndGlobalIndexString()}
-        let flatIndexBase = index * uniforms.numChannels;
-        for (var i = 0; i < uniforms.numChannels; i = i + 1) {
-          let flatIndex = flatIndexBase + i;
-          if (flatIndex < uniforms.size) {
-            let coords = getCoordsFromIndex(flatIndexBase);
-            let values = ${textureLoad};
-            result[flatIndex] = i32(floor(255.0 * values[i]));
+        let flatIndex = index * uniforms.numChannels;
+        if (flatIndex < uniforms.size) {
+          let coords = getCoordsFromIndex(flatIndex);
+          let values = ${textureLoad};
+          for (var i = 0; i < uniforms.numChannels; i = i + 1) {
+            result[flatIndex + i] = i32(floor(255.0 * values[i]));
           }
         }
       }


### PR DESCRIPTION
Move textureLoad out of the for loop since coords.yx doesn't change,
which can reduce the number of accessing texture.

Before: FromPixels 0.69 in BodyPix
After: FromPixels 0.39 in BodyPix

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.