### PR TITLE
webgpu: Fix wgsl failure from MatMulSplitKProgram

### DIFF
--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -629,11 +629,10 @@ function getOutputCoordsSnippet(
   const {x, y = [], z = []} = dispatchLayout;
 
   const outRank = outShape.length;
-  const dims = [x, y, z];
-  const rank = dims[0].length + dims[1].length + dims[2].length;
+  const rank = x.length + y.length + z.length;
+  // getOutputCoords is only meaningful when the output rank is same with
+  // dispatch layout rank.
   if (rank !== outRank) {
-    // getOutputCoords is only meaningful when the output rank is same with
-    // dispatch layout rank.
     return '';
   }
 
@@ -648,6 +647,8 @@ function getOutputCoordsSnippet(
   }
 
   let gatherDimensionsStr = '';
+  const dims = [x, y, z];
+
   for (let i = 0; i < dims.length; i++) {
     const arr = dims[i];
 

--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -630,7 +630,7 @@ function getOutputCoordsSnippet(
 
   const outRank = outShape.length;
   const dims = [x, y, z];
-  let rank = dims[0].length + dims[1].length + dims[2].length;
+  const rank = dims[0].length + dims[1].length + dims[2].length;
   if (rank !== outRank) {
     // getOutputCoords is only meaningful when the output rank is same with
     // dispatch layout rank.

--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -629,6 +629,14 @@ function getOutputCoordsSnippet(
   const {x, y = [], z = []} = dispatchLayout;
 
   const outRank = outShape.length;
+  const dims = [x, y, z];
+  let rank = dims[0].length + dims[1].length + dims[2].length;
+  if (rank !== outRank) {
+    // getOutputCoords is only meaningful when the output rank is same with
+    // dispatch layout rank.
+    return '';
+  }
+
   if (x.length === outRank) {
     const dtype = getCoordsDataType(outRank);
     const snippet = `fn getOutputCoords() -> ${dtype}{
@@ -640,18 +648,12 @@ function getOutputCoordsSnippet(
   }
 
   let gatherDimensionsStr = '';
-  const dims = [x, y, z];
-
-  let rank = 0;
-
   for (let i = 0; i < dims.length; i++) {
     const arr = dims[i];
 
     if (arr.length === 0) {
       continue;
     }
-
-    rank += arr.length;
 
     if (arr.length === 1) {
       gatherDimensionsStr += `let d${arr[0]} = i32(globalId[${i}]);`;


### PR DESCRIPTION
Fix that Tint WGSL reader failure: index 3 out of bounds [0..2] in MatMulSplitKProgram.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6838)
<!-- Reviewable:end -->
