### PR TITLE
[webgpu] use inverseSqrt()

### DIFF
--- a/tfjs-backend-webgpu/src/unary_op_util.ts
+++ b/tfjs-backend-webgpu/src/unary_op_util.ts
@@ -89,7 +89,7 @@ const RELU6_VEC4 =
 const RELU_VEC4 = `
   return select(a, vec4<f32>(0.0), a < vec4<f32>(0.0));
 `;
-const RSQRT = `return 1.0/sqrt(a);`;
+const RSQRT = `return inverseSqrt(a);`;
 const SIGMOID = `return 1.0 / (1.0 + exp(-1.0 * a));`;
 const SIN = `return sin(a);`;
 const SINH = `


### PR DESCRIPTION
sqrt() based on inverseSqrt(), so avoiding double division.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6917)
<!-- Reviewable:end -->
