### PR TITLE
[benchmark tools] Update mobilenet models

### DIFF
--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -70,7 +70,6 @@ It's easy to set up a web server to host benchmarks and run against them via e2e
 * Model related parameters:
 
   <b>architecture</b>: same as architecture (only certain models has it, such as MobileNetV3 and posenet)<br>
-  <b>alpha</b>: same as alpha (only certain models has it, such as MobileNetV3)<br>
   <b>benchmark</b>: same as models<br>
   <b>inputSize</b>: same as inputSizes<br>
   <b>inputType</b>: same as inputTypes<br>

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -75,7 +75,7 @@ It's easy to set up a web server to host benchmarks and run against them via e2e
   <b>inputSize</b>: same as inputSizes<br>
   <b>inputType</b>: same as inputTypes<br>
   <b>modelUrl</b>: same as modelUrl, for custom models only<br>
-  <b>${InputeName}Shape</b>: the input shape array, separated by comma, for     custom models only.  For example, bodypix's [graph model](https://storage.    googleapis.com/tfjs-models/savedmodel/bodypix/mobilenet/float/075/    model-stride16.json) has an input named sub_2, then users could add     '`sub_2Shape=1,1,1,3`' in the URL to populate its shape.<br>
+  <b>${InputeName}Shape</b>: the input shape array, separated by comma, for custom models only. For example, bodypix's [graph model](https://storage.googleapis.com/tfjs-models/savedmodel/bodypix/mobilenet/float/075/model-stride16.json) has an input named sub_2, then users could add '`sub_2Shape=1,1,1,3`' in the URL to populate its shape.<br>
 
 * Environment related parameters:
 

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -69,8 +69,8 @@ It's easy to set up a web server to host benchmarks and run against them via e2e
 
 * Model related parameters:
 
-  <b>architecture</b>: same as architecture<br>
-  <b>alpha</b>: same as alpha<br>
+  <b>architecture</b>: same as architecture (only certain models has it, such as MobileNetV3 and posenet)<br>
+  <b>alpha</b>: same as alpha (only certain models has it, such as MobileNetV3)<br>
   <b>benchmark</b>: same as models<br>
   <b>inputSize</b>: same as inputSizes<br>
   <b>inputType</b>: same as inputTypes<br>

--- a/e2e/benchmarks/local-benchmark/README.md
+++ b/e2e/benchmarks/local-benchmark/README.md
@@ -67,14 +67,20 @@ the benchmark.
 # Benchmark test
 It's easy to set up a web server to host benchmarks and run against them via e2e/benchmarks/local-benchmark/index.html. You can manually specify the optional url parameters as needed. Here are the list of supported url parameters:
 
-<b>architecture</b>: same as architecture<br>
-<b>backend</b>: same as backend<br>
-<b>benchmark</b>: same as models<br>
-<b>inputSize</b>: same as inputSizes<br>
-<b>inputType</b>: same as inputTypes<br>
-<b>localBuild</b>: local build name list, separated by comma. The name is in short form (in general the name without the tfjs- and backend- prefixes, for example webgl for tfjs-backend-webgl, core for tfjs-core). Example: 'webgl,core'.<br>
-<b>run</b>: same as numRuns<br>
-<b>task</b>: correctness to "Test correctness" or performance to "Run benchmark"<br>
-<b>warmup</b>: same as numWarmups<br>
-<b>modelUrl</b>: same as modelUrl, for custom models only<br>
-<b>${InputeName}Shape</b>: the input shape array, separated by comma, for custom models only.  For example, bodypix's [graph model](https://storage.googleapis.com/tfjs-models/savedmodel/bodypix/mobilenet/float/075/model-stride16.json) has an input named sub_2, then users could add '`sub_2Shape=1,1,1,3`' in the URL to populate its shape.<br>
+* Model related parameters:
+
+  <b>architecture</b>: same as architecture<br>
+  <b>alpha</b>: same as alpha<br>
+  <b>benchmark</b>: same as models<br>
+  <b>inputSize</b>: same as inputSizes<br>
+  <b>inputType</b>: same as inputTypes<br>
+  <b>modelUrl</b>: same as modelUrl, for custom models only<br>
+  <b>${InputeName}Shape</b>: the input shape array, separated by comma, for     custom models only.  For example, bodypix's [graph model](https://storage.    googleapis.com/tfjs-models/savedmodel/bodypix/mobilenet/float/075/    model-stride16.json) has an input named sub_2, then users could add     '`sub_2Shape=1,1,1,3`' in the URL to populate its shape.<br>
+
+* Environment related parameters:
+
+  <b>backend</b>: same as backend<br>
+  <b>localBuild</b>: local build name list, separated by comma. The name is in short form (in general the name without the tfjs- and backend- prefixes, for example webgl for tfjs-backend-webgl, core for tfjs-core). Example: 'webgl,core'.<br>
+  <b>run</b>: same as numRuns<br>
+  <b>task</b>: correctness to "Test correctness" or performance to "Run benchmark"<br>
+  <b>warmup</b>: same as numWarmups<br>

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -126,7 +126,6 @@ limitations under the License.
     let inputSizeController = null;
     let inputTypeController = null;
     let modelArchitectureController = null;
