### PR TITLE
[webgpu] Add a huge matmul test

### DIFF
--- a/tfjs-backend-webgpu/src/matmul_test.ts
+++ b/tfjs-backend-webgpu/src/matmul_test.ts
@@ -1219,6 +1219,17 @@ function matmulTest(programType: MatMulProgramType) {
       ]);
     });
 
+    it('A x B with large K. [16,2048]x[2048,16]', async () => {
+      const a = tf.tensor2d(new Array(16 * 2048).fill(1), [16, 2048]);
+      const b = tf.tensor2d(new Array(2048 * 16).fill(1), [2048, 16]);
+
+      const c = tf.matMul(a, b);
+      const cData = await c.data();
+
+      expect(c.shape).toEqual([16, 16]);
+      expectArraysClose(cData, new Array(16 * 16).fill(2048));
+    });
+
     it('matmul followed by mul', async () => {
       const a = tf.tensor2d([1, 2, 3, 4], [2, 2]);
       const b = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);


### PR DESCRIPTION
Currently the matMul splitK kernel has a threshold of K=128 for dispatching multiple workgroups along the Z axis, but the existing 'matMul A x B multiple tiles' spec is not large enough to cover the case.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7153)
<!-- Reviewable:end -->
