### PR TITLE
[webgpu] Tweak WGSL entry point emission so '{' isn't visually swallowed

### DIFF
--- a/tfjs-backend-webgpu/src/addn_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/addn_packed_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class AddNPackedProgram implements WebGPUProgram {
@@ -52,7 +52,7 @@ export class AddNPackedProgram implements WebGPUProgram {
                           .join(' + ');
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         for (var i = 0; i < ${this.workPerThread}; i = i + 1) {
           let flatIndex = index * ${this.workPerThread} + i;
           if (flatIndex < uniforms.size) {

--- a/tfjs-backend-webgpu/src/argminmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/argminmax_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getCoordsXYZ, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsXYZ, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ArgMinMaxProgram implements WebGPUProgram {
@@ -91,7 +91,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
 
       ${sharedMemorySnippet}
 
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         let outputIndex = index / i32(workGroupSizeX);
         let reduceLength = ${getInputShapeLastDim()};
 

--- a/tfjs-backend-webgpu/src/batchnorm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/batchnorm_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class BatchNormProgram implements WebGPUProgram {
@@ -69,7 +69,7 @@ export class BatchNormProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size)
         {
           let xValue = getXByOutputIndex(index);

--- a/tfjs-backend-webgpu/src/binary_op_complex_webgpu.ts
+++ b/tfjs-backend-webgpu/src/binary_op_complex_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util} from '@tensorflow/tfjs-core';
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class BinaryOpComplexProgram implements WebGPUProgram {
@@ -48,7 +48,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
         ${opStr}
       }
 
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if(index < uniforms.size) {
           let areal = getARealByOutputIndex(index);
           let aimag = getAImagByOutputIndex(index);

--- a/tfjs-backend-webgpu/src/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/binary_op_webgpu.ts
@@ -18,7 +18,7 @@
 import {backend_util, util} from '@tensorflow/tfjs-core';
 
 import {BinaryOpType, getBinaryOpString} from './binary_op_util';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class BinaryOpProgram implements WebGPUProgram {
@@ -105,8 +105,7 @@ export class BinaryOpProgram implements WebGPUProgram {
           ${opStr}
         }
         var<workgroup> sharedBuf : array<f32, ${this.lastDimensionSize}>;
-        ${getMainHeaderAndGlobalIndexString()}
-
+        ${main('index')} {
           // Fill in the shared memory buffer. Here we need a loop to make sure
           // that all data in A|B are uploaded when |sharedMemorySize| is larger
           // than work group size.
@@ -136,7 +135,7 @@ export class BinaryOpProgram implements WebGPUProgram {
        fn binaryOperation(a : ${dType}, b : ${dType}) -> ${dType} {
          ${opStr}
        }
-       ${getMainHeaderAndGlobalIndexString()}
+       ${main('index')} {
          if (index < uniforms.size) {
            let a = getAByOutputIndex(index);
            let b = getBByOutputIndex(index);

--- a/tfjs-backend-webgpu/src/clip_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/clip_vec4_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ClipVec4Program implements WebGPUProgram {
@@ -41,7 +41,7 @@ export class ClipVec4Program implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if(index < uniforms.size) {
           let value = getAByOutputIndex(index);
           var clampedValue : vec4<f32>;

--- a/tfjs-backend-webgpu/src/clip_webgpu.ts
+++ b/tfjs-backend-webgpu/src/clip_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ClipProgram implements WebGPUProgram {
@@ -41,7 +41,7 @@ export class ClipProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if(index < uniforms.size) {
           let value = getAByOutputIndex(index);
           if (isnan(value)) {

--- a/tfjs-backend-webgpu/src/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/concat_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ConcatProgram implements WebGPUProgram {
@@ -67,7 +67,7 @@ export class ConcatProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         for(var i = 0; i < ${this.workPerThread}; i = i + 1) {
           let flatIndex = index * ${this.workPerThread} + i;
           if(flatIndex < uniforms.size) {

--- a/tfjs-backend-webgpu/src/conv_backprop_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv_backprop_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class Conv2DDerInputProgram implements WebGPUProgram {
@@ -45,7 +45,7 @@ export class Conv2DDerInputProgram implements WebGPUProgram {
     const colDim = this.isChannelsLast ? 2 : 3;
     const channelDim = this.isChannelsLast ? 3 : 1;
     return `
-    ${getMainHeaderAndGlobalIndexString()} {
+    ${main('index')} {
       if(index < uniforms.size) {
         let coords = getCoordsFromIndex(index);
         let batch = coords[0];

--- a/tfjs-backend-webgpu/src/crop_and_resize_webgpu.ts
+++ b/tfjs-backend-webgpu/src/crop_and_resize_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class CropAndResizeProgram implements WebGPUProgram {
@@ -78,7 +78,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
     // tslint:disable-next-line:max-line-length
     // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/crop_and_resize_op_gpu.cu.cc
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+    ${main('index')} {
       if (index < uniforms.size) {
         let coords = getCoordsFromIndex(index);
         let height_ratio = f32(${heightRatio});

--- a/tfjs-backend-webgpu/src/cum_webgpu.ts
+++ b/tfjs-backend-webgpu/src/cum_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export enum CumOpType {
@@ -70,7 +70,7 @@ export class CumProgram implements WebGPUProgram {
       idxString = (this.reverse ? 'end + pow2' : 'end - pow2');
     }
     return `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
        if (index < uniforms.size) {
          var coords = getCoordsFromIndex(index);
 

--- a/tfjs-backend-webgpu/src/depth_to_space_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depth_to_space_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class DepthToSpaceProgram implements WebGPUProgram {
@@ -40,7 +40,7 @@ export class DepthToSpaceProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let coords = getCoordsFromIndex(index);
           let b = coords[0];

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_nchw_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_nchw_shared_webgpu.ts
@@ -83,10 +83,10 @@ export class DepthwiseConv2DNCHWSharedProgram implements WebGPUProgram {
       }
 
       ${getWorkGroupSizeString()}
-      fn main(@builtin(local_invocation_id) LocalId : vec3<u32>,
-              @builtin(global_invocation_id) GlobalId : vec3<u32>,
-              @builtin(local_invocation_index) LocalIndex: u32,
-              @builtin(num_workgroups) NumWorkgroups: vec3<u32>) {
+      fn _start(@builtin(local_invocation_id) LocalId : vec3<u32>,
+                @builtin(global_invocation_id) GlobalId : vec3<u32>,
+                @builtin(local_invocation_index) LocalIndex: u32,
+                @builtin(num_workgroups) NumWorkgroups: vec3<u32>) {
         localId = LocalId;
         globalId = GlobalId;
         let localIndex = i32(LocalIndex);

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
@@ -76,7 +76,7 @@ export class DepthwiseConv2DVec4Program implements WebGPUProgram {
         return value;
       }
       ${getWorkGroupSizeString()}
-      fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+      fn _start(@builtin(global_invocation_id) globalId: vec3<u32>) {
         let batch = i32(globalId.z) / uniforms.outShape[1];
         let r = i32(globalId.z) % uniforms.outShape[1];
         let c = i32(globalId.y) * 4;

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_webgpu.ts
@@ -18,7 +18,7 @@
 import {backend_util} from '@tensorflow/tfjs-core';
 
 import {activationFnSnippet, biasActivationSnippet} from './activation_util';
-import {getMainHeaderString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class DepthwiseConv2DProgram implements WebGPUProgram {
@@ -67,7 +67,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
     const userCode = `
       ${activationFnSnippet(this.activation, this.hasPreluActivation, false, 4)}
 
-      ${getMainHeaderString()}
+      ${main()} {
         let coords = getOutputCoords();
         let batch = coords[0];
         let xRCCorner = vec2<i32>(coords.${

--- a/tfjs-backend-webgpu/src/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/fill_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class FillProgram implements WebGPUProgram {
@@ -39,7 +39,7 @@ export class FillProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-    ${getMainHeaderAndGlobalIndexString()}
+    ${main('index')} {
       if (index < uniforms.size) {
         setOutputAtIndex(index, uniforms.value);
       }

--- a/tfjs-backend-webgpu/src/flip_left_right_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flip_left_right_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class FlipLeftRightProgram implements WebGPUProgram {
@@ -37,7 +37,7 @@ export class FlipLeftRightProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let coords = getCoordsFromIndex(index);
           let coordX = uniforms.xShape[2] - coords[2] - 1;

--- a/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class FromPixelsProgram implements WebGPUProgram {
@@ -48,7 +48,7 @@ export class FromPixelsProgram implements WebGPUProgram {
         this.importVideo ? 'texture_external' : 'texture_2d<f32>';
     return `
       @binding(1) @group(0) var src: ${textureType};
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         let flatIndex = index * uniforms.numChannels;
         if (flatIndex < uniforms.size) {
           let coords = getCoordsFromIndex(flatIndex);

--- a/tfjs-backend-webgpu/src/gather_nd_webgpu.ts
+++ b/tfjs-backend-webgpu/src/gather_nd_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getCoordsDataType, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class GatherNDProgram implements WebGPUProgram {
@@ -46,7 +46,7 @@ export class GatherNDProgram implements WebGPUProgram {
       strideString = 'uniforms.strides';
     }
     const userCode = `
-        ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let coords = getCoordsFromIndex(index);
           var flattenIndex = 0;

--- a/tfjs-backend-webgpu/src/gather_webgpu.ts
+++ b/tfjs-backend-webgpu/src/gather_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class GatherProgram implements WebGPUProgram {
@@ -41,7 +41,7 @@ export class GatherProgram implements WebGPUProgram {
   getUserCode(): string {
     const sourceCoords = getSourceCoords(this.aShape);
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let resRC = getCoordsFromIndex(index);
           let indexZ = i32(getIndices(resRC.x, resRC.z));

--- a/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_packed_webgpu.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 import {activationFnSnippet, biasActivationSnippet, typeSnippet} from './activation_util';
-import {getMainHeaderString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, computeWorkGroupInfoForMatMul} from './webgpu_util';
 
 export function matMulReadFnSource(
@@ -192,10 +192,10 @@ export function makeMatMulPackedVec4Source(
   const TileInner = ${tileInner};
 
   @compute @workgroup_size(workGroupSizeX, workGroupSizeY, workGroupSizeZ)
-  fn main(@builtin(local_invocation_id) LocalId : vec3<u32>,
-          @builtin(global_invocation_id) GlobalId : vec3<u32>,
-          @builtin(num_workgroups) NumWorkgroups: vec3<u32>,
-          @builtin(workgroup_id) workgroupId: vec3<u32>) {
+  fn _start(@builtin(local_invocation_id) LocalId : vec3<u32>,
+            @builtin(global_invocation_id) GlobalId : vec3<u32>,
+            @builtin(num_workgroups) NumWorkgroups: vec3<u32>,
+            @builtin(workgroup_id) workgroupId: vec3<u32>) {
     localId = LocalId;
     globalId = GlobalId;
     numWorkgroups = NumWorkgroups;
@@ -309,10 +309,10 @@ export function makeMatMulPackedSource(
     const TileInner = ${tileInner};
 
     @compute @workgroup_size(workGroupSizeX, workGroupSizeY, workGroupSizeZ)
-    fn main(@builtin(local_invocation_id) LocalId : vec3<u32>,
-            @builtin(global_invocation_id) GlobalId : vec3<u32>,
-            @builtin(num_workgroups) NumWorkgroups: vec3<u32>,
-            @builtin(workgroup_id) workgroupId: vec3<u32>) {
+    fn _start(@builtin(local_invocation_id) LocalId : vec3<u32>,
+              @builtin(global_invocation_id) GlobalId : vec3<u32>,
+              @builtin(num_workgroups) NumWorkgroups: vec3<u32>,
+              @builtin(workgroup_id) workgroupId: vec3<u32>) {
       localId = LocalId;
       globalId = GlobalId;
       numWorkgroups = NumWorkgroups;
@@ -421,7 +421,7 @@ export function makeVectorMatrixProductSource(
     const TileSize = ${workGroupSize[0] * 4};
     var<workgroup> mm_Asub : array<vec4<f32>, ${workGroupSize[0]}>;
 
-    ${getMainHeaderString()}
+    ${main()} {
       let tileCol = i32(localId.x);
       let globalCol = i32(globalId.x);
       let globalRow = i32(globalId.y);

--- a/tfjs-backend-webgpu/src/matmul_reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_reduce_webgpu.ts
@@ -19,13 +19,13 @@ import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {activationFnSnippet} from './activation_util';
 import {matMulReadWriteFnSource} from './matmul_packed_webgpu';
-import {getMainHeaderString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch} from './webgpu_util';
 
 export function makeMatMulReduceSource(): string {
   return `
     var<workgroup> sumValues : array<f32, workGroupSizeX>;
-    ${getMainHeaderString()}
+    ${main()} {
       let coords = getOutputCoords();
       let batch = coords[0];
       let row = coords[1];

--- a/tfjs-backend-webgpu/src/matmul_small_output_size_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_small_output_size_webgpu.ts
@@ -18,7 +18,7 @@
 import {backend_util, TensorInfo} from '@tensorflow/tfjs-core';
 import {activationFnSnippet} from './activation_util';
 import {matMulReadWriteFnSource} from './matmul_packed_webgpu';
-import {getMainHeaderString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 
 export function makeMatMulSmallOutputSizeSource(
     workGroupSize: [number, number, number]): string {
@@ -35,7 +35,7 @@ export function makeMatMulSmallOutputSizeSource(
   // shared memory, so it is instruction-Level parallelism for arithmetic
   // operations and others handle IO operations between barrier api, makes ALU
   // and load/store units work simultaneously, could improves the performance.
-  ${getMainHeaderString()}
+  ${main()} {
     let tileRow = i32(localId.y);
     let tileCol = i32(localId.x);
     let globalRow = i32(globalId.y);

--- a/tfjs-backend-webgpu/src/matmul_splitK_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_splitK_webgpu.ts
@@ -19,7 +19,7 @@ import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {activationFnSnippet, biasActivationSnippet, typeSnippet} from './activation_util';
 import {makeMatMulPackedSource, makeMatMulPackedVec4Source, matMulReadFnSource} from './matmul_packed_webgpu';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class MatMulSplitKProgram implements WebGPUProgram {
@@ -167,7 +167,7 @@ export class BiasActivationProgram implements WebGPUProgram {
   getUserCode(): string {
     return `
     ${activationFnSnippet(this.activation, this.hasPreluActivationWeights)}
-    ${getMainHeaderAndGlobalIndexString()}
+    ${main('index')} {
       if (index < uniforms.size) {
         let coords = getCoordsFromIndex(index);
         var value = getXByOutputIndex(index);

--- a/tfjs-backend-webgpu/src/mirror_pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/mirror_pad_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getCoordsDataType, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class MirrorPadProgram implements WebGPUProgram {
@@ -66,7 +66,7 @@ export class MirrorPadProgram implements WebGPUProgram {
         'coords';
 
     return `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let start = ${dtype}(${start});
           let end = ${dtype}(${end});

--- a/tfjs-backend-webgpu/src/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pad_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getCoordsDataType, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class PadProgram implements WebGPUProgram {
@@ -63,7 +63,7 @@ export class PadProgram implements WebGPUProgram {
         'coords';
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let start = ${startValue};
           let end = ${endValue};

--- a/tfjs-backend-webgpu/src/pool2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pool2d_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class Pool2DProgram implements WebGPUProgram {
@@ -57,7 +57,7 @@ export class Pool2DProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
       if (index < uniforms.size) {
         let coords = getCoordsFromIndex(index);
           let batch = coords[0];

--- a/tfjs-backend-webgpu/src/pool_filtersizeone_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pool_filtersizeone_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
@@ -41,7 +41,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let coords = getCoordsFromIndex(index);
           let batch = coords[0];

--- a/tfjs-backend-webgpu/src/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/reduce_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {backend_util} from '@tensorflow/tfjs-core';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ReduceProgram implements WebGPUProgram {
@@ -90,7 +90,7 @@ export class ReduceProgram implements WebGPUProgram {
             'outputCoords[0]'} * uniforms.reduceSize;
           return offset;
        }
-       ${getMainHeaderAndGlobalIndexString()}
+       ${main('index')} {
          let outputIndex = index / i32(workGroupSizeX);
          let offset = getOffset(outputIndex);
          var bestValue = ${initValue};

--- a/tfjs-backend-webgpu/src/resize_bilinear_webgpu.ts
+++ b/tfjs-backend-webgpu/src/resize_bilinear_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ResizeBilinearProgram implements WebGPUProgram {
@@ -43,7 +43,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
         let coords = getCoordsFromIndex(index);
           let b = coords[0];

--- a/tfjs-backend-webgpu/src/resize_nearest_neighbor_webgpu.ts
+++ b/tfjs-backend-webgpu/src/resize_nearest_neighbor_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ResizeNearestNeighborProgram implements WebGPUProgram {
@@ -54,7 +54,7 @@ export class ResizeNearestNeighborProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let coords = getCoordsFromIndex(index);
           let b = coords[0];

--- a/tfjs-backend-webgpu/src/rotate_webgpu.ts
+++ b/tfjs-backend-webgpu/src/rotate_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class RotateProgram implements WebGPUProgram {
@@ -54,8 +54,7 @@ export class RotateProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-        ${getMainHeaderAndGlobalIndexString()}
-
+        ${main('index')} {
           if (index < uniforms.size) {
             let coords = getCoordsFromIndex(index);
             let coordXFloat = (f32(coords[2]) - uniforms.centerX) *

--- a/tfjs-backend-webgpu/src/scatter_webgpu.ts
+++ b/tfjs-backend-webgpu/src/scatter_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {DataType} from '@tensorflow/tfjs-core';
-import {getCoordsDataType, getMainHeaderAndGlobalIndexString, mapToWgslTypes, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getMainHeaderString as main, mapToWgslTypes, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class ScatterProgram implements WebGPUProgram {
@@ -121,8 +121,7 @@ export class ScatterProgram implements WebGPUProgram {
     const userCode = `
     ${getUpdatesCoordsFromFlatIndex}
 
-      ${getMainHeaderAndGlobalIndexString()}
-
+      ${main('index')} {
         if (index < uniforms.size) {
           let coords = getUpdatesCoordsFromFlatIndex(index);
           var flattenedIndex = 0;

--- a/tfjs-backend-webgpu/src/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/select_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class SelectProgram implements WebGPUProgram {
@@ -66,7 +66,7 @@ export class SelectProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let resRC = getCoordsFromIndex(index);
           let cVal = getC(${cCoords});

--- a/tfjs-backend-webgpu/src/slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/slice_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getCoordsDataType, getCoordsXYZ, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getCoordsXYZ, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class SliceProgram implements WebGPUProgram {
@@ -60,7 +60,7 @@ export class SliceProgram implements WebGPUProgram {
     }
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           var sourceLoc : ${dtype};
           let coords = getCoordsFromIndex(index);

--- a/tfjs-backend-webgpu/src/strided_slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/strided_slice_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getCoordsDataType, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class StridedSliceProgram implements WebGPUProgram {
@@ -62,7 +62,7 @@ export class StridedSliceProgram implements WebGPUProgram {
     }
 
     const userCode = `
-       ${getMainHeaderAndGlobalIndexString()}
+       ${main('index')} {
          if (index < uniforms.size) {
            let coords = getCoordsFromIndex(index);
            setOutputAtIndex(index, getX(${newCoords}));

--- a/tfjs-backend-webgpu/src/tile_webgpu.ts
+++ b/tfjs-backend-webgpu/src/tile_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class TileProgram implements WebGPUProgram {
@@ -45,7 +45,7 @@ export class TileProgram implements WebGPUProgram {
     const sourceCoords = getSourceCoords(this.rank, 'uniforms.');
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let resRC = getCoordsFromIndex(index);
           setOutputAtIndex(index, getA(${sourceCoords}));

--- a/tfjs-backend-webgpu/src/top_k_webgpu.ts
+++ b/tfjs-backend-webgpu/src/top_k_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 // Based on Algorithm 2 of Bitonic Top K, ref:
@@ -50,7 +50,7 @@ export class SwapProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-        ${getMainHeaderAndGlobalIndexString()}
+        ${main('index')} {
           if (index < uniforms.size) {
             let outC = getCoordsFromIndex(index);
             let batch = outC[0];
@@ -146,7 +146,7 @@ export class MergeProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const userCode = `
-        ${getMainHeaderAndGlobalIndexString()}
+        ${main('index')} {
           if (index < uniforms.size) {
             let outC = getCoordsFromIndex(index);
             let batch = outC[0];

--- a/tfjs-backend-webgpu/src/transform_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transform_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class TransformProgram implements WebGPUProgram {
@@ -101,7 +101,7 @@ export class TransformProgram implements WebGPUProgram {
             return outputValue;
           }
 
-          ${getMainHeaderAndGlobalIndexString()}
+          ${main('index')} {
             if (index < uniforms.size) {
               let coords = getCoordsFromIndex(index);
               var outputValue : f32;

--- a/tfjs-backend-webgpu/src/transpose_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transpose_shared_webgpu.ts
@@ -46,8 +46,8 @@ export class TransposeSharedProgram implements WebGPUProgram {
       var<workgroup> tile : array<array<f32, ${this.workGroupSize[0] + 1}>, ${
         this.workGroupSize[0]}>;
       ${getWorkGroupSizeString()}
-      fn main(@builtin(local_invocation_id) localId : vec3<u32>,
-              @builtin(workgroup_id) workgroupId : vec3<u32>) {
+      fn _start(@builtin(local_invocation_id) localId : vec3<u32>,
+                @builtin(workgroup_id) workgroupId : vec3<u32>) {
         var x = i32(workgroupId.x) * TILE_DIM + i32(localId.x);
         var y = i32(workgroupId.y) * TILE_DIM + i32(localId.y);
         let width = uniforms.outShape[0];

--- a/tfjs-backend-webgpu/src/transpose_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transpose_webgpu.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getCoordsDataType, getCoordsXYZ, getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getCoordsDataType, getCoordsXYZ, getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class TransposeProgram implements WebGPUProgram {
@@ -49,8 +49,7 @@ export class TransposeProgram implements WebGPUProgram {
     const switched = getSwitchedCoords(this.newDim);
 
     const userCode = `
-      ${getMainHeaderAndGlobalIndexString()}
-
+      ${main('index')} {
         for(var i = 0; i < ${this.workPerThread}; i = i + 1) {
           let flatIndex = index * ${this.workPerThread} + i;
           if(flatIndex < uniforms.size) {

--- a/tfjs-backend-webgpu/src/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/unary_op_webgpu.ts
@@ -16,7 +16,7 @@
  */
 
 import {getUnaryOpString, UnaryOpType} from './unary_op_util';
-import {getMainHeaderAndGlobalIndexString, WebGPUProgram} from './webgpu_program';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 import {computeDispatch, flatDispatchLayout} from './webgpu_util';
 
 export class UnaryOpProgram implements WebGPUProgram {
@@ -47,7 +47,7 @@ export class UnaryOpProgram implements WebGPUProgram {
       fn unaryOperation(a : f32) -> f32 {
         ${getUnaryOpString(this.op, false)}
       }
-      ${getMainHeaderAndGlobalIndexString()}
+      ${main('index')} {
         if (index < uniforms.size) {
           let a = getAByOutputIndex(index);
           setOutputAtIndex(index, unaryOperation(a));


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6764)
<!-- Reviewable:end -->