-    let modelAlphaController = null;
     let tunableFlagsControllers = null;
 
     function updateGUIFromURLState() {
@@ -286,7 +285,6 @@ limitations under the License.
       inputSize: 0,
       inputType: '',
       architecture: 'small',
-      alpha: '075',
       modelType: '',
       modelUrl: '',
       isModelChanged: false,
@@ -351,9 +349,6 @@ limitations under the License.
       }
       if (isParameterDefined('architectures')) {
         appendRow(parameterTable, 'architecture', state.architecture);
-      }
-      if (isParameterDefined('alphas')) {
-        appendRow(parameterTable, 'alpha', state.alpha);
       }
     }
 
@@ -519,8 +514,6 @@ limitations under the License.
         state.inputType = urlState.get('inputType');
       if (urlState.has('architecture'))
         state.architecture = urlState.get('architecture');
-      if (urlState.has('alpha'))
-        state.alpha = urlState.get('alpha');
     }
 
     async function loadModelAndRecordTime() {
@@ -542,7 +535,7 @@ limitations under the License.
       if (isTflite()) {
         await loadTfliteModel();
       } else {
-        model = await benchmark.load(inputSize, state.architecture, state.inputType, state.alpha);
+        model = await benchmark.load(inputSize, state.architecture, state.inputType);
       }
       state.inputs = [];
       const inputs = isTflite() ? tfliteModel.inputs : model.inputs
@@ -810,10 +803,6 @@ limitations under the License.
           modelParameterFolder.remove(modelArchitectureController);
           modelArchitectureController = null;
         }
-        if (modelAlphaController !== null) {
-          modelParameterFolder.remove(modelAlphaController);
-          modelAlphaController = null;
-        }
         if (inputSizeController !== null) {
           modelParameterFolder.remove(inputSizeController);
           inputSizeController = null;
@@ -861,25 +850,6 @@ limitations under the License.
           state.architecture = '';
         }
 
