### PR TITLE
[WebGL backend] Add a flag to enable Software WebGL

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
@@ -118,6 +118,7 @@ describe('BrowserStack benchmark', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
     const response = await fetch(`${KARMA_SERVER}/benchmark_parameters.json`);
     benchmarkParameters = await response.json();
+    tf.env().set('SOFTWARE_WEBGL_ENABLED', true);
   });
 
   it(`benchmark`, async () => {

--- a/tfjs-backend-webgl/src/canvas_util.ts
+++ b/tfjs-backend-webgl/src/canvas_util.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {env} from '@tensorflow/tfjs-core';
+
 const contexts: {[key: string]: WebGLRenderingContext} = {};
 
 const WEBGL_ATTRIBUTES: WebGLContextAttributes = {
@@ -90,6 +92,11 @@ function getWebGLRenderingContext(
     ev.preventDefault();
     delete contexts[webGLVersion];
   }, false);
+
+  if (env().getBool('SOFTWARE_WEBGL_ENABLED')) {
+    WEBGL_ATTRIBUTES.failIfMajorPerformanceCaveat = false;
+  }
+
   if (webGLVersion === 1) {
     return (canvas.getContext('webgl', WEBGL_ATTRIBUTES) ||
             canvas.getContext('experimental-webgl', WEBGL_ATTRIBUTES)) as

--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -240,3 +240,9 @@ ENV.registerFlag('TOPK_K_CPU_HANDOFF_THRESHOLD', () => 128);
 
 /** Whether we will use the experimental conv op. */
 ENV.registerFlag('WEBGL_EXP_CONV', () => false);
+
+/**
+ * If the device performance is low or if no hardware GPU is available, whether
+ * software WebGL will be used.
+ */
+ENV.registerFlag('SOFTWARE_WEBGL_ENABLED', () => ENV.getBool('IS_TEST'));


### PR DESCRIPTION
Previously, if the device does not have hardware GPU (even though it provides software webgl), it will disable webgl backend.

Example: for this case, WebGL backend will be disabled.
![image](https://user-images.githubusercontent.com/40653845/185701059-f68e6a5d-85b8-4b34-980e-bfbebd2c46b8.png)

This works for our users, but we want to run tests and benchmarks on WebGL backend, even if the devices only have software WebGL only (BrowserStack's windows devices). Then this PR adds a flag to disable/enable software WebGL to make it flexible.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext (search for `failIfMajorPerformanceCaveat `)

Fix https://github.com/tensorflow/tfjs/issues/6769.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6772)
<!-- Reviewable:end -->
