### PR TITLE
[local benchmark tool] Add convertedBy filed

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -334,6 +334,7 @@ limitations under the License.
       appendRow(parameterTable, 'task', 'Performance Benchmark');
       appendRow(parameterTable, 'benchmark', state.benchmark);
       appendRow(parameterTable, 'modelType', state.modelType || 'Unknown');
+      appendRow(parameterTable, 'convertedBy', model?.artifacts?.convertedBy || 'Unknown');
       if (state.benchmark === 'custom') {
         appendRow(parameterTable, 'modelUrl', state.modelUrl);
       }


### PR DESCRIPTION
This PR adds `convertedBy` filed in benchmark result tables to show the converter version.

Example:
![image](https://user-images.githubusercontent.com/40653845/184208492-294e6906-3624-4a98-bb6b-f42ca7489673.png)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6745)
<!-- Reviewable:end -->
