### PR TITLE
webgpu: support confusionMatrix and stft operators

### DIFF
--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -159,12 +159,6 @@ const TEST_FILTERS: TestFilter[] = [
     ]
   },
   {
-    startsWith: 'min ',
-    excludes: [
-      'stft',  // FFT' not registered.
-    ]
-  },
-  {
     startsWith: 'mul ',
     excludes: [
       'broadcast',  // Various: Actual != Expected, compile fails, etc.
@@ -191,9 +185,6 @@ const TEST_FILTERS: TestFilter[] = [
   {
     startsWith: 'range ',
     excludes: [
-      'bincount',           // Not yet implemented.
-      'denseBincount',      // Not yet implemented.
-      'oneHot',             // Not yet implemented.
       'sparseSegmentMean',  // 'SparseSegmentMean' not registered.
     ]
   },
@@ -241,8 +232,7 @@ const TEST_FILTERS: TestFilter[] = [
   {
     startsWith: 'transpose ',
     excludes: [
-      'oneHot',  // Not yet implemented.
-      'fused',   // Not yet implemented.
+      'fused',  // Not yet implemented.
     ]
   },
 
@@ -271,7 +261,6 @@ const TEST_FILTERS: TestFilter[] = [
       'maxPoolBackprop ',
       'maxPoolWithArgmax ',
       'multinomial ',
-      'confusionMatrix ',  // oneHot
       'poolBackprop ',
       'raggedGather ',
       'raggedRange ',
@@ -280,7 +269,6 @@ const TEST_FILTERS: TestFilter[] = [
       'method otsu',  // round
       'selu ',
       'sign webgpu',
-      'stft ',
       'softplus ',
       'sigmoidCrossEntropy ',
       'sparseFillEmptyRows ',


### PR DESCRIPTION
These two operators were automatically supported after the other related operators had beed implemented. The patch also relaxes some cases.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7092)
<!-- Reviewable:end -->
