### PR TITLE
webgpu: Avoid invalid const expression

### DIFF
--- a/tfjs-backend-webgpu/src/unary_op_util.ts
+++ b/tfjs-backend-webgpu/src/unary_op_util.ts
@@ -72,7 +72,7 @@ const EXP = `return exp(a);`;
 const FLOOR = `return floor(a);`;
 const IS_NAN = `return f32(isnan(a));`;
 const LINEAR = `return a;`;
-const LOG = `if (a < 0.0) { return 1.0/0.0; }
+const LOG = `if (a < 0.0) { return uniforms.NAN; }
   return log(a);`;
 const LOGICAL_NOT = `return f32(!(a >= 1.0));`;
 const NEG = `return -a;`;


### PR DESCRIPTION
WebGPU just changed the spec and invalid const expression is no longer allowed.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6831)
<!-- Reviewable:end -->
