### PR TITLE
Remove @types/webgl2 since they are included in lib/dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/seedrandom": "^2.4.28",
     "@types/shelljs": "^0.8.7",
     "@types/webgl-ext": "0.0.30",
-    "@types/webgl2": "0.0.6",
     "@webgpu/types": "0.1.21",
     "ajv": "~6.12.3",
     "argparse": "^1.0.10",

--- a/tfjs-backend-webgl/package.json
+++ b/tfjs-backend-webgl/package.json
@@ -34,7 +34,6 @@
     "@types/offscreencanvas": "~2019.3.0",
     "@types/seedrandom": "^2.4.28",
     "@types/webgl-ext": "0.0.30",
-    "@types/webgl2": "0.0.6",
     "seedrandom": "^3.0.5"
   },
   "peerDependencies": {

--- a/tfjs-backend-webgl/src/BUILD.bazel
+++ b/tfjs-backend-webgl/src/BUILD.bazel
@@ -54,7 +54,7 @@ ts_library(
         "@npm//@types/offscreencanvas",
         "@npm//@types/seedrandom",
         "@npm//@types/webgl-ext",
-        "@npm//@types/webgl2",
+        #"@npm//@types/webgl2",
     ],
 )
 

--- a/tfjs-backend-webgl/src/BUILD.bazel
+++ b/tfjs-backend-webgl/src/BUILD.bazel
@@ -54,7 +54,6 @@ ts_library(
         "@npm//@types/offscreencanvas",
         "@npm//@types/seedrandom",
         "@npm//@types/webgl-ext",
-        #"@npm//@types/webgl2",
     ],
 )
 
@@ -69,9 +68,7 @@ ts_library(
 
 ts_library(
     name = "tfjs-backend-webgl_test_lib",
-    # TODO(mattsoulanille): Mark as testonly when esbuild is fixed to allow it.
-    # https://github.com/bazelbuild/rules_nodejs/pull/2984
-    # testonly = True,
+    testonly = True,
     srcs = glob(TEST_SRCS) + [":tests"],
     module_name = "@tensorflow/tfjs-backend-webgl/dist",
     deps = [

--- a/tfjs-backend-webgl/yarn.lock
+++ b/tfjs-backend-webgl/yarn.lock
@@ -29,16 +29,6 @@
   resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.30.tgz#d2efe425869b84163c2d56e779dddadb9372cbfa"
   integrity sha512-AnxLHewubLVzoF/A4qdxBGHCKifw8cY32iro3DQX9TPcetE95zBeVt3jnsvtvAUf1vwzMfwzp4t/L2yqPlnjkQ==
 
-"@types/webgl-ext@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
-  integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
-
-"@types/webgl2@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.6.tgz#1ea2db791362bd8521548d664dbd3c5311cdf4b6"
-  integrity sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==
-
 core-js@^2.6.5:
   version "2.6.12"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"

--- a/tfjs/yarn.lock
+++ b/tfjs/yarn.lock
@@ -1888,11 +1888,6 @@
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.6.tgz#1ea2db791362bd8521548d664dbd3c5311cdf4b6"
-  integrity sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==
-
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,11 +427,6 @@
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.6.tgz#1ea2db791362bd8521548d664dbd3c5311cdf4b6"
-  integrity sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==
-
 "@webgpu/types@0.1.21":
   version "0.1.21"
   resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.21.tgz#b181202daec30d66ccd67264de23814cfd176d3a"


### PR DESCRIPTION
Remove @types/webgl2 since ts4 includes these types in lib/dom.

Fixes #4201

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7038)
<!-- Reviewable:end -->
