### PR TITLE
Optimize BatchMatMul by moving batch variable out of loops

### DIFF
--- a/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
+++ b/tfjs-backend-cpu/src/kernels/BatchMatMul.ts
@@ -93,12 +93,14 @@ export function batchMatMul(args: {
   const blockSize = backend.blockSize;
 
   for (let bi = 0; bi < batchDim; bi++) {
+    const batchIndexA = bi % batchDimA;
+    const batchIndexB = bi % batchDimB;
     for (let i0 = 0; i0 < leftDim; i0 += blockSize) {
+      // for when blockSize doesn't evenly divide the input
+      const iBlock = Math.min(i0 + blockSize, leftDim);
       for (let j0 = 0; j0 < rightDim; j0 += blockSize) {
+        const jBlock = Math.min(j0 + blockSize, rightDim);
         for (let k0 = 0; k0 < sharedDim; k0 += blockSize) {
-          // for when blockSize doesn't evenly divide the input
-          const iBlock = Math.min(i0 + blockSize, leftDim);
-          const jBlock = Math.min(j0 + blockSize, rightDim);
           const kBlock = Math.min(k0 + blockSize, sharedDim);
 
           for (let i = i0; i < iBlock; i++) {
@@ -106,8 +108,6 @@ export function batchMatMul(args: {
               let sum = 0.0;
 
               for (let k = k0; k < kBlock; k++) {
-                const batchIndexA = bi % batchDimA;
-                const batchIndexB = bi % batchDimB;
                 const aVal =
                     // tslint:disable-next-line: max-line-length
                     a3dValues[batchIndexA * aBatch + i * aOuterStep + k * aInnerStep];

--- a/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
+++ b/tfjs-backend-wasm/src/cc/batch_mat_mul_impl.cc
@@ -222,12 +222,14 @@ void slow_batch_matmul(const size_t a_id, const size_t* a_shape_ptr,
   std::fill(out_buf, out_buf + batch_dim * size, 0);
 
   for (size_t b = 0; b < batch_dim; ++b) {
+    const size_t batch_index_a = b % a_shape[0];
+    const size_t batch_index_b = b % b_shape[0];
     for (size_t i0 = 0; i0 < left_dim; i0 += kBlockSize) {
+      // for when kBlockSize doesn't evenly divide the input
+      const size_t i_block = std::min(i0 + kBlockSize, left_dim);
       for (size_t j0 = 0; j0 < right_dim; j0 += kBlockSize) {
+        const size_t j_block = std::min(j0 + kBlockSize, right_dim);
         for (size_t k0 = 0; k0 < shared_dim; k0 += kBlockSize) {
-          // for when kBlockSize doesn't evenly divide the input
-          const size_t i_block = std::min(i0 + kBlockSize, left_dim);
-          const size_t j_block = std::min(j0 + kBlockSize, right_dim);
           const size_t k_block = std::min(k0 + kBlockSize, shared_dim);
 
           for (size_t i = i0; i < i_block; ++i) {
@@ -235,8 +237,6 @@ void slow_batch_matmul(const size_t a_id, const size_t* a_shape_ptr,
               float sum = 0.0;
 
               for (size_t k = k0; k < k_block; ++k) {
-                const size_t batch_index_a = b % a_shape[0];
-                const size_t batch_index_b = b % b_shape[0];
                 sum += a_buf[batch_index_a * a_batch + i * a_outer_step +
                              k * a_inner_step] *
                        b_buf[k * b_inner_step + j * b_outer_step +

--- a/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/mulmat_packed_gpu.ts
@@ -90,9 +90,9 @@ export class MatMulPackedProgram implements GPGPUProgram {
 
       vec4 dot2x2ARowBCol(ivec3 rc) {
         vec4 result = vec4(0);
+        int batchA = ${batchASnippet};
+        int batchB = ${batchBSnippet};
         for (int i = 0; i < ${sharedDimensionPacked}; i++) {
-          int batchA = ${batchASnippet};
-          int batchB = ${batchBSnippet};
           vec4 a = getMatrixA(batchA, ${aSample});
           vec4 b = getMatrixB(batchB, ${bSample});
 


### PR DESCRIPTION
When computing a certain output value of BatchMatMul, it has to have a loop over the inputs' shared Dimension. However, batch variables are const over this loop, so we could move batch variables out of this loop.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7069)
<!-- Reviewable:end -->