-        if (isParameterDefined('alphas')) {
-          modelAlphaController = modelParameterFolder.add(state, 'alpha', benchmark['alphas']).name('alphas').onChange(async alpha => {
-            state.alpha = alpha;
-            state.isModelChanged = true;
-          });
-          // Current use first value as default.
-          let defaultModelAlpha = null;
-          if (isURLParameterDefined('alpha'))
-            defaultModelAlpha = urlState.get('alpha');
-          else
-            defaultModelAlpha = benchmark['alphas'][0];
-
-          modelAlphaController.setValue(defaultModelAlpha);
-          state.alpha = defaultModelAlpha;
-        } else {
-          // Model doesn't support alpha.
-          state.alpha = '';
-        }
-
         if (isParameterDefined('inputTypes')) {
           inputTypeController = modelParameterFolder.add(state, 'inputType', benchmark['inputTypes']).name('inputTypes').onChange(async inputType => {
             state.inputType = inputType;
@@ -901,7 +871,7 @@ limitations under the License.
 
         // Unfolding the model parameter UI if any model parameters are deinfed
         // in the current model.
-        if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures') || isParameterDefined('alphas')) {
+        if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures')) {
           modelParameterFolder.open();
         }
 
@@ -940,10 +910,6 @@ limitations under the License.
         modelArchitectureController = modelParameterFolder.add(state, 'architecture', benchmarks[state.benchmark]['architectures']);
         modelArchitectureController.setValue(state.architecture);
       }
-      if (isParameterDefined('alphas')) {
-        modelAlphaController = modelParameterFolder.add(state, 'alpha', benchmarks[state.benchmark]['alphas']);
-        modelAlphaController.setValue(state.alpha);
-      }
       if (isParameterDefined('inputSizes')) {
         inputSizeController = modelParameterFolder.add(state, 'inputSize', benchmarks[state.benchmark]['inputSizes']);
         inputSizeController.setValue(state.inputSize);
@@ -955,7 +921,7 @@ limitations under the License.
 
       // Unfolding the model parameter UI if any model parameters are deinfed
       // in the pre-selected model.
-      if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures') || isParameterDefined('alphas')) {
+      if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures')) {
           modelParameterFolder.open();
       }
 
@@ -1020,7 +986,7 @@ limitations under the License.
         tfliteModel.modelRunner.cleanUp();
       }
       const benchmark = benchmarks[state.benchmark];
-      tfliteModel = await benchmark.loadTflite(enableProfiling, state.architecture, state.alpha);
+      tfliteModel = await benchmark.loadTflite(enableProfiling, state.architecture);
     }
 
     function updateModelsDropdown(newValues) {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -126,6 +126,7 @@ limitations under the License.
     let inputSizeController = null;
     let inputTypeController = null;
     let modelArchitectureController = null;
+    let modelAlphaController = null;
     let tunableFlagsControllers = null;
 
     function updateGUIFromURLState() {
@@ -198,7 +199,7 @@ limitations under the License.
       numWarmups: warmupTimes,
       numRuns: runTimes,
       numProfiles: profileTimes,
-      benchmark: 'mobilenet_v2',
+      benchmark: 'mobilenet_v3',
       run: (v) => {
         runBenchmark().catch(e => {
           showMsg('Error: ' + e.message);
@@ -280,11 +281,12 @@ limitations under the License.
           appendRow(timeTable, '', '');
         }
       },
-      backend: 'wasm',
+      backend: 'webgl',
       kernelTiming: 'aggregate',
       inputSize: 0,
       inputType: '',
-      architecture: '',
+      architecture: 'small',
+      alpha: '075',
       modelType: '',
       modelUrl: '',
       isModelChanged: false,
@@ -349,6 +351,9 @@ limitations under the License.
       }
       if (isParameterDefined('architectures')) {
         appendRow(parameterTable, 'architecture', state.architecture);
+      }
+      if (isParameterDefined('alphas')) {
+        appendRow(parameterTable, 'alpha', state.alpha);
       }
     }
 
@@ -514,6 +519,8 @@ limitations under the License.
         state.inputType = urlState.get('inputType');
       if (urlState.has('architecture'))
         state.architecture = urlState.get('architecture');
+      if (urlState.has('alpha'))
+        state.alpha = urlState.get('alpha');
     }
 
     async function loadModelAndRecordTime() {
@@ -535,7 +542,7 @@ limitations under the License.
       if (isTflite()) {
         await loadTfliteModel();
       } else {
-        model = await benchmark.load(inputSize, state.architecture, state.inputType);
+        model = await benchmark.load(inputSize, state.architecture, state.inputType, state.alpha);
       }
       state.inputs = [];
       const inputs = isTflite() ? tfliteModel.inputs : model.inputs
@@ -803,6 +810,10 @@ limitations under the License.
           modelParameterFolder.remove(modelArchitectureController);
           modelArchitectureController = null;
         }
