### PR TITLE
webgpu: Skip raggedTensorToTensor test cases

### DIFF
--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -303,6 +303,7 @@ const TEST_FILTERS: TestFilter[] = [
       'reverse3d ',
       'reverse4d ',
       'reverse webgpu',
+      'raggedTensorToTensor ',
       'RFFT ',
       'round webgpu',
       'method otsu',  // round


### PR DESCRIPTION
Op raggedTensorToTensor is not implemented in WebGPU backend, so we
skip related cases.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6732)
<!-- Reviewable:end -->
