### PR TITLE
Create tensor from GPUBuffer (GPUReadData)

### DIFF
--- a/tfjs-backend-webgpu/src/tensor_test.ts
+++ b/tfjs-backend-webgpu/src/tensor_test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {describeWebGPU} from './test_util';
+
+async function createReadonlyGPUBufferFromData(
+    device: GPUDevice, data: number[], dtype: string) {
+  const bytesPerElement = 4;
+  const sizeInBytes = data.length * bytesPerElement;
+
+  const gpuWriteBuffer = device.createBuffer({
+    mappedAtCreation: true,
+    size: sizeInBytes,
+    usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC
+  });
+  const arrayBuffer = gpuWriteBuffer.getMappedRange();
+
+  new Float32Array(arrayBuffer).set(data);
+
+  gpuWriteBuffer.unmap();
+
+  const aBuffer = device.createBuffer({
+    mappedAtCreation: false,
+    size: sizeInBytes,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
+  });
+
+  const copyEncoder = device.createCommandEncoder();
+  copyEncoder.copyBufferToBuffer(gpuWriteBuffer, 0, aBuffer, 0, sizeInBytes);
+
+  const copyCommands = copyEncoder.finish();
+  device.queue.submit([copyCommands]);
+  gpuWriteBuffer.destroy();
+  return aBuffer;
+}
+
+type Shape = [number]|[number, number]|[number, number, number]|
+    [number, number, number, number]|[number, number, number, number, number]|
+        [number, number, number, number, number, number];
+
+describeWebGPU('tensor', () => {
+  it('tensor from GPUBuffer 1d 2d 3d 4d 5d 6d', async () => {
+    const device = tf.backend().getGPUDevice();
+    const aData = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    const b =
+        new Float32Array([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]);
+    const expected = [2, 4, 6, 8, 6, 8, 10, 12, 10, 12, 14, 16, 14, 16, 18, 20];
+    const dtype = 'float32';
+    const aBuffer = await createReadonlyGPUBufferFromData(device, aData, dtype);
+    {
+      const shape: Shape = [16];
+      const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+      const a = tf.tensor1d(gpuReadData);
+      const result = tf.add(a, tf.tensor1d(b, 'float32', shape));
+      tf.test_util.expectArraysClose(await result.data(), expected);
+      a.dispose();
+      result.dispose();
+    }
+    {
+      const shape: Shape = [8, 2];
+      const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+      const a = tf.tensor2d(gpuReadData);
+      const result = tf.add(a, tf.tensor2d(b, shape));
+      tf.test_util.expectArraysClose(await result.data(), expected);
+      a.dispose();
+      result.dispose();
+    }
+    {
+      const shape: Shape = [2, 4, 2];
+      const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+      const a = tf.tensor3d(gpuReadData);
+      const result = tf.add(a, tf.tensor3d(b, shape));
+      tf.test_util.expectArraysClose(await result.data(), expected);
+      a.dispose();
+      result.dispose();
+    }
+    {
+      const shape: Shape = [2, 2, 2, 2];
+      const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+      const a = tf.tensor4d(gpuReadData);
+      const result = tf.add(a, tf.tensor4d(b, shape));
+      tf.test_util.expectArraysClose(await result.data(), expected);
+      a.dispose();
+      result.dispose();
+    }
+    {
+      const shape: Shape = [1, 2, 2, 2, 2];
+      const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+      const a = tf.tensor5d(gpuReadData);
+      const result = tf.add(a, tf.tensor5d(b, shape));
+      tf.test_util.expectArraysClose(await result.data(), expected);
+      a.dispose();
+      result.dispose();
+    }
+    {
+      const shape: Shape = [1, 1, 2, 2, 2, 2];
+      const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+      const a = tf.tensor6d(gpuReadData);
+      const result = tf.add(a, tf.tensor6d(b, shape));
+      tf.test_util.expectArraysClose(await result.data(), expected);
+      a.dispose();
+      result.dispose();
+    }
+    aBuffer.destroy();
+  });
+
+  it('two tensors share the same GPUBuffer', async () => {
+    const device = tf.backend().getGPUDevice();
+    const aData = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    const expected =
+        [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32];
+    const dtype = 'float32';
+    const aBuffer = await createReadonlyGPUBufferFromData(device, aData, dtype);
+
+    const shape: Shape = [16];
+    const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
+    const a = tf.tensor1d(gpuReadData);
+    const b = tf.tensor1d(gpuReadData);
+    const result = tf.add(a, b);
+    tf.test_util.expectArraysClose(await result.data(), expected);
+    a.dispose();
+    result.dispose();
+    aBuffer.destroy();
+  });
+});

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {Backend, DataId, DataToGPUOptions, GPUData} from '../tensor';
+import {Backend, DataId, DataToGPUOptions, GPUData, GPUReadData} from '../tensor';
 import {BackendValues, DataType} from '../types';
 
 export const EPSILON_FLOAT32 = 1e-7;
