### PR TITLE
Add iOS and Android to WebGL presubmit tests

### DIFF
--- a/tfjs-backend-webgl/BUILD.bazel
+++ b/tfjs-backend-webgl/BUILD.bazel
@@ -112,6 +112,10 @@ tfjs_web_test(
         "win_10_chrome",
     ],
     headless = False,
+    presubmit_browsers = [
+        "bs_chrome_mac",
+        "bs_android_9",
+    ],
     static_files = STATIC_FILES,
 )
 
@@ -129,6 +133,10 @@ tfjs_web_test(
         "bs_ios_12",
     ],
     headless = False,
+    presubmit_browsers = [
+        "bs_safari_mac",
+        "bs_ios_12",
+    ],
     static_files = STATIC_FILES,
 )
 


### PR DESCRIPTION
iOS and Android have different enough implementations of WebGL that we should test them on each PR instead of just in nightly. This brings the number of browsers we test in PR presubmits from 10 to 12.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6681)
<!-- Reviewable:end -->
