### PR TITLE
[browserstack benchmark tool] Windows instances could not run WebGL backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,6 @@ e2e/integration_tests/convert_predict_data
 e2e/integration_tests/metadata
 e2e/scripts/storage
 e2e/scripts/htpasswd
-e2e/benchmarks/browserstack-benchmark/browsers.json
-e2e/benchmarks/browserstack-benchmark/benchmark_parameters.json
 e2e/benchmarks/browserstack-benchmark/benchmark_results.json
 e2e/benchmarks/browserstack-benchmark/benchmark_results.js
 e2e/benchmarks/browserstack-benchmark/benchmark_test_results.json

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_parameters.json
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_parameters.json
@@ -1,0 +1,5 @@
+{
+  "model": "MobileNetV3",
+  "numRuns": 10,
+  "backend": "webgl"
+}

--- a/e2e/benchmarks/browserstack-benchmark/browsers.json
+++ b/e2e/benchmarks/browserstack-benchmark/browsers.json
@@ -1,0 +1,10 @@
+{
+  "Windows_11_1": {
+    "base": "BrowserStack",
+    "browser": "chrome",
+    "browser_version": "103.0",
+    "os": "Windows",
+    "os_version": "11",
+    "device": null
+  }
+}


### PR DESCRIPTION
With changes in PR, running `yarn test --browserstack --browsers=Windows_11_1` will invoke a browserstack's win11 chrome103 instance to benchmark `MobileNetV3` on WebGL backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6768)
<!-- Reviewable:end -->
