### PR TITLE
fix diag() example.

### DIFF
--- a/tfjs-core/src/ops/diag.ts
+++ b/tfjs-core/src/ops/diag.ts
@@ -38,7 +38,7 @@ import {op} from './operation';
  * tf.diag(x).print()
  * ```
  * ```js
- * const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 6, 8], [4, 2])
+ * const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [4, 2])
  *
  * tf.diag(x).print()
  * ```


### PR DESCRIPTION
Fixed example to make it less confusing.

The second example has the following output:
```javascript
Tensor
    [[[[1, 0],
       [0, 0],
       [0, 0],
       [0, 0]],

      [[0, 2],
       [0, 0],
       [0, 0],
       [0, 0]]],


     [[[0, 0],
       [3, 0],
       [0, 0],
       [0, 0]],

      [[0, 0],
       [0, 4],
       [0, 0],
       [0, 0]]],


     [[[0, 0],
       [0, 0],
       [5, 0],
       [0, 0]],

      [[0, 0],
       [0, 0],
       [0, 6],
       [0, 0]]],


     [[[0, 0],
       [0, 0],
       [0, 0],
       [6, 0]],

      [[0, 0],
       [0, 0],
       [0, 0],
       [0, 8]]]]
```

- which I found confusing because there's a 6 in the left column (at position [3][0][3][0]), until I noticed the typo, where the 6 is repeated instead of a 7.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7111)
<!-- Reviewable:end -->
