### PR TITLE
[webgpu] Remove extra device stuff passing to the constructor

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -487,14 +487,14 @@ export class WebGPUBackend extends KernelBackend {
   }
 
   async time(f: () => void): Promise<WebGPUTimingInfo> {
-    if(!this.supportTimeQuery) {
+    if (!this.supportTimeQuery) {
       console.warn(
           `This device doesn't support timestamp-query extension. ` +
           `Start Chrome browser with flag ` +
           `--disable-dawn-features=disallow_unsafe_apis then try again. ` +
-          `Or zero will shown for the kernel time when profiling mode is` +
-          `enabled. Using performance.now is not workable for webgpu since` +
-          `it doesn't support synchronously to read data from GPU.`);
+          `Otherwise, zero will be shown for the kernel time when profiling ` +
+          `mode is enabled. Using performance.now is not workable for webgpu ` +
+          `since it doesn't support synchronous data read from GPU.`);
     }
     const oldActiveTimers = this.activeTimers;
     const newActiveTimers: TimerNode[] = [];

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -155,14 +155,6 @@ export class WebGPUBackend extends KernelBackend {
         type: 'timestamp',
         count: 2,
       });
-    } else {
-      console.warn(
-          `This device doesn't support timestamp-query extension. ` +
-          `Start Chrome browser with flag ` +
-          `--disable-dawn-features=disallow_unsafe_apis then try again. ` +
-          `Or zero will shown for the kernel time when profiling mode is` +
-          `enabled. Using performance.now is not workable for webgpu since` +
-          `it doesn't support synchronously to read data from GPU.`);
     }
 
     // Profiling tools like PIX needs this dummy canvas to
@@ -495,6 +487,15 @@ export class WebGPUBackend extends KernelBackend {
   }
 
   async time(f: () => void): Promise<WebGPUTimingInfo> {
+    if(!this.supportTimeQuery) {
+      console.warn(
+          `This device doesn't support timestamp-query extension. ` +
+          `Start Chrome browser with flag ` +
+          `--disable-dawn-features=disallow_unsafe_apis then try again. ` +
+          `Or zero will shown for the kernel time when profiling mode is` +
+          `enabled. Using performance.now is not workable for webgpu since` +
+          `it doesn't support synchronously to read data from GPU.`);
+    }
     const oldActiveTimers = this.activeTimers;
     const newActiveTimers: TimerNode[] = [];
 

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -135,7 +135,7 @@ export class WebGPUBackend extends KernelBackend {
     return WebGPUBackend.nextDataId++;
   }
 
-  constructor(device: GPUDevice, supportTimeQuery = false) {
+  constructor(device: GPUDevice) {
     super();
     if (!webgpu_util.isWebGPUSupported()) {
       throw new Error('WebGPU is not supported on this device');
@@ -145,7 +145,7 @@ export class WebGPUBackend extends KernelBackend {
     this.queue = device.queue;
     this.currentCommandEncoder = null;
     this.currentComputePass = null;
-    this.supportTimeQuery = supportTimeQuery;
+    this.supportTimeQuery = device.features.has('timestamp-query');
 
     this.bufferManager = new BufferManager(this.device);
     this.textureManager = new TextureManager(this.device);
@@ -155,6 +155,14 @@ export class WebGPUBackend extends KernelBackend {
         type: 'timestamp',
         count: 2,
       });
+    } else {
+      console.warn(
+          `This device doesn't support timestamp-query extension. ` +
+          `Start Chrome browser with flag ` +
+          `--disable-dawn-features=disallow_unsafe_apis then try again. ` +
+          `Or zero will shown for the kernel time when profiling mode is` +
+          `enabled. Using performance.now is not workable for webgpu since` +
+          `it doesn't support synchronously to read data from GPU.`);
     }
 
     // Profiling tools like PIX needs this dummy canvas to

--- a/tfjs-backend-webgpu/src/index.ts
+++ b/tfjs-backend-webgpu/src/index.ts
@@ -50,17 +50,9 @@ if (isWebGPUSupported()) {
 
     if (supportTimeQuery) {
       deviceDescriptor.requiredFeatures = ['timestamp-query' as const];
-    } else {
-      console.warn(
-          `This device doesn't support timestamp-query extension. ` +
-          `Start Chrome browser with flag ` +
-          `--disable-dawn-features=disallow_unsafe_apis then try again. ` +
-          `Or zero will shown for the kernel time when profiling mode is` +
-          `enabled. Using performance.now is not workable for webgpu since` +
-          `it doesn't support synchronously to read data from GPU.`);
     }
     const device: GPUDevice = await adapter.requestDevice(deviceDescriptor);
-    return new WebGPUBackend(device, supportTimeQuery);
+    return new WebGPUBackend(device);
   }, 3 /*priority*/);
 }
 


### PR DESCRIPTION
BUG

While passing both device and device feature to the constructor,
there is a potential mismatch between them and cause error, so only keep
unique device in backend constructor's parameter.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6689)
<!-- Reviewable:end -->
