### PR TITLE
Set IS_TEST before evaluate env constraints for testing

### DIFF
--- a/tfjs-core/src/jasmine_util.ts
+++ b/tfjs-core/src/jasmine_util.ts
@@ -217,6 +217,7 @@ export function describeWithFlags(
 
   TEST_ENVS.forEach(testEnv => {
     env().setFlags(testEnv.flags);
+    env().set('IS_TEST', true);
     if (envSatisfiesConstraints(env(), testEnv, constraints)) {
       const testName =
           name + ' ' + testEnv.name + ' ' + JSON.stringify(testEnv.flags || {});


### PR DESCRIPTION
Since `IS_TEST` is set true in all `describe(...)`, which means `IS_TEST` is always supposed to be true when testing, we want to keep `IS_TEST` as true as well when evaluating env constraints for testing: https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/jasmine_util.ts#L262-L265

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6872)
<!-- Reviewable:end -->