+        if (modelAlphaController !== null) {
+          modelParameterFolder.remove(modelAlphaController);
+          modelAlphaController = null;
+        }
         if (inputSizeController !== null) {
           modelParameterFolder.remove(inputSizeController);
           inputSizeController = null;
@@ -846,8 +857,27 @@ limitations under the License.
           modelArchitectureController.setValue(defaultModelArchitecture);
           state.architecture = defaultModelArchitecture;
         } else {
-          // Model doesn't support input size.
+          // Model doesn't support architecture.
           state.architecture = '';
+        }
+
+        if (isParameterDefined('alphas')) {
+          modelAlphaController = modelParameterFolder.add(state, 'alpha', benchmark['alphas']).name('alphas').onChange(async alpha => {
+            state.alpha = alpha;
+            state.isModelChanged = true;
+          });
+          // Current use first value as default.
+          let defaultModelAlpha = null;
+          if (isURLParameterDefined('alpha'))
+            defaultModelAlpha = urlState.get('alpha');
+          else
+            defaultModelAlpha = benchmark['alphas'][0];
+
+          modelAlphaController.setValue(defaultModelAlpha);
+          state.alpha = defaultModelAlpha;
+        } else {
+          // Model doesn't support alpha.
+          state.alpha = '';
         }
 
         if (isParameterDefined('inputTypes')) {
@@ -868,7 +898,10 @@ limitations under the License.
           // Model doesn't support input type.
           state.inputType = '';
         }
-        if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures')) {
+
+        // Unfolding the model parameter UI if any model parameters are deinfed
+        // in the current model.
+        if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures') || isParameterDefined('alphas')) {
           modelParameterFolder.open();
         }
 
@@ -881,7 +914,7 @@ limitations under the License.
             });
             modelUrlController.domElement.querySelector('input').placeholder =
               'https://your-domain.com/model-path/model.json';
-            if (modelUrlController != null && urlState.has('modelUrl')) {
+            if (modelUrlController != null && urlState && urlState.has('modelUrl')) {
               modelUrlController.setValue(urlState.get('modelUrl'));
             }
           }
@@ -899,18 +932,32 @@ limitations under the License.
       parameterFolder.add(state, 'kernelTiming', ['aggregate', 'individual']);
       parameterFolder.open();
 
+      // Show model parameter UI when loading the page.
       modelParameterFolder = gui.addFolder('Model Parameters');
+      // For each model parameter, show it only if it is defined in the
+      // pre-selected model.
       if (isParameterDefined('architectures')) {
-        modelArchitectureController = modelParameterFolder.add(state, 'architecture', []);
+        modelArchitectureController = modelParameterFolder.add(state, 'architecture', benchmarks[state.benchmark]['architectures']);
+        modelArchitectureController.setValue(state.architecture);
+      }
+      if (isParameterDefined('alphas')) {
+        modelAlphaController = modelParameterFolder.add(state, 'alpha', benchmarks[state.benchmark]['alphas']);
+        modelAlphaController.setValue(state.alpha);
       }
       if (isParameterDefined('inputSizes')) {
-        inputSizeController = modelParameterFolder.add(state, 'inputSize', []);
+        inputSizeController = modelParameterFolder.add(state, 'inputSize', benchmarks[state.benchmark]['inputSizes']);
+        inputSizeController.setValue(state.inputSize);
       }
       if (isParameterDefined('inputTypes')) {
-        inputTypeController = modelParameterFolder.add(state, 'inputType', []);
+        inputTypeController = modelParameterFolder.add(state, 'inputType', benchmarks[state.benchmark]['inputTypes']);
+        inputTypeController.setValue(state.inputType);
       }
 
-      modelParameterFolder.open();
+      // Unfolding the model parameter UI if any model parameters are deinfed
+      // in the pre-selected model.
+      if (isParameterDefined('inputSizes') || isParameterDefined('inputTypes') || isParameterDefined('architectures') || isParameterDefined('alphas')) {
+          modelParameterFolder.open();
+      }
 
       const envFolder = gui.addFolder('Environment');
       const backendsController = envFolder.add(
@@ -973,7 +1020,7 @@ limitations under the License.
         tfliteModel.modelRunner.cleanUp();
       }
       const benchmark = benchmarks[state.benchmark];
