### PR TITLE
Download error value for model debugging

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -171,11 +171,11 @@ limitations under the License.
       }
     }
 
-    async function predictAndGetPredictionData(predict, model, inferenceInput, debug, backend) {
+    async function predictAndGetPredictionData(predict, model, inferenceInput, debug) {
       const prediction = await predict(model, inferenceInput);
       let intermediateData = {};
       if (debug) {
-        intermediateData = await printTensors(model.getIntermediateTensors(), backend);
+        intermediateData = await getIntermediateTensorsData(model.getIntermediateTensors());
         model.disposeIntermediateTensors();
       }
       const predictionData = await getPredictionData(prediction);
@@ -232,7 +232,7 @@ limitations under the License.
           }
 
           const debug = keepIntermediateTensors & (benchmarks[state.benchmark].supportDebug !== false);
-          const referenceResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug, referenceBackend);
+          const referenceResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
           referenceData = referenceResult['data'];;
 
           await tf.setBackend(state.backend);
@@ -246,12 +246,12 @@ limitations under the License.
             tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY_FOR_GPU', true);
           }
 
-          const predictionResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug, state.backend);
+          const predictionResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
           predictionData = predictionResult['data'];;
           if (debug) {
-            const predictionJsonObject = predictionResult['intermediateData'];
-            const referenceJsonObject = referenceResult['intermediateData'];
-            compareJsons(predictionJsonObject, state.backend, referenceJsonObject, referenceBackend);
+            const predictionIntermediateObject = predictionResult['intermediateData'];
+            const referenceIntermediateObject = referenceResult['intermediateData'];
+            compareAndDownloadErrorValue(predictionIntermediateObject, state.backend, referenceIntermediateObject, referenceBackend);
           }
           if (state.backend === 'webgl' || state.backend === 'webgpu') {
             tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY_FOR_GPU', savedWillReadFrequently);

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -233,7 +233,7 @@ limitations under the License.
 
           const debug = keepIntermediateTensors & (benchmarks[state.benchmark].supportDebug !== false);
           const referenceResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
-          referenceData = referenceResult['data'];;
+          referenceData = referenceResult['data'];
 
           await tf.setBackend(state.backend);
           await showMsg(`Runing on ${state.backend}`);
@@ -247,11 +247,13 @@ limitations under the License.
           }
 
           const predictionResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
-          predictionData = predictionResult['data'];;
+          predictionData = predictionResult['data'];
           if (debug) {
             const predictionIntermediateObject = predictionResult['intermediateData'];
             const referenceIntermediateObject = referenceResult['intermediateData'];
-            compareAndDownloadErrorValue(predictionIntermediateObject, state.backend, referenceIntermediateObject, referenceBackend);
+            const hasIntermediateIndex = urlState && urlState.has('intermediateIndex');
+            const intermediateIndex = hasIntermediateIndex ? urlState.get('intermediateIndex') : "0-9";
+            downloadIntermediateTensors(predictionIntermediateObject, state.backend, referenceIntermediateObject, referenceBackend, state.benchmark, intermediateIndex);
           }
           if (state.backend === 'webgl' || state.backend === 'webgpu') {
             tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY_FOR_GPU', savedWillReadFrequently);

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -171,27 +171,15 @@ limitations under the License.
       }
     }
 
