### PR TITLE
Fix tfjs-inference python not throwing error

### DIFF
--- a/tfjs-inference/python/inference.py
+++ b/tfjs-inference/python/inference.py
@@ -69,4 +69,4 @@ def predict(binary_path,
 
   if popen.returncode != 0:
     raise ValueError('Inference failed with status %d\nstderr:\n%s' %
-                     (popen.returncode, stderr))
+                     (popen.returncode, stderr.decode()))

--- a/tfjs-inference/python/inference_test.py
+++ b/tfjs-inference/python/inference_test.py
@@ -103,8 +103,14 @@ class InferenceTest(tf.test.TestCase):
     test_data_dir = os.path.join('../test_data')
     tmp_dir = tempfile.mkdtemp()
 
+    # Throws an error
     with self.assertRaises(ValueError):
       inference.predict(binary_path, model_path, test_data_dir, tmp_dir, tf_output_name_file='non_exist.json')
+
+    # ...and does not create an output file.
+    with self.assertRaises(FileNotFoundError):
+      with open(os.path.join(tmp_dir, 'data.json'), 'rt') as f:
+        json.load(f)
 
     # Cleanup tmp dir.
     shutil.rmtree(tmp_dir)

--- a/tfjs-inference/python/inference_test.py
+++ b/tfjs-inference/python/inference_test.py
@@ -103,11 +103,8 @@ class InferenceTest(tf.test.TestCase):
     test_data_dir = os.path.join('../test_data')
     tmp_dir = tempfile.mkdtemp()
 
-    inference.predict(binary_path, model_path, test_data_dir, tmp_dir, tf_output_name_file='non_exist.json')
-
-    with self.assertRaises(FileNotFoundError):
-      with open(os.path.join(tmp_dir, 'data.json'), 'rt') as f:
-        json.load(f)
+    with self.assertRaises(ValueError):
+      inference.predict(binary_path, model_path, test_data_dir, tmp_dir, tf_output_name_file='non_exist.json')
 
     # Cleanup tmp dir.
     shutil.rmtree(tmp_dir)

--- a/tfjs-inference/src/index.ts
+++ b/tfjs-inference/src/index.ts
@@ -235,4 +235,7 @@ function createInputTensors(
   }, {});
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fix a bug where tfjs-inference does not propagate errors from JavaScript to Python.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6984)
<!-- Reviewable:end -->
