### PR TITLE
Fix batch matching for batch mat mul

### DIFF
--- a/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
+++ b/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
@@ -114,8 +114,10 @@ export function batchMatMul(args: {
                   batchIndexB = bi % batchDimB;
                 }
                 const aVal =
+                    // tslint:disable-next-line: max-line-length
                     a3dValues[batchIndexA * aBatch + i * aOuterStep + k * aInnerStep];
                 const bVal =
+                    // tslint:disable-next-line: max-line-length
                     b3dValues[k * bInnerStep + j * bOuterStep + batchIndexB * bBatch];
                 sum += aVal * bVal;
               }

--- a/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
+++ b/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
@@ -106,12 +106,17 @@ export function batchMatMul(args: {
               let sum = 0.0;
 
               for (let k = k0; k < kBlock; k++) {
-                const batchOffsetA = Math.min(bi, batchDimA - 1) * aBatch;
-                const batchOffsetB = Math.min(bi, batchDimB - 1) * bBatch;
+                let batchIndexA = bi;
+                let batchIndexB = bi;
+                if (bi >= batchDimA) {
+                  batchIndexA = bi % batchDimA;
+                } else if (bi >= batchDimB) {
+                  batchIndexB = bi % batchDimB;
+                }
                 const aVal =
-                    a3dValues[batchOffsetA + i * aOuterStep + k * aInnerStep];
+                    a3dValues[batchIndexA * aBatch + i * aOuterStep + k * aInnerStep];
                 const bVal =
-                    b3dValues[k * bInnerStep + j * bOuterStep + batchOffsetB];
+                    b3dValues[k * bInnerStep + j * bOuterStep + batchIndexB * bBatch];
                 sum += aVal * bVal;
               }
               resVals[bi * size + (i * rightDim + j)] += sum;

--- a/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
+++ b/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
@@ -106,13 +106,8 @@ export function batchMatMul(args: {
               let sum = 0.0;
 
               for (let k = k0; k < kBlock; k++) {
-                let batchIndexA = bi;
-                let batchIndexB = bi;
-                if (bi >= batchDimA) {
-                  batchIndexA = bi % batchDimA;
-                } else if (bi >= batchDimB) {
-                  batchIndexB = bi % batchDimB;
-                }
+                const batchIndexA = bi % batchDimA;
+                const batchIndexB = bi % batchDimB;
                 const aVal =
                     // tslint:disable-next-line: max-line-length
                     a3dValues[batchIndexA * aBatch + i * aOuterStep + k * aInnerStep];

--- a/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
+++ b/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
@@ -235,13 +235,8 @@ void slow_batch_matmul(const size_t a_id, const size_t* a_shape_ptr,
               float sum = 0.0;
 
               for (size_t k = k0; k < k_block; ++k) {
-                size_t batch_index_a = b;
-                size_t batch_index_b = b;
-                if (b >= a_shape[0]) {
-                  batch_index_a = b % a_shape[0];
-                } else if (b >= b_shape[0]) {
-                  batch_index_b = b % b_shape[0];
-                }
+                const size_t batch_index_a = b % a_shape[0];
+                const size_t batch_index_b = b % b_shape[0];
                 sum += a_buf[batch_index_a * a_batch + i * a_outer_step +
                              k * a_inner_step] *
                        b_buf[k * b_inner_step + j * b_outer_step +

--- a/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
@@ -78,9 +78,9 @@ export class MatMulPackedProgram implements GPGPUProgram {
     let batchASnippet = 'rc.x';
     let batchBSnippet = 'rc.x';
     if (aShape[0] < bShape[0]) {
-      batchASnippet = `int(min(float(rc.x), ${aShape[0] - 1}.))`;
+      batchASnippet = `imod(rc.x, ${aShape[0]})`;
     } else if (bShape[0] < aShape[0]) {
-      batchBSnippet = `int(min(float(rc.x), ${bShape[0] - 1}.))`;
+      batchBSnippet = `imod(rc.x, ${bShape[0]})`;
     }
 
     this.userCode = `

--- a/tfjs-core/src/ops/mat_mul_test.ts
+++ b/tfjs-core/src/ops/mat_mul_test.ts
@@ -894,6 +894,15 @@ describeWithFlags('matmulBatch', ALL_ENVS, () => {
     ]);
   });
 
+  it('A has more batch dimensions than B', async () => {
+    const a = tf.tensor4d(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [2, 2, 2, 2]);
+    const b = tf.tensor3d([1, 2, 3, 4], [2, 2, 1]);
+
+    const c = tf.matMul(a, b);
+    expectArraysClose(await c.data(), [5, 11, 39, 53, 29, 35, 95, 109]);
+  });
+
   it('batch dimensions do not match', () => {
     const a = tf.tensor3d(
         [


### PR DESCRIPTION
Fix https://github.com/tensorflow/tfjs/issues/7061 for CPU, WASM (native implementation) and WebGL backends.

This error is because of batch mismatch when A has more dimensions than B, and vice versa. 

For example: A's shape is `[2,4,3,3]` and B's shape is `[4,3,3]`. Then A's batch is the first two dimensions `[2, 4]` while B's batch is the first dimension `[4]`, so B's batch is supposed to be broadcasted to be `[2, 4]`. Then, to compute `output[1][0][0][0]`, we have to do dot product of `A[1][0]   [0][...]` with `B[0]   [...][0]`, but the current algorithm is doing dot product of `A[1][0][0][...]` with `B[3][...][0]`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7062)
<!-- Reviewable:end -->
