### PR TITLE
[wasm] Add Object.fromEntries polyfill to tests to fix Safari 11

### DIFF
--- a/tfjs-backend-wasm/src/BUILD.bazel
+++ b/tfjs-backend-wasm/src/BUILD.bazel
@@ -96,8 +96,8 @@ ts_library(
         "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
-        "@npm//core-js",
         "@npm//@types/jasmine",
+        "@npm//core-js",
         "@npm//jasmine",
     ],
 )
@@ -106,7 +106,6 @@ esbuild(
     name = "tfjs-backend-wasm_test_bundle",
     testonly = True,
     entry_point = "setup_test.ts",
-    target = "es6",
     external = [
         "@tensorflow/tfjs",
         "worker_threads",
@@ -117,6 +116,7 @@ esbuild(
         "os",
     ],
     sources_content = True,
+    target = "es6",
     deps = [
         ":tfjs-backend-wasm_lib",
         ":tfjs-backend-wasm_test_lib",

--- a/tfjs-backend-wasm/src/BUILD.bazel
+++ b/tfjs-backend-wasm/src/BUILD.bazel
@@ -96,6 +96,7 @@ ts_library(
         "//tfjs-core/src:tfjs-core_lib",
         "//tfjs-core/src:tfjs-core_src_lib",
         "//tfjs-core/src:tfjs-core_test_lib",
+        "@npm//core-js",
         "@npm//@types/jasmine",
         "@npm//jasmine",
     ],
@@ -105,6 +106,7 @@ esbuild(
     name = "tfjs-backend-wasm_test_bundle",
     testonly = True,
     entry_point = "setup_test.ts",
+    target = "es6",
     external = [
         "@tensorflow/tfjs",
         "worker_threads",

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -15,6 +15,9 @@
  * =============================================================================
  */
 
+// Import Object.fromEntries polyfill for Safari 11
+import 'core-js/es/object/from-entries';
+
 // Import core for side effects (e.g. flag registration)
 import '@tensorflow/tfjs-core';
 // tslint:disable-next-line:no-imports-from-dist


### PR DESCRIPTION
Safari 11 does not support `Object.fromEntries`, which is used in [test_util.ts](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-wasm/src/test_util.ts#L54). Add a polyfill for `Object.fromEntries` to the test suite to support testing on Safari 11 and set the target ECMAScript version to es6 in the test bundle.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6621)
<!-- Reviewable:end -->
