### PR TITLE
Fix browserstack-benchmark tool 

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/index.html
+++ b/e2e/benchmarks/browserstack-benchmark/index.html
@@ -20,6 +20,7 @@ limitations under the License.
         <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.7/dat.gui.min.js"></script>
         <script src='/socket.io/socket.io.js'></script>
         <script src="./node_modules/@tensorflow/tfjs/dist/tf.min.js"> </script>
+        <script>window.tf || document.write('<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs/dist/tf.min.js"><\/script>')</script>
         <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-vis"></script>
     </head>
     <body onload="onPageLoad()">

--- a/e2e/benchmarks/browserstack-benchmark/index.html
+++ b/e2e/benchmarks/browserstack-benchmark/index.html
@@ -20,7 +20,7 @@ limitations under the License.
         <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.7/dat.gui.min.js"></script>
         <script src='/socket.io/socket.io.js'></script>
         <script src="./node_modules/@tensorflow/tfjs/dist/tf.min.js"> </script>
-        <script src="./node_modules/@tensorflow/tfjs-vis/dist/tfjs-vis.umd.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-vis"></script>
     </head>
     <body onload="onPageLoad()">
         <script src='/../model_config.js'></script>

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "karma start",
     "test-node": "jasmine app_node_test.js",
-    "build-deps": "yarn build-core && yarn build-backend-cpu && yarn build-backend-wasm && yarn build-backend-webgl && yarn build-converter && yarn build-layers && yarn build-data && yarn build-tfjs && yarn build-vis",
+    "build-deps": "yarn build-core && yarn build-backend-cpu && yarn build-backend-wasm && yarn build-backend-webgl && yarn build-converter && yarn build-layers && yarn build-data && yarn build-tfjs",
     "build-tfjs": "cd ../../../tfjs && yarn && yarn build && yarn build-npm",
     "build-backend-cpu": "cd ../../../tfjs-backend-cpu && yarn && yarn build-npm",
     "build-backend-wasm": "cd ../../../tfjs-backend-wasm && yarn && yarn build && yarn build-npm",
@@ -38,7 +38,6 @@
     "build-core": "cd ../../../tfjs-core && yarn && yarn build && yarn build-npm",
     "build-data": "cd ../../../tfjs-data && yarn && yarn build",
     "build-layers": "cd ../../../tfjs-layers && yarn && yarn build && yarn build-npm",
-    "build-vis": "cd ../../../tfjs-vis && yarn && yarn build",
     "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --webDeps --cloud --maxBenchmarks=9 --firestore"
   },
   "license": "Apache-2.0",

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -103,7 +103,7 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
-      if (isTflite != null && isTflite()) {
+      if (typeof isTflite === 'function' && isTflite()) {
         return () => tfliteModel.predict(input);
       } else {
         return predictFunction(input);
@@ -124,7 +124,7 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
-      if (isTflite != null && isTflite()) {
+      if (typeof isTflite === 'function' && isTflite()) {
         return () => tfliteModel.predict(input);
       } else {
         return predictFunction(input);
@@ -434,7 +434,7 @@ const benchmarks = {
           inferenceInput = customInput ||
               generateInputFromDef(
                                state.inputs, model instanceof tf.GraphModel);
-          if (isTflite != null && isTflite()) {
+          if (typeof isTflite === 'function' && isTflite()) {
             return await tfliteModel.predict(inferenceInput);
           } else {
             const predict = getPredictFnForModel(model, inferenceInput);

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -74,7 +74,7 @@ const sentences = [
   'what is the forecast for here at tea time',
 ];
 
-function predictFunction(model, input) {
+function predictFunction(input) {
   let debug = false;
   try {
     debug = tf.env().getBool('KEEP_INTERMEDIATE_TENSORS');
@@ -103,10 +103,10 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
-      if (isTflite()) {
+      if (isTflite != null && isTflite()) {
         return () => tfliteModel.predict(input);
       } else {
-        return predictFunction(model, input);
+        return predictFunction(input);
       }
     },
   },
@@ -124,10 +124,10 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
-      if (isTflite()) {
+      if (isTflite != null && isTflite()) {
         return () => tfliteModel.predict(input);
       } else {
-        return predictFunction(model, input);
+        return predictFunction(input);
       }
     },
   },
@@ -140,7 +140,7 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.zeros([1, 128, 128, 3]);
-      return predictFunction(model, input);
+      return predictFunction(input);
     },
   },
   'face_detector': {
@@ -152,7 +152,7 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.zeros([1, 128, 128, 3]);
-      return predictFunction(model, input);
+      return predictFunction(input);
     },
   },
   'hand_detector': {
@@ -163,7 +163,7 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.zeros([1, 256, 256, 3]);
-      return predictFunction(model, input);
+      return predictFunction(input);
     },
   },
   'hand_skeleton': {
@@ -174,7 +174,7 @@ const benchmarks = {
     },
     predictFunc: () => {
       const input = tf.zeros([1, 256, 256, 3]);
-      return predictFunction(model, input);
+      return predictFunction(input);
     },
   },
   'AutoML Image': {
@@ -323,7 +323,7 @@ const benchmarks = {
     },
     predictFunc: (inputResolution = 128) => {
       const input = tf.randomNormal([1, inputResolution, inputResolution, 3]);
-      return predictFunction(model, input);
+      return predictFunction(input);
     },
   },
   'speech-commands': {
@@ -434,7 +434,7 @@ const benchmarks = {
           inferenceInput = customInput ||
               generateInputFromDef(
                                state.inputs, model instanceof tf.GraphModel);
-          if (isTflite()) {
+          if (isTflite != null && isTflite()) {
             return await tfliteModel.predict(inferenceInput);
           } else {
             const predict = getPredictFnForModel(model, inferenceInput);


### PR DESCRIPTION
This PR:
1. Removes local build for `tfjs-vis`, since this benchmark tool typically does not need it.
2. Removes unused `model` parameter from `predictFunction` function.
3. Add `typeof isTflite === 'function'` check before evaluation, because currently bs-benchmark tool does not support tflite.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6703)
<!-- Reviewable:end -->
