### PR TITLE
Setup optimization target deices/browsers

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/browser_list.json
+++ b/e2e/benchmarks/browserstack-benchmark/browser_list.json
@@ -89,7 +89,7 @@
   },
   {
     "os": "ios",
-    "os_version": "14",
+    "os_version": "15",
     "browser": "iphone",
     "device": "iPhone XS",
     "browser_version": null,
@@ -97,7 +97,7 @@
   },
   {
     "os": "ios",
-    "os_version": "13",
+    "os_version": "14",
     "browser": "iphone",
     "device": "iPhone XS",
     "browser_version": null,
@@ -113,7 +113,7 @@
   },
   {
     "os": "ios",
-    "os_version": "13",
+    "os_version": "14",
     "browser": "iphone",
     "device": "iPhone 11 Pro",
     "browser_version": null,
@@ -121,7 +121,7 @@
   },
   {
     "os": "ios",
-    "os_version": "13",
+    "os_version": "14",
     "browser": "iphone",
     "device": "iPhone 11",
     "browser_version": null,

--- a/e2e/benchmarks/browserstack-benchmark/index.js
+++ b/e2e/benchmarks/browserstack-benchmark/index.js
@@ -37,12 +37,13 @@ const state = {
   browser: {
     base: 'BrowserStack',
     browser: 'chrome',
-    browser_version: '84.0',
+    browser_version: '15.3',
     os: 'OS X',
-    os_version: 'Catalina',
+    os_version: 'Monterey',
     device: 'null'
   },
-  benchmark: {model: 'mobilenet_v2', modelUrl: '', numRuns: 1, backend: 'wasm'},
+  benchmark:
+      {model: 'mobilenet_v2', modelUrl: '', numRuns: 10, backend: 'webgl'},
 
   /**
    * An array of browser configurations, used to record the browsers to

--- a/e2e/benchmarks/browserstack-benchmark/index.js
+++ b/e2e/benchmarks/browserstack-benchmark/index.js
@@ -37,7 +37,7 @@ const state = {
   browser: {
     base: 'BrowserStack',
     browser: 'chrome',
-    browser_version: '15.3',
+    browser_version: '103.0',
     os: 'OS X',
     os_version: 'Monterey',
     device: 'null'

--- a/e2e/benchmarks/browserstack-benchmark/preconfigured_browser.json
+++ b/e2e/benchmarks/browserstack-benchmark/preconfigured_browser.json
@@ -33,7 +33,7 @@
     "Windows_7_1": {
       "base": "BrowserStack",
       "browser": "firefox",
-      "browser_version": "79.0",
+      "browser_version": "103.0",
       "os": "Windows",
       "os_version": "7",
       "device": null

--- a/e2e/benchmarks/browserstack-benchmark/preconfigured_browser.json
+++ b/e2e/benchmarks/browserstack-benchmark/preconfigured_browser.json
@@ -6,20 +6,28 @@
     "backend": ["wasm", "webgl"]
   },
   "browsers": {
-    "Windows_10_1": {
+    "Windows_11_1": {
       "base": "BrowserStack",
       "browser": "chrome",
-      "browser_version": "84.0",
+      "browser_version": "103.0",
       "os": "Windows",
-      "os_version": "10",
+      "os_version": "11",
       "device": null
     },
-    "Windows_10_2": {
+    "Windows_11_2": {
       "base": "BrowserStack",
       "browser": "edge",
-      "browser_version": "84.0",
+      "browser_version": "103.0",
       "os": "Windows",
-      "os_version": "10",
+      "os_version": "11",
+      "device": null
+    },
+    "Windows_11_3": {
+      "base": "BrowserStack",
+      "browser": "firefox",
+      "browser_version": "103.0",
+      "os": "Windows",
+      "os_version": "11",
       "device": null
     },
     "Windows_7_1": {
@@ -30,13 +38,37 @@
       "os_version": "7",
       "device": null
     },
-    "OS_X_Catalina_1": {
+    "OS_X_Monterey_1": {
       "base": "BrowserStack",
       "browser": "safari",
-      "browser_version": "13.1",
+      "browser_version": "15.3",
       "os": "OS X",
-      "os_version": "Catalina",
+      "os_version": "Monterey",
       "device": null
+    },
+    "OS_X_Monterey_2": {
+      "base": "BrowserStack",
+      "os": "OS X",
+      "os_version": "Monterey",
+      "browser": "chrome",
+      "device": null,
+      "browser_version": "103.0"
+    },
+    "iPhone_13_Pro_Max_1": {
+      "base": "BrowserStack",
+      "os": "ios",
+      "os_version": "15",
+      "browser": "iphone",
+      "device": "iPhone 13 Pro Max",
+      "browser_version": null
+    },
+    "iPhone_13_1": {
+      "base": "BrowserStack",
+      "os": "ios",
+      "os_version": "15",
+      "browser": "iphone",
+      "device": "iPhone 13",
+      "browser_version": null
     },
     "iPhone_12_Pro_Max_1": {
       "base": "BrowserStack",
@@ -54,20 +86,12 @@
       "os_version": "14",
       "device": "iPhone 12"
     },
-    "iPhone_XS_1": {
-      "base": "BrowserStack",
-      "browser": "iphone",
-      "browser_version": null,
-      "os": "ios",
-      "os_version": "14",
-      "device": "iPhone XS"
-    },
     "iPhone_11_Pro_Max_1": {
       "base": "BrowserStack",
       "browser": "iphone",
       "browser_version": null,
       "os": "ios",
-      "os_version": "13",
+      "os_version": "14",
       "device": "iPhone 11 Pro Max"
     },
     "iPhone_11_1": {
@@ -75,32 +99,72 @@
       "browser": "iphone",
       "browser_version": null,
       "os": "ios",
-      "os_version": "13",
+      "os_version": "14",
       "device": "iPhone 11"
     },
-    "iPhone_7_1": {
+    "iPhone_XS_1": {
       "base": "BrowserStack",
       "browser": "iphone",
       "browser_version": null,
       "os": "ios",
-      "os_version": "12",
-      "device": "iPhone 7"
+      "os_version": "15",
+      "device": "iPhone XS"
+    },
+    "Google_Pixel_6_Pro_1": {
+      "base": "BrowserStack",
+      "browser": "android",
+      "browser_version": null,
+      "os": "android",
+      "os_version": "12.0",
+      "device": "Google Pixel 6 Pro"
     },
     "Google_Pixel_5_1": {
       "base": "BrowserStack",
       "browser": "android",
       "browser_version": null,
       "os": "android",
-      "os_version": "11.0",
+      "os_version": "12.0",
       "device": "Google Pixel 5"
     },
-    "Samsung_Galaxy_S20_Ultra_1": {
+    "Samsung_Galaxy_S22_Ultra_1": {
+      "base": "BrowserStack",
+      "browser": "android",
+      "browser_version": null,
+      "os": "android",
+      "os_version": "12.0",
+      "device": "Samsung Galaxy S22 Ultra"
+    },
+    "Samsung_Galaxy_M52_1": {
+      "base": "BrowserStack",
+      "browser": "android",
+      "browser_version": null,
+      "os": "android",
+      "os_version": "11.0",
+      "device": "Samsung Galaxy M52"
+    },
+    "Samsung_Galaxy_A52_1": {
+      "base": "BrowserStack",
+      "browser": "android",
+      "browser_version": null,
+      "os": "android",
+      "os_version": "11.0",
+      "device": "Samsung Galaxy A52"
+    },
+    "Xiaomi_Redmi_Note_11_1": {
+      "base": "BrowserStack",
+      "browser": "android",
+      "browser_version": null,
+      "os": "android",
+      "os_version": "11.0",
+      "device": "Xiaomi Redmi Note 11"
+    },
+    "Samsung_Galaxy_Note_20_Ultra_1": {
       "base": "BrowserStack",
       "browser": "android",
       "browser_version": null,
       "os": "android",
       "os_version": "10.0",
-      "device": "Samsung Galaxy S20 Ultra"
+      "device": "Samsung Galaxy Note 20 Ultra"
     },
     "Samsung_Galaxy_A11_1": {
       "base": "BrowserStack",
@@ -118,14 +182,6 @@
       "os_version": "10.0",
       "device": "Google Pixel 4 XL"
     },
-    "Samsung_Galaxy_A51_1": {
-      "base": "BrowserStack",
-      "browser": "android",
-      "browser_version": null,
-      "os": "android",
-      "os_version": "10.0",
-      "device": "Samsung Galaxy A51"
-    },
     "Samsung_Galaxy_S10_Plus_1": {
       "base": "BrowserStack",
       "browser": "android",
@@ -133,14 +189,6 @@
       "os": "android",
       "os_version": "9.0",
       "device": "Samsung Galaxy S10 Plus"
-    },
-    "Google_Pixel_2_1": {
-      "base": "BrowserStack",
-      "browser": "android",
-      "browser_version": null,
-      "os": "android",
-      "os_version": "9.0",
-      "device": "Google Pixel 2"
     }
   }
 }

--- a/tfjs-automl/karma.conf.js
+++ b/tfjs-automl/karma.conf.js
@@ -78,12 +78,16 @@ module.exports = function(config) {
     browserStack: {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY,
+      timeout: 900,  // Seconds
       tunnelIdentifier:
           `tfjs_automl_${Date.now()}_${Math.floor(Math.random() * 1000)}`
     },
-    captureTimeout: 120000,
+    captureTimeout: 3e5,
     reportSlowerThan: 500,
-    browserNoActivityTimeout: 180000,
+    browserNoActivityTimeout: 3e5,
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 0,
+    browserSocketTimeout: 1.2e5,
     customLaunchers: {
       bs_chrome_mac: {
         base: 'BrowserStack',


### PR DESCRIPTION
This PR updates the list of the combinations of devices and browsers. The list currently is used only for our nightly-benchmark, and I **will use the devices/browsers in this list as WebGL optimization targets**. 

Specifically, the list will have 6 combinations on desktop/laptop and 17 combinations on mobile:
1. Windows
1.1 Win 11: Chrome, Firefox, Edge
1.2 Win 7: Firefox
2. Mac - Monterey: Safari, Chrome
3. Andriod
![image](https://user-images.githubusercontent.com/40653845/182975431-1ebfdd5f-1d0b-4007-a900-cc205b18d2e2.png)

4. iOS
![image](https://user-images.githubusercontent.com/40653845/182975160-3f7dd186-d082-48bc-a534-53dfc34cf25d.png)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6722)
<!-- Reviewable:end -->
