### PR TITLE
Disable Safari tests for tfdf

### DIFF
--- a/tfjs-tfdf/BUILD.bazel
+++ b/tfjs-tfdf/BUILD.bazel
@@ -103,6 +103,13 @@ tfjs_web_test(
     static_files = [
         "//tfjs-tfdf/wasm:wasm_files",
     ],
+    browsers = [
+        # TODO: Support Safari.
+        "bs_chrome_mac",
+        "bs_firefox_mac",
+        "bs_android_9",
+        "win_10_chrome",
+    ],
 )
 
 test_suite(


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.