### PR TITLE
[wasm] Increase beforeAll timeout for fetching wasm files

### DIFF
--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -409,7 +409,7 @@ const customInclude = (testName: string) => {
 };
 setupTestFilters(TEST_FILTERS, customInclude);
 
-beforeAll(setupCachedWasmPaths);
+beforeAll(setupCachedWasmPaths, 30_000);
 
 // Import and run all the tests from core.
 // tslint:disable-next-line:no-imports-from-dist


### PR DESCRIPTION
Increase the `beforeAll` timeout for fetching wasm files from 5 seconds to 30 to fix a Safari nightly failure.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6618)
<!-- Reviewable:end -->
