### PR TITLE
Add depth check for dilation2d

### DIFF
--- a/tfjs-core/src/ops/dilation2d.ts
+++ b/tfjs-core/src/ops/dilation2d.ts
@@ -31,7 +31,7 @@ import {reshape} from './reshape';
  * Computes the grayscale dilation over the input `x`.
  *
  * @param x The input tensor, rank 3 or rank 4 of shape
- *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is assumed.
+ *     `[batch, height, width, depth]`. If rank 3, batch of 1 is assumed.
  * @param filter The filter tensor, rank 3, of shape
  *     `[filterHeight, filterWidth, depth]`.
  * @param strides The strides of the sliding window for each dimension of the
@@ -86,6 +86,11 @@ function dilation2d_<T extends Tensor3D|Tensor4D>(
     x4D = reshape($x, [1, $x.shape[0], $x.shape[1], $x.shape[2]]);
     reshapedTo4D = true;
   }
+
+  util.assert(
+      x4D.shape[3] === $filter.shape[2],
+      () => `Error in dilation2d:  input and filter must have the same depth: ${
+          x4D.shape[3]} vs ${$filter.shape[2]}`);
 
   const inputs: Dilation2DInputs = {x: x4D, filter: $filter};
   const attrs: Dilation2DAttrs = {strides, pad, dilations};


### PR DESCRIPTION
Fix https://github.com/tensorflow/tfjs/issues/7112

According to [tensorflow](https://www.tensorflow.org/api_docs/python/tf/raw_ops/Dilation2D), the last dimension of input and the last dimension of filter are `depth` and they are supposed to have the same size, otherwise an error would be thrown:
![Screen Shot 2022-12-01 at 5 06 54 PM](https://user-images.githubusercontent.com/40653845/205191953-5013ddda-0d04-4daa-9844-a82c75464732.png)

So, we also want to throw an error if the depths of input and filter do not match.




To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7137)
<!-- Reviewable:end -->
