### PR TITLE
Upgrade Windows BrowserStack Chrome to 104

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -61,7 +61,7 @@ const CUSTOM_LAUNCHERS = {
   win_10_chrome: {
     base: 'BrowserStack',
     browser: 'chrome',
-    browser_version: '101.0',
+    browser_version: '104.0',
     os: 'Windows',
     os_version: '10'
   },


### PR DESCRIPTION
Upgrade Windows Chrome to version 104 on BrowserStack. Fixes the tfjs-tflite worker test:

```
bazel test //tfjs-tflite/src:win_10_chrome_worker_test
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6866)
<!-- Reviewable:end -->
