### PR TITLE
webgpu: Disable importExternalTexture

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -64,8 +64,10 @@ export function fromPixels(args: {
       [pixels.width, pixels.height];
   const outputShape = [height, width, numChannels];
 
+  // Disable importExternalTexture temporarily as it has problem in spec and
+  // browser impl
   const importVideo =
-      env().getBool('WEBGPU_IMPORT_EXTERNAL_TEXTURE') && isVideo;
+      false && env().getBool('WEBGPU_IMPORT_EXTERNAL_TEXTURE') && isVideo;
   const isVideoOrImage = isVideo || isImage;
   if (isImageBitmap || isCanvas || isVideoOrImage) {
     let textureInfo: TextureInfo;


### PR DESCRIPTION
WebGPU Working Group recently found some problem with importExtenalTexture in spec, so we have to disable it temporarily.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6868)
<!-- Reviewable:end -->
