### PR TITLE
Move flag ENGINE_COMPILE_ONLY from Core to WebGL backend

### DIFF
--- a/tfjs-backend-webgl/src/flags_webgl.ts
+++ b/tfjs-backend-webgl/src/flags_webgl.ts
@@ -274,3 +274,6 @@ ENV.registerFlag('WEBGL_AUTO_SQUARIFY_NARROW_TEXTURE_SHAPE', () => false);
  * doesn't have the builtin isnan.
  */
 ENV.registerFlag('WEBGL2_ISNAN_CUSTOM', () => false);
+
+/** Experimental flag, whether enter compile only phase. */
+ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);

--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -77,9 +77,6 @@ ENV.registerFlag('CHECK_COMPUTATION_FOR_ERRORS', () => true);
 /** Whether the backend needs to wrap input to imageBitmap. */
 ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);
 
-/** Experimental flag, whether enter compile only phase. */
-ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);
-
 /** Whether to enable canvas2d willReadFrequently for GPU backends */
 ENV.registerFlag('CANVAS2D_WILL_READ_FREQUENTLY_FOR_GPU', () => false);
 


### PR DESCRIPTION
Since this flag currently is only meaningful for WebGL backend, so moves it from Core to WebGL backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7019)
<!-- Reviewable:end -->
