### PR TITLE
[webgpu] Add Atan2, IsNaN, Reciprocal

### DIFF
--- a/tfjs-backend-webgpu/src/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/binary_op_util.ts
@@ -18,6 +18,7 @@
 export enum BinaryOpType {
   MUL,
   ADD,
+  ATAN2,
   SUB,
   DIV,
   EQUAL,
@@ -37,7 +38,32 @@ export enum BinaryOpType {
   COMPLEX_MULTIPLY_IMAG
 }
 
+const CHECK_NAN_SNIPPET = `
+  if (isnan(a)) { return a; }
+  if (isnan(b)) { return b; }
+  `;
+const CHECK_NAN_SNIPPET_VEC4 = `
+  if (isNaN.r) {
+    resultTemp.r = uniforms.NAN;
+  }
+  if (isNaN.g) {
+    resultTemp.g = uniforms.NAN;
+  }
+  if (isNaN.b) {
+    resultTemp.b = uniforms.NAN;
+  }
+  if (isNaN.a) {
+    resultTemp.a = uniforms.NAN;
+  }
+  `;
+
 const ADD = 'return a + b;';
+const ATAN2 = CHECK_NAN_SNIPPET + `
+  return atan2(a, b);
+`;
+const ATAN2_VEC4 = CHECK_NAN_SNIPPET_VEC4 + `
+  return atan2(a, b);
+`;
 // (Ar + Ai)(Br + Bi) =
 // ArBr + ArBi + AiBr + AiBi = ArBr - AB + ArBi + AiBr
 // Yr = ArBr - AB
@@ -61,24 +87,6 @@ const LESS_EQUAL_VEC4 = 'return vec4<f32>(a <= b);';
 const LOGICAL_AND = 'return f32(f32(a) >= 1.0 && f32(b) >= 1.0);';
 const LOGICAL_AND_VEC4 = `return (vec4<f32>(a >= vec4<f32>(1.0)) *
   vec4<f32>(b >= vec4<f32>(1.0)));`;
-const CHECK_NAN_SNIPPET = `
-  if (isnan(a)) { return a; }
-  if (isnan(b)) { return b; }
-  `;
-const CHECK_NAN_SNIPPET_VEC4 = `
-  if (isNaN.r) {
-    resultTemp.r = uniforms.NAN;
-  }
-  if (isNaN.g) {
-    resultTemp.g = uniforms.NAN;
-  }
-  if (isNaN.b) {
-    resultTemp.b = uniforms.NAN;
-  }
-  if (isNaN.a) {
-    resultTemp.a = uniforms.NAN;
-  }
-  `;
 const INT_DIV = `
   let s = sign(a) * sign(b);
   let ia = i32(round(a));
@@ -198,6 +206,8 @@ export function getBinaryOpString(
       return MUL;
     case BinaryOpType.ADD:
       return ADD;
+    case BinaryOpType.ATAN2:
+      return useVec4 ? ATAN2_VEC4 : ATAN2;
     case BinaryOpType.SUB:
       return SUB;
     case BinaryOpType.DIV:

--- a/tfjs-backend-webgpu/src/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/binary_op_util.ts
@@ -58,12 +58,6 @@ const CHECK_NAN_SNIPPET_VEC4 = `
   `;
 
 const ADD = 'return a + b;';
-const ATAN2 = CHECK_NAN_SNIPPET + `
-  return atan2(a, b);
-`;
-const ATAN2_VEC4 = CHECK_NAN_SNIPPET_VEC4 + `
-  return atan2(a, b);
-`;
 // (Ar + Ai)(Br + Bi) =
 // ArBr + ArBi + AiBr + AiBi = ArBr - AB + ArBi + AiBr
 // Yr = ArBr - AB
@@ -125,19 +119,20 @@ const NOT_EQUAL = `
 `;
 const NOT_EQUAL_VEC4 = `
   var result = vec4<f32>(a != b);
+  let valueForNaN = 1.0;
   var isANaN = isnanVec4(a);
   var isBNaN = isnanVec4(b);
   if (isANaN.r || isBNaN.r) {
-    result.r = 1.0;
+    result.r = valueForNaN;
   }
   if (isANaN.g || isBNaN.g) {
-    result.g = 1.0;
+    result.g = valueForNaN;
   }
   if (isANaN.b || isBNaN.b) {
-    result.b = 1.0;
+    result.b = valueForNaN;
   }
   if (isANaN.a || isBNaN.a) {
-    result.a = 1.0;
+    result.a = valueForNaN;
   }
 
   return result;
@@ -185,7 +180,7 @@ const PRELU_VEC4 = `
   return (aLessThanZero * (b * a)) + ((vec4<f32>(1.0) - aLessThanZero) * a);
   `;
 
-function getMinMaxString(op: string, useVec4: boolean) {
+function getBinaryWithNanString(op: string, useVec4: boolean) {
   const checkNanSnippet = useVec4 ? CHECK_NAN_SNIPPET_VEC4 : CHECK_NAN_SNIPPET;
   return useVec4 ? `
     var resultTemp = vec4<f32>(${op}(a, b));
@@ -207,7 +202,7 @@ export function getBinaryOpString(
     case BinaryOpType.ADD:
       return ADD;
     case BinaryOpType.ATAN2:
-      return useVec4 ? ATAN2_VEC4 : ATAN2;
+      return getBinaryWithNanString('atan2', useVec4);
     case BinaryOpType.SUB:
       return SUB;
     case BinaryOpType.DIV:
@@ -233,9 +228,9 @@ export function getBinaryOpString(
     case BinaryOpType.PRELU:
       return useVec4 ? PRELU_VEC4 : PRELU;
     case BinaryOpType.MAX:
-      return getMinMaxString('max', useVec4);
+      return getBinaryWithNanString('max', useVec4);
     case BinaryOpType.MIN:
-      return getMinMaxString('min', useVec4);
+      return getBinaryWithNanString('min', useVec4);
     case BinaryOpType.POW:
       return useVec4 ? POW_VEC4 : POW;
     case BinaryOpType.COMPLEX_MULTIPLY_REAL:

--- a/tfjs-backend-webgpu/src/kernels/Atan2.ts
+++ b/tfjs-backend-webgpu/src/kernels/Atan2.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Atan2, KernelConfig} from '@tensorflow/tfjs-core';
+import {BinaryOpType} from '../binary_op_util';
+import {binaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
+
+export const atan2 = binaryKernelFunc({opType: BinaryOpType.ATAN2});
+
+export const atan2Config: KernelConfig = {
+  kernelName: Atan2,
+  backendName: 'webgpu',
+  kernelFunc: atan2
+};

--- a/tfjs-backend-webgpu/src/kernels/IsNaN.ts
+++ b/tfjs-backend-webgpu/src/kernels/IsNaN.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {IsNan, KernelConfig} from '@tensorflow/tfjs-core';
+import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
+import {UnaryOpType} from '../unary_op_util';
+
+export const isNaN =
+    unaryKernelFunc({opType: UnaryOpType.IS_NAN, dtype: 'bool'});
+
+export const isNaNConfig: KernelConfig = {
+  kernelName: IsNan,
+  backendName: 'webgpu',
+  kernelFunc: isNaN
+};

--- a/tfjs-backend-webgpu/src/kernels/Reciprocal.ts
+++ b/tfjs-backend-webgpu/src/kernels/Reciprocal.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {KernelConfig, Reciprocal} from '@tensorflow/tfjs-core';
+import {unaryKernelFunc} from '../kernel_utils/kernel_funcs_utils';
+import {UnaryOpType} from '../unary_op_util';
+
+export const reciprocal = unaryKernelFunc({opType: UnaryOpType.RECIPROCAL});
+
+export const reciprocalConfig: KernelConfig = {
+  kernelName: Reciprocal,
+  backendName: 'webgpu',
+  kernelFunc: reciprocal
+};

--- a/tfjs-backend-webgpu/src/register_all_kernels.ts
+++ b/tfjs-backend-webgpu/src/register_all_kernels.ts
@@ -22,6 +22,7 @@ import {addConfig} from './kernels/Add';
 import {addNConfig} from './kernels/AddN';
 import {argMaxConfig} from './kernels/ArgMax';
 import {argMinConfig} from './kernels/ArgMin';
+import {atan2Config} from './kernels/Atan2';
 import {avgPoolConfig} from './kernels/AvgPool';
 import {batchMatMulConfig} from './kernels/BatchMatMul';
 import {batchToSpaceNDConfig} from './kernels/BatchToSpaceND';
@@ -59,6 +60,7 @@ import {greaterConfig} from './kernels/Greater';
 import {greaterEqualConfig} from './kernels/GreaterEqual';
 import {identityConfig} from './kernels/Identity';
 import {imagConfig} from './kernels/Imag';
+import {isNaNConfig} from './kernels/IsNaN';
 import {leakyReluConfig} from './kernels/LeakyRelu';
 import {lessConfig} from './kernels/Less';
 import {lessEqualConfig} from './kernels/LessEqual';
@@ -86,6 +88,7 @@ import {prodConfig} from './kernels/Prod';
 import {rangeConfig} from './kernels/Range';
 import {realConfig} from './kernels/Real';
 import {realDivConfig} from './kernels/RealDiv';
+import {reciprocalConfig} from './kernels/Reciprocal';
 import {reluConfig} from './kernels/Relu';
 import {relu6Config} from './kernels/Relu6';
 import {reshapeConfig} from './kernels/Reshape';
@@ -126,6 +129,7 @@ const kernelConfigs: KernelConfig[] = [
   addNConfig,
   argMaxConfig,
   argMinConfig,
+  atan2Config,
   avgPoolConfig,
   batchMatMulConfig,
   batchToSpaceNDConfig,
@@ -163,6 +167,7 @@ const kernelConfigs: KernelConfig[] = [
   greaterEqualConfig,
   identityConfig,
   imagConfig,
+  isNaNConfig,
   leakyReluConfig,
   lessConfig,
   lessEqualConfig,
@@ -190,6 +195,7 @@ const kernelConfigs: KernelConfig[] = [
   rangeConfig,
   realConfig,
   realDivConfig,
+  reciprocalConfig,
   reluConfig,
   relu6Config,
   reshapeConfig,

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -41,6 +41,12 @@ const TEST_FILTERS: TestFilter[] = [
     ]
   },
   {
+    startsWith: 'atan2 ',
+    excludes: [
+      'gradient',  // Not yet implemented.
+    ]
+  },
+  {
     startsWith: 'avgPool ',
     excludes: [
       'gradient',  // Not yet implemented.
@@ -124,6 +130,7 @@ const TEST_FILTERS: TestFilter[] = [
       'gradient'  // gradient function not found.
     ]
   },
+  {startsWith: 'isNaN ', excludes: []},
   {
     startsWith: 'matmul',
     excludes: [
@@ -192,6 +199,7 @@ const TEST_FILTERS: TestFilter[] = [
       'sparseSegmentMean',  // 'SparseSegmentMean' not registered.
     ]
   },
+  {startsWith: 'reciprocal ', excludes: []},
   {
     startsWith: 'relu ',
     excludes: [

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -130,7 +130,6 @@ const TEST_FILTERS: TestFilter[] = [
       'gradient'  // gradient function not found.
     ]
   },
-  {startsWith: 'isNaN ', excludes: []},
   {
     startsWith: 'matmul',
     excludes: [
@@ -199,7 +198,6 @@ const TEST_FILTERS: TestFilter[] = [
       'sparseSegmentMean',  // 'SparseSegmentMean' not registered.
     ]
   },
-  {startsWith: 'reciprocal ', excludes: []},
   {
     startsWith: 'relu ',
     excludes: [
@@ -267,7 +265,6 @@ const TEST_FILTERS: TestFilter[] = [
       'any webgpu ',
       'asin ',
       'asinh ',
-      'atan2 ',
       'atanh ',
       'avgPool3d ',
       'avgPool3dBackprop ',
@@ -288,7 +285,6 @@ const TEST_FILTERS: TestFilter[] = [
       'IRFFT ',
       'isFinite ',
       'isInf ',
-      'isNaN ',
       'linspace ',
       'localResponseNormalization ',
       'log1p ',
@@ -305,7 +301,6 @@ const TEST_FILTERS: TestFilter[] = [
       'oneHot ',
       'confusionMatrix ',  // oneHot
       'poolBackprop ',
-      'reciprocal ',
       'reverse1d ',
       'reverse2d ',
       'reverse3d ',

--- a/tfjs-backend-webgpu/src/unary_op_util.ts
+++ b/tfjs-backend-webgpu/src/unary_op_util.ts
@@ -24,6 +24,7 @@ export enum UnaryOpType {
   EXP,
   EXPM1,
   FLOOR,
+  IS_NAN,
   LINEAR,
   LOG,
   LOGICAL_NOT,
@@ -31,6 +32,7 @@ export enum UnaryOpType {
   RELU,
   RELU6,
   LEAKYRELU,
+  RECIPROCAL,
   RSQRT,
   SIN,
   SINH,
@@ -68,6 +70,7 @@ const ELU_VEC4 = `
 `;
 const EXP = `return exp(a);`;
 const FLOOR = `return floor(a);`;
+const IS_NAN = `return f32(isnan(a));`;
 const LINEAR = `return a;`;
 const LOG = `if (a < 0.0) { return 1.0/0.0; }
   return log(a);`;
@@ -78,6 +81,7 @@ const LEAKYRELU_VEC4 = `
   let aLessThanZero = vec4<f32>(a < vec4<f32>(0.0));
   return (aLessThanZero * (uniforms.alpha * a)) + ((vec4<f32>(1.0) - aLessThanZero) * a);
 `;
+const RECIPROCAL = `return 1.0 / a;`;
 const RELU = `return select(a, 0.0, a < 0.0);`;
 const RELU6 = 'return clamp(a, 0.0, 6.0);';
 const RELU6_VEC4 =
@@ -118,6 +122,8 @@ export function getUnaryOpString(type: UnaryOpType, useVec4?: boolean): string {
       return EXPM1;
     case UnaryOpType.FLOOR:
       return FLOOR;
+    case UnaryOpType.IS_NAN:
+      return IS_NAN;
     case UnaryOpType.LINEAR:
       return LINEAR;
     case UnaryOpType.LOG:
@@ -128,6 +134,8 @@ export function getUnaryOpString(type: UnaryOpType, useVec4?: boolean): string {
       return NEG;
     case UnaryOpType.LEAKYRELU:
       return useVec4 ? LEAKYRELU_VEC4 : LEAKYRELU;
+    case UnaryOpType.RECIPROCAL:
+      return RECIPROCAL;
     case UnaryOpType.RELU:
       return useVec4 ? RELU_VEC4 : RELU;
     case UnaryOpType.RELU6:

--- a/tfjs-core/src/ops/binary_ops_test.ts
+++ b/tfjs-core/src/ops/binary_ops_test.ts
@@ -1083,6 +1083,36 @@ describeWithFlags('atan2', ALL_ENVS, () => {
     expectArraysClose(await r.data(), expected);
   });
 
+  it('atan2 vec4 NaNs', async () => {
+    const aValues = [1.0, 2.0, 3.0, 4.0];
+    const cValues = [3.0, NaN, 3.0, 4.0];
+    const a = tf.tensor2d(aValues, [4, 1]);
+    const c = tf.tensor2d(cValues, [4, 1]);
+
+    const r = tf.atan2(a, c);
+    const expected = [];
+
+    for (let i = 0; i < a.size; i++) {
+      expected[i] = Math.atan2(aValues[i], cValues[i]);
+    }
+    expectArraysClose(await r.data(), expected);
+  });
+
+  it('atan2 vec4 all NaNs', async () => {
+    const aValues = [NaN, 2.0, NaN, NaN];
+    const cValues = [3.0, NaN, 3.0, 4.0];
+    const a = tf.tensor2d(aValues, [4, 1]);
+    const c = tf.tensor2d(cValues, [4, 1]);
+
+    const r = tf.atan2(a, c);
+    const expected = [];
+
+    for (let i = 0; i < a.size; i++) {
+      expected[i] = Math.atan2(aValues[i], cValues[i]);
+    }
+    expectArraysClose(await r.data(), expected);
+  });
+
   it('gradient: Scalar', async () => {
     const a = tf.scalar(5);
     const b = tf.scalar(2);


### PR DESCRIPTION
Typical use case:
Atan2: FaceLandmarkDetection,attention_mesh.
IsNan: ArPortraitDepth.
Reciprocal: MoveNet-MultiPose.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6743)
<!-- Reviewable:end -->
