### PR TITLE
[WebGL backend] fix tf.concat for inputs of one tensor

### DIFF
--- a/tfjs-backend-webgl/src/kernels/Concat_test.ts
+++ b/tfjs-backend-webgl/src/kernels/Concat_test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
+import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
+import {expectArraysClose} from '@tensorflow/tfjs-core/test_util';
+
+import {WEBGL_ENVS} from '../backend_webgl_test_registry';
+
+describeWithFlags('Concat', WEBGL_ENVS, () => {
+  it('Works if input size is larger than WEBGL_MAX_TEXTURES_IN_SHADER',
+     async () => {
+       const x1 = tf.tensor3d([1, 2, 3, 4], [2, 2, 1]);
+       const tensorNum = tf.env().getNumber('WEBGL_MAX_TEXTURES_IN_SHADER') + 1;
+       const input = [];
+       const expected = [];
+       for (let i = 0; i < tensorNum; i++) {
+         input.push(x1);
+         expected.push(1, 2, 3, 4);
+       }
+       const values = tf.concat(input, 0);
+       expect(values.shape).toEqual([tensorNum * 2, 2, 1]);
+       expectArraysClose(await values.data(), expected);
+     });
+});


### PR DESCRIPTION
Fix https://github.com/tensorflow/tfjs/issues/6884

When `tf.concat`'s input size is one, tfjs's WebGL backend should clone and return a same tensor as TensorFlow:
![image](https://user-images.githubusercontent.com/40653845/195471858-d1d5b05b-0e08-45b3-84c4-e71dba4ee309.png)

However, tfjs' WebGL backend throughs an error, because [concatImpl](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-webgl/src/kernels/Concat_impl.ts#L30) could not handle `inputs.length === 1`:
(failed to run `ConcatProgram`)


![image](https://user-images.githubusercontent.com/40653845/195472327-40ff0094-0815-42b4-a162-9a35928a4107.png)




To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6930)
<!-- Reviewable:end -->
