### PR TITLE
Some numpy type usages are deprecated

### DIFF
--- a/tfjs-converter/python/tensorflowjs/quantization_test.py
+++ b/tfjs-converter/python/tensorflowjs/quantization_test.py
@@ -171,7 +171,7 @@ class TestQuantizationUtil(unittest.TestCase):
   def testInvalidQuantizationTypes(self):
     # Invalid quantization type
     with self.assertRaises(ValueError):
-      quantization.quantize_weights(np.array([]), np.bool)
+      quantization.quantize_weights(np.array([]), bool)
 
     # Invalid data dtype for float16 quantization
     with self.assertRaises(ValueError):
@@ -191,7 +191,7 @@ class TestQuantizationUtil(unittest.TestCase):
 
     # Invalid dequantization type
     with self.assertRaises(ValueError):
-      d = np.ones(1, dtype=np.bool)
+      d = np.ones(1, dtype=bool)
       quantization.dequantize_weights(d, {})
 
   def testMapLayerFallthrough(self):

--- a/tfjs-converter/python/tensorflowjs/read_weights.py
+++ b/tfjs-converter/python/tensorflowjs/read_weights.py
@@ -25,7 +25,7 @@ import numpy as np
 from tensorflowjs import quantization
 
 _INPUT_DTYPES = [np.float16, np.float32, np.int32, np.complex64,
-                 uint8, uint16, object, bool]
+                 np.uint8, np.uint16, object, bool]
 
 # Number of bytes used to encode the length of a string in a string tensor.
 STRING_LENGTH_NUM_BYTES = 4

--- a/tfjs-converter/python/tensorflowjs/read_weights.py
+++ b/tfjs-converter/python/tensorflowjs/read_weights.py
@@ -25,7 +25,7 @@ import numpy as np
 from tensorflowjs import quantization
 
 _INPUT_DTYPES = [np.float16, np.float32, np.int32, np.complex64,
-                 np.uint8, np.uint16, np.object, np.bool]
+                 uint8, uint16, object, bool]
 
 # Number of bytes used to encode the length of a string in a string tensor.
 STRING_LENGTH_NUM_BYTES = 4
@@ -174,7 +174,7 @@ def decode_weights(weights_manifest, data_buffers, flatten=False):
       name = weight['name']
       if weight['dtype'] == 'string':
         # String array.
-        dtype = np.object
+        dtype = object
       elif quant_info:
         # Quantized array.
         dtype = np.dtype(quant_info['dtype'])

--- a/tfjs-converter/python/tensorflowjs/write_weights.py
+++ b/tfjs-converter/python/tensorflowjs/write_weights.py
@@ -25,7 +25,7 @@ from tensorflowjs import quantization
 from tensorflowjs import read_weights
 
 _OUTPUT_DTYPES = [np.float16, np.float32, np.int32, np.complex64,
-                  np.uint8, np.uint16, np.bool, np.object]
+                  np.uint8, np.uint16, bool, object]
 _AUTO_DTYPE_CONVERSION = {
     np.dtype(np.float16): np.float32,
     np.dtype(np.float64): np.float32,
@@ -259,7 +259,7 @@ def _stack_group_bytes(group):
     _assert_valid_weight_entry(entry)
     data = entry['data']
 
-    if data.dtype == np.object:
+    if data.dtype == object:
       data_bytes = _serialize_string_array(data)
     else:
       data_bytes = _serialize_numeric_array(data)
@@ -367,9 +367,9 @@ def _assert_valid_weight_entry(entry):
   data = entry['data']
 
   # String tensors can be backed by different numpy dtypes, thus we consolidate
-  # to a single 'np.object' dtype.
+  # to a single 'object' dtype.
   if data.dtype.name.startswith('str') or data.dtype.name.startswith('bytes'):
-    data = data.astype(np.object)
+    data = data.astype(object)
     entry['data'] = data
 
 

--- a/tfjs-converter/python/tensorflowjs/write_weights_test.py
+++ b/tfjs-converter/python/tensorflowjs/write_weights_test.py
@@ -719,7 +719,7 @@ class TestWriteWeights(tf.test.TestCase):
             'data': np.array([6, 7], 'float64')
         }, {
             'name': 'weight4',
-            'data': np.array(['hello'], np.object)
+            'data': np.array(['hello'], object)
         }]
     ]
 


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/6610

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6625)
<!-- Reviewable:end -->
