### PR TITLE
Support dump with graphmodel.execute

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -174,17 +174,14 @@ limitations under the License.
     async function predictAndGetData(predict, model, inferenceInput, enableDump) {
       const prediction = await predict(model, inferenceInput);
       let intermediateData = {};
-      let graphModel = null;
       if (enableDump) {
-        graphModel = getGraphModel(model);
+        const graphModel = getGraphModel(model);
         if (graphModel) {
           intermediateData = await getIntermediateTensorInfo(graphModel.getIntermediateTensors());
+          graphModel.disposeIntermediateTensors();
         }
       }
       const predictionData = await getPredictionData(prediction);
-      if (graphModel) {
-        graphModel.disposeIntermediateTensors();
-      }
       return {data: predictionData, intermediateData};
     }
 

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -174,14 +174,17 @@ limitations under the License.
     async function predictAndGetData(predict, model, inferenceInput, enableDump) {
       const prediction = await predict(model, inferenceInput);
       let intermediateData = {};
+      let graphModel = null;
       if (enableDump) {
-        const graphModel = getGraphModel(model);
+        graphModel = getGraphModel(model);
         if (graphModel) {
           intermediateData = await getIntermediateTensorInfo(graphModel.getIntermediateTensors());
-          graphModel.disposeIntermediateTensors();
         }
       }
       const predictionData = await getPredictionData(prediction);
+      if (graphModel) {
+        graphModel.disposeIntermediateTensors();
+      }
       return {data: predictionData, intermediateData};
     }
 

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -220,7 +220,6 @@ const benchmarks = {
   },
   'Coco-SSD': {
     type: 'GraphModel',
-    supportDump: false,
     // The model has has the dynamic ops, so it is supposed to use executeAsync.
     architectures: ['MobileNetV2', 'MobileNetV1', 'liteMobileNetV2'],
     load: async (inputResolution = 227, modelArchitecture = 'MobileNetV2') => {
@@ -329,7 +328,6 @@ const benchmarks = {
   },
   'AutoML Object': {
     type: 'GraphModel',
-    supportDump: false,
     load: async () => {
       const url =
           'https://storage.googleapis.com/tfjs-testing/tfjs-automl/object_detection/model.json';
@@ -370,7 +368,6 @@ const benchmarks = {
   },
   'TextToxicity': {
     type: 'GraphModel',
-    supportDump: false,
     // The model has has the dynamic ops, so it is supposed to use executeAsync.
     load: async () => {
       const url =
@@ -478,6 +475,8 @@ const benchmarks = {
     }
   },
   'speech-commands': {
+    // Sequential model doesn't support dump.
+    supportDump: false,
     load: async () => {
       const recognizer = speechCommands.create('BROWSER_FFT');
       await recognizer.ensureModelLoaded();

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -475,7 +475,8 @@ const benchmarks = {
     }
   },
   'speech-commands': {
-    // Sequential model doesn't support dump.
+    // Layer model doesn't support dump. TODO(xing.xu@intel.com):
+    // https://github.com/tensorflow/tfjs/issues/7010
     supportDump: false,
     load: async () => {
       const recognizer = speechCommands.create('BROWSER_FFT');

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -220,6 +220,7 @@ const benchmarks = {
   },
   'Coco-SSD': {
     type: 'GraphModel',
+    supportDump: false,
     // The model has has the dynamic ops, so it is supposed to use executeAsync.
     architectures: ['MobileNetV2', 'MobileNetV1', 'liteMobileNetV2'],
     load: async (inputResolution = 227, modelArchitecture = 'MobileNetV2') => {
@@ -328,6 +329,7 @@ const benchmarks = {
   },
   'AutoML Object': {
     type: 'GraphModel',
+    supportDump: false,
     load: async () => {
       const url =
           'https://storage.googleapis.com/tfjs-testing/tfjs-automl/object_detection/model.json';
@@ -368,6 +370,7 @@ const benchmarks = {
   },
   'TextToxicity': {
     type: 'GraphModel',
+    supportDump: false,
     // The model has has the dynamic ops, so it is supposed to use executeAsync.
     load: async () => {
       const url =

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -75,17 +75,7 @@ const sentences = [
 ];
 
 function predictFunction(input) {
-  let debug = false;
-  try {
-    debug = tf.env().getBool('KEEP_INTERMEDIATE_TENSORS');
-  } catch (e) {
-    console.warn(e.message);
-  }
-  if (debug) {
-    return model => model.executeAsync(input);
-  } else {
-    return model => model.predict(input);
-  }
+  return model => model.predict(input);
 }
 
 const benchmarks = {
@@ -231,7 +221,6 @@ const benchmarks = {
   'Coco-SSD': {
     type: 'GraphModel',
     // The model has has the dynamic ops, so it is supposed to use executeAsync.
-    supportDump: false,
     architectures: ['MobileNetV2', 'MobileNetV1', 'liteMobileNetV2'],
     load: async (inputResolution = 227, modelArchitecture = 'MobileNetV2') => {
       const tfliteBased = modelArchitecture.split('MobileNetV')[0];
@@ -327,7 +316,6 @@ const benchmarks = {
   },
   'AutoML Image': {
     type: 'GraphModel',
-    supportDump: false,
     load: async () => {
       const url =
           'https://storage.googleapis.com/tfjs-testing/tfjs-automl/img_classification/model.json';
@@ -340,7 +328,6 @@ const benchmarks = {
   },
   'AutoML Object': {
     type: 'GraphModel',
-    supportDump: false,
     load: async () => {
       const url =
           'https://storage.googleapis.com/tfjs-testing/tfjs-automl/object_detection/model.json';
@@ -355,7 +342,6 @@ const benchmarks = {
   },
   'USE - batchsize 30': {
     type: 'GraphModel',
-    supportDump: false,
     load: async () => {
       return use.load();
     },
@@ -369,7 +355,6 @@ const benchmarks = {
   },
   'USE - batchsize 1': {
     type: 'GraphModel',
-    supportDump: false,
     load: async () => {
       return use.load();
     },
@@ -384,7 +369,6 @@ const benchmarks = {
   'TextToxicity': {
     type: 'GraphModel',
     // The model has has the dynamic ops, so it is supposed to use executeAsync.
-    supportDump: false,
     load: async () => {
       const url =
           'https://storage.googleapis.com/tfhub-tfjs-modules/tensorflow/tfjs-model/toxicity/1/default/1/model.json';
@@ -425,7 +409,6 @@ const benchmarks = {
     inputSizes: [128, 256, 512, 1024],
     architectures: ['MobileNetV1', 'ResNet50'],
     inputTypes: ['image', 'tensor'],
-    supportDump: false,
     load: async (
         inputResolution = 128, modelArchitecture = 'MobileNetV1',
         inputType = 'image') => {
@@ -461,7 +444,6 @@ const benchmarks = {
   },
   'bodypix': {
     type: 'GraphModel',
-    supportDump: false,
     // The ratio to the default camera size [480, 640].
     inputSizes: [0.25, 0.5, 0.75, 1.0],
     architectures: ['ResNet50'],

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -272,12 +272,12 @@ export class GraphExecutor implements FunctionExecutor {
               outputNodeNames, intermediateTensorConsumerCount);
         }
       }
+      if (this.keepIntermediateTensors) {
+        this.clonedTensorsMap = this.cloneTensorMap(tensorsMap);
+      }
       // dispose the context for the root executor
       if (this.parent == null) {
         context.dispose(tensorsToKeep);
-      }
-      if (this.keepIntermediateTensors) {
-        this.clonedTensorsMap = this.cloneTensorMap(tensorsMap);
       }
 
       return outputs.map(name => getTensor(name, tensorsMap, context));

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -184,7 +184,7 @@ export class GraphExecutor implements FunctionExecutor {
 
   private keepTensors(
       tensorsToKeep: Tensor[], tensorsPendingDisposal: Tensor[] = null) {
-    if (this.keepTensorsForDump === false || tensorsToKeep == null) {
+    if (!this.keepTensorsForDump || tensorsToKeep == null) {
       return;
     }
     tensorsToKeep.forEach(tensor => {
@@ -246,7 +246,7 @@ export class GraphExecutor implements FunctionExecutor {
       const context = new ExecutionContext(
           this.weightMap, tensorArrayMap, tensorListMap,
           this.functionExecutorMap);
-      if (this.keepTensorsForDump === true) {
+      if (this.keepTensorsForDump) {
         this.tensorsPendingDisposal = [];
       }
 
@@ -289,7 +289,7 @@ export class GraphExecutor implements FunctionExecutor {
       return outputs.map(name => getTensor(name, tensorsMap, context));
     });
 
-    if (this.keepTensorsForDump === true) {
+    if (this.keepTensorsForDump) {
       this.tensorsMap = tensorsMap;
     } else {
       this.tensorsMap = null;
@@ -335,7 +335,7 @@ export class GraphExecutor implements FunctionExecutor {
             if (tensor && !tensor.kept && !tensorsToKeep.has(tensor.id)) {
               const count = intermediateTensorConsumerCount[tensor.id];
               if (count === 1) {
-                if (this.keepTensorsForDump === false) {
+                if (!this.keepTensorsForDump) {
                   tensor.dispose();
                 }
                 delete intermediateTensorConsumerCount[tensor.id];
@@ -366,7 +366,7 @@ export class GraphExecutor implements FunctionExecutor {
   }
 
   disposeIntermediateTensors() {
-    if (this.keepTensorsForDump === false) {
+    if (!this.keepTensorsForDump) {
       return;
     }
 
@@ -452,7 +452,7 @@ export class GraphExecutor implements FunctionExecutor {
     const inputIds = Object.keys(inputs).map(name => inputs[name].id);
     this.idsKeepForAsync =
         new Set<number>([...outputIds, ...inputIds, ...this.weightIds]);
-    if (this.keepTensorsForDump === false) {
+    if (!this.keepTensorsForDump) {
       this.disposeTensorsMap();
     }
 
@@ -582,7 +582,7 @@ export class GraphExecutor implements FunctionExecutor {
         }
         const currentContext = context.currentContext;
         if (util.isPromise(tensors)) {
-          if (this.keepTensorsForDump === true) {
+          if (this.keepTensorsForDump) {
             throw new Error(
                 'Dump is not supported for operator returns promises!');
           }
@@ -598,7 +598,7 @@ export class GraphExecutor implements FunctionExecutor {
           }));
         } else {
           tensorMap[nodeName] = tensors;
-          if (this.keepTensorsForDump === true) {
+          if (this.keepTensorsForDump) {
             this.tensorsPendingDisposal.push(...tensors);
           }
           this.checkTensorForDisposal(
@@ -680,7 +680,7 @@ export class GraphExecutor implements FunctionExecutor {
   private mapInputs(inputs: NamedTensorMap) {
     const result: NamedTensorMap = {};
     for (const inputName in inputs) {
-      const tensor = this._signature?.inputs?.[inputName];
+      const tensor = this._signature ?.inputs ?.[inputName];
       if (tensor != null) {
         result[tensor.name] = inputs[inputName];
       } else {
@@ -704,7 +704,7 @@ export class GraphExecutor implements FunctionExecutor {
 
   private mapOutputs(outputs: string[]) {
     return outputs.map(name => {
-      const tensor = this._signature?.outputs?.[name];
+      const tensor = this._signature ?.outputs ?.[name];
       if (tensor != null) {
         return tensor.name;
       }

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -185,6 +185,9 @@ export class GraphExecutor implements FunctionExecutor {
         Object.entries(tensorsMap).map(([name, tensorsList]) => {
           return [
             name, tensorsList.map(tensor => {
+              if (tensor == null) {
+                return null;
+              }
               const clone = tensor.clone();
               keep(clone);
               return clone;
@@ -557,10 +560,6 @@ export class GraphExecutor implements FunctionExecutor {
         }
         const currentContext = context.currentContext;
         if (util.isPromise(tensors)) {
-          if (this.keepIntermediateTensors) {
-            throw new Error(
-                'Keep intermediate tensors is not supported for operator returns promises!');
-          }
           promises.push(tensors.then(t => {
             tensorMap[nodeName] = t;
             context.currentContext = currentContext;


### PR DESCRIPTION
Currently only graph model predicting with executeAsync supports dump. This has two drawbackes:
1. Models predict with execute don't support dump.
2. Some models have a wrapping layer over graph model (such as bodypix, pose-detection), to support dumping by graphModel.executeAsync, non trival changes are required, example change: https://github.com/tensorflow/tfjs-models/pull/841.

This change removes these limitations and enables dumping on more models.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6953)
<!-- Reviewable:end -->
