### PR TITLE
Use a predetermined seed for tfjs-layers tests

### DIFF
--- a/tfjs-layers/BUILD.bazel
+++ b/tfjs-layers/BUILD.bazel
@@ -57,6 +57,7 @@ tfjs_web_test(
         "win_10_chrome",
     ],
     headless = False,
+    seed = "12345",
     static_files = [
         # Listed here so sourcemaps are served
         "//tfjs-layers/src:tfjs-layers_test_bundle",
@@ -77,6 +78,7 @@ tfjs_web_test(
         "bs_ios_12",
     ],
     headless = False,
+    seed = "12345",
     static_files = [
         # Listed here so sourcemaps are served
         "//tfjs-layers/src:tfjs-layers_test_bundle",

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -153,6 +153,12 @@ module.exports = function(config) {
     browserSocketTimeout: 1.2e5,
     ...extraConfig,
     customLaunchers: CUSTOM_LAUNCHERS,
-    client: {args: TEMPLATE_args},
+    client: {
+      args: TEMPLATE_args,
+      jasmine: {
+        random: TEMPLATE_jasmine_random,
+        seed: "TEMPLATE_jasmine_seed",
+      },
+    },
   });
 }

--- a/tools/tfjs_web_test.bzl
+++ b/tools/tfjs_web_test.bzl
@@ -74,17 +74,17 @@ _make_karma_config = rule(
             default = "",
             doc = "The browser to run",
         ),
-        "template": attr.label(
-            default = Label("@//tools:karma_template.conf.js"),
-            allow_single_file = True,
-            doc = "The karma config template to expand",
-        ),
         "seed": attr.string(
             default = "",
             doc = """Use this seed for test order.
 
             If not specified or empty, use a random seed every time.
             """,
+        ),
+        "template": attr.label(
+            default = Label("@//tools:karma_template.conf.js"),
+            allow_single_file = True,
+            doc = "The karma config template to expand",
         ),
         "_grep": attr.label(default = "@//:grep"),
     },


### PR DESCRIPTION
Run tfjs-layers tests in a static, non-random order. This is a temporary fix for #6543.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6878)
<!-- Reviewable:end -->
