### PR TITLE
webgpu: dont use mod as it is a reserved keyword

### DIFF
--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -352,8 +352,8 @@ const commonSnippet = `
 
   fn idiv(a: i32, b: i32, sign: f32) -> i32 {
     var res: i32 = a / b;
-    let mod: i32 = a % b;
-    if (sign < 0. && mod != 0) {
+    let modulo: i32 = a % b;
+    if (sign < 0. && modulo != 0) {
       res = res - 1;
     }
     return res;


### PR DESCRIPTION
as per https://gpuweb.github.io/gpuweb/wgsl/#reserved-words, `mod` is a reserved keyword, which is causing the webgpu implementation of deno to error. seems chrome doesnt check for these keywords yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6667)
<!-- Reviewable:end -->