-    async function printTensors(tensorsMap) {
-      if (!tensorsMap) {
-        return;
-      }
-      const keysOfTensors = Object.keys(tensorsMap);
-      for (let i = 0; i < keysOfTensors.length; i++) {
-        console.warn(keysOfTensors[i]);
-        for (let j = 0; j < tensorsMap[keysOfTensors[i]].length; j++) {
-          console.warn(await (tensorsMap[keysOfTensors[i]][j]).data());
-        }
-      }
-    }
-
-    async function predictAndGetPredictionData(predict, model, inferenceInput, debug) {
+    async function predictAndGetPredictionData(predict, model, inferenceInput, debug, backend) {
       const prediction = await predict(model, inferenceInput);
+      let intermediateData = {};
       if (debug) {
-        await printTensors(model.getIntermediateTensors());
+        intermediateData = await printTensors(model.getIntermediateTensors(), backend);
         model.disposeIntermediateTensors();
       }
       const predictionData = await getPredictionData(prediction);
-      return predictionData;
+      return {data: predictionData, intermediateData};
     }
 
     const state = {
@@ -222,14 +210,15 @@ limitations under the License.
 
         // load model and run inference
         try {
-          tf.setBackend('cpu');
+          const referenceBackend = 'cpu';
+          tf.setBackend(referenceBackend);
           await loadModelAndRecordTime();
           await showMsg('Testing correctness');
           await showInputs();
           await showCorrectnessTestParameters();
 
           let inferenceInput;
-          await showMsg('Runing on cpu');
+          await showMsg(`Runing on ${referenceBackend}`);
           if (state.benchmark === 'custom') {
             inferenceInput = generateInputFromDef(
               state.inputs, model instanceof tf.GraphModel);
@@ -243,7 +232,8 @@ limitations under the License.
           }
 
           const debug = keepIntermediateTensors & (benchmarks[state.benchmark].supportDebug !== false);
-          referenceData = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
+          const referenceResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug, referenceBackend);
+          referenceData = referenceResult['data'];;
 
           await tf.setBackend(state.backend);
           await showMsg(`Runing on ${state.backend}`);
@@ -256,8 +246,13 @@ limitations under the License.
             tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY_FOR_GPU', true);
           }
 
-          predictionData = await predictAndGetPredictionData(predict, model, inferenceInput, debug);
-
+          const predictionResult = await predictAndGetPredictionData(predict, model, inferenceInput, debug, state.backend);
+          predictionData = predictionResult['data'];;
+          if (debug) {
+            const predictionJsonObject = predictionResult['intermediateData'];
+            const referenceJsonObject = referenceResult['intermediateData'];
+            compareJsons(predictionJsonObject, state.backend, referenceJsonObject, referenceBackend);
+          }
           if (state.backend === 'webgl' || state.backend === 'webgpu') {
             tf.env().set('CANVAS2D_WILL_READ_FREQUENTLY_FOR_GPU', savedWillReadFrequently);
           }

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -51,7 +51,7 @@ const TUNABLE_FLAG_NAME_MAP = {
   WEBGL_PACK_DEPTHWISECONV: 'Packed depthwise Conv2d',
   WEBGL_USE_SHAPES_UNIFORMS: 'Use shapes uniforms',
   CHECK_COMPUTATION_FOR_ERRORS: 'Check each op result',
-  KEEP_INTERMEDIATE_TENSORS: 'Print intermediate tensors',
+  KEEP_INTERMEDIATE_TENSORS: 'Download tensors',
 };
 if (tf.engine().backendNames().includes('webgpu')) {
   TUNABLE_FLAG_NAME_MAP['WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE'] =

--- a/e2e/benchmarks/local-benchmark/util.js
+++ b/e2e/benchmarks/local-benchmark/util.js
@@ -190,9 +190,9 @@ function parseIntermediateIndex(intermediateIndexStr, maxIndex) {
       const end = Number(value[1]);
       const arrayLength = end - start + 1;
       const subArray = Array.from({length: arrayLength}, (v, i) => i + start);
-      flatArray = [...flatArray, ...subArray];
+      flatArray.push(...subArray);
     } else if (value.length == 1) {
-      flatArray = [...flatArray, ...[Number(value)]];
+      flatArray.push(Number(value));
     } else {
       throw new Error(`${intermediateIndexStr} is not supported!`);
     }

--- a/e2e/benchmarks/local-benchmark/util.js
+++ b/e2e/benchmarks/local-benchmark/util.js
@@ -176,7 +176,8 @@ function expectArraysClose(actual, expected, epsilon, key) {
   }
 }
 
-async function compareJsons(jsonObject1, backend1, jsonObject2, backend2) {
+async function compareAndDownloadErrorValue(
+    jsonObject1, backend1, jsonObject2, backend2) {
   const keys = Object.keys(jsonObject1);
   var errorCount = 0;
   for (let i = 0; i < keys.length; i++) {
@@ -200,7 +201,7 @@ async function compareJsons(jsonObject1, backend1, jsonObject2, backend2) {
   }
 }
 
-async function printTensors(tensorsMap, backend) {
+async function getIntermediateTensorsData(tensorsMap) {
   if (!tensorsMap) {
     return;
   }
@@ -209,11 +210,9 @@ async function printTensors(tensorsMap, backend) {
   for (let i = 0; i < keysOfTensors.length; i++) {
     const key = keysOfTensors[i];
     const dataArray = [];
-    const dataLengthArray = [];
     for (let j = 0; j < tensorsMap[key].length; j++) {
       const data = await (tensorsMap[key][j]).data();
       dataArray.push(data);
-      dataLengthArray.push(data.length);
     }
     jsonObject[key] = dataArray;
   }


### PR DESCRIPTION
For model with too many nodes, such as benchmark=FaceLandmarkDetection&architecture=attention_mesh, debug mode may possibly print very long logs in console. This is too hard to investigate the difference between reference and prediction.

Instead of printing logs in console,  this change downloads the logs into json file. This will simplify the model debugging. 

This change also adds a new url parameter intermediateIndex, this parameter can be used to control which intermediate tensors to be downloaded. For example, below parameter will download intermediate tensor of index: from 0 to 3, 9, from 10 to 100.
```
intermediateIndex=0-3,9,10-100
```

To download all:
```
intermediateIndex=-1
```

Default download 0-9:
```
intermediateIndex=0-9
```


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6770)
<!-- Reviewable:end -->
