### PR TITLE
Increase timeout and add Gpu info to nightly benchmark

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -281,7 +281,7 @@ function runBrowserStackBenchmark(tabId) {
     const command = `yarn ${args.join(' ')}`;
     console.log(`Running: ${command}`);
 
-    execFile('yarn', args, (error, stdout, stderr) => {
+    execFile('yarn', args, { timeout: 3e5 }, (error, stdout, stderr) => {
       if (error) {
         console.log(`\n${error}`);
         console.log(`stdout: ${stdout}`);

--- a/e2e/benchmarks/browserstack-benchmark/app_node_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_node_test.js
@@ -6,6 +6,7 @@ const {
   serializeTensors,
   getReadableDate,
   formatForFirestore,
+  makeCompatableWithFirestore,
   runFirestore,
   firebaseConfig
 } = require('./firestore.js');
@@ -237,10 +238,16 @@ describe('test adding to firestore', () => {
     db.add.and.returnValue(Promise.resolve({ id: 123 }));
     let expectedAdd = {
       result:
-        formatForFirestore(mockResultValue, serializeTensors, getReadableDate)
+        formatForFirestore(mockResultValue, makeCompatableWithFirestore,
+          getReadableDate)
     };
     addResultToFirestore(db, mockResultValue.tabId, mockResultValue);
     expect(db.add).toHaveBeenCalledWith(expectedAdd);
+  });
+
+  it('Expects gpu info is appended to device info', () => {
+    addGpuInfo(mockResultValue);
+    expect(mockResultValue.deviceInfo.device).toEqual('');
   });
 
   it('Expects a date key to exist and have the correct value', () => {

--- a/e2e/benchmarks/browserstack-benchmark/app_node_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_node_test.js
@@ -3,10 +3,10 @@ const { benchmark, write, getOneBenchmarkResult, runBenchmarkFromFile, scheduleM
   require('./app.js');
 const {
   addResultToFirestore,
-  serializeTensors,
+  makeCompatableWithFirestore,
+  addGpuInfo,
   getReadableDate,
   formatForFirestore,
-  makeCompatableWithFirestore,
   runFirestore,
   firebaseConfig
 } = require('./firestore.js');
@@ -247,7 +247,9 @@ describe('test adding to firestore', () => {
 
   it('Expects gpu info is appended to device info', () => {
     addGpuInfo(mockResultValue);
-    expect(mockResultValue.deviceInfo.device).toEqual('');
+    expect(mockResultValue.deviceInfo.device).toEqual(
+      '(GPU: ANGLE (ATI Technologies Inc., AMD Radeon Pro 5300M OpenGL ' +
+      'Engine, OpenGL 4.1))');
   });
 
   it('Expects a date key to exist and have the correct value', () => {
@@ -258,7 +260,8 @@ describe('test adding to firestore', () => {
 
   it('Expects serialization to cover all nested arrays', () => {
     const mockSerializedResults =
-      formatForFirestore(mockResultValue, serializeTensors, mockDate);
+      formatForFirestore(mockResultValue, makeCompatableWithFirestore,
+        mockDate);
     for (kernel of mockSerializedResults.benchmarkInfo.memoryInfo.kernels) {
       expect(typeof (kernel.inputShapes)).toEqual('string');
       expect(typeof (kernel.outputShapes)).toEqual('string');

--- a/e2e/benchmarks/browserstack-benchmark/firestore.js
+++ b/e2e/benchmarks/browserstack-benchmark/firestore.js
@@ -148,6 +148,7 @@ function getReadableDate() {
 
 exports.addResultToFirestore = addResultToFirestore;
 exports.makeCompatableWithFirestore = makeCompatableWithFirestore;
+exports.addGpuInfo = addGpuInfo;
 exports.serializeTensors = serializeTensors;
 exports.getReadableDate = getReadableDate;
 exports.formatForFirestore = formatForFirestore;

--- a/e2e/benchmarks/browserstack-benchmark/firestore.js
+++ b/e2e/benchmarks/browserstack-benchmark/firestore.js
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-const {initializeApp, deleteApp, applicationDefault, cert} = require('firebase-admin/app');
-const {getFirestore, Timestamp, FieldValue} = require('firebase-admin/firestore');
+const { initializeApp, deleteApp, applicationDefault, cert } = require('firebase-admin/app');
+const { getFirestore, Timestamp, FieldValue } = require('firebase-admin/firestore');
 
 let app;
 /**
@@ -62,8 +62,8 @@ async function endFirebaseInstance() {
 async function addResultToFirestore(db, resultId, result) {
   try {
     const firestoreMap =
-        formatForFirestore(result, serializeTensors, getReadableDate);
-    await db.add({result: firestoreMap}).then((ref) => {
+      formatForFirestore(result, makeCompatableWithFirestore, getReadableDate);
+    await db.add({ result: firestoreMap }).then((ref) => {
       console.log(`Added ${resultId} to Firestore with ID: ${ref.id}`);
     });
   } catch (err) {
@@ -78,7 +78,8 @@ async function addResultToFirestore(db, resultId, result) {
  * @param result Individual result in a list of fulfilled promises
  */
 function formatForFirestore(
-    result, makeCompatable = serializeTensors, getDate = getReadableDate) {
+  result, makeCompatable = makeCompatableWithFirestore,
+  getDate = getReadableDate) {
   let firestoreMap = {};
   firestoreMap.benchmarkInfo = makeCompatable(result);
   firestoreMap.date = getDate();
@@ -87,9 +88,41 @@ function formatForFirestore(
 }
 
 /**
- *Benchmark results contain tensors that are represented as nested arrays.
- *Nested arrays are not supported on Firestore, so they are serialized
- *before they are stored.
+ * This function makes the result object returned from benchmark app aligned
+ * with target firestore collection's schema.
+ *
+ * @param result Individual result in a list of fulfilled promises
+ */
+function makeCompatableWithFirestore(result) {
+  addGpuInfo(result);
+  serializeTensors(result);
+  return result;
+}
+
+/**
+ * Append GPU info to device name.
+ *
+ * @param result Individual result in a list of fulfilled promises
+ */
+function addGpuInfo(result) {
+  const gpuInfo = result.gpuInfo;
+  delete result.gpuInfo;
+  if (gpuInfo == null || gpuInfo === 'MISS') {
+    return;
+  }
+
+  if (result.deviceInfo.device == null) {
+    result.deviceInfo.device = `(GPU: ${gpuInfo})`;
+  } else {
+    result.deviceInfo.device = `${result.deviceInfo.device} (GPU: ${gpuInfo})`;
+  }
+  return result;
+}
+
+/**
+ * Benchmark results contain tensors that are represented as nested arrays.
+ * Nested arrays are not supported on Firestore, so they are serialized
+ * before they are stored.
  *
  * @param result Individual result in a list of fulfilled promises
  */
@@ -114,6 +147,7 @@ function getReadableDate() {
 }
 
 exports.addResultToFirestore = addResultToFirestore;
+exports.makeCompatableWithFirestore = makeCompatableWithFirestore;
 exports.serializeTensors = serializeTensors;
 exports.getReadableDate = getReadableDate;
 exports.formatForFirestore = formatForFirestore;

--- a/e2e/benchmarks/browserstack-benchmark/firestore_test_value.json
+++ b/e2e/benchmarks/browserstack-benchmark/firestore_test_value.json
@@ -4186,5 +4186,14 @@
       }
     ]
   },
-  "tabId": "OS_X_Catalina_1"
+  "deviceInfo": {
+    "base": "BrowserStack",
+    "browser": "chrome",
+    "browser_version": "103.0",
+    "device": null,
+    "os": "OS X",
+    "os_version": "Monterey"
+  },
+  "tabId": "OS_X_Catalina_1",
+  "gpuInfo": "ANGLE (ATI Technologies Inc., AMD Radeon Pro 5300M OpenGL Engine, OpenGL 4.1)"
 }

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -33,7 +33,7 @@
     "build-tfjs": "cd ../../../tfjs && yarn && yarn build-npm",
     "build-all-link-packages": "cd ../../../ && yarn && cd ./link-package && yarn build",
     "build-individual-link-package": "cd ../../../ && yarn && cd ./link-package && yarn build-deps-for",
-    "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=9 --firestore",
+    "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=12 --firestore",
     "run-cloud-benchmarks-weekly-cycle": "yarn run-cloud-benchmarks --weeklyCycleRun=-1"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR:
1. Set a timeout for child processes spawned from `app.js` program. Even though we have set a couple of timeout in karma, we also want to restrict the time of the child processes running the karma test (in a higher level). Otherwise, some benchmark item takes too much time. (for example, the following test on A11 machine takes approximately 21 minutes.)
![image](https://user-images.githubusercontent.com/40653845/206316562-89bb1da9-971d-48be-a376-ce122e6ccd32.png)
2. Append GPU info to device info. (Alternative solution: add a new filed for GPU info. However, we have to change the schema of the firestore collection.)
3. Changes `maxBenchmarks` from 9 to 12. Because currently we have 23 target devices, this change possibly reduces time each model (if no re-try happens, approximately reduce from `ceil(23 / 9) * average benchmark time` to `ceil(23 / 12) * average benchmark time`).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.