### PR TITLE
Remove 'sideEffects' field from package.jsons

### DIFF
--- a/tfjs-backend-cpu/package.json
+++ b/tfjs-backend-cpu/package.json
@@ -42,14 +42,6 @@
     "util": false,
     "crypto": false
   },
-  "sideEffects": [
-    "./dist/register_all_kernels.js",
-    "./dist/base.js",
-    "./dist/index.js",
-    "./src/register_all_kernels.mjs",
-    "./src/base.mjs",
-    "./src/index.mjs"
-  ],
   "resolutions": {
     "minimist": "1.2.6"
   }

--- a/tfjs-backend-webgl/package.json
+++ b/tfjs-backend-webgl/package.json
@@ -42,19 +42,5 @@
   "browser": {
     "util": false,
     "crypto": false
-  },
-  "sideEffects": [
-    "./dist/register_all_kernels.js",
-    "./dist/flags_webgl.js",
-    "./dist/base.js",
-    "./dist/index.js",
-    "./dist/register_all_kernels.mjs",
-    "./dist/flags_webgl.mjs",
-    "./dist/base.mjs",
-    "./dist/index.mjs",
-    "./src/register_all_kernels.mjs",
-    "./src/flags_webgl.mjs",
-    "./src/base.mjs",
-    "./src/index.mjs"
-  ]
+  }
 }

--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -52,26 +52,6 @@
     "crypto": false,
     "worker_threads": false
   },
-  "sideEffects": [
-    "./dist/index.js",
-    "./dist/engine.js",
-    "./dist/tensor.js",
-    "./dist/base_side_effects.js",
-    "./dist/flags.js",
-    "./dist/platforms/*.js",
-    "./dist/register_all_gradients.js",
-    "./dist/public/chained_ops/*.js",
-    "./dist/io/*.js",
-    "./src/index.mjs",
-    "./src/engine.mjs",
-    "./src/tensor.mjs",
-    "./src/base_side_effects.mjs",
-    "./src/flags.mjs",
-    "./src/platforms/*.mjs",
-    "./src/register_all_gradients.mjs",
-    "./src/public/chained_ops/*.mjs",
-    "./src/io/*.mjs"
-  ],
   "resolutions": {
     "minimist": "1.2.6"
   }


### PR DESCRIPTION
Some of tfjs's package.json files have a `sideEffects` field to mark certain files as side-effectful for bundlers. However, bundlers can do static analysis to find side effects automatically, and this is usually more accurate and less error-prone than relying on a manually maintained list.

This PR removes the `sideEffects` field from the package.json files.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.