### PR TITLE
Add tfdf ops as supported by tfjs-converter

### DIFF
--- a/tfjs-converter/python/tensorflowjs/op_list/tfdf.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/tfdf.json
@@ -1,0 +1,11 @@
+[
+  {
+    "tfOpName": "SimpleMLCreateModelResource"
+  },
+  {
+    "tfOpName": "SimpleMLLoadModelFromPathWithHandle"
+  },
+  {
+    "tfOpName": "SimpleMLInferenceOpWithHandle"
+  }
+]


### PR DESCRIPTION
Add SimpleMLCreateModelResource, SimpleMLLoadModelFromPathWithHandle, and SimpleMLInferenceOpWithHandle ops as supported by tfjs converter to allow converting tfdf models.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.