### PR TITLE
Pin webgpu types to an exact version

### DIFF
--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -47,7 +47,7 @@
     "@types/offscreencanvas": "~2019.3.0",
     "@types/seedrandom": "^2.4.28",
     "@types/webgl-ext": "0.0.30",
-    "@webgpu/types": "^0.1.16",
+    "@webgpu/types": "0.1.16",
     "long": "4.0.0",
     "node-fetch": "~2.6.1",
     "seedrandom": "^3.0.5"


### PR DESCRIPTION
@webgpu/types does not appear to follow semver for breaking changes yet, so pin an exact version instead of allowing a minor version range. Without the version pinned, tfjs-node verdaccio tests fail because they install 0.1.19 instead of 0.1.16.

https://console.cloud.google.com/cloud-build/builds/7b3cc52f-8b95-4b89-9fc0-d4dd2ee9f9e2;step=0?project=learnjs-174218

Pinning the version fixes tfjs-node (tested locally because there is another issue with the verdaccio test not fixed by this PR).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6640)
<!-- Reviewable:end -->
