### PR TITLE
webgpu: Switch to new extension timestamp-query-inside-passes

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -147,7 +147,8 @@ export class WebGPUBackend extends KernelBackend {
     this.queue = device.queue;
     this.currentCommandEncoder = null;
     this.currentComputePass = null;
-    this.supportTimeQuery = device.features.has('timestamp-query');
+    this.supportTimeQuery =
+        device.features.has('timestamp-query-inside-passes');
     this.adapterInfo = new AdapterInfo(adapterInfo);
 
     this.bufferManager = new BufferManager(this.device);
@@ -492,7 +493,7 @@ export class WebGPUBackend extends KernelBackend {
   async time(f: () => void): Promise<WebGPUTimingInfo> {
     if (!this.supportTimeQuery) {
       console.warn(
-          `This device doesn't support timestamp-query extension. ` +
+          `This device doesn't support timestamp-query-inside-passes extension. ` +
           `Start Chrome browser with flag ` +
           `--disable-dawn-features=disallow_unsafe_apis then try again. ` +
           `Otherwise, zero will be shown for the kernel time when profiling ` +

--- a/tfjs-backend-webgpu/src/base.ts
+++ b/tfjs-backend-webgpu/src/base.ts
@@ -37,6 +37,10 @@ if (isWebGPUSupported()) {
     const adapter = await navigator.gpu.requestAdapter(gpuDescriptor);
     const deviceDescriptor: GPUDeviceDescriptor = {};
 
+    // Note that timestamp-query-inside-passes is not formally in spec as
+    // timestamp within a pass is not generally supported on all the platforms.
+    // More details can be found at
+    // https://github.com/gpuweb/gpuweb/blob/main/proposals/timestamp-query-inside-passes.md
     if (adapter.features.has('timestamp-query-inside-passes')) {
       deviceDescriptor.requiredFeatures =
           // tslint:disable-next-line:no-any

--- a/tfjs-backend-webgpu/src/base.ts
+++ b/tfjs-backend-webgpu/src/base.ts
@@ -35,9 +35,15 @@ if (isWebGPUSupported()) {
     };
 
     const adapter = await navigator.gpu.requestAdapter(gpuDescriptor);
-    const adapterLimits = adapter.limits;
     const deviceDescriptor: GPUDeviceDescriptor = {};
-    const supportTimeQuery = adapter.features.has('timestamp-query');
+
+    if (adapter.features.has('timestamp-query-inside-passes')) {
+      deviceDescriptor.requiredFeatures =
+          // tslint:disable-next-line:no-any
+          ['timestamp-query-inside-passes' as any];
+    }
+
+    const adapterLimits = adapter.limits;
     deviceDescriptor.requiredLimits = {
       'maxComputeWorkgroupStorageSize':
           adapterLimits.maxComputeWorkgroupStorageSize,
@@ -46,9 +52,6 @@ if (isWebGPUSupported()) {
       'maxStorageBufferBindingSize': adapterLimits.maxStorageBufferBindingSize,
     };
 
-    if (supportTimeQuery) {
-      deviceDescriptor.requiredFeatures = ['timestamp-query'];
-    }
     const device: GPUDevice = await adapter.requestDevice(deviceDescriptor);
     const adapterInfo = await adapter.requestAdapterInfo();
     return new WebGPUBackend(device, adapterInfo);


### PR DESCRIPTION
To get timestamp inside a pass, we need to switch to new extension timestamp-query-inside-passes to adapt the new changes in spec and Chrome implementation.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6988)
<!-- Reviewable:end -->
