### PR TITLE
Run only a single benchmark at once

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/cloudbuild.yml
+++ b/e2e/benchmarks/browserstack-benchmark/cloudbuild.yml
@@ -23,11 +23,11 @@ availableSecrets:
       env: 'BROWSERSTACK_ACCESS_KEY'
     - versionName: projects/834911136599/secrets/FIREBASE_KEY/versions/latest
       env: 'FIREBASE_KEY'
-timeout: 3600s
+timeout: 28800s # 8h
 logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:
   logStreamingOption: 'STREAM_ON'
-  machineType: 'N1_HIGHCPU_8'
+  # machineType: 'E2_MEDIUM' # The default cloudbuild machine is e2-medium.
   substitution_option: 'ALLOW_LOOSE'

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -33,7 +33,7 @@
     "build-tfjs": "cd ../../../tfjs && yarn && yarn build-npm",
     "build-all-link-packages": "cd ../../../ && yarn && cd ./link-package && yarn build",
     "build-individual-link-package": "cd ../../../ && yarn && cd ./link-package && yarn build-deps-for",
-    "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=9 --firestore"
+    "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=1 --firestore"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Instead of running browserstack benchmarks in parallel, run only one benchmark at a time. This avoids the ETXTBSY error that appears on cloudbuild (but not locally) when running them in parallel.

Also, use the smallest cloudbuild machine and raise the timeout to 8 hours.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6728)
<!-- Reviewable:end -->
