### PR TITLE
[browserstack benchmark tool] Add a html to present benchmark results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ e2e/scripts/htpasswd
 e2e/benchmarks/browserstack-benchmark/browsers.json
 e2e/benchmarks/browserstack-benchmark/benchmark_parameters.json
 e2e/benchmarks/browserstack-benchmark/benchmark_results.json
+e2e/benchmarks/browserstack-benchmark/benchmark_results.js
 e2e/benchmarks/browserstack-benchmark/benchmark_test_results.json
 tfjs-converter/python/tensorflowjs.egg-info
 tfjs-inference/binaries

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -112,9 +112,9 @@ The following are supported options arguments which trigger options features:
     node app.js --maxTries=positive_integer
     ```
   * --outfile
-    - Writes results to an accessible external file, benchmark_results.json.
+    - Writes results to an accessible external file, benchmark_results.js or benchmark_results.json. Expects 'html' or 'json'. If you set it as \'html\', benchmark_results.js will be generated and you could review the benchmark results by openning benchmark_result.html file.
     ``` shell
-    node app.js --outfile
+    node app.js --outfile=js
     ```
   * --v, --version
     - Shows node version in use.

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -178,7 +178,8 @@ async function benchmark(config, runOneBenchmark = getOneBenchmarkResult) {
   // benchmarks return results
   const fulfilled = await Promise.allSettled(results);
   if (cliArgs?.outfile) {
-    await write('./benchmark_results.json', fulfilled);
+    await write(
+        './benchmark_results.js', `let res = ${JSON.stringify(fulfilled)};`);
   } else {
     console.log('\Benchmarks complete.\n');
   }
@@ -287,12 +288,12 @@ function runBrowserStackBenchmark(tabId) {
  */
 function write(filePath, msg) {
   return new Promise((resolve, reject) => {
-    fs.writeFile(filePath, JSON.stringify(msg, null, 2), 'utf8', err => {
+    fs.writeFile(filePath, msg, 'utf8', err => {
       if (err) {
         console.log(`Error: ${err}.`);
         return reject(err);
       } else {
-        console.log('\nOutput written.');
+        console.log(`\nOutput written to ${filePath}.`);
         return resolve();
       }
     });

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -179,7 +179,8 @@ async function benchmark(config, runOneBenchmark = getOneBenchmarkResult) {
   const fulfilled = await Promise.allSettled(results);
   if (cliArgs?.outfile) {
     await write(
-        './benchmark_results.js', `let res = ${JSON.stringify(fulfilled)};`);
+        './benchmark_results.js',
+        `let benchmarkResults = ${JSON.stringify(fulfilled)};`);
   } else {
     console.log('\Benchmarks complete.\n');
   }

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -177,10 +177,12 @@ async function benchmark(config, runOneBenchmark = getOneBenchmarkResult) {
   // Optionally written to an outfile or pushed to a database once all
   // benchmarks return results
   const fulfilled = await Promise.allSettled(results);
-  if (cliArgs?.outfile) {
+  if (cliArgs?.outfile === 'html') {
     await write(
         './benchmark_results.js',
         `let benchmarkResults = ${JSON.stringify(fulfilled)};`);
+  } else if (cliArgs?.outfile === 'json') {
+    await write('./benchmark_results.json', JSON.stringify(fulfilled));
   } else {
     console.log('\Benchmarks complete.\n');
   }
@@ -357,8 +359,14 @@ function setupHelpMessage() {
     help: 'Store benchmark results in Firestore database',
     action: 'store_true'
   });
-  parser.add_argument(
-      '--outfile', {help: 'write results to outfile', action: 'store_true'});
+  parser.add_argument('--outfile', {
+    help: 'write results to outfile. Expects \'html\' or \'json\'. ' +
+        'If you set it as \'html\', benchmark_results.js will be generated ' +
+        'and you could review the benchmark results by openning ' +
+        'benchmark_result.html file.',
+    type: 'string',
+    action: 'store'
+  });
   parser.add_argument('-v', '--version', {action: 'version', version});
   parser.add_argument('--localBuild', {
     help: 'local build name list, separated by comma. The name is in short ' +

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_results.html
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_results.html
@@ -17,7 +17,6 @@ limitations under the License.
 <body style="margin: 5%"></body>
 <script src="./benchmark_results.js"></script>
 <script>
-  // node app.js --localBuild=core,webgl --benchmark='./preconfigured_browser.json' --maxBenchmarks=4 --cloud --outfile
 
   /**
    * Returns the table name for this benchmark record, which is a combination
@@ -151,8 +150,11 @@ limitations under the License.
   }
 
   function onPageLoad() {
-    const structuredBenchmarkResults = parseBenchmarkResults(res);
-    renderStructuredBenchmarkResults(structuredBenchmarkResults);
+    // benchmarkResults is supposed to be loaded from benchmark_results.js.
+    if (benchmarkResults != null) {
+      const structuredBenchmarkResults = parseBenchmarkResults(benchmarkResults);
+      renderStructuredBenchmarkResults(structuredBenchmarkResults);
+    }
   }
 
   onPageLoad();

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_results.html
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_results.html
@@ -1,9 +1,30 @@
+<!-- Copyright 2022 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================-->
+
 <html>
 <body style="margin: 5%"></body>
 <script src="./benchmark_results.js"></script>
 <script>
   // node app.js --localBuild=core,webgl --benchmark='./preconfigured_browser.json' --maxBenchmarks=4 --cloud --outfile
 
+  /**
+   * Returns the table name for this benchmark record, which is a combination
+   * of benchmark category (model or codeSnippet) and backend.
+   *
+   * Example: 'Code Snippet (webgl)'.
+   */
   function getTableName(benchmarkReocrd) {
     let benchmarkCategory =
       benchmarkReocrd?.value?.modelInfo?.model !== 'codeSnippet'?
@@ -11,22 +32,43 @@
     return `${benchmarkCategory} (${benchmarkReocrd?.value?.modelInfo?.backend})`;
   }
 
+  /**
+   * Returns the combination between device os and device name.
+   *
+   * Example: 'OS X(Monterey) safari15.3', 'android(12.0) Google Pixel 5'.
+   */
   function getDeviceName(benchmarkReocrd) {
     let deviceInfo = benchmarkReocrd?.value?.deviceInfo || {};
     return `${deviceInfo.os}(${deviceInfo.os_version})  ${deviceInfo.device || deviceInfo.browser + deviceInfo.browser_version} `;
   }
 
+  /**
+   * Returns the codeSnippet or model name.
+   *
+   * Example: 'MobileNetV2'.
+   */
   function getBenchmarkTargetName(benchmarkReocrd) {
     let benchmarkTargetName =
       benchmarkReocrd?.value?.modelInfo?.model;
       if (benchmarkTargetName === 'codeSnippet') {
-        benchmarkTargetName = benchmarkReocrd?.value?.codeSnippet
-            .replaceAll('\n', '')
-            .replaceAll('\t', '');
+        benchmarkTargetName = benchmarkReocrd?.value?.codeSnippet || 'NA'
       }
-    return `${benchmarkTargetName || 'NA'}`;
+    return `${benchmarkTargetName.replaceAll('\n', '').replaceAll('\t', '')}`;
   }
 
+  /**
+   * Reorganize the data in benchmarkResults to  dict (object) that is aligned
+   * with tables. The generated dict is a mapping between table name and table
+   * dict. Each tale dict is also a mapping between device name and device
+   * benchmark info dict. The device benchmark info dict is a mapping between the
+   * model name and the average inference time for it.
+   *
+   * @param {object} benchmarkResults This is supposed to be loaded from
+   *     `benchmark_results.js` file and it is an array of benchmarkRecords. Each
+   * benchmarkRecord contains `status` and `value` fileds and `value` also
+   * contains an object with `timeInfo`, `memoryInfo`, `deviceInfo` and
+   * `modelInfo` fileds.
+   */
   function parseBenchmarkResults(benchmarkResults) {
     const structuredBenchmarkResults = {};
     for (let benchmarkReocrd of benchmarkResults) {
@@ -50,21 +92,30 @@
     return structuredBenchmarkResults;
   }
 
-  function initializeTable(tableHeaderfileds) {
-    const table = document.createElement("TABLE");
-    let header = table.createTHead();
+  /**
+   * Create a table element, with table head and caption.
+   */
+  function initializeTable(tableName, tableHeaderfileds) {
+    const tableElem = document.createElement("TABLE");
+    let header = tableElem.createTHead();
     let row = header.insertRow(0);
     row.insertCell(0);
     for (let filedIndex in tableHeaderfileds) {
       let cell = row.insertCell(row.cells.length);
       cell.innerHTML = `<b>${tableHeaderfileds[filedIndex]}</b>`;
     }
-    return table;
+    tableElem.createCaption().innerHTML = tableName;
+    tableElem.setAttribute('border', '1');
+    return tableElem;
   }
 
-  function addDeviceData(table, tableHeaderfileds, tableData, deviceName) {
+
+  /**
+   * Add a row to the table element with a certain device benchmark record.
+   */
+  function addDevice(tableElem, tableHeaderfileds, tableData, deviceName) {
     const deviceData = tableData[deviceName];
-    const row = table.insertRow(table.rows.length);
+    const row = tableElem.insertRow(tableElem.rows.length);
     let deviceNameCell = row.insertCell(0);
     deviceNameCell.innerHTML = deviceName;
 
@@ -74,26 +125,28 @@
     }
   }
 
-  function renderBenchmarkTable(tableName, structuredBenchmarkResults) {
+  function buildTableElem(tableName, structuredBenchmarkResults) {
     const tableData = structuredBenchmarkResults[tableName];
 
-    let table, tableHeaderfileds;
-    for (const deviceName in tableData) {
-      if (table == null) {
-        tableHeaderfileds = Object.keys(tableData[deviceName]);
-        table = initializeTable(tableHeaderfileds);
-      }
-      addDeviceData(table, tableHeaderfileds, tableData, deviceName);
+    if (tableData == null || Object.keys(tableData).length === 0) {
+      return;
     }
 
-     table.createCaption().innerHTML = tableName;
-    table.setAttribute('border', '1');
-    document.body.appendChild(table);
+    // Pick up one random device to know column names for the table.
+    const firstDeviceName = Object.keys(tableData)[0];
+    const tableHeaderfileds = Object.keys(tableData[firstDeviceName]);
+    const tableElem = initializeTable(tableName, tableHeaderfileds);
+
+    for (const deviceName in tableData) {
+      addDevice(tableElem, tableHeaderfileds, tableData, deviceName);
+    }
+    return tableElem;
   }
 
   function renderStructuredBenchmarkResults(structuredBenchmarkResults) {
     for (let tableName in structuredBenchmarkResults) {
-      renderBenchmarkTable(tableName, structuredBenchmarkResults);
+      const tableElem = buildTableElem(tableName, structuredBenchmarkResults);
+      document.body.appendChild(tableElem);
     }
   }
 

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_results.html
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_results.html
@@ -1,0 +1,107 @@
+<html>
+<body style="margin: 5%"></body>
+<script src="./benchmark_results.js"></script>
+<script>
+  // node app.js --localBuild=core,webgl --benchmark='./preconfigured_browser.json' --maxBenchmarks=4 --cloud --outfile
+
+  function getTableName(benchmarkReocrd) {
+    let benchmarkCategory =
+      benchmarkReocrd?.value?.modelInfo?.model !== 'codeSnippet'?
+          'Model' : 'Code Snippet';
+    return `${benchmarkCategory} (${benchmarkReocrd?.value?.modelInfo?.backend})`;
+  }
+
+  function getDeviceName(benchmarkReocrd) {
+    let deviceInfo = benchmarkReocrd?.value?.deviceInfo || {};
+    return `${deviceInfo.os}(${deviceInfo.os_version})  ${deviceInfo.device || deviceInfo.browser + deviceInfo.browser_version} `;
+  }
+
+  function getBenchmarkTargetName(benchmarkReocrd) {
+    let benchmarkTargetName =
+      benchmarkReocrd?.value?.modelInfo?.model;
+      if (benchmarkTargetName === 'codeSnippet') {
+        benchmarkTargetName = benchmarkReocrd?.value?.codeSnippet
+            .replaceAll('\n', '')
+            .replaceAll('\t', '');
+      }
+    return `${benchmarkTargetName || 'NA'}`;
+  }
+
+  function parseBenchmarkResults(benchmarkResults) {
+    const structuredBenchmarkResults = {};
+    for (let benchmarkReocrd of benchmarkResults) {
+      if (benchmarkReocrd.status !== 'fulfilled') {
+        return;
+      }
+      let tableName = getTableName(benchmarkReocrd);
+      let deviceName = getDeviceName(benchmarkReocrd);
+      let benchmarkTargetName = getBenchmarkTargetName(benchmarkReocrd);
+
+      if (structuredBenchmarkResults[tableName] == null) {
+        structuredBenchmarkResults[tableName] = {};
+      }
+      if (structuredBenchmarkResults[tableName][deviceName] == null) {
+        structuredBenchmarkResults[tableName][deviceName] = {};
+      }
+
+      structuredBenchmarkResults[tableName][deviceName][benchmarkTargetName]
+        = benchmarkReocrd?.value?.timeInfo?.averageTime;
+    }
+    return structuredBenchmarkResults;
+  }
+
+  function initializeTable(tableHeaderfileds) {
+    const table = document.createElement("TABLE");
+    let header = table.createTHead();
+    let row = header.insertRow(0);
+    row.insertCell(0);
+    for (let filedIndex in tableHeaderfileds) {
+      let cell = row.insertCell(row.cells.length);
+      cell.innerHTML = `<b>${tableHeaderfileds[filedIndex]}</b>`;
+    }
+    return table;
+  }
+
+  function addDeviceData(table, tableHeaderfileds, tableData, deviceName) {
+    const deviceData = tableData[deviceName];
+    const row = table.insertRow(table.rows.length);
+    let deviceNameCell = row.insertCell(0);
+    deviceNameCell.innerHTML = deviceName;
+
+    for (const filedName of tableHeaderfileds) {
+      const cell = row.insertCell(row.cells.length);
+      cell.innerHTML = deviceData[filedName] || 'NA';
+    }
+  }
+
+  function renderBenchmarkTable(tableName, structuredBenchmarkResults) {
+    const tableData = structuredBenchmarkResults[tableName];
+
+    let table, tableHeaderfileds;
+    for (const deviceName in tableData) {
+      if (table == null) {
+        tableHeaderfileds = Object.keys(tableData[deviceName]);
+        table = initializeTable(tableHeaderfileds);
+      }
+      addDeviceData(table, tableHeaderfileds, tableData, deviceName);
+    }
+
+     table.createCaption().innerHTML = tableName;
+    table.setAttribute('border', '1');
+    document.body.appendChild(table);
+  }
+
+  function renderStructuredBenchmarkResults(structuredBenchmarkResults) {
+    for (let tableName in structuredBenchmarkResults) {
+      renderBenchmarkTable(tableName, structuredBenchmarkResults);
+    }
+  }
+
+  function onPageLoad() {
+    const structuredBenchmarkResults = parseBenchmarkResults(res);
+    renderStructuredBenchmarkResults(structuredBenchmarkResults);
+  }
+
+  onPageLoad();
+</script>
+</html>


### PR DESCRIPTION
For browserstack benchmark tool, when you run:
`node app.js --benchmark='./preconfigured_browser.json'  --cloud --outfile`,  the program will benchmark all models on devices configured in `preconfigured_browser.json` file and then write down the benchmark results into a json file `benchmark_results.json`, which is too large to be readable.

This PR:
1. lets the program write the benchmark results into a javascript variable (in `benchmark_results.js`), instead of a json file (`benchmark_results.json`). Then the benchmark results could be loaded easily to the html file.
2. add a html file, which loads `benchmark_results.js` and renders the benchmark results into a table.

Then, whenever complete `node app.js --benchmark='./preconfigured_browser.json'  --cloud --outfile`, users no longer need to read benchmark_results.json, and, they could simply open `benchmark_results.html` to see the results.

## Preview
![image](https://user-images.githubusercontent.com/40653845/184025600-488ed957-97d7-478b-a348-e1c0ebb49207.png)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6740)
<!-- Reviewable:end -->

(For developers only: if want to use typescript to re-write this, could continue on https://github.com/tensorflow/tfjs/pull/6741)
