### PR TITLE
Fix incorrect import path in center crop layer

### DIFF
--- a/tfjs-layers/src/layers/preprocessing/center_crop.ts
+++ b/tfjs-layers/src/layers/preprocessing/center_crop.ts
@@ -8,14 +8,14 @@
  * =============================================================================
  */
 
-import {serialization,DataType,unstack,stack,tensor,Tensor,Tensor1D,Tensor2D, Tensor3D, Tensor4D, tidy, range} from '@tensorflow/tfjs-core';
+import {serialization,DataType,unstack,stack,tensor,Tensor,Tensor1D,Tensor2D, Tensor3D, Tensor4D, tidy, range, image} from '@tensorflow/tfjs-core';
 import {getExactlyOneShape, getExactlyOneTensor} from '../../utils/types_utils';
-import {resizeBilinear} from '@tensorflow/tfjs-core/ops/image/resize_bilinear';
-import {cropAndResize} from '@tensorflow/tfjs-core/ops/image/crop_and_resize';
 import {LayerArgs, Layer} from '../../engine/topology';
 import {Kwargs} from '../../types';
 import {Shape} from '../../keras_format/common';
 import * as K from '../../backend/tfjs_backend';
+
+const {resizeBilinear, cropAndResize} = image;
 
 export declare interface CenterCropArgs extends LayerArgs{
   height: number;


### PR DESCRIPTION
`center_crop.ts` imported some dependencies from `@tensorflow/tfjs-core/ops/...`. This works in Bazel (not completely sure why), but is not standard and should be avoided.

Fixes #6944

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6946)
<!-- Reviewable:end -->
