### PR TITLE
Avoid testing webgl1 in webgl2 layers test

### DIFF
--- a/tfjs-layers/src/BUILD.bazel
+++ b/tfjs-layers/src/BUILD.bazel
@@ -78,9 +78,7 @@ ts_library(
 
 ts_library(
     name = "tfjs-layers_test_lib",
-    # disable testonly for the issue in the nodejs build target.
-    # https://github.com/bazelbuild/rules_nodejs/pull/2984
-    #testonly = True,
+    testonly = True,
     srcs = glob(TEST_SRCS) + [":tests"],
     module_name = "@tensorflow/tfjs-layers/dist",
     deps = [

--- a/tfjs-layers/src/setup_tests.ts
+++ b/tfjs-layers/src/setup_tests.ts
@@ -28,7 +28,8 @@ import '@tensorflow/tfjs-backend-webgl';
 // tslint:disable-next-line: no-imports-from-dist
 import {parseTestEnvFromKarmaFlags, registerTestEnv, setTestEnvs, TEST_ENVS} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
-registerTestEnv({
+// Register test environments.
+const webgl1TestEnv = {
   name: 'webgl1',
   backendName: 'webgl',
   flags: {
@@ -37,6 +38,17 @@ registerTestEnv({
     'WEBGL_SIZE_UPLOAD_UNIFORM': 0
   },
   isDataSync: true
+};
+registerTestEnv(webgl1TestEnv);
+registerTestEnv({name: 'cpu', backendName: 'cpu'});
+registerTestEnv({
+  name: 'webgl2',
+  backendName: 'webgl',
+  flags: {
+    'WEBGL_VERSION': 2,
+    'WEBGL_CPU_FORWARD': false,
+    'WEBGL_SIZE_UPLOAD_UNIFORM': 0
+  }
 });
 
 // Allow flags to override test envs
@@ -44,8 +56,13 @@ registerTestEnv({
 declare let __karma__: any;
 if (typeof __karma__ !== 'undefined') {
   const testEnv = parseTestEnvFromKarmaFlags(__karma__.config.args, TEST_ENVS);
+
   if (testEnv != null) {
     setTestEnvs([testEnv]);
+  } else {
+    // Exclude webgl1 unless it is specifically requested because it causes
+    // test flakiness when switching between webgl1 and webgl2.
+    setTestEnvs(TEST_ENVS.filter(env => env !== webgl1TestEnv));
   }
 }
 

--- a/tfjs-layers/src/utils/test_utils.ts
+++ b/tfjs-layers/src/utils/test_utils.ts
@@ -14,21 +14,9 @@
 
 import {memory, Tensor, test_util, util} from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
-import {ALL_ENVS, describeWithFlags, registerTestEnv} from '@tensorflow/tfjs-core/dist/jasmine_util';
+import {ALL_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
 import {ValueError} from '../errors';
-
-// Register backends.
-registerTestEnv({name: 'cpu', backendName: 'cpu'});
-registerTestEnv({
-  name: 'webgl2',
-  backendName: 'webgl',
-  flags: {
-    'WEBGL_VERSION': 2,
-    'WEBGL_CPU_FORWARD': false,
-    'WEBGL_SIZE_UPLOAD_UNIFORM': 0
-  }
-});
 
 /**
  * Expect values are close between a Tensor or number array.


### PR DESCRIPTION
webgl1 was accidentally being tested in webgl2 layers tests. This seems to have been a cause of layers flakiness. Test failures seemed to happen when switching from webgl1 to webgl2.

This PR prevents the webgl1 test env from being used in tfjs-layers unless it is explicitly requested (such as by running `//tfjs-layers:tfjs-layers_webgl1_test`).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6849)
<!-- Reviewable:end -->
