### PR TITLE
webgpu: enlarge the splitted dimInner size

### DIFF
--- a/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
@@ -210,7 +210,7 @@ export function makeMatMulPackedVec4Source(
     let globalRowStart = i32(workgroupId.y) * ${tileAOuter};
 
     let numTiles = ${
-      splitK ? `${splitedDimInner / tileInner}` :
+      splitK ? `${Math.ceil(splitedDimInner / tileInner)}` :
                '(uniforms.dimInner - 1) / TileInner + 1'};
     var kStart = ${splitK ? `i32(globalId.z) * ${splitedDimInner}` : '0'};
 
@@ -326,7 +326,7 @@ export function makeMatMulPackedSource(
       let globalRowStart = i32(workgroupId.y) * ${tileAOuter};
 
       let numTiles = ${
-      splitK ? `${splitedDimInner / tileInner}` :
+      splitK ? `${Math.ceil(splitedDimInner / tileInner)}` :
                '(uniforms.dimInner - 1) / TileInner + 1'};
       var kStart = ${splitK ? `i32(globalId.z) * ${splitedDimInner}` : '0'};
 

--- a/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
@@ -160,7 +160,7 @@ const calculateResultSnippet =
 
 export function makeMatMulPackedVec4Source(
     workPerThread: number[], workGroupSize: [number, number, number],
-    transposeA = false, tileInner = 32, splitK = false,
+    transposeA = false, tileInner = 32, splitK = false, splitedDimInner = 32,
     isVectorA = false): string {
   const tileAOuter = workGroupSize[1] * workPerThread[1];
   const tileBOuter = workGroupSize[0] * workPerThread[0];
@@ -209,8 +209,10 @@ export function makeMatMulPackedVec4Source(
     let batch = ${splitK ? '0' : 'i32(globalId.z)'};
     let globalRowStart = i32(workgroupId.y) * ${tileAOuter};
 
-    let numTiles = ${splitK ? '1' : '(uniforms.dimInner - 1) / TileInner + 1'};
-    var kStart = ${splitK ? 'i32(globalId.z) * TileInner' : '0'};
+    let numTiles = ${
+      splitK ? `${splitedDimInner / tileInner}` :
+               '(uniforms.dimInner - 1) / TileInner + 1'};
+    var kStart = ${splitK ? `i32(globalId.z) * ${splitedDimInner}` : '0'};
 
     var acc: array<vec4<f32>, RowPerThread>;
 
@@ -281,7 +283,8 @@ const readDataFromSubASnippet = (transposeA: boolean) => {
 
 export function makeMatMulPackedSource(
     workPerThread: number[], workGroupSize: [number, number, number],
-    transposeA = false, tileInner = 32, splitK = false): string {
+    transposeA = false, tileInner = 32, splitK = false,
+    splitedDimInner = 32): string {
   const tileAOuter = workPerThread[1] * workGroupSize[1];
   const tileBOuter = workPerThread[0] * workGroupSize[0];
   const tileAWidth = transposeA ? tileAOuter : tileInner;
@@ -323,8 +326,9 @@ export function makeMatMulPackedSource(
       let globalRowStart = i32(workgroupId.y) * ${tileAOuter};
 
       let numTiles = ${
-      splitK ? '1' : '(uniforms.dimInner - 1) / TileInner + 1'};
-      var kStart = ${splitK ? 'i32(globalId.z) * TileInner' : '0'};
+      splitK ? `${splitedDimInner / tileInner}` :
+               '(uniforms.dimInner - 1) / TileInner + 1'};
+      var kStart = ${splitK ? `i32(globalId.z) * ${splitedDimInner}` : '0'};
 
       var acc : array<array<f32, ColPerThread>, RowPerThread>;
 
@@ -565,7 +569,7 @@ export class MatMulPackedProgram implements WebGPUProgram {
         this.isVec4 ?
             makeMatMulPackedVec4Source(
                 this.elementsPerThread, this.workGroupSize, this.transposeA,
-                this.tileInner, false, this.isVectorA) :
+                this.tileInner, false, null, this.isVectorA) :
             (this.isVectorA ? makeVectorMatrixProductSource(
                                   this.workGroupSize, this.transposeA) :
                               makeMatMulPackedSource(

--- a/tfjs-backend-webgpu/src/matmul_splitK_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_splitK_webgpu.ts
@@ -37,7 +37,7 @@ export class MatMulSplitKProgram implements WebGPUProgram {
   batchAEqualOne: boolean;
   batchBEqualOne: boolean;
   isVec4 = false;
-  tileInner = 32;
+  splitedDimInner = 128;
 
   constructor(
       outputShape: [number, number, number], dimInner: number,
@@ -51,7 +51,8 @@ export class MatMulSplitKProgram implements WebGPUProgram {
     this.isVec4 = (transposeA && this.outputShape[1] % 4 === 0 ||
                    !transposeA && dimInner % 4 === 0) &&
         this.outputShape[2] % 4 === 0;
-    this.elementsPerThread = [4, 4, this.tileInner];
+    this.elementsPerThread = [4, 4, this.splitedDimInner];
+
     if (!this.isVec4) {
       if (this.outputShape[1] < 16) {
         this.elementsPerThread[1] = 1;
@@ -119,10 +120,10 @@ export class MatMulSplitKProgram implements WebGPUProgram {
       ${
         this.isVec4 ? makeMatMulPackedVec4Source(
                           this.elementsPerThread, this.workGroupSize,
-                          this.transposeA, this.tileInner, true) :
+                          this.transposeA, 32, true, this.splitedDimInner) :
                       makeMatMulPackedSource(
                           this.elementsPerThread, this.workGroupSize,
-                          this.transposeA, this.tileInner, true)}
+                          this.transposeA, 32, true, this.splitedDimInner)}
     `;
     return userCode;
   }


### PR DESCRIPTION
This PR enlarges the splitted dimInner size to reduce the number of calls to atomic operations.

Before
Conv2d 0.28ms input0: [5,5,2048] input1:[1,1,2048,32]
After
conv2d 0.12ms input0: [5,5,2048] input1:[1,1,2048,32]

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6755)
<!-- Reviewable:end -->
