### PR TITLE
[browserstack benchmark tool] Update browser list with new devices

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/browser_list.json
+++ b/e2e/benchmarks/browserstack-benchmark/browser_list.json
@@ -1,10 +1,10 @@
 [
   {
     "os": "Windows",
-    "os_version": "10",
+    "os_version": "11",
     "browser": "chrome",
     "device": null,
-    "browser_version": "84.0",
+    "browser_version": "103.0",
     "real_mobile": null
   },
   {
@@ -17,43 +17,59 @@
   },
   {
     "os": "Windows",
-    "os_version": "10",
+    "os_version": "11",
     "browser": "edge",
     "device": null,
-    "browser_version": "84.0",
+    "browser_version": "103.0",
     "real_mobile": null
   },
   {
     "os": "Windows",
-    "os_version": "10",
+    "os_version": "11",
     "browser": "firefox",
     "device": null,
-    "browser_version": "79.0",
+    "browser_version": "103.0",
     "real_mobile": null
   },
   {
     "os": "OS X",
-    "os_version": "Catalina",
+    "os_version": "Monterey",
     "browser": "chrome",
     "device": null,
-    "browser_version": "84.0",
+    "browser_version": "103.0",
     "real_mobile": null
   },
   {
     "os": "OS X",
-    "os_version": "Catalina",
+    "os_version": "Monterey",
     "browser": "safari",
     "device": null,
-    "browser_version": "13.1",
+    "browser_version": "15.3",
     "real_mobile": null
   },
   {
     "os": "OS X",
-    "os_version": "Catalina",
+    "os_version": "Monterey",
     "browser": "firefox",
     "device": null,
-    "browser_version": "79.0",
+    "browser_version": "103.0",
     "real_mobile": null
+  },
+  {
+    "os": "ios",
+    "os_version": "15",
+    "browser": "iphone",
+    "device": "iPhone 13 Pro Max",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "15",
+    "browser": "iphone",
+    "device": "iPhone 13",
+    "browser_version": null,
+    "real_mobile": true
   },
   {
     "os": "ios",
@@ -124,6 +140,42 @@
     "os_version": "13",
     "browser": "iphone",
     "device": "iPhone SE 2020",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "ios",
+    "os_version": "15",
+    "browser": "iphone",
+    "device": "iPhone 13",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "ios",
+    "os_version": "15",
+    "browser": "ipad",
+    "device": "iPad 9th",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "ios",
+    "os_version": "15",
+    "browser": "ipad",
+    "device": "iPad Air 5",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "ios",
+    "os_version": "14",
+    "browser": "ipad",
+    "device": "iPad Air 4",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "ios",
+    "os_version": "14",
+    "browser": "ipad",
+    "device": "iPad 8th",
     "browser_version": null,
     "real_mobile": true
   },
@@ -244,6 +296,63 @@
     "os_version": "12",
     "browser": "ipad",
     "device": "iPad Air 2019",
+    "browser_version": null,
+    "real_mobile": true
+  },
+  {
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S22 Ultra",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S22 Plus",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S22",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Samsung Galaxy S21",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Google Pixel 6 Pro",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Google Pixel 6",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Google Pixel 5",
+    "browser_version": null,
+    "real_mobile": true
+  },{
+    "os": "android",
+    "os_version": "12.0",
+    "browser": "android",
+    "device": "Samsung Galaxy Tab S8",
     "browser_version": null,
     "real_mobile": true
   },


### PR DESCRIPTION
Adds/updates browsers/devices for the BS benchmark tool:
1. Windows: updates OS from 10 to 11 and updates browser version to the latest for all browser.
2. Mac: updates OS from Catalina to Monterey and updates browser version to the latest for all browser.
3. ios iphone: adds os_version as 15
4. ios ipad: adds os_version as 14 and 15
5. android: adds os_version as 12.0

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6713)
<!-- Reviewable:end -->
