### PR TITLE
[tfjs-converter] Revert "fix protobuf version to 3.20.0 (#6612)"

### DIFF
--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -48,7 +48,6 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     requires = [
-        "protobuf==3.20.0",
         "tensorflow>=2.1.0,<3",
         "six>=1.12.0,<2",
         "tensorflow-hub>=0.7.0,<0.13",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,4 +1,3 @@
-protobuf==3.20.0
 tensorflow>=2.1.0,<3
 numpy~=1.19.2
 six>=1.12.0,<2


### PR DESCRIPTION
Removed the version locking on protobuf pip, given the nightly is not failing any more. fixes https://github.com/tensorflow/tfjs/issues/6698

nightly test [link](https://github.com/tensorflow/tfjs/pull/6721/checks?check_run_id=7681954087) 
This reverts commit 438917fa3e4413af11dce206f877a39a4461776e.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6721)
<!-- Reviewable:end -->
