### PR TITLE
Use VAOs for save+restore of vertexAttribPointer state between different webgl programs.

### DIFF
--- a/tfjs-backend-webgl/src/gpgpu_context.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context.ts
@@ -69,7 +69,7 @@ export class GPGPUContext {
     }
     gl = this.gl;
 
-    if (gl instanceof WebGL2RenderingContext) {
+    if (env().getNumber('WEBGL_VERSION') === 2) {
       const gl2: WebGL2RenderingContext = gl;
       this.createVertexArray = () => {
         return webgl_util.callAndCheck(gl2,

--- a/tfjs-backend-webgl/src/gpgpu_context.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context.ts
@@ -70,7 +70,7 @@ export class GPGPUContext {
     gl = this.gl;
 
     if (env().getNumber('WEBGL_VERSION') === 2) {
-      const gl2: WebGL2RenderingContext = gl;
+      const gl2 = gl as WebGL2RenderingContext;
       this.createVertexArray = () => {
         return webgl_util.callAndCheck(gl2,
           () => gl2.createVertexArray());

--- a/tfjs-backend-webgl/src/gpgpu_context_test.ts
+++ b/tfjs-backend-webgl/src/gpgpu_context_test.ts
@@ -24,7 +24,7 @@ import {expectArraysEqual} from '@tensorflow/tfjs-core/dist/test_util';
 import {WEBGL_ENVS} from './backend_webgl_test_registry';
 import * as canvas_util from './canvas_util';
 import {getGlslDifferences} from './glsl_version';
-import {GPGPUContext, linearSearchLastTrue} from './gpgpu_context';
+import {GPGPUContext, GPGPUContextProgram, linearSearchLastTrue} from './gpgpu_context';
 import * as tex_util from './tex_util';
 import {Texture} from './tex_util';
 import {createFragmentShader} from './webgl_util';
@@ -117,7 +117,7 @@ describeWithFlags(
 describeWithFlags(
     'GPGPUContext setOutputMatrixWriteRegion', DOWNLOAD_FLOAT_ENVS, () => {
       let gpgpu: GPGPUContext;
-      let program: WebGLProgram;
+      let program: GPGPUContextProgram;
       let output: WebGLTexture;
 
       beforeEach(() => {

--- a/tfjs-backend-webgl/src/gpgpu_math.ts
+++ b/tfjs-backend-webgl/src/gpgpu_math.ts
@@ -17,7 +17,7 @@
 
 import {backend_util, env, Tensor, TypedArray, util} from '@tensorflow/tfjs-core';
 
-import {GPGPUContext} from './gpgpu_context';
+import {GPGPUContext, GPGPUContextProgram} from './gpgpu_context';
 import * as shader_compiler from './shader_compiler';
 import {InputInfo, ShapeInfo, UniformType} from './shader_compiler';
 import {PackingScheme, TextureData, TextureUsage} from './tex_util';
@@ -47,7 +47,7 @@ export interface GPGPUProgram {
 }
 
 export interface GPGPUBinary {
-  webGLProgram: WebGLProgram;
+  webGLProgram: GPGPUContextProgram;
   program: GPGPUProgram;
   uniformLocations: {[name: string]: WebGLUniformLocation};
   customUniformLocations?: WebGLUniformLocation[];

--- a/tfjs-backend-webgl/src/webgl_util.ts
+++ b/tfjs-backend-webgl/src/webgl_util.ts
@@ -158,6 +158,11 @@ export function linkProgram(gl: WebGLRenderingContext, program: WebGLProgram) {
   }
 }
 
+/// validateProgram is effectively "If we `useProgram(program); drawArrays();`,
+/// give feedback in log about perf/correctness warnings or errors that would
+/// occur."
+/// So make sure we set up all vertex/texture/sampler/uniform data before
+/// calling validateProgram!
 export function validateProgram(
     gl: WebGLRenderingContext, program: WebGLProgram) {
   callAndCheck(gl, () => gl.validateProgram(program));


### PR DESCRIPTION
gpgpucontext.createProgram() calls vertexAttribPointer, but if you call this twice, the second createProgram() might overwrite the vertexAttribPointer data with different values. We believe this is the case more commonly in Firefox, and WebGL's spec has no guarantees per se here.

vertexAttribPointer should either be refreshed in gpgpucontext.useProgram, or ideally we can use a VAO and just (re)bind that in gpgpucontext.useProgram.

---

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6913)
<!-- Reviewable:end -->