@@ -127,6 +127,9 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   write(values: BackendValues, shape: number[], dtype: DataType): DataId {
     return notYetImplemented('write');
   }
+  writeFromGPUBuffer(vauels: GPUReadData): DataId {
+    return notYetImplemented('writeFromGPUBuffer');
+  }
   move(
       dataId: DataId, values: BackendValues, shape: number[], dtype: DataType,
       refCount: number): void {
@@ -138,6 +141,10 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   /** Returns the highest precision for floats in bits (e.g. 16 or 32) */
   floatPrecision(): 16|32 {
     return notYetImplemented('floatPrecision');
+  }
+  /** Return the GPUDevice (WebGPU backend only) */
+  getGPUDevice(): GPUDevice {
+    return notYetImplemented('getDevice');
   }
   /** Returns the smallest representable number.  */
   epsilon(): number {

--- a/tfjs-core/src/base.ts
+++ b/tfjs-core/src/base.ts
@@ -53,7 +53,7 @@ export {Optimizer} from './optimizers/optimizer';
 export {OptimizerConstructors} from './optimizers/optimizer_constructors';
 export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
-export {DataToGPUOptions, DataToGPUWebGLOption, GPUData, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, Variable} from './tensor';
+export {DataToGPUOptions, DataToGPUWebGLOption, GPUData, GPUReadData, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, Variable} from './tensor';
 export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
 export {BackendValues, DataType, DataTypeMap, DataValues, NumericDataType, PixelData, Rank, RecursiveArray, ScalarLike, ShapeMap, sumOutType, TensorLike, TypedArray, upcastType} from './types';
 

--- a/tfjs-core/src/ops/tensor1d.ts
+++ b/tfjs-core/src/ops/tensor1d.ts
@@ -15,11 +15,13 @@
  * =============================================================================
  */
 
-import {Tensor1D} from '../tensor';
+import {ENGINE} from '../engine';
+import {GPUReadData, Tensor1D} from '../tensor';
 import {inferShape} from '../tensor_util_env';
 import {TensorLike1D} from '../types';
 import {DataType} from '../types';
 import {assertNonNull} from '../util';
+
 import {makeTensor} from './tensor_ops_util';
 
 /**
@@ -33,17 +35,23 @@ import {makeTensor} from './tensor_ops_util';
  * ```
  *
  * @param values The values of the tensor. Can be array of numbers,
- *     or a `TypedArray`.
+ *     or a `TypedArray`, or a `GPUReadData`.
  * @param dtype The data type.
  *
  * @doc {heading: 'Tensors', subheading: 'Creation'}
  */
-export function tensor1d(values: TensorLike1D, dtype?: DataType): Tensor1D {
-  assertNonNull(values);
-  const inferredShape = inferShape(values, dtype);
-  if (inferredShape.length !== 1) {
-    throw new Error('tensor1d() requires values to be a flat/TypedArray');
+export function tensor1d(
+    values: TensorLike1D|GPUReadData, dtype?: DataType,
+    shape?: number[]): Tensor1D {
+  if (values instanceof GPUReadData) {
+    return ENGINE.makeTensorFromGPUBuffer(values) as Tensor1D;
+  } else {
+    assertNonNull(values);
+    const inferredShape = inferShape(values, dtype);
+    if (inferredShape.length !== 1) {
+      throw new Error('tensor1d() requires values to be a flat/TypedArray');
+    }
+    const shape: number[] = null;
+    return makeTensor(values, shape, inferredShape, dtype) as Tensor1D;
   }
-  const shape: number[] = null;
-  return makeTensor(values, shape, inferredShape, dtype) as Tensor1D;
 }

--- a/tfjs-core/src/ops/tensor2d.ts
+++ b/tfjs-core/src/ops/tensor2d.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
-import {Tensor2D} from '../tensor';
+import {ENGINE} from '../engine';
+import {GPUReadData, Tensor2D} from '../tensor';
 import {inferShape} from '../tensor_util_env';
 import {TensorLike2D} from '../types';
 import {DataType} from '../types';
@@ -38,7 +39,7 @@ import {makeTensor} from './tensor_ops_util';
  * ```
  *
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`.
+ *     or a flat array, or a `TypedArray`, or a `GPUReadData`.
  * @param shape The shape of the tensor. If not provided, it is inferred from
  *     `values`.
  * @param dtype The data type.
@@ -46,21 +47,25 @@ import {makeTensor} from './tensor_ops_util';
  * @doc {heading: 'Tensors', subheading: 'Creation'}
  */
 export function tensor2d(
-    values: TensorLike2D, shape?: [number, number],
+    values: TensorLike2D|GPUReadData, shape?: [number, number],
     dtype?: DataType): Tensor2D {
-  assertNonNull(values);
-  if (shape != null && shape.length !== 2) {
-    throw new Error('tensor2d() requires shape to have two numbers');
+  if (values instanceof GPUReadData) {
+    return ENGINE.makeTensorFromGPUBuffer(values) as Tensor2D;
+  } else {
+    assertNonNull(values);
+    if (shape != null && shape.length !== 2) {
+      throw new Error('tensor2d() requires shape to have two numbers');
+    }
+    const inferredShape = inferShape(values, dtype);
+    if (inferredShape.length !== 2 && inferredShape.length !== 1) {
+      throw new Error(
+          'tensor2d() requires values to be number[][] or flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor2d() requires shape to be provided when `values` ' +
+          'are a flat/TypedArray');
+    }
+    return makeTensor(values, shape, inferredShape, dtype) as Tensor2D;
   }
-  const inferredShape = inferShape(values, dtype);
-  if (inferredShape.length !== 2 && inferredShape.length !== 1) {
-    throw new Error(
-        'tensor2d() requires values to be number[][] or flat/TypedArray');
-  }
-  if (inferredShape.length === 1 && shape == null) {
-    throw new Error(
-        'tensor2d() requires shape to be provided when `values` ' +
-        'are a flat/TypedArray');
-  }
-  return makeTensor(values, shape, inferredShape, dtype) as Tensor2D;
 }

--- a/tfjs-core/src/ops/tensor3d.ts
+++ b/tfjs-core/src/ops/tensor3d.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
-import {Tensor3D} from '../tensor';
+import {ENGINE} from '../engine';
+import {GPUReadData, Tensor3D} from '../tensor';
 import {inferShape} from '../tensor_util_env';
 import {TensorLike3D} from '../types';
 import {DataType} from '../types';
@@ -38,7 +39,7 @@ import {makeTensor} from './tensor_ops_util';
  * ```
  *
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`.
+ *     or a flat array, or a `TypedArray`, or a `GPUReadData`.
  * @param shape The shape of the tensor. If not provided,  it is inferred from
  *     `values`.
  * @param dtype The data type.
@@ -46,21 +47,25 @@ import {makeTensor} from './tensor_ops_util';
  * @doc {heading: 'Tensors', subheading: 'Creation'}
  */
 export function tensor3d(
-    values: TensorLike3D, shape?: [number, number, number],
+    values: TensorLike3D|GPUReadData, shape?: [number, number, number],
     dtype?: DataType): Tensor3D {
-  assertNonNull(values);
-  if (shape != null && shape.length !== 3) {
-    throw new Error('tensor3d() requires shape to have three numbers');
+  if (values instanceof GPUReadData) {
+    return ENGINE.makeTensorFromGPUBuffer(values) as Tensor3D;
+  } else {
+    assertNonNull(values);
+    if (shape != null && shape.length !== 3) {
+      throw new Error('tensor3d() requires shape to have three numbers');
+    }
+    const inferredShape = inferShape(values, dtype);
+    if (inferredShape.length !== 3 && inferredShape.length !== 1) {
+      throw new Error(
+          'tensor3d() requires values to be number[][][] or flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor3d() requires shape to be provided when `values` ' +
+          'are a flat array');
+    }
+    return makeTensor(values, shape, inferredShape, dtype) as Tensor3D;
   }
-  const inferredShape = inferShape(values, dtype);
-  if (inferredShape.length !== 3 && inferredShape.length !== 1) {
-    throw new Error(
-        'tensor3d() requires values to be number[][][] or flat/TypedArray');
-  }
-  if (inferredShape.length === 1 && shape == null) {
-    throw new Error(
-        'tensor3d() requires shape to be provided when `values` ' +
-        'are a flat array');
-  }
-  return makeTensor(values, shape, inferredShape, dtype) as Tensor3D;
 }

--- a/tfjs-core/src/ops/tensor5d.ts
+++ b/tfjs-core/src/ops/tensor5d.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
-import {Tensor5D} from '../tensor';
+import {ENGINE} from '../engine';
+import {GPUReadData, Tensor5D} from '../tensor';
 import {inferShape} from '../tensor_util_env';
 import {TensorLike5D} from '../types';
 import {DataType} from '../types';
@@ -38,7 +39,7 @@ import {makeTensor} from './tensor_ops_util';
  * ```
  *
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`.
+ *     or a flat array, or a `TypedArray`, or a `GPUReadData`.
  * @param shape The shape of the tensor. Optional. If not provided,
  *   it is inferred from `values`.
  * @param dtype The data type.
@@ -46,22 +47,27 @@ import {makeTensor} from './tensor_ops_util';
  * @doc {heading: 'Tensors', subheading: 'Creation'}
  */
 export function tensor5d(
-    values: TensorLike5D, shape?: [number, number, number, number, number],
+    values: TensorLike5D|GPUReadData,
+    shape?: [number, number, number, number, number],
     dtype?: DataType): Tensor5D {
-  assertNonNull(values);
-  if (shape != null && shape.length !== 5) {
-    throw new Error('tensor5d() requires shape to have five numbers');
+  if (values instanceof GPUReadData) {
+    return ENGINE.makeTensorFromGPUBuffer(values) as Tensor5D;
+  } else {
+    assertNonNull(values);
+    if (shape != null && shape.length !== 5) {
+      throw new Error('tensor5d() requires shape to have five numbers');
+    }
+    const inferredShape = inferShape(values, dtype);
+    if (inferredShape.length !== 5 && inferredShape.length !== 1) {
+      throw new Error(
+          'tensor5d() requires values to be ' +
+          'number[][][][][] or flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor5d() requires shape to be provided when `values` ' +
+          'are a flat array');
+    }
+    return makeTensor(values, shape, inferredShape, dtype) as Tensor5D;
   }
-  const inferredShape = inferShape(values, dtype);
-  if (inferredShape.length !== 5 && inferredShape.length !== 1) {
-    throw new Error(
-        'tensor5d() requires values to be ' +
-        'number[][][][][] or flat/TypedArray');
-  }
-  if (inferredShape.length === 1 && shape == null) {
-    throw new Error(
-        'tensor5d() requires shape to be provided when `values` ' +
-        'are a flat array');
-  }
-  return makeTensor(values, shape, inferredShape, dtype) as Tensor5D;
 }

--- a/tfjs-core/src/ops/tensor6d.ts
+++ b/tfjs-core/src/ops/tensor6d.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
-import {Tensor6D} from '../tensor';
+import {ENGINE} from '../engine';
+import {GPUReadData, Tensor6D} from '../tensor';
 import {inferShape} from '../tensor_util_env';
 import {TensorLike6D} from '../types';
 import {DataType} from '../types';
@@ -38,7 +39,7 @@ import {makeTensor} from './tensor_ops_util';
  * ```
  *
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`.
+ *     or a flat array, or a `TypedArray`, or a `GPUReadData`.
  * @param shape The shape of the tensor. Optional. If not provided,
  *   it is inferred from `values`.
  * @param dtype The data type.
@@ -46,25 +47,29 @@ import {makeTensor} from './tensor_ops_util';
  * @doc {heading: 'Tensors', subheading: 'Creation'}
  */
 export function tensor6d(
-    values: TensorLike6D,
+    values: TensorLike6D|GPUReadData,
     shape?: [number, number, number, number, number, number],
     dtype?: DataType): Tensor6D {
-  assertNonNull(values);
-  if (shape != null && shape.length !== 6) {
-    throw new Error('tensor6d() requires shape to have six numbers');
+  if (values instanceof GPUReadData) {
+    return ENGINE.makeTensorFromGPUBuffer(values) as Tensor6D;
+  } else {
+    assertNonNull(values);
+    if (shape != null && shape.length !== 6) {
+      throw new Error('tensor6d() requires shape to have six numbers');
+    }
+    const inferredShape = inferShape(values, dtype);
+    if (inferredShape.length !== 6 && inferredShape.length !== 1) {
+      throw new Error(
+          'tensor6d() requires values to be number[][][][][][] or ' +
+          'flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor6d() requires shape to be provided when `values` ' +
+          'are a flat array');
+    }
+    shape = shape ||
+        inferredShape as [number, number, number, number, number, number];
+    return makeTensor(values, shape, inferredShape, dtype) as Tensor6D;
   }
-  const inferredShape = inferShape(values, dtype);
-  if (inferredShape.length !== 6 && inferredShape.length !== 1) {
-    throw new Error(
-        'tensor6d() requires values to be number[][][][][][] or ' +
-        'flat/TypedArray');
-  }
-  if (inferredShape.length === 1 && shape == null) {
-    throw new Error(
-        'tensor6d() requires shape to be provided when `values` ' +
-        'are a flat array');
-  }
-  shape = shape ||
-      inferredShape as [number, number, number, number, number, number];
-  return makeTensor(values, shape, inferredShape, dtype) as Tensor6D;
 }

--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -173,6 +173,19 @@ export interface GPUData {
   bufSize?: number;
 }
 
+// TODO: merge this with GPUData and add WebGL support.
+export class GPUReadData {
+  readonly buffer: GPUBuffer;
+  readonly shape: number[];
+  readonly dtype: DataType;
+
+  constructor(buffer: GPUBuffer, shape: number[], dtype?: DataType) {
+    this.buffer = buffer;
+    this.shape = shape;
+    this.dtype = dtype || 'float32';
+  }
+}
+
 export interface TensorTracker {
   makeTensor(
       values: DataValues, shape: number[], dtype: DataType,


### PR DESCRIPTION
This only works on WebGPU.
TODO: refine API docs; Add more dtype.
Use case: 
```
const shape: Shape = [16];
const gpuReadData = new tf.GPUReadData(aBuffer, shape, dtype);
const a = tf.tensor1d(gpuReadData);
```


 BUG: https://github.com/tensorflow/tfjs/issues/6232

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6690)
<!-- Reviewable:end -->
