### PR TITLE
fix(platform_browser): not crash in web worker

### DIFF
--- a/tfjs-core/src/platforms/platform_browser.ts
+++ b/tfjs-core/src/platforms/platform_browser.ts
@@ -62,7 +62,7 @@ export class PlatformBrowser implements Platform {
   // Interleaving window.postMessage and setTimeout will trick the browser and
   // avoid the clamp.
   setTimeoutCustom(functionRef: Function, delay: number): void {
-    if (typeof window === 'undefined' ||
+    if (!('window' in globalThis) ||
         !env().getBool('USE_SETTIMEOUTCUSTOM')) {
       setTimeout(functionRef, delay);
       return;


### PR DESCRIPTION
When running in web worker, with WebGPU flag turned on (Chrome 107), there's an error.

> ReferenceError: window is not defined

![image](https://user-images.githubusercontent.com/5757359/200264996-649c44e2-0ca3-4b2b-85b2-f16ffa7a271f.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7017)
<!-- Reviewable:end -->
