### PR TITLE
[Benchmark] Add GPU hardware info to the benchmark tools

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -583,11 +583,12 @@ async function getRendererInfo() {
   try {
     let webglBackend = tf.findBackend('webgl');
     if (webglBackend == null) {
-      await tf.setBackend('webgl');
+      if (!(await tf.setBackend('webgl'))) {
+        throw new Error('Failed to initialize WebGL backend.');
+      }
       webglBackend = tf.backend();
     }
-
-    const gl = tf.backend().gpgpu.gl;
+    const gl = webglBackend.gpgpu.gl;
     const dbgRenderInfo = gl.getExtension('WEBGL_debug_renderer_info');
     webglRenderer = gl.getParameter(dbgRenderInfo.UNMASKED_RENDERER_WEBGL);
   } catch (e) {

--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -573,3 +573,26 @@ async function resetBackend(backendName) {
 
   return true;
 }
+
+/**
+ * Get the renderer info from the WebGL backend.
+ */
+async function getRendererInfo() {
+  const curBackendName = tf.getBackend();
+  let webglRenderer;
+  try {
+    let webglBackend = tf.findBackend('webgl');
+    if (webglBackend == null) {
+      await tf.setBackend('webgl');
+      webglBackend = tf.backend();
+    }
+
+    const gl = tf.backend().gpgpu.gl;
+    const dbgRenderInfo = gl.getExtension('WEBGL_debug_renderer_info');
+    webglRenderer = gl.getParameter(dbgRenderInfo.UNMASKED_RENDERER_WEBGL);
+  } catch (e) {
+    webglRenderer = 'NA';
+  }
+  await tf.setBackend(curBackendName);
+  return webglRenderer;
+}

--- a/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
+++ b/e2e/benchmarks/browserstack-benchmark/benchmark_models.js
@@ -85,8 +85,7 @@ async function benchmarkModel(benchmarkParameters) {
     memoryInfo = await profileModelInference(model, input);
   }
 
-  return `<tfjs_benchmark>${
-      JSON.stringify({timeInfo, memoryInfo})}</tfjs_benchmark>`;
+  return {timeInfo, memoryInfo};
 }
 
 async function benchmarkCodeSnippet(benchmarkParameters) {
@@ -108,8 +107,7 @@ async function benchmarkCodeSnippet(benchmarkParameters) {
   timeInfo = await timeInference(predict, benchmarkParameters.numRuns);
   memoryInfo = await profileInference(predict);
 
-  return `<tfjs_benchmark>${
-      JSON.stringify({timeInfo, memoryInfo})}</tfjs_benchmark>`;
+  return {timeInfo, memoryInfo};
 }
 
 describe('BrowserStack benchmark', () => {
@@ -124,18 +122,24 @@ describe('BrowserStack benchmark', () => {
   it(`benchmark`, async () => {
     try {
       // Setup benchmark environments.
-      await tf.setBackend(benchmarkParameters.backend);
+      const targetBackend = benchmarkParameters.backend;
+      await tf.setBackend(targetBackend);
 
       // Run benchmark and stringify results.
-      let resultStr;
+      let resultObj;
       if (benchmarkParameters.model === 'codeSnippet') {
-        resultStr = await benchmarkCodeSnippet(benchmarkParameters);
+        resultObj = await benchmarkCodeSnippet(benchmarkParameters);
       } else {
-        resultStr = await benchmarkModel(benchmarkParameters);
+        resultObj = await benchmarkModel(benchmarkParameters);
       }
 
+      // Get GPU hardware info.
+      resultObj.gpuInfo =
+          targetBackend === 'webgl' ? (await getRendererInfo()) : 'MISS';
+
       // Report results.
-      console.log(resultStr);
+      console.log(
+          `<tfjs_benchmark>${JSON.stringify(resultObj)}</tfjs_benchmark>`);
     } catch (error) {
       console.log(`<tfjs_error>${error}</tfjs_error>`);
     }

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -215,6 +215,7 @@ limitations under the License.
           envDiv.innerHTML = '';
           showVersions();
           await showEnvironment();
+          await showGpuInfo();
         }
 
         let match, predictionData, referenceData;
@@ -321,6 +322,11 @@ limitations under the License.
         layers: tf.version_layers,
         converter: tf.version_converter
       }, null, 2);
+    }
+
+    async function showGpuInfo() {
+      const gpuHardwareInfo = await getRendererInfo();
+      envDiv.innerHTML += `<br>{<br>  GPU info: \n  ${gpuHardwareInfo}<br>}<br>`;
     }
 
     async function showEnvironment() {
@@ -739,6 +745,7 @@ limitations under the License.
         envDiv.innerHTML = '';
         showVersions();
         await showEnvironment();
+        await showGpuInfo();
         if (!canProceed) {
           return;
         }
@@ -978,6 +985,7 @@ limitations under the License.
       tunableFlagsControllers = await showFlagSettingsAndReturnTunableFlagControllers(envFolder, state.backend);
       showVersions();
       await showEnvironment();
+      await showGpuInfo();
       updateGUIFromURLState();
     }
 


### PR DESCRIPTION
Through the following code snippet, we could get the GPU info, so we want to attach this info to the local benchmark tool's page and the browserstack benchmark tool's results.
```js
const gl = tf.backend().gpgpu.gl;
const dbgRenderInfo = gl.getExtension('WEBGL_debug_renderer_info');
const webglRenderer = gl.getParameter(dbgRenderInfo.UNMASKED_RENDERER_WEBGL);
```

On Mac pro:
![image](https://user-images.githubusercontent.com/40653845/194191323-71407329-76a3-4f8a-834e-b60d6a06a927.png)


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6907)
<!-- Reviewable:end -->
