### PR TITLE
[tfjs-converter] remove kept flag after tensor is replaced or popped from the tensor list

### DIFF
--- a/tfjs-converter/src/executor/tensor_list.ts
+++ b/tfjs-converter/src/executor/tensor_list.ts
@@ -143,6 +143,7 @@ export class TensorList {
     const outputElementShape =
         inferElementShape(this.elementShape, this.tensors, elementShape);
     const tensor = this.tensors.pop();
+    tensor.kept = false;
 
     assertShapesMatchAllowUndefinedSize(
         tensor.shape, elementShape, 'TensorList shape mismatch: ');
@@ -243,6 +244,12 @@ export class TensorList {
     assertShapesMatchAllowUndefinedSize(
         this.elementShape, tensor.shape, 'TensorList shape mismatch: ');
     keep(tensor);
+
+    // dispose the previous value if it is replacing.
+    if (this.tensors[elementIndex] != null) {
+      this.tensors[elementIndex].kept = false;
+    }
+
     this.tensors[elementIndex] = tensor;
   }
 

--- a/tfjs-converter/src/executor/tensor_list_test.ts
+++ b/tfjs-converter/src/executor/tensor_list_test.ts
@@ -122,7 +122,8 @@ describe('TensorList', () => {
     it('should create no new tensors', () => {
       tensorList.pushBack(tensor);
       const numTensors = memory().numTensors;
-      tensorList.popBack(SHAPE, DTYPE);
+      const tensorPoped = tensorList.popBack(SHAPE, DTYPE);
+      expect(tensorPoped.kept).toBeFalsy();
       // a new reshaped tensor
       expect(memory().numTensors).toEqual(numTensors + 1);
     });
@@ -163,6 +164,14 @@ describe('TensorList', () => {
       const numTensors = memory().numTensors;
       tensorList.setItem(0, tensor);
       expect(memory().numTensors).toEqual(numTensors);
+    });
+    it('should remove kept flag for replaced tensor', () => {
+      tensorList = new TensorList([], [-1, 1], DTYPE, SIZE);
+      tensorList.setItem(0, tensor);
+      expect(tensor.kept).toBeTruthy();
+      tensorList.setItem(0, tensor2);
+      expect(tensor.kept).toBeFalsy();
+      expect(tensor2.kept).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
This ensures popped or replaced tensor can be disposed.
Fixes the nightly failure.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6759)
<!-- Reviewable:end -->
