### PR TITLE
webgpu: Correct depthwise conv2d vec4 condition

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
+++ b/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
@@ -55,7 +55,7 @@ export function depthwiseConv2dNative(args: {
     program = new DepthwiseConv2DNCHWSharedProgram(
         convInfo.outShape, convInfo.filterHeight, convInfo.filterWidth);
   } else if (
-      isChannelsLast && convInfo.inHeight > 4 && convInfo.inWidth > 4 &&
+      isChannelsLast && convInfo.outHeight > 4 && convInfo.outWidth > 4 &&
       convInfo.strideWidth <= 2 &&
       convInfo.inChannels === convInfo.outChannels &&
       convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&

--- a/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
@@ -64,7 +64,7 @@ export function fusedDepthwiseConv2D(args: {
   ];
 
   let program: DepthwiseConv2DProgram|DepthwiseConv2DVec4Program;
-  if (convInfo.inHeight > 4 && convInfo.inWidth > 4 &&
+  if (convInfo.outHeight > 4 && convInfo.outWidth > 4 &&
       convInfo.strideWidth <= 2 &&
       convInfo.inChannels === convInfo.outChannels &&
       convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&


### PR DESCRIPTION
We should use the output width/height instead of input width/height as the condition of whether going to vec4 version since the task is splitted as output shape.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7035)
<!-- Reviewable:end -->
