### PR TITLE
Use more strict permissions on benchmark deploy workflow

### DIFF
--- a/.github/workflows/deploy-benchmark-preview.yml
+++ b/.github/workflows/deploy-benchmark-preview.yml
@@ -5,8 +5,13 @@ on:
     paths:
     - "e2e/benchmarks/**"
 
+permissions:
+  contents: read
+
 jobs:
   build_and_preview:
+    permissions:
+      pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Grant only read permission by default and selectively add write permission only where necessary to the Firebase benchmark preview site workflow. See more details in #6814.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6852)
<!-- Reviewable:end -->
