### PR TITLE
webgpu: Tune the condition of Conv2DDerInputProgram

### DIFF
--- a/tfjs-backend-webgpu/src/conv_backprop_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv_backprop_webgpu.ts
@@ -51,7 +51,7 @@ export class Conv2DDerInputProgram implements WebGPUProgram {
         let batch = coords[0];
         let d1 = coords[${channelDim}];
 
-        let dyCorner = vec2<i32>(coords[${rowDim}]), coords[${
+        let dyCorner = vec2<i32>(coords[${rowDim}], coords[${
         colDim}]) - uniforms.pads;
         let dyRCorner = dyCorner.x;
         let dyCCorner = dyCorner.y;
@@ -66,7 +66,7 @@ export class Conv2DDerInputProgram implements WebGPUProgram {
               wRPerm < 0) {
             continue;
           }
-          let idyR = dyR;
+          let idyR = i32(dyR);
 
           for (var wC = 0; wC < uniforms.filterDims.y; wC = wC + 1) {
             let dyC = (f32(dyCCorner) + f32(wC)) / f32(uniforms.stride.y);
@@ -75,7 +75,7 @@ export class Conv2DDerInputProgram implements WebGPUProgram {
                 fract(dyC) > 0.0 || wCPerm < 0) {
               continue;
             }
-            let idyC = dyC;
+            let idyC = i32(dyC);
 
             for (var d2 = 0; d2 < uniforms.outBackprop[3]; d2 = d2 + 1) {
               if (${this.isChannelsLast}) {

--- a/tfjs-backend-webgpu/src/kernels/Conv2DBackpropInput.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv2DBackpropInput.ts
@@ -57,9 +57,7 @@ export function conv2DBackpropInput(args: {
   if (env().getBool('WEBGPU_USE_NAIVE_CONV2D_TRANSPOSE') ||
       convInfo.inChannels < 32 && convInfo.outChannels < 32) {
     // When inChannels and outChannels are both less than 32,
-    // Conv2DDerInputProgram is much faster than Conv2DDerInputMMProgram. The
-    // most likely reason is that in such situation, the EU utilization in
-    // Conv2DDerInputMMProgram is too low.
+    // Conv2DDerInputProgram is much faster than Conv2DDerInputMMProgram.
     program = new Conv2DDerInputProgram(convInfo);
   } else {
     program = new Conv2DDerInputMMProgram(convInfo);

--- a/tfjs-backend-webgpu/src/kernels/Conv2DBackpropInput.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv2DBackpropInput.ts
@@ -58,7 +58,7 @@ export function conv2DBackpropInput(args: {
       convInfo.inChannels < 32 && convInfo.outChannels < 32) {
     // When inChannels and outChannels are both less than 32,
     // Conv2DDerInputProgram is much faster than Conv2DDerInputMMProgram. The
-    // most likely reason is that in such situation, the UE utilization in
+    // most likely reason is that in such situation, the EU utilization in
     // Conv2DDerInputMMProgram is too low.
     program = new Conv2DDerInputProgram(convInfo);
   } else {

--- a/tfjs-backend-webgpu/src/kernels/Conv2DBackpropInput.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv2DBackpropInput.ts
@@ -54,8 +54,12 @@ export function conv2DBackpropInput(args: {
     },
   ];
   let program: Conv2DDerInputProgram|Conv2DDerInputMMProgram;
-  if (env().getBool('WEBGPU_USE_NAIVE_CONV2D_TRANSPOSE')) {
-    // Keep Conv2DDerInputProgram for reference.
+  if (env().getBool('WEBGPU_USE_NAIVE_CONV2D_TRANSPOSE') ||
+      convInfo.inChannels < 32 && convInfo.outChannels < 32) {
+    // When inChannels and outChannels are both less than 32,
+    // Conv2DDerInputProgram is much faster than Conv2DDerInputMMProgram. The
+    // most likely reason is that in such situation, the UE utilization in
+    // Conv2DDerInputMMProgram is too low.
     program = new Conv2DDerInputProgram(convInfo);
   } else {
     program = new Conv2DDerInputMMProgram(convInfo);


### PR DESCRIPTION
With this change, Conv2DBackpropInput with inputs [1, 128, 128, 16],
[2, 2, 1, 16] in SelfieSegmentation-General becomes 0.53ms from 2.25ms.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6790)
<!-- Reviewable:end -->
