### PR TITLE
Make link-package's build-deps-for script check transitive deps

### DIFF
--- a/BAZEL_MIGRATION.md
+++ b/BAZEL_MIGRATION.md
@@ -384,12 +384,12 @@ Update all downstream dependencies that depend on the package to point to its lo
 
 To find downstream packages, run `grep -r --exclude=yarn.lock --exclude-dir=node_modules "link:.*tfjs-foo" .` in the root of the repository.
 
-#### Update Downstream Packages' build-link-package Scripts
-Make sure to list the new package in the call to `yarn build-deps-for ...` script for downstream packages. This includes packages that have `tfjs-foo` as a transitive dependency.
+#### Remove the 'build-tfjs-foo' Script from Downstream Packages
+Remove the `build-tfjs-foo` script from downstream packages' package.json files.
 ```json
 "scripts": {
-  "build-link-package": "cd ../link-package && yarn build-deps-for tfjs-foo tfjs-some-other-dependency",
-  "build-tfjs-foo": "remove this script", // <-- Don't forget to remove this earlier build script from downstream packages.
+  "build-deps": "....... && yarn build-tfjs-foo" // <-- Remove 'yarn build-deps-foo'.
+  "build-tfjs-foo": "remove this script", // <-- Also remove it here.
 }
 ```
 ### Move linting to the repo-wide lint script

--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc && npx mkdirp dist/proto && cp src/proto/api_pb.js dist/proto/api_pb.js",
     "build-ci": "tsc && npx mkdirp dist/proto && cp src/proto/api_pb.js dist/proto/api_pb.js",
-    "build-link-package": "cd ../link-package && yarn build-deps-for tfjs-node tfjs",
+    "build-link-package": "cd ../link-package && yarn build-deps-for tfjs-node",
     "build-union": "cd ../tfjs && yarn && yarn build",
     "build-union-ci": "cd ../tfjs && yarn && yarn build-ci",
     "build-deps": "yarn build-link-package && yarn build-union",

--- a/tfjs-node/package.json
+++ b/tfjs-node/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc && npx mkdirp dist/proto && cp src/proto/api_pb.js dist/proto/api_pb.js",
     "build-ci": "tsc && npx mkdirp dist/proto && cp src/proto/api_pb.js dist/proto/api_pb.js",
-    "build-link-package": "cd ../link-package && yarn build-deps-for tfjs-node tfjs",
+    "build-link-package": "cd ../link-package && yarn build-deps-for tfjs-node",
     "build-union": "cd ../tfjs && yarn && yarn build",
     "build-union-ci": "cd ../tfjs && yarn && yarn build-ci",
     "build-deps": "yarn build-link-package && yarn build-union",


### PR DESCRIPTION
Make build-deps-for check for Bazel dependencies transitively instead of just on the packages passed to it. Additionally, change the behavior of `build-deps-for` so that when it is passed a Bazel package, it will directly build the package instead of building just its dependencies.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6712)
<!-- Reviewable:end -->
