### PR TITLE
[core] Fix undefined `expect` in test_util

### DIFF
--- a/tfjs-core/src/test_util.ts
+++ b/tfjs-core/src/test_util.ts
@@ -93,7 +93,9 @@ function expectArraysPredicate(
           `Expected: ${expectedFlat}.`);
     }
   }
-  expect().nothing();
+  if (typeof expect !== 'undefined') {
+    expect().nothing();
+  }
 }
 
 export interface DoneFn {
@@ -103,7 +105,9 @@ export interface DoneFn {
 
 export function expectPromiseToFail(fn: () => Promise<{}>, done: DoneFn): void {
   fn().then(() => done.fail(), () => done());
-  expect().nothing();
+  if (typeof expect !== 'undefined') {
+    expect().nothing();
+  }
 }
 
 export function expectArraysEqual(actual: TensorLike, expected: TensorLike) {
@@ -127,7 +131,9 @@ export function expectNumbersClose(a: number, e: number, epsilon?: number) {
   if (!areClose(a, e, epsilon)) {
     throw new Error(`Numbers differ: actual === ${a}, expected === ${e}`);
   }
-  expect().nothing();
+  if (typeof expect !== 'undefined') {
+    expect().nothing();
+  }
 }
 
 function areClose(a: number, e: number, epsilon: number): boolean {


### PR DESCRIPTION
expect().nothing() should only be called in jasmine test framework, add
if condition to avoid calling outside of the framework.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6671)
<!-- Reviewable:end -->
