### PR TITLE
[webgpu] Remove 'yarn --cwd' from publish script

### DIFF
--- a/tfjs-backend-webgpu/package.json
+++ b/tfjs-backend-webgpu/package.json
@@ -15,7 +15,7 @@
     "bundle": "yarn build",
     "bundle-ci": "yarn bundle",
     "build-npm": "yarn build",
-    "publish-npm": "yarn --cwd .. bazel run tfjs-backend-webgpu:tfjs-backend-webgpu_pkg.publish",
+    "publish-npm": "bazel run //tfjs-backend-webgpu:tfjs-backend-webgpu_pkg.publish",
     "test": "yarn --cwd .. bazel test tfjs-backend-webgpu:tfjs-backend-webgpu_test --test_output=streamed",
     "test-dev": "yarn --cwd .. bazel run tfjs-backend-webgpu:tfjs-backend-webgpu_test --test_output=streamed"
   },


### PR DESCRIPTION
Some scripts call `yarn` multiple times. Each additional time `yarn` is nested, an additional `--` needs to be passed before arguments can be passed (since we're using yarn 1). Other packages' publishing scripts require two instances of `--`, and this is [what the publish-npm script assumes](https://github.com/tensorflow/tfjs/blob/master/scripts/publish-npm.ts#L132).

tfjs-backend-webgpu uses an additional call to yarn to change directory to the root of the monorepo, so it requires three instances of `--` before `--otp=######` can be passed during publishing.

This PR removes the extra call to yarn and instead uses the full name of the Bazel target, `//tfjs-backend-webgpu:tfjs-backend-webgpu_pkg.publish`. This should not affect the published artifacts since Bazel always creates a separate output tree for them anyway.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.