### PR TITLE
[webgpu] Replace string 'W(w)orkGroup' => 'W(w)orkgroup'

### DIFF
--- a/tfjs-backend-webgpu/src/addn_packed_webgpu.ts
+++ b/tfjs-backend-webgpu/src/addn_packed_webgpu.ts
@@ -25,7 +25,7 @@ export class AddNPackedProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames: string[];
   workPerThread = 1;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
 
   constructor(shapes: number[][]) {
@@ -33,7 +33,7 @@ export class AddNPackedProgram implements WebGPUProgram {
     this.variableNames = shapes.map((_, i) => `T${i}`);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
     this.shaderKey = 'addN';
   }

--- a/tfjs-backend-webgpu/src/batchnorm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/batchnorm_webgpu.ts
@@ -27,7 +27,7 @@ export class BatchNormProgram implements WebGPUProgram {
   variableNames: string[];
   uniforms = 'varianceEpsilon : f32,';
   // This is an experimental value.
-  workGroupSize: [number, number, number] = [128, 1, 1];
+  workgroupSize: [number, number, number] = [128, 1, 1];
   offsetShape: number[]|null;
   scaleShape: number[]|null;
   varianceEpsilon: number;
@@ -42,7 +42,7 @@ export class BatchNormProgram implements WebGPUProgram {
     this.outputShape = xShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     if (offsetShape != null) {
       backend_util.assertAndGetBroadcastShape(xShape, offsetShape);

--- a/tfjs-backend-webgpu/src/binary_op_complex_webgpu.ts
+++ b/tfjs-backend-webgpu/src/binary_op_complex_webgpu.ts
@@ -26,7 +26,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [128, 1, 1];
+  workgroupSize: [number, number, number] = [128, 1, 1];
   op: BinaryOpType;
   size = true;
 
@@ -34,7 +34,7 @@ export class BinaryOpComplexProgram implements WebGPUProgram {
     this.outputShape = backend_util.assertAndGetBroadcastShape(aShape, bShape);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.shaderKey = `binaryOpComplex_${op}`;
     this.op = op;

--- a/tfjs-backend-webgpu/src/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/binary_op_webgpu.ts
@@ -30,7 +30,7 @@ export class BinaryOpProgram implements WebGPUProgram {
   shaderKey: string;
   size = true;
   variableNames = ['A', 'B'];
-  workGroupSize: [number, number, number];
+  workgroupSize: [number, number, number];
   workPerThread: number;
 
   private lastDimensionSize: number;
@@ -59,7 +59,7 @@ export class BinaryOpProgram implements WebGPUProgram {
       this.type = 'shared';
       // This is an experimental value when using shared memory.
       // Note that the maximum of workgroup X dimension is 256.
-      this.workGroupSize = [256, 1, 1];
+      this.workgroupSize = [256, 1, 1];
       this.workPerThread = 1;
     } else {
       if (util.arraysEqual(aShape, bShape) &&
@@ -75,10 +75,10 @@ export class BinaryOpProgram implements WebGPUProgram {
       this.shaderKey = `binary_${this.type}_${op}`;
       // TODO(jiajia.qin@intel.com): Heuristically select a good work group
       // size.
-      this.workGroupSize = [128, 1, 1];
+      this.workgroupSize = [128, 1, 1];
     }
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
   }
 

--- a/tfjs-backend-webgpu/src/clip_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/clip_vec4_webgpu.ts
@@ -26,7 +26,7 @@ export class ClipVec4Program implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workPerThread = 4;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   isVec4 = true;
   size = true;
 
@@ -34,7 +34,7 @@ export class ClipVec4Program implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
     this.shaderKey = 'clipVec4';
   }

--- a/tfjs-backend-webgpu/src/clip_webgpu.ts
+++ b/tfjs-backend-webgpu/src/clip_webgpu.ts
@@ -25,7 +25,7 @@ export class ClipProgram implements WebGPUProgram {
   uniforms = 'minVal : f32, maxVal : f32,';
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   minVal: number;
   maxVal: number;
   size = true;
@@ -34,7 +34,7 @@ export class ClipProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.shaderKey = 'clip';
   }

--- a/tfjs-backend-webgpu/src/concat_webgpu.ts
+++ b/tfjs-backend-webgpu/src/concat_webgpu.ts
@@ -27,7 +27,7 @@ export class ConcatProgram implements WebGPUProgram {
   variableNames: string[];
   uniforms = '';
   workPerThread = 1;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
   offsetLength: number;
 
@@ -37,7 +37,7 @@ export class ConcatProgram implements WebGPUProgram {
     this.variableNames = shapes.map((_, i) => `T${i}`);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
 
     this.offsetLength = shapes.length - 1;

--- a/tfjs-backend-webgpu/src/conv2d_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv2d_mm_webgpu.ts
@@ -20,7 +20,7 @@ import {backend_util} from '@tensorflow/tfjs-core';
 import {activationFnSnippet, biasActivationSnippet, typeSnippet} from './activation_util';
 import {makeMatMulPackedSource, makeMatMulPackedVec4Source} from './matmul_packed_webgpu';
 import {WebGPUProgram} from './webgpu_program';
-import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d} from './webgpu_util';
+import {computeDispatch, computeWorkgroupSizeForConv2d, computeWorkPerThreadForConv2d} from './webgpu_util';
 
 function conv2dCommonSnippet(
     isChannelsLast: boolean, fitAOuter: boolean, fitBOuter: boolean,
@@ -162,7 +162,7 @@ export class Conv2DMMProgram implements WebGPUProgram {
   variableTypes: string[];
   uniforms =
       `filterDims : vec2<i32>, pad : vec2<i32>, stride : vec2<i32>, dilation : vec2<i32>, dimAOuter : i32, dimBOuter : i32, dimInner : i32,`;
-  workGroupSize: [number, number, number];
+  workgroupSize: [number, number, number];
   elementsPerThread: [number, number, number];
   addBias: boolean;
   activation: backend_util.Activation;
@@ -192,13 +192,13 @@ export class Conv2DMMProgram implements WebGPUProgram {
         convInfo.outChannels % 4 === 0;
     this.dispatchLayout = this.isChannelsLast ? {x: [3], y: [1, 2], z: [0]} :
                                                 {x: [2, 3], y: [1], z: [0]};
-    this.workGroupSize = computeWorkGroupSizeForConv2d(
+    this.workgroupSize = computeWorkgroupSizeForConv2d(
         this.dispatchLayout, this.outputShape, this.isVec4);
     this.elementsPerThread = computeWorkPerThreadForConv2d(
         this.dispatchLayout, this.outputShape, this.isVec4);
 
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         this.elementsPerThread);
 
     if (this.isVec4) {
@@ -235,10 +235,10 @@ export class Conv2DMMProgram implements WebGPUProgram {
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;
 
-    this.tileAOuter = this.workGroupSize[1] * this.elementsPerThread[1];
-    this.tileBOuter = this.workGroupSize[0] * this.elementsPerThread[0];
+    this.tileAOuter = this.workgroupSize[1] * this.elementsPerThread[1];
+    this.tileBOuter = this.workgroupSize[0] * this.elementsPerThread[0];
     this.tileInner = Math.max(
-        this.workGroupSize[0] * this.innerElementSize, this.workGroupSize[1]);
+        this.workgroupSize[0] * this.innerElementSize, this.workgroupSize[1]);
 
     this.fitAOuter = dimAOuter % this.tileAOuter === 0;
     this.fitBOuter = dimBOuter % this.tileBOuter === 0;
@@ -253,10 +253,10 @@ export class Conv2DMMProgram implements WebGPUProgram {
   getUserCode(): string {
     const matMulSource = this.isVec4 ?
         makeMatMulPackedVec4Source(
-            this.elementsPerThread, this.workGroupSize, !this.isChannelsLast,
+            this.elementsPerThread, this.workgroupSize, !this.isChannelsLast,
             this.tileInner) :
         makeMatMulPackedSource(
-            this.elementsPerThread, this.workGroupSize, !this.isChannelsLast,
+            this.elementsPerThread, this.workgroupSize, !this.isChannelsLast,
             this.tileInner, false, null, this.sequentialAccessByThreads);
     const elementsSize =
         this.isVec4 ? [this.innerElementSize, 4, 4] : [1, 1, 1];

--- a/tfjs-backend-webgpu/src/conv2d_naive_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv2d_naive_webgpu.ts
@@ -29,7 +29,7 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
   variableNames = ['x', 'W'];
   uniforms =
       'filterDims: vec2<i32>, pad: vec2<i32>, stride: vec2<i32>, dilation: vec2<i32>,';
-  workGroupSize: [number, number, number] = [4, 4, 8];
+  workgroupSize: [number, number, number] = [4, 4, 8];
   addBias: boolean;
   activation: backend_util.Activation;
   hasPreluActivationWeights: boolean;
@@ -44,7 +44,7 @@ export class Conv2DNaiveProgram implements WebGPUProgram {
     this.dispatchLayout = this.isChannelsLast ? {x: [2], y: [1], z: [0, 3]} :
                                                 {x: [3], y: [2], z: [0, 1]};
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.addBias = addBias;
     this.activation = activation;
     this.hasPreluActivationWeights = hasPreluActivationWeights;

--- a/tfjs-backend-webgpu/src/conv_backprop_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv_backprop_mm_webgpu.ts
@@ -19,7 +19,7 @@ import {backend_util, util} from '@tensorflow/tfjs-core';
 import {typeSnippet} from './activation_util';
 import {makeMatMulPackedSource, makeMatMulPackedVec4Source} from './matmul_packed_webgpu';
 import {WebGPUProgram} from './webgpu_program';
-import {computeDispatch, computeWorkGroupSizeForConv2d, computeWorkPerThreadForConv2d} from './webgpu_util';
+import {computeDispatch, computeWorkgroupSizeForConv2d, computeWorkPerThreadForConv2d} from './webgpu_util';
 
 function conv2dTransposeCommonSnippet(innerElementSize = 4) {
   const getWSnippet = (innerElementSize: number) => {
@@ -120,7 +120,7 @@ export class Conv2DDerInputMMProgram implements WebGPUProgram {
   variableTypes: string[];
   uniforms =
       'filterDims : vec2<i32>, pads : vec2<i32>, stride : vec2<i32>, outBackprop : vec4<i32>, dimAOuter : i32, dimBOuter : i32, dimInner : i32,';
-  workGroupSize: [number, number, number];
+  workgroupSize: [number, number, number];
   elementsPerThread: [number, number, number];
   isVec4?: boolean;
 
@@ -133,13 +133,13 @@ export class Conv2DDerInputMMProgram implements WebGPUProgram {
     this.isVec4 =
         convInfo.inChannels % 4 === 0 && convInfo.outChannels % 4 === 0;
     this.dispatchLayout = {x: [3], y: [1, 2], z: [0]};
-    this.workGroupSize = computeWorkGroupSizeForConv2d(
+    this.workgroupSize = computeWorkgroupSizeForConv2d(
         this.dispatchLayout, this.outputShape, this.isVec4);
     this.elementsPerThread = computeWorkPerThreadForConv2d(
         this.dispatchLayout, this.outputShape, this.isVec4);
 
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         this.elementsPerThread);
 
     if (this.isVec4) {
@@ -152,8 +152,8 @@ export class Conv2DDerInputMMProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const matMulSource = this.isVec4 ?
-        makeMatMulPackedVec4Source(this.elementsPerThread, this.workGroupSize) :
-        makeMatMulPackedSource(this.elementsPerThread, this.workGroupSize);
+        makeMatMulPackedVec4Source(this.elementsPerThread, this.workgroupSize) :
+        makeMatMulPackedSource(this.elementsPerThread, this.workgroupSize);
     const userCode = `
     ${conv2dTransposeCommonSnippet(this.isVec4 ? 4 : 1)}
     ${matMulSource}

--- a/tfjs-backend-webgpu/src/conv_backprop_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv_backprop_webgpu.ts
@@ -27,7 +27,7 @@ export class Conv2DDerInputProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   isChannelsLast: boolean;
   size = true;
 
@@ -35,7 +35,7 @@ export class Conv2DDerInputProgram implements WebGPUProgram {
     this.outputShape = convInfo.inShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.isChannelsLast = convInfo.dataFormat === 'channelsLast';
     this.shaderKey = `conv2DDerInput_${this.isChannelsLast}`;
   }

--- a/tfjs-backend-webgpu/src/crop_and_resize_webgpu.ts
+++ b/tfjs-backend-webgpu/src/crop_and_resize_webgpu.ts
@@ -25,7 +25,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['Image', 'Boxes', 'BoxInd'];
   uniforms = 'extrapolationValue : f32,';
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   methodId: number;
   cropHeightBiggerThan1: boolean;
   cropWidthBiggerThan1: boolean;
@@ -38,7 +38,7 @@ export class CropAndResizeProgram implements WebGPUProgram {
     this.outputShape = [numBoxes, cropSize[0], cropSize[1], channnel];
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.methodId = method === 'bilinear' ? 1 : 0;
     this.cropHeightBiggerThan1 = this.outputShape[1] > 1;

--- a/tfjs-backend-webgpu/src/cum_webgpu.ts
+++ b/tfjs-backend-webgpu/src/cum_webgpu.ts
@@ -29,7 +29,7 @@ export class CumProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
-  workGroupSize: [number, number, number];
+  workgroupSize: [number, number, number];
   // pow(i32, i32) is not supported, use pow(f32, f32) instead.
   uniforms = 'index : f32,';
   size = true;
@@ -39,12 +39,12 @@ export class CumProgram implements WebGPUProgram {
 
   constructor(
       op: CumOpType, shape: number[], exclusive: boolean, reverse: boolean) {
-    const workGroupSizeX = 128;
-    this.workGroupSize = [workGroupSizeX, 1, 1];
+    const workgroupSizeX = 128;
+    this.workgroupSize = [workgroupSizeX, 1, 1];
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.exclusive = exclusive;
     this.reverse = reverse;
     this.op = op;

--- a/tfjs-backend-webgpu/src/depth_to_space_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depth_to_space_webgpu.ts
@@ -25,7 +25,7 @@ export class DepthToSpaceProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
   uniforms = 'blockSize : i32,';
 
@@ -33,7 +33,7 @@ export class DepthToSpaceProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.shaderKey = `depthToSpace_${dataFormat}`;
     this.dataFormat = dataFormat;
   }

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_nchw_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_nchw_shared_webgpu.ts
@@ -28,7 +28,7 @@ export class DepthwiseConv2DNCHWSharedProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'W'];
   uniforms = `pad : vec2<i32>, inDims : vec2<i32>,`;
-  workGroupSize: [number, number, number] = [16, 16, 1];
+  workgroupSize: [number, number, number] = [16, 16, 1];
   addBias: boolean;
   activation: backend_util.Activation;
   hasPreluActivation: boolean;
@@ -42,7 +42,7 @@ export class DepthwiseConv2DNCHWSharedProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = {x: [3], y: [2], z: [0, 1]};
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     if (addBias) {
       this.variableNames.push('bias');
@@ -62,10 +62,10 @@ export class DepthwiseConv2DNCHWSharedProgram implements WebGPUProgram {
 
   getUserCode(): string {
     const filterSize = this.filterWidth * this.filterHeight;
-    const workGroupSize =
-        this.workGroupSize[0] * this.workGroupSize[1] * this.workGroupSize[2];
-    const tileAHeight = this.workGroupSize[1] + this.filterHeight - 1;
-    const tileAWidth = this.workGroupSize[0] + this.filterWidth - 1;
+    const workgroupSize =
+        this.workgroupSize[0] * this.workgroupSize[1] * this.workgroupSize[2];
+    const tileAHeight = this.workgroupSize[1] + this.filterHeight - 1;
+    const tileAWidth = this.workgroupSize[0] + this.filterWidth - 1;
 
     const userCode = `
       ${
@@ -101,9 +101,9 @@ export class DepthwiseConv2DNCHWSharedProgram implements WebGPUProgram {
 
         // Load one tile of X into local memory.
         for (var inputRow = localRow; inputRow < ${
-        tileAHeight}; inputRow = inputRow + ${this.workGroupSize[1]}) {
+        tileAHeight}; inputRow = inputRow + ${this.workgroupSize[1]}) {
           for (var inputCol = localCol; inputCol < ${
-        tileAWidth}; inputCol = inputCol + ${this.workGroupSize[0]}) {
+        tileAWidth}; inputCol = inputCol + ${this.workgroupSize[0]}) {
             let rowOffset = inputRow - localRow;
             let colOffset = inputCol - localCol;
             mm_Asub[inputRow][inputCol] = readX(batch, d1, inputRowStart + rowOffset, inputColStart + colOffset);
@@ -113,10 +113,10 @@ export class DepthwiseConv2DNCHWSharedProgram implements WebGPUProgram {
         // Load one tile of W into local memory.
         var wIndex = i32(localIndex);
         ${
-        filterSize < workGroupSize ?
+        filterSize < workgroupSize ?
             `if (wIndex < ${filterSize})` :
             `for(; wIndex < ${filterSize}; wIndex = wIndex + ${
-                workGroupSize})`}
+                workgroupSize})`}
 
         {
           let wRow = wIndex / ${this.filterWidth};

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
@@ -27,7 +27,7 @@ export class DepthwiseConv2DVec4Program implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'W'];
   uniforms = 'pad : vec2<i32>, inDims : vec2<i32>,';
-  workGroupSize: [number, number, number] = [4, 4, 4];
+  workgroupSize: [number, number, number] = [4, 4, 4];
   workPerThread = 4;
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
@@ -41,7 +41,7 @@ export class DepthwiseConv2DVec4Program implements WebGPUProgram {
     this.outputShape = convInfo.outShape;
     this.dispatchLayout = {x: [3], y: [2], z: [0, 1]};
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [4, this.workPerThread, 1]);
 
     util.assert(

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_webgpu.ts
@@ -30,7 +30,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
   uniforms = `pad : vec2<i32>, inDims : vec2<i32>, filterHeight : i32,
       filterWidth : i32, stride : vec2<i32>, dilation : vec2<i32>,`;
   // This is an experimental value.
-  workGroupSize: [number, number, number] = [256, 1, 1];
+  workgroupSize: [number, number, number] = [256, 1, 1];
   convInfo: backend_util.Conv2DInfo;
   addBias: boolean;
   activation: backend_util.Activation;
@@ -44,7 +44,7 @@ export class DepthwiseConv2DProgram implements WebGPUProgram {
     this.outputShape = convInfo.outShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.isChannelsLast = convInfo.dataFormat === 'channelsLast';
 
     if (addBias) {

--- a/tfjs-backend-webgpu/src/fill_webgpu.ts
+++ b/tfjs-backend-webgpu/src/fill_webgpu.ts
@@ -25,14 +25,14 @@ export class FillProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   uniforms = 'value : f32,';
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.shaderKey = 'fill';
   }

--- a/tfjs-backend-webgpu/src/flip_left_right_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flip_left_right_webgpu.ts
@@ -24,14 +24,14 @@ export class FlipLeftRightProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
 
   constructor(imageShape: [number, number, number, number]) {
     this.outputShape = imageShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.shaderKey = 'flipLeftRight';
   }
 

--- a/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
+++ b/tfjs-backend-webgpu/src/from_pixels_webgpu.ts
@@ -26,14 +26,14 @@ export class FromPixelsProgram implements WebGPUProgram {
   shaderKey: string;
   importVideo: boolean;
   variableNames: string[] = [];
-  workGroupSize: [number, number, number] =
+  workgroupSize: [number, number, number] =
       [256, 1, 1];  // The empirical value.
 
   constructor(outputShape: number[], numChannels: number, importVideo = false) {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [numChannels, 1, 1]);
 
     this.importVideo = importVideo;

--- a/tfjs-backend-webgpu/src/gather_nd_webgpu.ts
+++ b/tfjs-backend-webgpu/src/gather_nd_webgpu.ts
@@ -25,14 +25,14 @@ export class GatherNDProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames: string[] = ['A', 'indices'];
   uniforms: string;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
   sliceDim: number;
   constructor(sliceDim: number, shape: number[]) {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.shaderKey = `gathernd_${sliceDim}`;
     this.sliceDim = sliceDim;
     this.uniforms = `sliceDim : i32, strides : ${getCoordsDataType(sliceDim)},`;

--- a/tfjs-backend-webgpu/src/gather_webgpu.ts
+++ b/tfjs-backend-webgpu/src/gather_webgpu.ts
@@ -24,7 +24,7 @@ export class GatherProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames: string[] = ['A', 'indices'];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   aShape: number[];
   size = true;
 
@@ -34,7 +34,7 @@ export class GatherProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.shaderKey = `gather`;
   }
 

--- a/tfjs-backend-webgpu/src/matmul_reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_reduce_webgpu.ts
@@ -24,7 +24,7 @@ import {computeDispatch} from './webgpu_util';
 
 export function makeMatMulReduceSource(): string {
   return `
-    var<workgroup> sumValues : array<f32, workGroupSizeX>;
+    var<workgroup> sumValues : array<f32, workgroupSizeX>;
     ${main()} {
       let coords = getOutputCoords();
       let batch = coords[0];
@@ -32,7 +32,7 @@ export function makeMatMulReduceSource(): string {
       let col = coords[2];
       var sum = 0.0;
       let Length = uniforms.dimInner;
-      for (var k = i32(localId.x); k < Length; k = k + i32(workGroupSizeX)) {
+      for (var k = i32(localId.x); k < Length; k = k + i32(workgroupSizeX)) {
         let dataA = mm_readA(batch, row, k);
         let dataB = mm_readB(batch, k, col);
         sum = sum + dataA * dataB;
@@ -40,7 +40,7 @@ export function makeMatMulReduceSource(): string {
       sumValues[localId.x] = sum;
       workgroupBarrier();
 
-      for(var currentSize = workGroupSizeX / 2u; currentSize > 1u;
+      for(var currentSize = workgroupSizeX / 2u; currentSize > 1u;
           currentSize = currentSize / 2u) {
         if (localId.x < currentSize)
         {
@@ -64,7 +64,7 @@ export class MatMulReduceProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A', 'B'];
   uniforms = `dimAOuter : i32, dimBOuter : i32, dimInner : i32,`;
-  workGroupSize: [number, number, number] = [256, 1, 1];
+  workgroupSize: [number, number, number] = [256, 1, 1];
   transposeA: boolean;
   transposeB: boolean;
   addBias: boolean;
@@ -81,7 +81,7 @@ export class MatMulReduceProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = {x: [], y: [1, 2], z: [0]};
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     const addBias = bias != null;
     const hasPreluActivationWeights = preluActivationWeights != null;

--- a/tfjs-backend-webgpu/src/matmul_small_output_size_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_small_output_size_webgpu.ts
@@ -21,9 +21,9 @@ import {matMulReadWriteFnSource} from './matmul_packed_webgpu';
 import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
 
 export function makeMatMulSmallOutputSizeSource(
-    workGroupSize: [number, number, number]): string {
-  const tileAOuter = workGroupSize[1];
-  const tileBOuter = workGroupSize[0];
+    workgroupSize: [number, number, number]): string {
+  const tileAOuter = workgroupSize[1];
+  const tileBOuter = workgroupSize[0];
   const tileInner = tileAOuter > tileBOuter ? tileAOuter : tileBOuter;
   return `
   var<workgroup> mm_Asub : array<array<f32, ${tileInner}>, ${tileAOuter}>;
@@ -85,7 +85,7 @@ export class MatMulSmallOutputSizeProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A', 'B'];
   uniforms = `dimAOuter : i32, dimBOuter : i32, dimInner : i32,`;
-  workGroupSize: [number, number, number] = [16, 8, 1];
+  workgroupSize: [number, number, number] = [16, 8, 1];
   transposeA: boolean;
   transposeB: boolean;
   addBias: boolean;
@@ -104,8 +104,8 @@ export class MatMulSmallOutputSizeProgram implements WebGPUProgram {
 
     this.dispatchLayout = {x: [2], y: [1], z: [0]};
     this.dispatch = [
-      Math.ceil(outputShape[2] / this.workGroupSize[0]),
-      Math.ceil(outputShape[1] / this.workGroupSize[1]), outputShape[0]
+      Math.ceil(outputShape[2] / this.workgroupSize[0]),
+      Math.ceil(outputShape[1] / this.workgroupSize[1]), outputShape[0]
     ];
 
     const addBias = bias != null;
@@ -136,7 +136,7 @@ export class MatMulSmallOutputSizeProgram implements WebGPUProgram {
         matMulReadWriteFnSource(
             this.addBias, this.activation, this.batchAEqualOne,
             this.batchBEqualOne, this.transposeA, this.transposeB)}
-      ${makeMatMulSmallOutputSizeSource(this.workGroupSize)}
+      ${makeMatMulSmallOutputSizeSource(this.workgroupSize)}
     `;
     return userCode;
   }

--- a/tfjs-backend-webgpu/src/matmul_splitK_webgpu.ts
+++ b/tfjs-backend-webgpu/src/matmul_splitK_webgpu.ts
@@ -29,7 +29,7 @@ export class MatMulSplitKProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A', 'B'];
   uniforms = `dimAOuter : i32, dimBOuter : i32, dimInner : i32,`;
-  workGroupSize: [number, number, number] = [8, 8, 1];
+  workgroupSize: [number, number, number] = [8, 8, 1];
   elementsPerThread: [number, number, number];
   transposeA: boolean;
   transposeB: boolean;
@@ -68,7 +68,7 @@ export class MatMulSplitKProgram implements WebGPUProgram {
           this.outputShape[0], this.outputShape[1], this.outputShape[2],
           dimInner
         ],
-        this.workGroupSize, this.elementsPerThread);
+        this.workgroupSize, this.elementsPerThread);
 
     this.transposeA = transposeA;
     this.transposeB = transposeB;
@@ -119,10 +119,10 @@ export class MatMulSplitKProgram implements WebGPUProgram {
       }
       ${
         this.isVec4 ? makeMatMulPackedVec4Source(
-                          this.elementsPerThread, this.workGroupSize,
+                          this.elementsPerThread, this.workgroupSize,
                           this.transposeA, 32, true, this.splitedDimInner) :
                       makeMatMulPackedSource(
-                          this.elementsPerThread, this.workGroupSize,
+                          this.elementsPerThread, this.workgroupSize,
                           this.transposeA, 32, true, this.splitedDimInner)}
     `;
     return userCode;
@@ -136,7 +136,7 @@ export class BiasActivationProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
   private addBias: boolean;
   private activation: backend_util.Activation;
@@ -149,7 +149,7 @@ export class BiasActivationProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.addBias = bias != null;
     this.hasPreluActivationWeights = preluActivationWeights != null;
     this.activation = activation;

--- a/tfjs-backend-webgpu/src/mirror_pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/mirror_pad_webgpu.ts
@@ -25,7 +25,7 @@ export class MirrorPadProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['x'];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   xShape: number[];
   offset: number;
   size = true;
@@ -37,7 +37,7 @@ export class MirrorPadProgram implements WebGPUProgram {
         (p, i) => p[0] /* beforePad */ + xShape[i] + p[1] /* afterPad */);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.xShape = xShape;
     paddings.map((_, i) => {

--- a/tfjs-backend-webgpu/src/pad_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pad_webgpu.ts
@@ -25,7 +25,7 @@ export class PadProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'constantValue : f32,';
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   xShape: number[];
   size = true;
 
@@ -34,7 +34,7 @@ export class PadProgram implements WebGPUProgram {
         (p, i) => p[0] /* beforePad */ + xShape[i] + p[1] /* afterPad */);
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     paddings.map((_, i) => {
       this.uniforms += ` pad${i} : vec2<i32>,`;
     });

--- a/tfjs-backend-webgpu/src/pool2d_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pool2d_webgpu.ts
@@ -27,9 +27,9 @@ export class Pool2DProgram implements WebGPUProgram {
   variableNames = ['x'];
   uniforms =
       `stride : vec2<i32>, pad : vec2<i32>, dilation : vec2<i32>, convDims : vec2<i32>, filterDims : vec2<i32>,`;
-  // TODO(jiajia.qin@intel.com): Dynamically choose different workGroupSize for
+  // TODO(jiajia.qin@intel.com): Dynamically choose different workgroupSize for
   // different output shapes.
-  workGroupSize: [number, number, number] = [128, 1, 1];
+  workgroupSize: [number, number, number] = [128, 1, 1];
   poolType: 'max'|'avg';
   size = true;
 
@@ -39,7 +39,7 @@ export class Pool2DProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
 
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.shaderKey = `pool2D_${poolType}`;
     this.poolType = poolType;

--- a/tfjs-backend-webgpu/src/pool_filtersizeone_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pool_filtersizeone_webgpu.ts
@@ -26,7 +26,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = `stride : vec2<i32>,`;
-  workGroupSize: [number, number, number] = [256, 1, 1];
+  workgroupSize: [number, number, number] = [256, 1, 1];
   size = true;
 
   constructor(convInfo: backend_util.Conv2DInfo) {
@@ -34,7 +34,7 @@ export class PoolWithFilterSizeEqualsOneProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
 
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.shaderKey = 'poolWithFilterSizeEqualsOne';
   }

--- a/tfjs-backend-webgpu/src/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/reduce_webgpu.ts
@@ -24,7 +24,7 @@ export class ReduceProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   variableNames = ['x'];
   uniforms = 'reduceSize : i32,';
   reduceType: 'max'|'mean'|'min'|'prod'|'sum';
@@ -73,7 +73,7 @@ export class ReduceProgram implements WebGPUProgram {
         `setOutputAtIndex(outputIndex, bestValue);`;
 
     const sharedMemorySnippet = `
-         var<workgroup> xBestValues : array<f32, ${this.workGroupSize[0]}>;
+         var<workgroup> xBestValues : array<f32, ${this.workgroupSize[0]}>;
        `;
 
     const userCode = `
@@ -91,20 +91,20 @@ export class ReduceProgram implements WebGPUProgram {
           return offset;
        }
        ${main('index')} {
-         let outputIndex = index / i32(workGroupSizeX);
+         let outputIndex = index / i32(workgroupSizeX);
          let offset = getOffset(outputIndex);
          var bestValue = ${initValue};
          let Length = uniforms.reduceSize;
-         let WorkPerThread = DIV_CEIL(u32(Length), workGroupSizeX);
+         let WorkPerThread = DIV_CEIL(u32(Length), workgroupSizeX);
          for (var k = i32(localId.x); k < Length && outputIndex < uniforms.size;
-             k = k + i32(workGroupSizeX)) {
+             k = k + i32(workgroupSizeX)) {
            let candidate = f32(x[offset + k]);
            ${reduceOp}
          }
          xBestValues[localId.x] = bestValue;
          workgroupBarrier();
 
-         var reduceSize = min(u32(Length), workGroupSizeX);
+         var reduceSize = min(u32(Length), workgroupSizeX);
          for (var currentSize = reduceSize / 2u; reduceSize > 1u;
              currentSize = reduceSize / 2u) {
            let interval = DIV_CEIL(reduceSize, 2u);

--- a/tfjs-backend-webgpu/src/resize_bilinear_webgpu.ts
+++ b/tfjs-backend-webgpu/src/resize_bilinear_webgpu.ts
@@ -25,7 +25,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'adjustHeightWidth : vec2<f32>, halfPixelCenters : f32,';
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
 
   constructor(
@@ -36,7 +36,7 @@ export class ResizeBilinearProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
 
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.shaderKey = `resizeBilinear`;
   }

--- a/tfjs-backend-webgpu/src/resize_nearest_neighbor_webgpu.ts
+++ b/tfjs-backend-webgpu/src/resize_nearest_neighbor_webgpu.ts
@@ -25,7 +25,7 @@ export class ResizeNearestNeighborProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms = 'adjustHeightWidth : vec2<f32>, roundBase : f32,';
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   halfPixelCenters: boolean;
   size = true;
 
@@ -37,7 +37,7 @@ export class ResizeNearestNeighborProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
 
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.halfPixelCenters = halfPixelCenters;
     this.shaderKey = `resizeNearest_${halfPixelCenters}`;

--- a/tfjs-backend-webgpu/src/rotate_webgpu.ts
+++ b/tfjs-backend-webgpu/src/rotate_webgpu.ts
@@ -25,7 +25,7 @@ export class RotateProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms: string;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   fillSnippet: string;
   size = true;
 
@@ -35,7 +35,7 @@ export class RotateProgram implements WebGPUProgram {
     this.outputShape = imageShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.uniforms = `centerX : f32, centerY : f32, sinRadians : f32,
           cosRadians : f32,`;
     this.shaderKey = 'rotate';

--- a/tfjs-backend-webgpu/src/scatter_webgpu.ts
+++ b/tfjs-backend-webgpu/src/scatter_webgpu.ts
@@ -27,7 +27,7 @@ export class ScatterProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   updatesRank: number;
   indicesRank: number;
   sliceDimGreaterThanOne: boolean;
@@ -44,7 +44,7 @@ export class ScatterProgram implements WebGPUProgram {
     this.dispatchLayout = flatDispatchLayout(flattenXShape);
     // Dispatching based on |updates| shape instead of output shape.
     this.dispatch =
-        computeDispatch(this.dispatchLayout, flattenXShape, this.workGroupSize);
+        computeDispatch(this.dispatchLayout, flattenXShape, this.workgroupSize);
     this.sliceDimGreaterThanOne = sliceDim > 1;
     this.shaderKey = `scatter_${indicesRank}_${updatesRank}_${
         this.sliceDimGreaterThanOne}_${outputDtype}_${sumDupeIndices}`;

--- a/tfjs-backend-webgpu/src/select_webgpu.ts
+++ b/tfjs-backend-webgpu/src/select_webgpu.ts
@@ -24,7 +24,7 @@ export class SelectProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   cRank: number;
   rank: number;
   size = true;
@@ -33,7 +33,7 @@ export class SelectProgram implements WebGPUProgram {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
 
     this.cRank = cRank;
     this.rank = rank;

--- a/tfjs-backend-webgpu/src/slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/slice_webgpu.ts
@@ -27,7 +27,7 @@ export class SliceProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workPerThread = 1;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   start: number[];
   size = true;
 
@@ -36,7 +36,7 @@ export class SliceProgram implements WebGPUProgram {
     this.rank = destSize.length;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
 
     this.start = start;

--- a/tfjs-backend-webgpu/src/strided_slice_webgpu.ts
+++ b/tfjs-backend-webgpu/src/strided_slice_webgpu.ts
@@ -27,14 +27,14 @@ export class StridedSliceProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   // TODO(xing.xu): Increase the workPerThread.
   workPerThread = 1;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
 
   constructor(destSize: number[]) {
     this.outputShape = destSize;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
 
     const dtype = getCoordsDataType(this.outputShape.length);

--- a/tfjs-backend-webgpu/src/tile_webgpu.ts
+++ b/tfjs-backend-webgpu/src/tile_webgpu.ts
@@ -24,7 +24,7 @@ export class TileProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
   rank: number;
 
@@ -36,7 +36,7 @@ export class TileProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.rank = this.outputShape.length;
     this.shaderKey = 'tile';
   }

--- a/tfjs-backend-webgpu/src/top_k_webgpu.ts
+++ b/tfjs-backend-webgpu/src/top_k_webgpu.ts
@@ -35,14 +35,14 @@ export class SwapProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'indices'];
   uniforms: string;
-  workGroupSize: [number, number, number] = [256, 1, 1];
+  workgroupSize: [number, number, number] = [256, 1, 1];
   size = true;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.uniforms = `inputSize : i32, firstPass : i32, negativeInf : f32,
         dir : i32, inc : i32,`;
     this.shaderKey = 'swap';
@@ -128,14 +128,14 @@ export class MergeProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x', 'indices'];
   uniforms: string;
-  workGroupSize: [number, number, number] = [256, 1, 1];
+  workgroupSize: [number, number, number] = [256, 1, 1];
   size = true;
 
   constructor(shape: number[]) {
     this.outputShape = shape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     // |n| Size of the original input of TopK
     // |firstPass| indicates if this is the first time swap is being used which
     // means no indices input containing the top K is present yet.

--- a/tfjs-backend-webgpu/src/transform_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transform_webgpu.ts
@@ -25,14 +25,14 @@ export class TransformProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
 
   constructor(outShape: [number, number, number, number]) {
     this.outputShape = outShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.shaderKey = 'transform';
   }
 

--- a/tfjs-backend-webgpu/src/transpose_shared_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transpose_shared_webgpu.ts
@@ -25,7 +25,7 @@ export class TransposeSharedProgram implements WebGPUProgram {
   dispatchLayout: {x: number[], y: number[]};
   dispatch: [number, number, number];
   // Note that the maximum number of workgroup invocations by webgpu is 256.
-  workGroupSize: [number, number, number] = [16, 16, 1];
+  workgroupSize: [number, number, number] = [16, 16, 1];
 
   constructor(aShape: number[], newDim: number[]) {
     const outputShape: number[] = new Array(aShape.length);
@@ -35,16 +35,16 @@ export class TransposeSharedProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = {x: [0], y: [1]};
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize, [1, 1, 1]);
+        this.dispatchLayout, this.outputShape, this.workgroupSize, [1, 1, 1]);
 
     this.shaderKey = 'transposeShared';
   }
 
   getUserCode(): string {
     const userCode = `
-      const TILE_DIM = ${this.workGroupSize[0]};
-      var<workgroup> tile : array<array<f32, ${this.workGroupSize[0] + 1}>, ${
-        this.workGroupSize[0]}>;
+      const TILE_DIM = ${this.workgroupSize[0]};
+      var<workgroup> tile : array<array<f32, ${this.workgroupSize[0] + 1}>, ${
+        this.workgroupSize[0]}>;
       ${main()} {
         var x = i32(workgroupId.x) * TILE_DIM + i32(localId.x);
         var y = i32(workgroupId.y) * TILE_DIM + i32(localId.y);

--- a/tfjs-backend-webgpu/src/transpose_webgpu.ts
+++ b/tfjs-backend-webgpu/src/transpose_webgpu.ts
@@ -25,7 +25,7 @@ export class TransposeProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   workPerThread = 1;
-  workGroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number] = [64, 1, 1];
   newDim: number[];
   size = true;
 
@@ -37,7 +37,7 @@ export class TransposeProgram implements WebGPUProgram {
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize,
+        this.dispatchLayout, this.outputShape, this.workgroupSize,
         [this.workPerThread, 1, 1]);
 
     this.newDim = newDim;

--- a/tfjs-backend-webgpu/src/unary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/unary_op_webgpu.ts
@@ -25,19 +25,19 @@ export class UnaryOpProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['A'];
-  workGroupSize: [number, number, number];
+  workgroupSize: [number, number, number];
   op: UnaryOpType;
   uniforms?: string;
   size = true;
 
   constructor(outputShape: number[], op: UnaryOpType) {
     // TODO(jiajia.qin@intel.com): Heuristically select a good work group size.
-    const workGroupSizeX = 128;
-    this.workGroupSize = [workGroupSizeX, 1, 1];
+    const workgroupSizeX = 128;
+    this.workgroupSize = [workgroupSizeX, 1, 1];
     this.outputShape = outputShape;
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workGroupSize);
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
     this.op = op;
     this.shaderKey = `unary_${op}`;
   }

--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -37,36 +37,36 @@ export function tilesFitEvenlyIntoShape(
 }
 
 // Computes dispatch geometry based on layout of output dimensions and
-// workGroupSize.
+// workgroupSize.
 export function computeDispatch(
     layout: {x: number[], y?: number[], z?: number[]}, outputShape: number[],
-    workGroupSize: [number, number, number] = [1, 1, 1],
+    workgroupSize: [number, number, number] = [1, 1, 1],
     elementsPerThread: [number, number, number] =
         [1, 1, 1]): [number, number, number] {
   const [dispatchX, dispatchY, dispatchZ] = [
     Math.ceil(
         arrayProduct(layout.x.map(d => outputShape[d])) /
-        (workGroupSize[0] * elementsPerThread[0])),
+        (workgroupSize[0] * elementsPerThread[0])),
     layout.y ? Math.ceil(
                    arrayProduct(layout.y.map(d => outputShape[d])) /
-                   (workGroupSize[1] * elementsPerThread[1])) :
+                   (workgroupSize[1] * elementsPerThread[1])) :
                1,
     layout.z ? Math.ceil(
                    arrayProduct(layout.z.map(d => outputShape[d])) /
-                   (workGroupSize[2] * elementsPerThread[2])) :
+                   (workgroupSize[2] * elementsPerThread[2])) :
                1
   ];
   return [dispatchX, dispatchY, dispatchZ];
 }
 
-export type WorkGroupInfo = {
-  workGroupSize: [number, number, number],
+export type WorkgroupInfo = {
+  workgroupSize: [number, number, number],
   elementsPerThread: [number, number, number],
 };
 
-export function computeWorkGroupInfoForMatMul(
+export function computeWorkgroupInfoForMatMul(
     dimAOuter: number, dimInner: number, dimBOuter: number,
-    transposeA = false): WorkGroupInfo {
+    transposeA = false): WorkgroupInfo {
   // These are experimental values. Usually, we need to adjust the work group
   // size based on the input shapes to improve the EU occupancy.
   // TODO: WebGPU limits the maximum allowed shared memory size as 16K. To make
@@ -74,7 +74,7 @@ export function computeWorkGroupInfoForMatMul(
   // size to [8, 8, 1] and the work per thread size is [4, 4, 1]. But we should
   // revisit it and find the balance between work group size and work per thread
   // size.
-  const workGroupSize: [number, number, number] = [8, 8, 1];
+  const workgroupSize: [number, number, number] = [8, 8, 1];
   const elementsPerThread: [number, number, number] = [4, 4, 1];
 
   if (!transposeA) {
@@ -83,14 +83,14 @@ export function computeWorkGroupInfoForMatMul(
     }
 
     if (dimInner <= 16 && dimBOuter <= 16) {
-      workGroupSize[0] = 4;
+      workgroupSize[0] = 4;
     }
   }
 
-  return {workGroupSize, elementsPerThread};
+  return {workgroupSize, elementsPerThread};
 }
 
-export function computeWorkGroupSizeForConv2d(
+export function computeWorkgroupSizeForConv2d(
     layout: {x: number[], y?: number[], z?: number[]}, outputShape: number[],
     isVec4 = false): [number, number, number] {
   if (isVec4) {
@@ -128,7 +128,7 @@ export function computeWorkPerThreadForConv2d(
   const dim1 = arrayProduct(layout.y.map(d => outputShape[d]));
   // TODO(jiajia.qin@intel.com): More fine tune based on outputShape.
   // The following conditions correspond to the values set in
-  // computeWorkGroupSizeForConv2d.
+  // computeWorkgroupSizeForConv2d.
   if (dim0 <= 4) {
     return [1, 2, 1];
   }

--- a/tfjs-backend-webgpu/src/webgpu_util_test.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util_test.ts
@@ -19,28 +19,28 @@ import {computeDispatch} from './webgpu_util';
 
 describe('webgpu util', () => {
   it('computeDispatch returns dispatch dimensions based on layout of ' +
-         'output dimensions and workGroupSize.',
+         'output dimensions and workgroupSize.',
      () => {
        const layout = {x: [0], y: [1], z: [2, 3]};
        const outputShape = [1, 2, 3, 2];
 
-       const workGroupSize = [2, 2, 1] as [number, number, number];
+       const workgroupSize = [2, 2, 1] as [number, number, number];
 
-       const dispatch = computeDispatch(layout, outputShape, workGroupSize);
+       const dispatch = computeDispatch(layout, outputShape, workgroupSize);
        expect(dispatch).toEqual([1, 1, 6]);
      });
 
   it('computeDispatch returns dispatch dimensions based on layout of ' +
-         'output dimensions, workGroupSize, and elementsPerThread.',
+         'output dimensions, workgroupSize, and elementsPerThread.',
      () => {
        const layout = {x: [0], y: [1], z: [2, 3]};
        const outputShape = [4, 8, 12, 2];
 
-       const workGroupSize = [2, 1, 1] as [number, number, number];
+       const workgroupSize = [2, 1, 1] as [number, number, number];
        const elementsPerThread = [2, 2, 3] as [number, number, number];
 
        const dispatch = computeDispatch(
-           layout, outputShape, workGroupSize, elementsPerThread);
+           layout, outputShape, workgroupSize, elementsPerThread);
        expect(dispatch).toEqual([1, 4, 8]);
      });
 });


### PR DESCRIPTION
As workgroup is a single word in WebGPU spec.
Also calculate flatWorkgroupSize in CPU side and store value in shaders to avoid duplicate compute in GPU

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6940)
<!-- Reviewable:end -->
