### PR TITLE
Use a template literal type for kernel registry key

### DIFF
--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -22,7 +22,8 @@ import {Tensor} from './tensor';
 import {DataType, RecursiveArray} from './types';
 
 const kernelRegistry =
-    getGlobal('kernelRegistry', () => new Map<string, KernelConfig>());
+    getGlobal('kernelRegistry', () => new Map<`${string}_${string}`,
+              KernelConfig>());
 const gradRegistry =
     getGlobal('gradRegistry', () => new Map<string, GradConfig>());
 
@@ -210,6 +211,7 @@ export function copyRegisteredKernels(
   });
 }
 
-function makeKey(kernelName: string, backendName: string) {
+function makeKey(kernelName: string,
+                 backendName: string): `${string}_${string}` {
   return `${backendName}_${kernelName}`;
 }


### PR DESCRIPTION
This more precisely represents the type of the kernel registry key as `${backendName}_${kernelName}` instead of just `string`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6976)
<!-- Reviewable:end -->
