### PR TITLE
Make tfjs-tfdf work with bundlers

### DIFF
--- a/tfjs-tfdf/BUILD.bazel
+++ b/tfjs-tfdf/BUILD.bazel
@@ -29,12 +29,15 @@ tfjs_bundle(
         "@tensorflow/tfjs-converter",
         "path",
         "fs",
-        "jszip",
+    ],
+    leave_as_require = [
+        "path",
+        "fs",
+        "crypto",
     ],
     globals = {
         "@tensorflow/tfjs-converter": "tf",
         "@tensorflow/tfjs-core": "tf",
-        "jszip": "JSZip",
     },
     umd_name = "tfdf",
     deps = [
@@ -92,7 +95,6 @@ pkg_npm(
         ":copy_bundles",
         ":copy_src_to_dist",
         ":copy_wasm_files",
-        "//tfjs-tfdf/wasm:wasm_files",
     ],
 )
 

--- a/tfjs-tfdf/BUILD.bazel
+++ b/tfjs-tfdf/BUILD.bazel
@@ -30,15 +30,15 @@ tfjs_bundle(
         "path",
         "fs",
     ],
+    globals = {
+        "@tensorflow/tfjs-converter": "tf",
+        "@tensorflow/tfjs-core": "tf",
+    },
     leave_as_require = [
         "path",
         "fs",
         "crypto",
     ],
-    globals = {
-        "@tensorflow/tfjs-converter": "tf",
-        "@tensorflow/tfjs-core": "tf",
-    },
     umd_name = "tfdf",
     deps = [
         "//tfjs-tfdf/src:tfdf_web_api_client_js",

--- a/tfjs-tfdf/package.json
+++ b/tfjs-tfdf/package.json
@@ -3,10 +3,16 @@
   "version": "0.0.1",
   "description": "TensorFlow Decision Forests support for TensorFlow.js",
   "main": "dist/tf-tfdf.node.js",
-  "module": "dist/index.js",
+  "module": "dist/tf-tfdf.fesm.js",
   "jsdelivr": "dist/tf-tfdf.min.js",
   "unpkg": "dist/tf-tfdf.min.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/tf-tfdf.fesm.js",
+      "require": "./dist/tf-tfdf.node.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/tensorflow/tfjs.git",


### PR DESCRIPTION
Set the ESM entrypoint to the flat ESM bundle. Set the cjs entrypoint to the node (cjs) bundle.

Prevent node-specific 'require's in the emscripten bundle from being hoisted to the top of the file. Now, it checks if it's running in node before requiring node-specific things like 'fs' or 'path'.

Node is not yet supported. I think it may be trying `fetch` the wasm files instead of opening them on the filesystem.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7054)
<!-- Reviewable:end -->
