### PR TITLE
Use the firebase-admin package instead of firebase to push benchmark results

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/app_node_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_node_test.js
@@ -126,9 +126,8 @@ describe('test app.js cli', () => {
     // Writes to mock results file
     await write(filePath, mockResults);
 
-    fs.readFile(filePath, 'utf8', (err, data) => {
-      expect(data).toEqual(JSON.stringify(mockResults, null, 2));
-    });
+    const contents = fs.readFileSync(filePath, 'utf8');
+    expect(contents).toEqual(JSON.stringify(mockResults, null, 2));
   });
 
   it('benchmark function benchmarks each browser-device pairing ', async () => {
@@ -216,27 +215,25 @@ describe('test app.js cli', () => {
 
 describe('test adding to firestore', () => {
   let db;
-  let mockDb;
   let mockResultValue;
+  let mockSerialization;
+  let mockDate;
 
   beforeAll(async () => {
     // Set a longer jasmine timeout than 5 seconds
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
-
-    // References result collection and checks credentials
-    db = await runFirestore(firebaseConfig);
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 1_000_000;
   });
 
   beforeEach(() => {
     // mockResultValue is the result of a successful benchmark
     mockResultValue = require('./firestore_test_value.json');
-    mockDb = spyOn(db, 'add');
+    db = jasmine.createSpyObj('firestore', ['add']);
     mockSerialization = jasmine.createSpy('mockSerialization');
     mockDate = jasmine.createSpy('mockDate').and.returnValue('7/21/2021');
   });
 
   it('Expects db.add to be called with formatted results', () => {
-    mockDb.and.returnValue(Promise.resolve({id: 123}));
+    db.add.and.returnValue(Promise.resolve({id: 123}));
     let expectedAdd = {
       result:
           formatForFirestore(mockResultValue, serializeTensors, getReadableDate)

--- a/e2e/benchmarks/browserstack-benchmark/firestore.js
+++ b/e2e/benchmarks/browserstack-benchmark/firestore.js
@@ -15,46 +15,36 @@
  * =============================================================================
  */
 
-require('firebase/firestore');
-require('firebase/auth');
+const {initializeApp, deleteApp, applicationDefault, cert} = require('firebase-admin/app');
+const {getFirestore, Timestamp, FieldValue} = require('firebase-admin/firestore');
 
-const firebase = require('firebase/app');
-const firebaseConfig = {
-  apiKey: process.env.FIREBASE_KEY,
-  authDomain: 'learnjs-174218.firebaseapp.com',
-  databaseURL: 'https://learnjs-174218.firebaseio.com',
-  projectId: 'learnjs-174218',
-  storageBucket: 'learnjs-174218.appspot.com',
-  messagingSenderId: '834911136599',
-  appId: '1:834911136599:web:4b65685455bdf916a1ec12'
-};
-
+let app;
 /**
  * Initializes Firebase, signs in with secret credentials, and accesses the
  * Firestore collection of results.
  *
  * @param firebaseConfig A configuration with Firebase credentials
  */
-async function runFirestore(firebaseConfig) {
+async function runFirestore() {
   try {
-    firebase.initializeApp(firebaseConfig);
-    await firebase.auth().signInAnonymously();
-    console.log('\nSuccesfuly signed into Firebase with anonymous account.');
+    app = initializeApp({
+      credential: applicationDefault()
+    });
+    const db = getFirestore();
 
-    // Reference to the "BenchmarkResults" collection on firestore that contains
-    // the benchmark results.
-    return firebase.firestore().collection('BenchmarkResults');
+    console.log('\nSuccesfuly signed into Firebase.');
+    return db.collection('BenchmarkResults');
   } catch (err) {
-    console.log(`\nError code: ${err.code}`);
-    throw new Error(`Error message: ${err.message}`);
+    console.warn(`Failed to connect to firebase database: ${err.message}`);
+    throw err;
   }
 }
 
 /**
  * Deletes the Firebase instance, which allows the Node.js process to finish.
  */
-function endFirebaseInstance() {
-  firebase.app().delete();
+async function endFirebaseInstance() {
+  await deleteApp(app);
   console.log('Exited Firebase instance.');
 }
 
@@ -128,5 +118,4 @@ exports.serializeTensors = serializeTensors;
 exports.getReadableDate = getReadableDate;
 exports.formatForFirestore = formatForFirestore;
 exports.runFirestore = runFirestore;
-exports.firebaseConfig = firebaseConfig;
 exports.endFirebaseInstance = endFirebaseInstance;

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -12,7 +12,7 @@
     "@tensorflow/tfjs-backend-wasm": "link:../../../link_package/node_modules/@tensorflow/tfjs-backend-wasm",
     "@tensorflow/tfjs-vis": "link:../../../tfjs-vis",
     "argparse": "^2.0.1",
-    "firebase": "^8.7.1",
+    "firebase-admin": "^11.0.1",
     "jasmine": "^3.7.0",
     "karma": "^6.3.16",
     "karma-browserstack-launcher": "^1.6.0",

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "karma start",
     "test-node": "jasmine app_node_test.js",
-    "build-all-deps": "yarn build-link-package && yarn build-tfjs",
+    "build-all-deps": "yarn build-all-link-packages && yarn build-tfjs",
     "build-tfjs": "cd ../../../tfjs && yarn && yarn build-npm",
     "build-all-link-packages": "cd ../../../link-package && yarn build",
     "build-individual-link-package": "cd ../../../link-package && yarn build-deps-for",


### PR DESCRIPTION
Replace the firebase package with firebase-admin. The firebase-admin package is more appropriate for our use case of running benchmarks in GCP and pushing them to Firestore. [Per their docs](https://www.npmjs.com/package/firebase-admin), "The Firebase Admin Node.js SDK enables access to Firebase services from privileged environments (such as servers or cloud) in Node.js." It uses application default credentials, which are available in GCP.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6711)
<!-- Reviewable:end -->
