### PR TITLE
[tfjs-converter] fixed protobuf version mismatch error on cloudbuild

### DIFF
--- a/tfjs-converter/python/.pylintrc
+++ b/tfjs-converter/python/.pylintrc
@@ -412,7 +412,7 @@ max-public-methods=20
 max-returns=6
 
 # Maximum number of statements in function / method body
-max-statements=50
+max-statements=80
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2

--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -48,6 +48,7 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     requires = [
+        "protobuf<3.20,>=3.9.2",
         "tensorflow>=2.1.0,<3",
         "six>=1.12.0,<2",
         "tensorflow-hub>=0.7.0,<0.13",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,5 +1,5 @@
+protobuf<3.20,>=3.9.2
 tensorflow>=2.1.0,<3
-numpy~=1.19.2
 six>=1.12.0,<2
 tensorflow-hub>=0.7.0,<0.13; python_version >= "3"
 packaging~=20.9

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -637,7 +637,7 @@ def _convert_tf_saved_model(output_dir,
   num_outputs = len(output_node_names)
   structured_outputs = concrete_func.structured_outputs
   if use_structured_outputs_names and structured_outputs is not None:
-    if type(structured_outputs) is not dict:
+    if not isinstance(structured_outputs, dict):
       raise Exception('Converter only supports dict structured_outputs.')
 
     # As per tensorflow/python/util/nest.py: "If `structure` is or contains a
@@ -649,7 +649,8 @@ def _convert_tf_saved_model(output_dir,
     # We don't support anything more complex due to the GraphModel.predict
     # function return type in typescript.
     test_sequence = list(range(num_outputs))
-    actual_structure = tf.nest.pack_sequence_as(structured_outputs, test_sequence, True)
+    actual_structure = tf.nest.pack_sequence_as(
+        structured_outputs, test_sequence, True)
     expected_structure = dict(zip(sorted_keys, test_sequence))
     if actual_structure != expected_structure:
       raise Exception('Converter only supports structured_outputs of form '
@@ -812,7 +813,7 @@ def convert_tf_saved_model(saved_model_dir,
                           skip_op_check=skip_op_check,
                           strip_debug_ops=strip_debug_ops,
                           use_structured_outputs_names=
-                                             use_structured_outputs_names,
+                          use_structured_outputs_names,
                           weight_shard_size_bytes=weight_shard_size_bytes,
                           control_flow_v2=control_flow_v2,
                           experiments=experiments,
@@ -999,7 +1000,7 @@ def convert_tf_hub_module(module_handle, output_dir,
                            skip_op_check=skip_op_check,
                            strip_debug_ops=strip_debug_ops,
                            use_structured_outputs_names=
-                                              use_structured_outputs_names,
+                           use_structured_outputs_names,
                            weight_shard_size_bytes=weight_shard_size_bytes,
                            control_flow_v2=control_flow_v2,
                            experiments=experiments,
@@ -1044,7 +1045,7 @@ def convert_keras_model_to_graph_model(keras_model,
                           skip_op_check=skip_op_check,
                           strip_debug_ops=strip_debug_ops,
                           use_structured_outputs_names=
-                                             use_structured_outputs_names,
+                          use_structured_outputs_names,
                           weight_shard_size_bytes=weight_shard_size_bytes,
                           control_flow_v2=control_flow_v2,
                           experiments=experiments,

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -274,15 +274,15 @@ class ConvertTest(tf.test.TestCase):
     output3 = tf.keras.layers.Multiply(name='c')([output1, output2])
 
     inputs = {
-      "input1": input1,
-      "input3": input3,
-      "input2": input2
+        "input1": input1,
+        "input3": input3,
+        "input2": input2
     }
 
     outputs = {
-      "a": output1,
-      "c": output3,
-      "b": output2
+        "a": output1,
+        "c": output3,
+        "b": output2
     }
 
     model = tf.keras.Model(inputs=inputs, outputs=outputs)
@@ -933,7 +933,8 @@ class ConvertTest(tf.test.TestCase):
     self.assertIsNot(signature['inputs'], None)
     self.assertIsNot(signature['outputs'], None)
 
-    self.assertEqual(["a", "b", "c"], model_json['userDefinedMetadata']['structuredOutputKeys'])
+    self.assertEqual(["a", "b", "c"],
+                     model_json['userDefinedMetadata']['structuredOutputKeys'])
 
   def test_convert_saved_model_structured_outputs_false(self):
     self._create_saved_model_with_structured_outputs()

--- a/tfjs-converter/python/tensorflowjs/resource_loader_test.py
+++ b/tfjs-converter/python/tensorflowjs/resource_loader_test.py
@@ -29,7 +29,7 @@ class ResourceLoaderTest(unittest.TestCase):
     files = resource_loader.list_dir('op_list')
     self.assertGreater(len(files), 0)
     for filename in files:
-      self.assertTrue(filename.endswith('.json'))
+      self.assertTrue(filename == 'BUILD' or filename.endswith('.json'))
 
   def testReadingFileInOpList(self):
     file_path = path.join('op_list', 'arithmetic.json')


### PR DESCRIPTION
Seems the cloud build still having trouble to correctly compute the pip deps.
Manually set the protobuf version to be the same as tensorflow.
ref https://github.com/tensorflow/tfjs/issues/6698

We can find the nightly test below.
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6737)
<!-- Reviewable:end -->
