### PR TITLE
Run verdaccio tests concurrently with bazel tests

### DIFF
--- a/scripts/cloudbuild_e2e_expected.yml
+++ b/scripts/cloudbuild_e2e_expected.yml
@@ -35,6 +35,8 @@ steps:
       - yarn-common
   - name: gcr.io/learnjs-174218/release
     id: bazel-tests
+    waitFor:
+      - yarn-common
     entrypoint: bash
     args:
       - ./scripts/run_bazel_ci_tests.sh

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -4,6 +4,7 @@ steps:
   entrypoint: 'yarn'
   id: 'yarn-common'
   args: ['install']
+  waitedForByPackages: true
 
 # Test generate_cloudbuild.js
 # See #4523 for why this is special-cased into every cloudbuild.
@@ -45,6 +46,9 @@ steps:
   secretEnv: ['BROWSERSTACK_KEY']
   waitFor: ['yarn-common']
   nightlyOnly: true
+  # Verdaccio tests change the yarn registry, so other package tests must wait
+  # for them to finish before starting.
+  waitedForByPackages: true
   args:
     - '-eEuo'
     - 'pipefail'
@@ -57,19 +61,9 @@ steps:
 # Bazel tests
 # These use a remote cache and only re-run if changes occurred, so we run them
 # in every build.
-#
-# No 'waitFor' field because non-bazel tests must run after verdaccio nightly
-# tests. It's easier to make bazel tests wait for verdaccio since the other
-# tests wait for bazel tests. However, verdaccio nightly tests might not be
-# included (such as in non-nightly CI), so we can't `waitFor` them. Instead
-# we rely on the default behavior of waiting for all prior steps.
-#
-# TODO(mattsoulanille): Clean this up. Allow waiting for verdaccio nightly tests
-# and remove the field from `waitFor` if the tests aren't actually present.
-# Add them to all the non-bazel tests and run bazel tests concurrently with
-# verdaccio tests.
 - name: 'gcr.io/learnjs-174218/release'
   id: 'bazel-tests'
+  waitFor: ['yarn-common']
   entrypoint: 'bash'
   args:
     - './scripts/run_bazel_ci_tests.sh'
@@ -94,6 +88,7 @@ steps:
   id: 'yarn-link-package-build'
   args: ['build', '--bazel_options=--config=ci']
   waitFor: ['yarn-link-package']
+  waitedForByPackages: true
 
 # General configuration
 secrets:

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -35,6 +35,8 @@ steps:
       - yarn-common
   - name: gcr.io/learnjs-174218/release
     id: bazel-tests
+    waitFor:
+      - yarn-common
     entrypoint: bash
     args:
       - ./scripts/run_bazel_ci_tests.sh


### PR DESCRIPTION
Previously, nightly Verdaccio tests ran exclusively with Bazel tests because it was as convenient way to make the rest of the build steps wait for Verdaccio to finish. This PR properly sets up the `waitFor` field of the other steps to depend on Verdaccio tests when they're present.

To do this, the PR adds a new `waitedForByPackages` flag to the cloudbuild config, which makes all non-bazel packages `waitFor` any step it's added to.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/6999)
<!-- Reviewable:end -->