-      tfliteModel = await benchmark.loadTflite(enableProfiling);
+      tfliteModel = await benchmark.loadTflite(enableProfiling, state.architecture, state.alpha);
     }
 
     function updateModelsDropdown(newValues) {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -199,7 +199,7 @@ limitations under the License.
       numWarmups: warmupTimes,
       numRuns: runTimes,
       numProfiles: profileTimes,
-      benchmark: 'mobilenet_v3',
+      benchmark: 'MobileNetV3',
       run: (v) => {
         runBenchmark().catch(e => {
           showMsg('Error: ' + e.message);

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -284,7 +284,7 @@ limitations under the License.
       kernelTiming: 'aggregate',
       inputSize: 0,
       inputType: '',
-      architecture: 'small',
+      architecture: 'small_075',
       modelType: '',
       modelUrl: '',
       isModelChanged: false,

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -91,14 +91,20 @@ function predictFunction(input) {
 const benchmarks = {
   'mobilenet_v3': {
     type: 'GraphModel',
-    load: async () => {
-      const url =
-          'https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v3_small_100_224/classification/5/default/1';
+    alphas: ['075', '100'],
+    architectures: ['small', 'large'],
+    load: async (
+        inputResolution = 224, modelArchitecture = 'small',
+        inputType = 'tensor', alpha = '075') => {
+      const url = `https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v3_${
+          modelArchitecture}_${alpha}_224/classification/5/default/1`;
       return tf.loadGraphModel(url, {fromTFHub: true});
     },
-    loadTflite: async (enableProfiling = false) => {
-      const url =
-          'https://tfhub.dev/google/lite-model/imagenet/mobilenet_v3_small_100_224/classification/5/metadata/1';
+    loadTflite: async (
+        enableProfiling = false, modelArchitecture = 'small',
+        alpha = '075') => {
+      const url = `https://tfhub.dev/google/lite-model/imagenet/mobilenet_v3_${
+          modelArchitecture}_${alpha}_224/classification/5/metadata/1`;
       return tflite.loadTFLiteModel(url, {enableProfiling});
     },
     predictFunc: () => {
@@ -112,10 +118,28 @@ const benchmarks = {
   },
   'mobilenet_v2': {
     type: 'GraphModel',
+    alphas: ['050', '075', '100'],
+    load: async (
+        inputResolution = 224, modelArchitecture = '', inputType = 'tensor',
+        alpha = '050') => {
+      const url = `https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_${
+          alpha}_224/classification/3/default/1`;
+      return tf.loadGraphModel(url, {fromTFHub: true});
+    },
+    predictFunc: () => {
+      const input = tf.randomNormal([1, 224, 224, 3]);
+      return predictFunction(input);
+    },
+  },
+  // Currently, for mibilnet_v2, only alpha=100 has tflite model. Since users
+  // could tune the alpha for 'mobilenet_v2' tfjs models, while we could only
+  // provides mibilnet_v2_lite with alpha=100 on the tflite backend, so
+  // mibilnet_v2_lite is separated from mibilnet_v2 and fixes alpha=100; othwise
+  // it would confuse users.
+  'mobilenet_v2_lite': {
+    type: 'GraphModel',
     load: async () => {
-      const url =
-          'https://storage.googleapis.com/learnjs-data/mobilenet_v2_100_fused/model.json';
-      return tf.loadGraphModel(url);
+      throw new Error(`Please set tflite as the backend to run this model.`);
     },
     loadTflite: async (enableProfiling = false) => {
       const url =

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -89,7 +89,7 @@ function predictFunction(input) {
 }
 
 const benchmarks = {
-  'mobilenet_v3': {
+  'MobileNetV3': {
     type: 'GraphModel',
     alphas: ['075', '100'],
     architectures: ['small', 'large'],
@@ -116,7 +116,7 @@ const benchmarks = {
       }
     },
   },
-  'mobilenet_v2': {
+  'MobileNetV2': {
     type: 'GraphModel',
     alphas: ['050', '075', '100'],
     load: async (
@@ -136,7 +136,7 @@ const benchmarks = {
   // provides mibilnet_v2_lite with alpha=100 on the tflite backend, so
   // mibilnet_v2_lite is separated from mibilnet_v2 and fixes alpha=100; othwise
   // it would confuse users.
-  'mobilenet_v2_lite': {
+  'MobileNetV2Lite': {
     type: 'GraphModel',
     load: async () => {
       throw new Error(`Please set tflite as the backend to run this model.`);

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -92,19 +92,16 @@ const benchmarks = {
   'MobileNetV3': {
     type: 'GraphModel',
     alphas: ['075', '100'],
-    architectures: ['small', 'large'],
-    load: async (
-        inputResolution = 224, modelArchitecture = 'small',
-        inputType = 'tensor', alpha = '075') => {
+    architectures: ['small_075', 'small_100', 'large_075', 'large_100'],
+    load: async (inputResolution = 224, modelArchitecture = 'small_075') => {
       const url = `https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v3_${
-          modelArchitecture}_${alpha}_224/classification/5/default/1`;
+          modelArchitecture}_224/classification/5/default/1`;
       return tf.loadGraphModel(url, {fromTFHub: true});
     },
     loadTflite: async (
-        enableProfiling = false, modelArchitecture = 'small',
-        alpha = '075') => {
+        enableProfiling = false, modelArchitecture = 'small_075') => {
       const url = `https://tfhub.dev/google/lite-model/imagenet/mobilenet_v3_${
-          modelArchitecture}_${alpha}_224/classification/5/metadata/1`;
+          modelArchitecture}_224/classification/5/metadata/1`;
       return tflite.loadTFLiteModel(url, {enableProfiling});
     },
     predictFunc: () => {
@@ -118,12 +115,10 @@ const benchmarks = {
   },
   'MobileNetV2': {
     type: 'GraphModel',
-    alphas: ['050', '075', '100'],
-    load: async (
-        inputResolution = 224, modelArchitecture = '', inputType = 'tensor',
-        alpha = '050') => {
+    architectures: ['050', '075', '100'],
+    load: async (inputResolution = 224, modelArchitecture = '050') => {
       const url = `https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_${
-          alpha}_224/classification/3/default/1`;
+          modelArchitecture}_224/classification/3/default/1`;
       return tf.loadGraphModel(url, {fromTFHub: true});
     },
     predictFunc: () => {

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -91,7 +91,6 @@ function predictFunction(input) {
 const benchmarks = {
   'MobileNetV3': {
     type: 'GraphModel',
-    alphas: ['075', '100'],
     architectures: ['small_075', 'small_100', 'large_075', 'large_100'],
     load: async (inputResolution = 224, modelArchitecture = 'small_075') => {
       const url = `https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v3_${
@@ -126,11 +125,11 @@ const benchmarks = {
       return predictFunction(input);
     },
   },
-  // Currently, for mibilnet_v2, only alpha=100 has tflite model. Since users
-  // could tune the alpha for 'mobilenet_v2' tfjs models, while we could only
-  // provides mibilnet_v2_lite with alpha=100 on the tflite backend, so
-  // mibilnet_v2_lite is separated from mibilnet_v2 and fixes alpha=100; othwise
-  // it would confuse users.
+  // Currently, for mibilnet_v2, only the architectures with alpha=100 has
+  // tflite model. Since users could tune the alpha for 'mobilenet_v2' tfjs
+  // models, while we could only provides mibilnet_v2_lite with alpha=100 on the
+  // tflite backend, so mibilnet_v2_lite is separated from mibilnet_v2 and fixes
+  // alpha=100; othwise it would confuse users.
   'MobileNetV2Lite': {
     type: 'GraphModel',
     load: async () => {


### PR DESCRIPTION
As discussed in the spreadsheet, we will supports alpha variable for mobilenet V2 and V3, so this PR:
1. Supports `075 and 100 alphas` and `small and large architectures` for mobilenet v3.
2. Supports `050, 075 and 100 alphas` for mobilenet v2.
3. Updates README.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6729)
<!-- Reviewable:end -->
