### PR TITLE
Do not log bazel test output in cloudbuild

### DIFF
--- a/scripts/run_bazel_ci_tests.sh
+++ b/scripts/run_bazel_ci_tests.sh
@@ -25,4 +25,4 @@ else
   TARGETS=`./node_modules/.bin/bazel query --output label 'attr("tags", "ci", ...)'`
 fi
 
-yarn bazel test --config=ci --flaky_test_attempts=3 --test_output=all --local_test_jobs=25 $TARGETS
+yarn bazel test --config=ci --flaky_test_attempts=3 --local_test_jobs=25 $TARGETS


### PR DESCRIPTION
Bazel test output is already logged in the results UI. Logging it in cloudbuild makes the log very long (> 5MB) which then truncates the rest of the logs.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6897)
<!-- Reviewable:end -->
