### PR TITLE
Increase cloudbuild.yml timeout to 2 hours

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   env: ['NIGHTLY=$_NIGHTLY']
 
 # General settings.
-timeout: 3600s
+timeout: 7200s
 logsBucket: 'gs://tfjs-build-logs'
 options:
   logStreamingOption: 'STREAM_ON'


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6902)
<!-- Reviewable:end -->
