### PR TITLE
[Benchmark tools] Add mobilenet V3

### DIFF
--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -89,16 +89,16 @@ function predictFunction(model, input) {
 }
 
 const benchmarks = {
-  'mobilenet_v2': {
+  'mobilenet_v3': {
     type: 'GraphModel',
     load: async () => {
       const url =
-          'https://storage.googleapis.com/learnjs-data/mobilenet_v2_100_fused/model.json';
-      return tf.loadGraphModel(url);
+          'https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v3_small_100_224/classification/5/default/1';
+      return tf.loadGraphModel(url, {fromTFHub: true});
     },
     loadTflite: async (enableProfiling = false) => {
       const url =
-          'https://tfhub.dev/tensorflow/lite-model/mobilenet_v2_1.0_224/1/metadata/1';
+          'https://tfhub.dev/google/lite-model/imagenet/mobilenet_v3_small_100_224/classification/5/metadata/1';
       return tflite.loadTFLiteModel(url, {enableProfiling});
     },
     predictFunc: () => {

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -110,6 +110,27 @@ const benchmarks = {
       }
     },
   },
+  'mobilenet_v2': {
+    type: 'GraphModel',
+    load: async () => {
+      const url =
+          'https://storage.googleapis.com/learnjs-data/mobilenet_v2_100_fused/model.json';
+      return tf.loadGraphModel(url);
+    },
+    loadTflite: async (enableProfiling = false) => {
+      const url =
+          'https://tfhub.dev/tensorflow/lite-model/mobilenet_v2_1.0_224/1/metadata/1';
+      return tflite.loadTFLiteModel(url, {enableProfiling});
+    },
+    predictFunc: () => {
+      const input = tf.randomNormal([1, 224, 224, 3]);
+      if (isTflite()) {
+        return () => tfliteModel.predict(input);
+      } else {
+        return predictFunction(model, input);
+      }
+    },
+  },
   'mesh_128': {
     type: 'GraphModel',
     load: async () => {


### PR DESCRIPTION
Originally, the benchmark tools (local benchmark tool and BS benchmark tool)are using mobilenet_v2_100_224 ([tfjs_model](https://storage.googleapis.com/learnjs-data/mobilenet_v2_100_fused/model.json), [tflite_model](https://tfhub.dev/google/lite-model/imagenet/mobilenet_v3_small_100_224/classification/5/metadata/1)). This PR addss V3 model: https://tfhub.dev/google/imagenet/mobilenet_v3_small_100_224/classification/5

Both models' inputs are [-1, 224, 224, 3] and outputs are [-1, 1001].

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6615)
<!-- Reviewable:end -->
