### PR TITLE
Build tfjs-node node addon with the release docker

### DIFF
--- a/dockers/release-docker/Dockerfile
+++ b/dockers/release-docker/Dockerfile
@@ -47,4 +47,3 @@ RUN pip3 install virtualenv
 # Install absl
 RUN pip3 install absl-py
 
-ENTRYPOINT /bin/bash

--- a/tfjs-node/scripts/build-and-upload-addon.sh
+++ b/tfjs-node/scripts/build-and-upload-addon.sh
@@ -27,7 +27,8 @@ PACKAGE_NAME=$(node scripts/get-addon-name.js)
 NAPI_VERSION=`node -p "process.versions.napi"`
 # remove the pre-built addon tarball if it already exist
 rm -f $PACKAGE_NAME
-yarn install-from-source
+# Build the native binding in docker to use a known version of GLIBC
+docker run -it --rm --mount type=bind,source=$(pwd),target=/tfjs-node/ --user "$(id -u):$(id -g)" gcr.io/learnjs-174218/release  bash -c "cd tfjs-node && yarn build-addon-from-source"
 if [ "$1" = "publish" ]; then
   # build a new pre-built addon tarball
   tar -czvf $PACKAGE_NAME -C lib napi-v$NAPI_VERSION/tfjs_binding.node


### PR DESCRIPTION
Build the tfjs-node and tfjs-node-gpu node addons with the release docker image when publishing them to npm. This ensures a consistent GLIBCXX version is used when publishing.

```sh
objdump -T lib/napi-v8/tfjs_binding.node | grep GLIBCXX
```

Before:
```
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt19__throw_logic_errorPKc
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt17__throw_bad_allocv
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _Znwm
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZdaPv
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4.29) _ZSt28__throw_bad_array_new_lengthv
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _Znam
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt20__throw_length_errorPKc
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4.18) _ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
```

After:
```
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt19__throw_logic_errorPKc
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt17__throw_bad_allocv
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _Znwm
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZdaPv
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _Znam
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZdlPv
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4.18) _ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm
0000000000000000      DF *UND*	0000000000000000 (GLIBCXX_3.4) _ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6925)
<!-- Reviewable:end -->
