### PR TITLE
Mark all calls to 'op()' as pure

### DIFF
--- a/tfjs-core/src/ops/abs.ts
+++ b/tfjs-core/src/ops/abs.ts
@@ -48,4 +48,4 @@ function abs_<T extends Tensor>(x: T|TensorLike): T {
   }
 }
 
-export const abs = op({abs_});
+export const abs = /* @__PURE__ */ op({abs_});

--- a/tfjs-core/src/ops/acos.ts
+++ b/tfjs-core/src/ops/acos.ts
@@ -40,4 +40,4 @@ function acos_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Acos, inputs as unknown as NamedTensorMap);
 }
-export const acos = op({acos_});
+export const acos = /* @__PURE__ */ op({acos_});

--- a/tfjs-core/src/ops/acosh.ts
+++ b/tfjs-core/src/ops/acosh.ts
@@ -43,4 +43,4 @@ function acosh_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Acosh, inputs as unknown as NamedTensorMap);
 }
-export const acosh = op({acosh_});
+export const acosh = /* @__PURE__ */ op({acosh_});

--- a/tfjs-core/src/ops/add.ts
+++ b/tfjs-core/src/ops/add.ts
@@ -57,4 +57,4 @@ function add_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   return ENGINE.runKernel(Add, inputs as unknown as NamedTensorMap);
 }
 
-export const add = op({add_});
+export const add = /* @__PURE__ */ op({add_});

--- a/tfjs-core/src/ops/add_n.ts
+++ b/tfjs-core/src/ops/add_n.ts
@@ -69,4 +69,4 @@ function addN_<T extends Tensor>(tensors: Array<T|TensorLike>): T {
   return ENGINE.runKernel(AddN, inputs as unknown as NamedTensorMap);
 }
 
-export const addN = op({addN_});
+export const addN = /* @__PURE__ */ op({addN_});

--- a/tfjs-core/src/ops/all.ts
+++ b/tfjs-core/src/ops/all.ts
@@ -66,4 +66,4 @@ function all_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const all = op({all_});
+export const all = /* @__PURE__ */ op({all_});

--- a/tfjs-core/src/ops/any.ts
+++ b/tfjs-core/src/ops/any.ts
@@ -67,4 +67,4 @@ function any_<T extends Tensor>(
 }
 
 // tslint:disable-next-line:variable-name
-export const any = op({any_});
+export const any = /* @__PURE__ */ op({any_});

--- a/tfjs-core/src/ops/arg_max.ts
+++ b/tfjs-core/src/ops/arg_max.ts
@@ -60,4 +60,4 @@ function argMax_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const argMax = op({argMax_});
+export const argMax = /* @__PURE__ */ op({argMax_});

--- a/tfjs-core/src/ops/arg_min.ts
+++ b/tfjs-core/src/ops/arg_min.ts
@@ -60,4 +60,4 @@ function argMin_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const argMin = op({argMin_});
+export const argMin = /* @__PURE__ */ op({argMin_});

--- a/tfjs-core/src/ops/asin.ts
+++ b/tfjs-core/src/ops/asin.ts
@@ -41,4 +41,4 @@ function asin_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Asin, inputs as unknown as NamedTensorMap);
 }
-export const asin = op({asin_});
+export const asin = /* @__PURE__ */ op({asin_});

--- a/tfjs-core/src/ops/asinh.ts
+++ b/tfjs-core/src/ops/asinh.ts
@@ -44,4 +44,4 @@ function asinh_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Asinh, inputs as unknown as NamedTensorMap);
 }
-export const asinh = op({asinh_});
+export const asinh = /* @__PURE__ */ op({asinh_});

--- a/tfjs-core/src/ops/atan.ts
+++ b/tfjs-core/src/ops/atan.ts
@@ -43,4 +43,4 @@ function atan_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Atan, inputs as unknown as NamedTensorMap);
 }
-export const atan = op({atan_});
+export const atan = /* @__PURE__ */ op({atan_});

--- a/tfjs-core/src/ops/atan2.ts
+++ b/tfjs-core/src/ops/atan2.ts
@@ -52,4 +52,4 @@ function atan2_<T extends Tensor>(
   return ENGINE.runKernel(Atan2, inputs as unknown as NamedTensorMap);
 }
 
-export const atan2 = op({atan2_});
+export const atan2 = /* @__PURE__ */ op({atan2_});

--- a/tfjs-core/src/ops/atanh.ts
+++ b/tfjs-core/src/ops/atanh.ts
@@ -44,4 +44,4 @@ function atanh_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Atanh, inputs as unknown as NamedTensorMap);
 }
-export const atanh = op({atanh_});
+export const atanh = /* @__PURE__ */ op({atanh_});

--- a/tfjs-core/src/ops/avg_pool.ts
+++ b/tfjs-core/src/ops/avg_pool.ts
@@ -92,4 +92,4 @@ function avgPool_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const avgPool = op({avgPool_});
+export const avgPool = /* @__PURE__ */ op({avgPool_});

--- a/tfjs-core/src/ops/avg_pool_3d.ts
+++ b/tfjs-core/src/ops/avg_pool_3d.ts
@@ -112,4 +112,4 @@ function avgPool3d_<T extends Tensor4D|Tensor5D>(
   return res;
 }
 
-export const avgPool3d = op({avgPool3d_});
+export const avgPool3d = /* @__PURE__ */ op({avgPool3d_});

--- a/tfjs-core/src/ops/avg_pool_3d_grad.ts
+++ b/tfjs-core/src/ops/avg_pool_3d_grad.ts
@@ -96,4 +96,4 @@ function avgPool3dGrad_<T extends Tensor4D|Tensor5D>(
   return res;
 }
 
-export const avgPool3dGrad = op({avgPool3dGrad_});
+export const avgPool3dGrad = /* @__PURE__ */ op({avgPool3dGrad_});

--- a/tfjs-core/src/ops/avg_pool_grad.ts
+++ b/tfjs-core/src/ops/avg_pool_grad.ts
@@ -93,4 +93,4 @@ function avgPoolGrad_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const avgPoolGrad = op({avgPoolGrad_});
+export const avgPoolGrad = /* @__PURE__ */ op({avgPoolGrad_});

--- a/tfjs-core/src/ops/basic_lstm_cell.ts
+++ b/tfjs-core/src/ops/basic_lstm_cell.ts
@@ -77,4 +77,4 @@ function basicLSTMCell_(
   return [newC, newH];
 }
 
-export const basicLSTMCell = op({basicLSTMCell_});
+export const basicLSTMCell = /* @__PURE__ */ op({basicLSTMCell_});

--- a/tfjs-core/src/ops/batch_to_space_nd.ts
+++ b/tfjs-core/src/ops/batch_to_space_nd.ts
@@ -104,4 +104,4 @@ function batchToSpaceND_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const batchToSpaceND = op({batchToSpaceND_});
+export const batchToSpaceND = /* @__PURE__ */ op({batchToSpaceND_});

--- a/tfjs-core/src/ops/batchnorm.ts
+++ b/tfjs-core/src/ops/batchnorm.ts
@@ -108,4 +108,4 @@ function batchNorm_<R extends Rank>(
   return reshape(res, $x.shape);
 }
 
-export const batchNorm = op({batchNorm_});
+export const batchNorm = /* @__PURE__ */ op({batchNorm_});

--- a/tfjs-core/src/ops/batchnorm2d.ts
+++ b/tfjs-core/src/ops/batchnorm2d.ts
@@ -77,4 +77,4 @@ function batchNorm2d_(
   return batchNorm($x, $mean, $variance, $offset, $scale, varianceEpsilon);
 }
 
-export const batchNorm2d = op({batchNorm2d_});
+export const batchNorm2d = /* @__PURE__ */ op({batchNorm2d_});

--- a/tfjs-core/src/ops/batchnorm3d.ts
+++ b/tfjs-core/src/ops/batchnorm3d.ts
@@ -77,4 +77,4 @@ function batchNorm3d_(
   return batchNorm($x, $mean, $variance, $offset, $scale, varianceEpsilon);
 }
 
-export const batchNorm3d = op({batchNorm3d_});
+export const batchNorm3d = /* @__PURE__ */ op({batchNorm3d_});

--- a/tfjs-core/src/ops/batchnorm4d.ts
+++ b/tfjs-core/src/ops/batchnorm4d.ts
@@ -76,4 +76,4 @@ function batchNorm4d_(
   return batchNorm($x, $mean, $variance, $offset, $scale, varianceEpsilon);
 }
 
-export const batchNorm4d = op({batchNorm4d_});
+export const batchNorm4d = /* @__PURE__ */ op({batchNorm4d_});

--- a/tfjs-core/src/ops/bincount.ts
+++ b/tfjs-core/src/ops/bincount.ts
@@ -67,4 +67,4 @@ function bincount_<T extends Tensor1D>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const bincount = op({bincount_});
+export const bincount = /* @__PURE__ */ op({bincount_});

--- a/tfjs-core/src/ops/broadcast_args.ts
+++ b/tfjs-core/src/ops/broadcast_args.ts
@@ -59,4 +59,4 @@ function broadcastArgs_<R extends Rank>(
   return ENGINE.runKernel(BroadcastArgs, inputs as unknown as NamedTensorMap);
 }
 
-export const broadcastArgs = op({ broadcastArgs_ });
+export const broadcastArgs = /* @__PURE__ */ op({ broadcastArgs_ });

--- a/tfjs-core/src/ops/broadcast_to.ts
+++ b/tfjs-core/src/ops/broadcast_to.ts
@@ -86,4 +86,4 @@ function broadcastTo_<R extends Rank>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const broadcastTo = op({broadcastTo_});
+export const broadcastTo = /* @__PURE__ */ op({broadcastTo_});

--- a/tfjs-core/src/ops/browser.ts
+++ b/tfjs-core/src/ops/browser.ts
@@ -371,4 +371,4 @@ export async function toPixels(
   return bytes;
 }
 
-export const fromPixels = op({fromPixels_});
+export const fromPixels = /* @__PURE__ */ op({fromPixels_});

--- a/tfjs-core/src/ops/cast.ts
+++ b/tfjs-core/src/ops/cast.ts
@@ -57,4 +57,4 @@ function cast_<T extends Tensor>(x: T|TensorLike, dtype: DataType): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const cast = op({cast_});
+export const cast = /* @__PURE__ */ op({cast_});

--- a/tfjs-core/src/ops/ceil.ts
+++ b/tfjs-core/src/ops/ceil.ts
@@ -42,4 +42,4 @@ function ceil_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: CeilInputs = {x: $x};
   return ENGINE.runKernel(Ceil, inputs as unknown as NamedTensorMap);
 }
-export const ceil = op({ceil_});
+export const ceil = /* @__PURE__ */ op({ceil_});

--- a/tfjs-core/src/ops/clip_by_value.ts
+++ b/tfjs-core/src/ops/clip_by_value.ts
@@ -60,4 +60,4 @@ function clipByValue_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const clipByValue = op({clipByValue_});
+export const clipByValue = /* @__PURE__ */ op({clipByValue_});

--- a/tfjs-core/src/ops/clone.ts
+++ b/tfjs-core/src/ops/clone.ts
@@ -47,4 +47,4 @@ function clone_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(Identity, inputs as unknown as NamedTensorMap);
 }
 
-export const clone = op({clone_});
+export const clone = /* @__PURE__ */ op({clone_});

--- a/tfjs-core/src/ops/complex.ts
+++ b/tfjs-core/src/ops/complex.ts
@@ -56,4 +56,4 @@ function complex_<T extends Tensor>(real: T|TensorLike, imag: T|TensorLike): T {
   return ENGINE.runKernel(Complex, inputs as unknown as NamedTensorMap);
 }
 
-export const complex = op({complex_});
+export const complex = /* @__PURE__ */ op({complex_});

--- a/tfjs-core/src/ops/concat.ts
+++ b/tfjs-core/src/ops/concat.ts
@@ -93,4 +93,4 @@ function concat_<T extends Tensor>(tensors: Array<T|TensorLike>, axis = 0): T {
       attr as unknown as NamedAttrMap);
 }
 
-export const concat = op({concat_});
+export const concat = /* @__PURE__ */ op({concat_});

--- a/tfjs-core/src/ops/concat_1d.ts
+++ b/tfjs-core/src/ops/concat_1d.ts
@@ -35,4 +35,4 @@ function concat1d_(tensors: Array<Tensor1D|TensorLike>): Tensor1D {
   return concat(tensors, 0 /* axis */);
 }
 
-export const concat1d = op({concat1d_});
+export const concat1d = /* @__PURE__ */ op({concat1d_});

--- a/tfjs-core/src/ops/concat_2d.ts
+++ b/tfjs-core/src/ops/concat_2d.ts
@@ -52,4 +52,4 @@ function concat2d_(
   return concat(tensors, axis);
 }
 
-export const concat2d = op({concat2d_});
+export const concat2d = /* @__PURE__ */ op({concat2d_});

--- a/tfjs-core/src/ops/concat_3d.ts
+++ b/tfjs-core/src/ops/concat_3d.ts
@@ -56,4 +56,4 @@ function concat3d_(
   return concat(tensors, axis);
 }
 
-export const concat3d = op({concat3d_});
+export const concat3d = /* @__PURE__ */ op({concat3d_});

--- a/tfjs-core/src/ops/concat_4d.ts
+++ b/tfjs-core/src/ops/concat_4d.ts
@@ -33,4 +33,4 @@ function concat4d_(
   return concat(tensors, axis);
 }
 
-export const concat4d = op({concat4d_});
+export const concat4d = /* @__PURE__ */ op({concat4d_});

--- a/tfjs-core/src/ops/confusion_matrix.ts
+++ b/tfjs-core/src/ops/confusion_matrix.ts
@@ -93,4 +93,4 @@ export function confusionMatrix_(
   return cast(product, 'int32');
 }
 
-export const confusionMatrix = op({confusionMatrix_});
+export const confusionMatrix = /* @__PURE__ */ op({confusionMatrix_});

--- a/tfjs-core/src/ops/conv1d.ts
+++ b/tfjs-core/src/ops/conv1d.ts
@@ -113,4 +113,4 @@ function conv1d_<T extends Tensor2D|Tensor3D>(
   return reshape(res, [res.shape[0], res.shape[2], res.shape[3]]) as T;
 }
 
-export const conv1d = op({conv1d_});
+export const conv1d = /* @__PURE__ */ op({conv1d_});

--- a/tfjs-core/src/ops/conv2d.ts
+++ b/tfjs-core/src/ops/conv2d.ts
@@ -116,4 +116,4 @@ function conv2d_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const conv2d = op({conv2d_});
+export const conv2d = /* @__PURE__ */ op({conv2d_});

--- a/tfjs-core/src/ops/conv2d_backprop_filter.ts
+++ b/tfjs-core/src/ops/conv2d_backprop_filter.ts
@@ -92,4 +92,4 @@ function conv2DBackpropFilter_<T extends Tensor3D|Tensor4D>(
              attrs as unknown as NamedAttrMap) as Tensor4D;
 }
 
-export const conv2DBackpropFilter = op({conv2DBackpropFilter_});
+export const conv2DBackpropFilter = /* @__PURE__ */ op({conv2DBackpropFilter_});

--- a/tfjs-core/src/ops/conv2d_backprop_input.ts
+++ b/tfjs-core/src/ops/conv2d_backprop_input.ts
@@ -108,4 +108,4 @@ function conv2DBackpropInput_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const conv2DBackpropInput = op({conv2DBackpropInput_});
+export const conv2DBackpropInput = /* @__PURE__ */ op({conv2DBackpropInput_});

--- a/tfjs-core/src/ops/conv2d_transpose.ts
+++ b/tfjs-core/src/ops/conv2d_transpose.ts
@@ -55,4 +55,4 @@ function conv2dTranspose_<T extends Tensor3D|Tensor4D>(
       outputShape, $x, $filter, strides, pad, 'NHWC', dimRoundingMode);
 }
 
-export const conv2dTranspose = op({conv2dTranspose_});
+export const conv2dTranspose = /* @__PURE__ */ op({conv2dTranspose_});

--- a/tfjs-core/src/ops/conv3d.ts
+++ b/tfjs-core/src/ops/conv3d.ts
@@ -117,4 +117,4 @@ function conv3d_<T extends Tensor4D|Tensor5D>(
   return res;
 }
 
-export const conv3d = op({conv3d_});
+export const conv3d = /* @__PURE__ */ op({conv3d_});

--- a/tfjs-core/src/ops/conv3d_backprop_filter.ts
+++ b/tfjs-core/src/ops/conv3d_backprop_filter.ts
@@ -82,4 +82,4 @@ function conv3DBackpropFilter_<T extends Tensor4D|Tensor5D>(
              attrs as unknown as NamedAttrMap) as Tensor5D;
 }
 
-export const conv3DBackpropFilter = op({conv3DBackpropFilter_});
+export const conv3DBackpropFilter = /* @__PURE__ */ op({conv3DBackpropFilter_});

--- a/tfjs-core/src/ops/conv3d_backprop_input.ts
+++ b/tfjs-core/src/ops/conv3d_backprop_input.ts
@@ -104,4 +104,4 @@ function conv3DBackpropInput_<T extends Tensor4D|Tensor5D>(
   return res;
 }
 
-export const conv3DBackpropInput = op({conv3DBackpropInput_});
+export const conv3DBackpropInput = /* @__PURE__ */ op({conv3DBackpropInput_});

--- a/tfjs-core/src/ops/conv3d_transpose.ts
+++ b/tfjs-core/src/ops/conv3d_transpose.ts
@@ -52,4 +52,4 @@ function conv3dTranspose_<T extends Tensor4D|Tensor5D>(
   return conv3DBackpropInput(outputShape, $x, $filter, strides, pad);
 }
 
-export const conv3dTranspose = op({conv3dTranspose_});
+export const conv3dTranspose = /* @__PURE__ */ op({conv3dTranspose_});

--- a/tfjs-core/src/ops/cos.ts
+++ b/tfjs-core/src/ops/cos.ts
@@ -43,4 +43,4 @@ function cos_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Cos, inputs as unknown as NamedTensorMap);
 }
-export const cos = op({cos_});
+export const cos = /* @__PURE__ */ op({cos_});

--- a/tfjs-core/src/ops/cosh.ts
+++ b/tfjs-core/src/ops/cosh.ts
@@ -42,4 +42,4 @@ function cosh_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Cosh, inputs as unknown as NamedTensorMap);
 }
-export const cosh = op({cosh_});
+export const cosh = /* @__PURE__ */ op({cosh_});

--- a/tfjs-core/src/ops/cumprod.ts
+++ b/tfjs-core/src/ops/cumprod.ts
@@ -66,4 +66,4 @@ function cumprod_<T extends Tensor>(
   );
 }
 
-export const cumprod = op({ cumprod_ });
+export const cumprod = /* @__PURE__ */ op({ cumprod_ });

--- a/tfjs-core/src/ops/cumsum.ts
+++ b/tfjs-core/src/ops/cumsum.ts
@@ -60,4 +60,4 @@ function cumsum_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const cumsum = op({cumsum_});
+export const cumsum = /* @__PURE__ */ op({cumsum_});

--- a/tfjs-core/src/ops/dense_bincount.ts
+++ b/tfjs-core/src/ops/dense_bincount.ts
@@ -75,4 +75,4 @@ function denseBincount_<T extends Tensor1D|Tensor2D>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const denseBincount = op({denseBincount_});
+export const denseBincount = /* @__PURE__ */ op({denseBincount_});

--- a/tfjs-core/src/ops/depth_to_space.ts
+++ b/tfjs-core/src/ops/depth_to_space.ts
@@ -102,4 +102,4 @@ function depthToSpace_(
       attrs as unknown as NamedAttrMap);
 }
 
-export const depthToSpace = op({depthToSpace_});
+export const depthToSpace = /* @__PURE__ */ op({depthToSpace_});

--- a/tfjs-core/src/ops/depthwise_conv2d.ts
+++ b/tfjs-core/src/ops/depthwise_conv2d.ts
@@ -119,4 +119,4 @@ function depthwiseConv2d_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const depthwiseConv2d = op({depthwiseConv2d_});
+export const depthwiseConv2d = /* @__PURE__ */ op({depthwiseConv2d_});

--- a/tfjs-core/src/ops/diag.ts
+++ b/tfjs-core/src/ops/diag.ts
@@ -54,4 +54,4 @@ function diag_(x: Tensor): Tensor {
   return ENGINE.runKernel(Diag, inputs as unknown as NamedTensorMap);
 }
 
-export const diag = op({diag_});
+export const diag = /* @__PURE__ */ op({diag_});

--- a/tfjs-core/src/ops/dilation2d.ts
+++ b/tfjs-core/src/ops/dilation2d.ts
@@ -107,4 +107,4 @@ function dilation2d_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const dilation2d = op({dilation2d_});
+export const dilation2d = /* @__PURE__ */ op({dilation2d_});

--- a/tfjs-core/src/ops/div.ts
+++ b/tfjs-core/src/ops/div.ts
@@ -67,4 +67,4 @@ function div_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
                           inputs as unknown as NamedTensorMap, attrs) as T;
 }
 
-export const div = op({div_});
+export const div = /* @__PURE__ */ op({div_});

--- a/tfjs-core/src/ops/div_no_nan.ts
+++ b/tfjs-core/src/ops/div_no_nan.ts
@@ -69,4 +69,4 @@ function divNoNan_<T extends Tensor>(
   return where(bEqualsZero, zeros, divResult) as T;
 }
 
-export const divNoNan = op({divNoNan_});
+export const divNoNan = /* @__PURE__ */ op({divNoNan_});

--- a/tfjs-core/src/ops/dot.ts
+++ b/tfjs-core/src/ops/dot.ts
@@ -79,4 +79,4 @@ function dot_(t1: Tensor|TensorLike, t2: Tensor|TensorLike): Tensor {
   }
 }
 
-export const dot = op({dot_});
+export const dot = /* @__PURE__ */ op({dot_});

--- a/tfjs-core/src/ops/dropout.ts
+++ b/tfjs-core/src/ops/dropout.ts
@@ -76,4 +76,4 @@ function dropout_(
   return mul($x, multiplier);
 }
 
-export const dropout = op({dropout_});
+export const dropout = /* @__PURE__ */ op({dropout_});

--- a/tfjs-core/src/ops/einsum.ts
+++ b/tfjs-core/src/ops/einsum.ts
@@ -109,4 +109,4 @@ export function einsum_(equation: string, ...tensors: Tensor[]): Tensor {
       attrs as unknown as NamedAttrMap);
 }
 
-export const einsum = op({einsum_});
+export const einsum = /* @__PURE__ */ op({einsum_});

--- a/tfjs-core/src/ops/elu.ts
+++ b/tfjs-core/src/ops/elu.ts
@@ -44,4 +44,4 @@ function elu_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(Elu, inputs as unknown as NamedTensorMap);
 }
 
-export const elu = op({elu_});
+export const elu = /* @__PURE__ */ op({elu_});

--- a/tfjs-core/src/ops/equal.ts
+++ b/tfjs-core/src/ops/equal.ts
@@ -53,4 +53,4 @@ function equal_<T extends Tensor>(
   return ENGINE.runKernel(Equal, inputs as unknown as NamedTensorMap);
 }
 
-export const equal = op({equal_});
+export const equal = /* @__PURE__ */ op({equal_});

--- a/tfjs-core/src/ops/erf.ts
+++ b/tfjs-core/src/ops/erf.ts
@@ -52,4 +52,4 @@ function erf_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: ErfInputs = {x: $x};
   return ENGINE.runKernel(Erf, inputs as unknown as NamedTensorMap);
 }
-export const erf = op({erf_});
+export const erf = /* @__PURE__ */ op({erf_});

--- a/tfjs-core/src/ops/euclidean_norm.ts
+++ b/tfjs-core/src/ops/euclidean_norm.ts
@@ -50,4 +50,4 @@ function euclideanNorm_(
   return norm(x, 'euclidean', axis, keepDims);
 }
 
-export const euclideanNorm = op({euclideanNorm_});
+export const euclideanNorm = /* @__PURE__ */ op({euclideanNorm_});

--- a/tfjs-core/src/ops/exp.ts
+++ b/tfjs-core/src/ops/exp.ts
@@ -42,4 +42,4 @@ function exp_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: ExpInputs = {x: $x};
   return ENGINE.runKernel(Exp, inputs as unknown as NamedTensorMap);
 }
-export const exp = op({exp_});
+export const exp = /* @__PURE__ */ op({exp_});

--- a/tfjs-core/src/ops/expand_dims.ts
+++ b/tfjs-core/src/ops/expand_dims.ts
@@ -55,4 +55,4 @@ function expandDims_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const expandDims = op({expandDims_});
+export const expandDims = /* @__PURE__ */ op({expandDims_});

--- a/tfjs-core/src/ops/expm1.ts
+++ b/tfjs-core/src/ops/expm1.ts
@@ -43,4 +43,4 @@ function expm1_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: Expm1Inputs = {x: $x};
   return ENGINE.runKernel(Expm1, inputs as unknown as NamedTensorMap);
 }
-export const expm1 = op({expm1_});
+export const expm1 = /* @__PURE__ */ op({expm1_});

--- a/tfjs-core/src/ops/eye.ts
+++ b/tfjs-core/src/ops/eye.ts
@@ -79,4 +79,4 @@ function eye_(
   }
 }
 
-export const eye = op({eye_});
+export const eye = /* @__PURE__ */ op({eye_});

--- a/tfjs-core/src/ops/floor.ts
+++ b/tfjs-core/src/ops/floor.ts
@@ -41,4 +41,4 @@ function floor_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: FloorInputs = {x: $x};
   return ENGINE.runKernel(Floor, inputs as unknown as NamedTensorMap);
 }
-export const floor = op({floor_});
+export const floor = /* @__PURE__ */ op({floor_});

--- a/tfjs-core/src/ops/floorDiv.ts
+++ b/tfjs-core/src/ops/floorDiv.ts
@@ -62,4 +62,4 @@ function floorDiv_<T extends Tensor>(
   return ENGINE.runKernel(FloorDiv, inputs as unknown as NamedTensorMap);
 }
 
-export const floorDiv = op({floorDiv_});
+export const floorDiv = /* @__PURE__ */ op({floorDiv_});

--- a/tfjs-core/src/ops/fused/conv2d.ts
+++ b/tfjs-core/src/ops/fused/conv2d.ts
@@ -329,4 +329,4 @@ function fusedConv2d_<T extends Tensor3D|Tensor4D>({
     return customOpWithBias(x4D, $filter, $bias) as T;
   }
 }
-export const conv2d = op({fusedConv2d_});
+export const conv2d = /* @__PURE__ */ op({fusedConv2d_});

--- a/tfjs-core/src/ops/fused/depthwise_conv2d.ts
+++ b/tfjs-core/src/ops/fused/depthwise_conv2d.ts
@@ -257,4 +257,4 @@ function fusedDepthwiseConv2d_<T extends Tensor3D|Tensor4D>({
     return customOpWithBias(x4D, $filter, $bias) as T;
   }
 }
-export const depthwiseConv2d = op({fusedDepthwiseConv2d_});
+export const depthwiseConv2d = /* @__PURE__ */ op({fusedDepthwiseConv2d_});

--- a/tfjs-core/src/ops/fused/mat_mul.ts
+++ b/tfjs-core/src/ops/fused/mat_mul.ts
@@ -210,4 +210,4 @@ function fusedMatMul_({
     }
   }
 
-  export const matMul = op({fusedMatMul_});
+  export const matMul = /* @__PURE__ */ op({fusedMatMul_});

--- a/tfjs-core/src/ops/gather.ts
+++ b/tfjs-core/src/ops/gather.ts
@@ -64,4 +64,4 @@ function gather_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const gather = op({gather_});
+export const gather = /* @__PURE__ */ op({gather_});

--- a/tfjs-core/src/ops/gather_nd.ts
+++ b/tfjs-core/src/ops/gather_nd.ts
@@ -69,4 +69,4 @@ function gatherND_(x: Tensor|TensorLike, indices: Tensor|TensorLike): Tensor {
   return ENGINE.runKernel(GatherNd, inputs as unknown as NamedTensorMap);
 }
 
-export const gatherND = op({gatherND_});
+export const gatherND = /* @__PURE__ */ op({gatherND_});

--- a/tfjs-core/src/ops/greater.ts
+++ b/tfjs-core/src/ops/greater.ts
@@ -53,4 +53,4 @@ function greater_<T extends Tensor>(
   return ENGINE.runKernel(Greater, inputs as unknown as NamedTensorMap);
 }
 
-export const greater = op({greater_});
+export const greater = /* @__PURE__ */ op({greater_});

--- a/tfjs-core/src/ops/greater_equal.ts
+++ b/tfjs-core/src/ops/greater_equal.ts
@@ -53,4 +53,4 @@ function greaterEqual_<T extends Tensor>(
   return ENGINE.runKernel(GreaterEqual, inputs as unknown as NamedTensorMap);
 }
 
-export const greaterEqual = op({greaterEqual_});
+export const greaterEqual = /* @__PURE__ */ op({greaterEqual_});

--- a/tfjs-core/src/ops/imag.ts
+++ b/tfjs-core/src/ops/imag.ts
@@ -43,4 +43,4 @@ function imag_<T extends Tensor>(input: T|TensorLike): T {
   return ENGINE.runKernel(Imag, inputs as unknown as NamedTensorMap);
 }
 
-export const imag = op({imag_});
+export const imag = /* @__PURE__ */ op({imag_});

--- a/tfjs-core/src/ops/image/crop_and_resize.ts
+++ b/tfjs-core/src/ops/image/crop_and_resize.ts
@@ -95,4 +95,4 @@ function cropAndResize_(
   return res as Tensor4D;
 }
 
-export const cropAndResize = op({cropAndResize_});
+export const cropAndResize = /* @__PURE__ */ op({cropAndResize_});

--- a/tfjs-core/src/ops/image/flip_left_right.ts
+++ b/tfjs-core/src/ops/image/flip_left_right.ts
@@ -45,4 +45,4 @@ function flipLeftRight_(image: Tensor4D|TensorLike): Tensor4D {
   return res as Tensor4D;
 }
 
-export const flipLeftRight = op({flipLeftRight_});
+export const flipLeftRight = /* @__PURE__ */ op({flipLeftRight_});

--- a/tfjs-core/src/ops/image/grayscale_to_rgb.ts
+++ b/tfjs-core/src/ops/image/grayscale_to_rgb.ts
@@ -56,4 +56,4 @@ function grayscaleToRGB_<T extends Tensor2D|Tensor3D|Tensor4D|Tensor5D|
   return tile($image, reps);
 }
 
-export const grayscaleToRGB = op({grayscaleToRGB_});
+export const grayscaleToRGB = /* @__PURE__ */ op({grayscaleToRGB_});

--- a/tfjs-core/src/ops/image/non_max_suppression.ts
+++ b/tfjs-core/src/ops/image/non_max_suppression.ts
@@ -61,4 +61,4 @@ function nonMaxSuppression_(
       NonMaxSuppressionV3, {boxes: $boxes, scores: $scores}, attrs);
 }
 
-export const nonMaxSuppression = op({nonMaxSuppression_});
+export const nonMaxSuppression = /* @__PURE__ */ op({nonMaxSuppression_});

--- a/tfjs-core/src/ops/image/non_max_suppression_padded.ts
+++ b/tfjs-core/src/ops/image/non_max_suppression_padded.ts
@@ -80,4 +80,4 @@ function nonMaxSuppressionPadded_(
   return {selectedIndices: result[0], validOutputs: result[1]};
 }
 
-export const nonMaxSuppressionPadded = op({nonMaxSuppressionPadded_});
+export const nonMaxSuppressionPadded = /* @__PURE__ */ op({nonMaxSuppressionPadded_});

--- a/tfjs-core/src/ops/image/non_max_suppression_with_score.ts
+++ b/tfjs-core/src/ops/image/non_max_suppression_with_score.ts
@@ -83,4 +83,4 @@ function nonMaxSuppressionWithScore_(
   return {selectedIndices: result[0], selectedScores: result[1]};
 }
 
-export const nonMaxSuppressionWithScore = op({nonMaxSuppressionWithScore_});
+export const nonMaxSuppressionWithScore = /* @__PURE__ */ op({nonMaxSuppressionWithScore_});

--- a/tfjs-core/src/ops/image/resize_bilinear.ts
+++ b/tfjs-core/src/ops/image/resize_bilinear.ts
@@ -86,4 +86,4 @@ function resizeBilinear_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const resizeBilinear = op({resizeBilinear_});
+export const resizeBilinear = /* @__PURE__ */ op({resizeBilinear_});

--- a/tfjs-core/src/ops/image/resize_nearest_neighbor.ts
+++ b/tfjs-core/src/ops/image/resize_nearest_neighbor.ts
@@ -90,4 +90,4 @@ function resizeNearestNeighbor_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const resizeNearestNeighbor = op({resizeNearestNeighbor_});
+export const resizeNearestNeighbor = /* @__PURE__ */ op({resizeNearestNeighbor_});

--- a/tfjs-core/src/ops/image/rotate_with_offset.ts
+++ b/tfjs-core/src/ops/image/rotate_with_offset.ts
@@ -61,4 +61,4 @@ function rotateWithOffset_(
   return res as Tensor4D;
 }
 
-export const rotateWithOffset = op({rotateWithOffset_});
+export const rotateWithOffset = /* @__PURE__ */ op({rotateWithOffset_});

--- a/tfjs-core/src/ops/image/threshold.ts
+++ b/tfjs-core/src/ops/image/threshold.ts
@@ -160,4 +160,4 @@ function otsu(histogram: Tensor1D, total: number):Tensor1D {
     return bestThresh;
 }
 
-export const threshold = op({ threshold_ });
+export const threshold = /* @__PURE__ */ op({ threshold_ });

--- a/tfjs-core/src/ops/image/transform.ts
+++ b/tfjs-core/src/ops/image/transform.ts
@@ -91,4 +91,4 @@ function transform_(
       attrs as unknown as NamedAttrMap);
 }
 
-export const transform = op({transform_});
+export const transform = /* @__PURE__ */ op({transform_});

--- a/tfjs-core/src/ops/is_finite.ts
+++ b/tfjs-core/src/ops/is_finite.ts
@@ -43,4 +43,4 @@ function isFinite_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(IsFinite, inputs as unknown as NamedTensorMap);
 }
-export const isFinite = op({isFinite_});
+export const isFinite = /* @__PURE__ */ op({isFinite_});

--- a/tfjs-core/src/ops/is_inf.ts
+++ b/tfjs-core/src/ops/is_inf.ts
@@ -43,4 +43,4 @@ function isInf_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(IsInf, inputs as unknown as NamedTensorMap);
 }
-export const isInf = op({isInf_});
+export const isInf = /* @__PURE__ */ op({isInf_});

--- a/tfjs-core/src/ops/is_nan.ts
+++ b/tfjs-core/src/ops/is_nan.ts
@@ -42,4 +42,4 @@ function isNaN_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(IsNan, inputs as unknown as NamedTensorMap);
 }
-export const isNaN = op({isNaN_});
+export const isNaN = /* @__PURE__ */ op({isNaN_});

--- a/tfjs-core/src/ops/leaky_relu.ts
+++ b/tfjs-core/src/ops/leaky_relu.ts
@@ -53,4 +53,4 @@ function leakyRelu_<T extends Tensor>(x: T|TensorLike, alpha = 0.2): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const leakyRelu = op({leakyRelu_});
+export const leakyRelu = /* @__PURE__ */ op({leakyRelu_});

--- a/tfjs-core/src/ops/less.ts
+++ b/tfjs-core/src/ops/less.ts
@@ -52,4 +52,4 @@ function less_<T extends Tensor>(
   return ENGINE.runKernel(Less, inputs as unknown as NamedTensorMap);
 }
 
-export const less = op({less_});
+export const less = /* @__PURE__ */ op({less_});

--- a/tfjs-core/src/ops/less_equal.ts
+++ b/tfjs-core/src/ops/less_equal.ts
@@ -53,4 +53,4 @@ function lessEqual_<T extends Tensor>(
   return ENGINE.runKernel(LessEqual, inputs as unknown as NamedTensorMap);
 }
 
-export const lessEqual = op({lessEqual_});
+export const lessEqual = /* @__PURE__ */ op({lessEqual_});

--- a/tfjs-core/src/ops/linalg/band_part.ts
+++ b/tfjs-core/src/ops/linalg/band_part.ts
@@ -123,4 +123,4 @@ function bandPart_<T extends Tensor>(
              shape) as T;
 }
 
-export const bandPart = op({bandPart_});
+export const bandPart = /* @__PURE__ */ op({bandPart_});

--- a/tfjs-core/src/ops/linalg/gram_schmidt.ts
+++ b/tfjs-core/src/ops/linalg/gram_schmidt.ts
@@ -106,4 +106,4 @@ function gramSchmidt_(xs: Tensor1D[]|Tensor2D): Tensor1D[]|Tensor2D {
   }
 }
 
-export const gramSchmidt = op({gramSchmidt_});
+export const gramSchmidt = /* @__PURE__ */ op({gramSchmidt_});

--- a/tfjs-core/src/ops/linalg/qr.ts
+++ b/tfjs-core/src/ops/linalg/qr.ts
@@ -198,4 +198,4 @@ function qr2d(x: Tensor2D, fullMatrices = false): [Tensor2D, Tensor2D] {
   }) as [Tensor2D, Tensor2D];
 }
 
-export const qr = op({qr_});
+export const qr = /* @__PURE__ */ op({qr_});

--- a/tfjs-core/src/ops/local_response_normalization.ts
+++ b/tfjs-core/src/ops/local_response_normalization.ts
@@ -77,4 +77,4 @@ function localResponseNormalization_<T extends Tensor3D|Tensor4D>(
   }
 }
 
-export const localResponseNormalization = op({localResponseNormalization_});
+export const localResponseNormalization = /* @__PURE__ */ op({localResponseNormalization_});

--- a/tfjs-core/src/ops/log.ts
+++ b/tfjs-core/src/ops/log.ts
@@ -42,4 +42,4 @@ function log_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: LogInputs = {x: $x};
   return ENGINE.runKernel(Log, inputs as unknown as NamedTensorMap);
 }
-export const log = op({log_});
+export const log = /* @__PURE__ */ op({log_});

--- a/tfjs-core/src/ops/log1p.ts
+++ b/tfjs-core/src/ops/log1p.ts
@@ -43,4 +43,4 @@ function log1p_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: Log1pInputs = {x: $x};
   return ENGINE.runKernel(Log1p, inputs as unknown as NamedTensorMap);
 }
-export const log1p = op({log1p_});
+export const log1p = /* @__PURE__ */ op({log1p_});

--- a/tfjs-core/src/ops/log_sigmoid.ts
+++ b/tfjs-core/src/ops/log_sigmoid.ts
@@ -60,4 +60,4 @@ function logSigmoid_<T extends Tensor>(x: T|TensorLike): T {
 
   return customOp($x) as T;
 }
-export const logSigmoid = op({logSigmoid_});
+export const logSigmoid = /* @__PURE__ */ op({logSigmoid_});

--- a/tfjs-core/src/ops/log_softmax.ts
+++ b/tfjs-core/src/ops/log_softmax.ts
@@ -103,4 +103,4 @@ function logSoftmax_<T extends Tensor>(logits: T|TensorLike, axis = -1): T {
   //            attrs as unknown as NamedAttrMap);
 }
 
-export const logSoftmax = op({logSoftmax_});
+export const logSoftmax = /* @__PURE__ */ op({logSoftmax_});

--- a/tfjs-core/src/ops/log_sum_exp.ts
+++ b/tfjs-core/src/ops/log_sum_exp.ts
@@ -78,4 +78,4 @@ function logSumExp_<T extends Tensor>(
   return res as T;
 }
 
-export const logSumExp = op({logSumExp_});
+export const logSumExp = /* @__PURE__ */ op({logSumExp_});

--- a/tfjs-core/src/ops/logical_and.ts
+++ b/tfjs-core/src/ops/logical_and.ts
@@ -50,4 +50,4 @@ function logicalAnd_<T extends Tensor>(
   return ENGINE.runKernel(LogicalAnd, inputs as unknown as NamedTensorMap);
 }
 
-export const logicalAnd = op({logicalAnd_});
+export const logicalAnd = /* @__PURE__ */ op({logicalAnd_});

--- a/tfjs-core/src/ops/logical_not.ts
+++ b/tfjs-core/src/ops/logical_not.ts
@@ -42,4 +42,4 @@ function logicalNot_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(LogicalNot, inputs as unknown as NamedTensorMap);
 }
 
-export const logicalNot = op({logicalNot_});
+export const logicalNot = /* @__PURE__ */ op({logicalNot_});

--- a/tfjs-core/src/ops/logical_or.ts
+++ b/tfjs-core/src/ops/logical_or.ts
@@ -47,4 +47,4 @@ function logicalOr_<T extends Tensor>(
   const inputs: LogicalOrInputs = {a: $a, b: $b};
   return ENGINE.runKernel(LogicalOr, inputs as unknown as NamedTensorMap);
 }
-export const logicalOr = op({logicalOr_});
+export const logicalOr = /* @__PURE__ */ op({logicalOr_});

--- a/tfjs-core/src/ops/logical_xor.ts
+++ b/tfjs-core/src/ops/logical_xor.ts
@@ -50,4 +50,4 @@ function logicalXor_<T extends Tensor>(
   return logicalAnd(logicalOr(a, b), logicalNot(logicalAnd(a, b)));
 }
 
-export const logicalXor = op({logicalXor_});
+export const logicalXor = /* @__PURE__ */ op({logicalXor_});

--- a/tfjs-core/src/ops/losses/absolute_difference.ts
+++ b/tfjs-core/src/ops/losses/absolute_difference.ts
@@ -59,4 +59,4 @@ function absoluteDifference_<T extends Tensor, O extends Tensor>(
   return computeWeightedLoss(losses, $weights, reduction);
 }
 
-export const absoluteDifference = op({absoluteDifference_});
+export const absoluteDifference = /* @__PURE__ */ op({absoluteDifference_});

--- a/tfjs-core/src/ops/losses/compute_weighted_loss.ts
+++ b/tfjs-core/src/ops/losses/compute_weighted_loss.ts
@@ -81,4 +81,4 @@ function computeWeightedLoss_<T extends Tensor, O extends Tensor>(
 
   throw Error(`Unknown reduction: ${reduction}`);
 }
-export const computeWeightedLoss = op({computeWeightedLoss_});
+export const computeWeightedLoss = /* @__PURE__ */ op({computeWeightedLoss_});

--- a/tfjs-core/src/ops/losses/cosine_distance.ts
+++ b/tfjs-core/src/ops/losses/cosine_distance.ts
@@ -61,4 +61,4 @@ function cosineDistance_<T extends Tensor, O extends Tensor>(
   const losses = sub(one, sum(mul($labels, $predictions), axis, true));
   return computeWeightedLoss(losses, $weights, reduction);
 }
-export const cosineDistance = op({cosineDistance_});
+export const cosineDistance = /* @__PURE__ */ op({cosineDistance_});

--- a/tfjs-core/src/ops/losses/hinge_loss.ts
+++ b/tfjs-core/src/ops/losses/hinge_loss.ts
@@ -60,4 +60,4 @@ function hingeLoss_<T extends Tensor, O extends Tensor>(
   const losses = relu(sub(one, mul($labels, $predictions)));
   return computeWeightedLoss(losses, $weights, reduction);
 }
-export const hingeLoss = op({hingeLoss_});
+export const hingeLoss = /* @__PURE__ */ op({hingeLoss_});

--- a/tfjs-core/src/ops/losses/huber_loss.ts
+++ b/tfjs-core/src/ops/losses/huber_loss.ts
@@ -68,4 +68,4 @@ function huberLoss_<T extends Tensor, O extends Tensor>(
       add(mul(scalar(0.5), square(quadratic)), mul(deltaScalar, linear));
   return computeWeightedLoss(losses, $weights, reduction);
 }
-export const huberLoss = op({huberLoss_});
+export const huberLoss = /* @__PURE__ */ op({huberLoss_});

--- a/tfjs-core/src/ops/losses/log_loss.ts
+++ b/tfjs-core/src/ops/losses/log_loss.ts
@@ -67,4 +67,4 @@ function logLoss_<T extends Tensor, O extends Tensor>(
   const losses = sub(l1, l2);
   return computeWeightedLoss(losses, $weights, reduction);
 }
-export const logLoss = op({logLoss_});
+export const logLoss = /* @__PURE__ */ op({logLoss_});

--- a/tfjs-core/src/ops/losses/mean_squared_error.ts
+++ b/tfjs-core/src/ops/losses/mean_squared_error.ts
@@ -57,4 +57,4 @@ function meanSquaredError_<T extends Tensor, O extends Tensor>(
   const losses = squaredDifference($labels, $predictions);
   return computeWeightedLoss(losses, $weights, reduction);
 }
-export const meanSquaredError = op({meanSquaredError_});
+export const meanSquaredError = /* @__PURE__ */ op({meanSquaredError_});

--- a/tfjs-core/src/ops/losses/sigmoid_cross_entropy.ts
+++ b/tfjs-core/src/ops/losses/sigmoid_cross_entropy.ts
@@ -118,4 +118,4 @@ function sigmoidCrossEntropy_<T extends Tensor, O extends Tensor>(
   return computeWeightedLoss(losses, $weights, reduction);
 }
 
-export const sigmoidCrossEntropy = op({sigmoidCrossEntropy_});
+export const sigmoidCrossEntropy = /* @__PURE__ */ op({sigmoidCrossEntropy_});

--- a/tfjs-core/src/ops/losses/softmax_cross_entropy.ts
+++ b/tfjs-core/src/ops/losses/softmax_cross_entropy.ts
@@ -153,4 +153,4 @@ function softmaxCrossEntropy_<T extends Tensor, O extends Tensor>(
   return computeWeightedLoss(losses, $weights, reduction);
 }
 
-export const softmaxCrossEntropy = op({softmaxCrossEntropy_});
+export const softmaxCrossEntropy = /* @__PURE__ */ op({softmaxCrossEntropy_});

--- a/tfjs-core/src/ops/mat_mul.ts
+++ b/tfjs-core/src/ops/mat_mul.ts
@@ -56,4 +56,4 @@ function matMul_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const matMul = op({matMul_});
+export const matMul = /* @__PURE__ */ op({matMul_});

--- a/tfjs-core/src/ops/max.ts
+++ b/tfjs-core/src/ops/max.ts
@@ -66,4 +66,4 @@ function max_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const max = op({max_});
+export const max = /* @__PURE__ */ op({max_});

--- a/tfjs-core/src/ops/max_pool.ts
+++ b/tfjs-core/src/ops/max_pool.ts
@@ -90,4 +90,4 @@ function maxPool_<T extends Tensor3D|Tensor4D>(
   return res;
 }
 
-export const maxPool = op({maxPool_});
+export const maxPool = /* @__PURE__ */ op({maxPool_});

--- a/tfjs-core/src/ops/max_pool_3d.ts
+++ b/tfjs-core/src/ops/max_pool_3d.ts
@@ -103,4 +103,4 @@ function maxPool3d_<T extends Tensor4D|Tensor5D>(
   return res;
 }
 
-export const maxPool3d = op({maxPool3d_});
+export const maxPool3d = /* @__PURE__ */ op({maxPool3d_});

--- a/tfjs-core/src/ops/max_pool_3d_grad.ts
+++ b/tfjs-core/src/ops/max_pool_3d_grad.ts
@@ -107,4 +107,4 @@ function maxPool3dGrad_<T extends Tensor4D|Tensor5D>(
   return res;
 }
 
-export const maxPool3dGrad = op({maxPool3dGrad_});
+export const maxPool3dGrad = /* @__PURE__ */ op({maxPool3dGrad_});

--- a/tfjs-core/src/ops/max_pool_grad.ts
+++ b/tfjs-core/src/ops/max_pool_grad.ts
@@ -81,4 +81,4 @@ function maxPoolGrad_(
              attrs as unknown as NamedAttrMap) as Tensor4D;
 }
 
-export const maxPoolGrad = op({maxPoolGrad_});
+export const maxPoolGrad = /* @__PURE__ */ op({maxPoolGrad_});

--- a/tfjs-core/src/ops/max_pool_with_argmax.ts
+++ b/tfjs-core/src/ops/max_pool_with_argmax.ts
@@ -76,4 +76,4 @@ function maxPoolWithArgmax_<T extends Tensor4D>(
   return {result: result[0], indexes: result[1]};
 }
 
-export const maxPoolWithArgmax = op({maxPoolWithArgmax_});
+export const maxPoolWithArgmax = /* @__PURE__ */ op({maxPoolWithArgmax_});

--- a/tfjs-core/src/ops/maximum.ts
+++ b/tfjs-core/src/ops/maximum.ts
@@ -71,4 +71,4 @@ function maximum_<T extends Tensor>(
   return ENGINE.runKernel(Maximum, inputs as unknown as NamedTensorMap);
 }
 
-export const maximum = op({maximum_});
+export const maximum = /* @__PURE__ */ op({maximum_});

--- a/tfjs-core/src/ops/mean.ts
+++ b/tfjs-core/src/ops/mean.ts
@@ -66,4 +66,4 @@ function mean_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const mean = op({mean_});
+export const mean = /* @__PURE__ */ op({mean_});

--- a/tfjs-core/src/ops/min.ts
+++ b/tfjs-core/src/ops/min.ts
@@ -66,4 +66,4 @@ function min_<T extends Tensor>(
              attrs as unknown as NamedAttrMap) as T;
 }
 
-export const min = op({min_});
+export const min = /* @__PURE__ */ op({min_});

--- a/tfjs-core/src/ops/minimum.ts
+++ b/tfjs-core/src/ops/minimum.ts
@@ -72,4 +72,4 @@ function minimum_<T extends Tensor>(
   return ENGINE.runKernel(Minimum, inputs as unknown as NamedTensorMap);
 }
 
-export const minimum = op({minimum_});
+export const minimum = /* @__PURE__ */ op({minimum_});

--- a/tfjs-core/src/ops/mirror_pad.ts
+++ b/tfjs-core/src/ops/mirror_pad.ts
@@ -89,4 +89,4 @@ function mirrorPad_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const mirrorPad = op({mirrorPad_});
+export const mirrorPad = /* @__PURE__ */ op({mirrorPad_});

--- a/tfjs-core/src/ops/mod.ts
+++ b/tfjs-core/src/ops/mod.ts
@@ -63,4 +63,4 @@ function mod_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   return ENGINE.runKernel(Mod, inputs as unknown as NamedTensorMap);
 }
 
-export const mod = op({mod_});
+export const mod = /* @__PURE__ */ op({mod_});

--- a/tfjs-core/src/ops/moments.ts
+++ b/tfjs-core/src/ops/moments.ts
@@ -58,4 +58,4 @@ function moments_(
   return {mean: xMean, variance};
 }
 
-export const moments = op({moments_});
+export const moments = /* @__PURE__ */ op({moments_});

--- a/tfjs-core/src/ops/moving_average.ts
+++ b/tfjs-core/src/ops/moving_average.ts
@@ -81,4 +81,4 @@ function movingAverage_<T extends Tensor>(
   return add($v, update);
 }
 
-export const movingAverage = op({movingAverage_});
+export const movingAverage = /* @__PURE__ */ op({movingAverage_});

--- a/tfjs-core/src/ops/mul.ts
+++ b/tfjs-core/src/ops/mul.ts
@@ -59,4 +59,4 @@ function mul_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
 
   return ENGINE.runKernel(Multiply, inputs as unknown as NamedTensorMap);
 }
-export const mul = op({mul_});
+export const mul = /* @__PURE__ */ op({mul_});

--- a/tfjs-core/src/ops/multi_rnn_cell.ts
+++ b/tfjs-core/src/ops/multi_rnn_cell.ts
@@ -66,4 +66,4 @@ function multiRNNCell_(
   }
   return [newC, newH];
 }
-export const multiRNNCell = op({multiRNNCell_});
+export const multiRNNCell = /* @__PURE__ */ op({multiRNNCell_});

--- a/tfjs-core/src/ops/multinomial.ts
+++ b/tfjs-core/src/ops/multinomial.ts
@@ -80,4 +80,4 @@ function multinomial_(
   return origRank === 1 ? reshape(res, [res.size]) as Tensor1D : res;
 }
 
-export const multinomial = op({multinomial_});
+export const multinomial = /* @__PURE__ */ op({multinomial_});

--- a/tfjs-core/src/ops/neg.ts
+++ b/tfjs-core/src/ops/neg.ts
@@ -43,4 +43,4 @@ function neg_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: NegInputs = {x: $x};
   return ENGINE.runKernel(Neg, inputs as unknown as NamedTensorMap);
 }
-export const neg = op({neg_});
+export const neg = /* @__PURE__ */ op({neg_});

--- a/tfjs-core/src/ops/norm.ts
+++ b/tfjs-core/src/ops/norm.ts
@@ -137,4 +137,4 @@ function normImpl(
   throw new Error(`Error in norm: invalid axis: ${axis}`);
 }
 
-export const norm = op({norm_});
+export const norm = /* @__PURE__ */ op({norm_});

--- a/tfjs-core/src/ops/not_equal.ts
+++ b/tfjs-core/src/ops/not_equal.ts
@@ -52,4 +52,4 @@ function notEqual_<T extends Tensor>(
   return ENGINE.runKernel(NotEqual, inputs as unknown as NamedTensorMap);
 }
 
-export const notEqual = op({notEqual_});
+export const notEqual = /* @__PURE__ */ op({notEqual_});

--- a/tfjs-core/src/ops/one_hot.ts
+++ b/tfjs-core/src/ops/one_hot.ts
@@ -65,4 +65,4 @@ function oneHot_(
       attrs as unknown as NamedAttrMap);
 }
 
-export const oneHot = op({oneHot_});
+export const oneHot = /* @__PURE__ */ op({oneHot_});

--- a/tfjs-core/src/ops/ones_like.ts
+++ b/tfjs-core/src/ops/ones_like.ts
@@ -43,4 +43,4 @@ function onesLike_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(OnesLike, inputs as unknown as NamedTensorMap);
 }
 
-export const onesLike = op({onesLike_});
+export const onesLike = /* @__PURE__ */ op({onesLike_});

--- a/tfjs-core/src/ops/operation_test.ts
+++ b/tfjs-core/src/ops/operation_test.ts
@@ -20,7 +20,7 @@ import {op} from './operation';
 describeWithFlags('operation', ALL_ENVS, () => {
   it('executes and preserves function name', () => {
     const f = () => 2;
-    const opfn = op({'opName': f});
+    const opfn = /* @__PURE__ */ op({'opName': f});
 
     expect(opfn.name).toBe('opName__op');
     expect(opfn()).toBe(2);
@@ -28,7 +28,7 @@ describeWithFlags('operation', ALL_ENVS, () => {
 
   it('executes, preserves function name, strips underscore', () => {
     const f = () => 2;
-    const opfn = op({'opName_': f});
+    const opfn = /* @__PURE__ */ op({'opName_': f});
 
     expect(opfn.name).toBe('opName__op');
     expect(opfn()).toBe(2);

--- a/tfjs-core/src/ops/outer_product.ts
+++ b/tfjs-core/src/ops/outer_product.ts
@@ -52,4 +52,4 @@ function outerProduct_(
   return matMul(v12D, v22D);
 }
 
-export const outerProduct = op({outerProduct_});
+export const outerProduct = /* @__PURE__ */ op({outerProduct_});

--- a/tfjs-core/src/ops/pad.ts
+++ b/tfjs-core/src/ops/pad.ts
@@ -64,4 +64,4 @@ function pad_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const pad = op({pad_});
+export const pad = /* @__PURE__ */ op({pad_});

--- a/tfjs-core/src/ops/pad1d.ts
+++ b/tfjs-core/src/ops/pad1d.ts
@@ -32,4 +32,4 @@ function pad1d_(
   return pad(x, [paddings], constantValue);
 }
 
-export const pad1d = op({pad1d_});
+export const pad1d = /* @__PURE__ */ op({pad1d_});

--- a/tfjs-core/src/ops/pad2d.ts
+++ b/tfjs-core/src/ops/pad2d.ts
@@ -33,4 +33,4 @@ function pad2d_(
   return pad(x, paddings, constantValue);
 }
 
-export const pad2d = op({pad2d_});
+export const pad2d = /* @__PURE__ */ op({pad2d_});

--- a/tfjs-core/src/ops/pad3d.ts
+++ b/tfjs-core/src/ops/pad3d.ts
@@ -34,4 +34,4 @@ function pad3d_(
   return pad(x, paddings, constantValue);
 }
 
-export const pad3d = op({pad3d_});
+export const pad3d = /* @__PURE__ */ op({pad3d_});

--- a/tfjs-core/src/ops/pad4d.ts
+++ b/tfjs-core/src/ops/pad4d.ts
@@ -38,4 +38,4 @@ function pad4d_(
   return pad(x, paddings, constantValue);
 }
 
-export const pad4d = op({pad4d_});
+export const pad4d = /* @__PURE__ */ op({pad4d_});

--- a/tfjs-core/src/ops/pool.ts
+++ b/tfjs-core/src/ops/pool.ts
@@ -164,4 +164,4 @@ function withSpaceToBatchBasePaddings(
   });
 }
 
-export const pool = op({pool_});
+export const pool = /* @__PURE__ */ op({pool_});

--- a/tfjs-core/src/ops/pow.ts
+++ b/tfjs-core/src/ops/pow.ts
@@ -63,4 +63,4 @@ function pow_<T extends Tensor>(
   return ENGINE.runKernel(Pow, inputs as unknown as NamedTensorMap);
 }
 
-export const pow = op({pow_});
+export const pow = /* @__PURE__ */ op({pow_});

--- a/tfjs-core/src/ops/prelu.ts
+++ b/tfjs-core/src/ops/prelu.ts
@@ -48,4 +48,4 @@ function prelu_<T extends Tensor>(x: T|TensorLike, alpha: T|TensorLike): T {
   return ENGINE.runKernel(Prelu, inputs as unknown as NamedTensorMap);
 }
 
-export const prelu = op({prelu_});
+export const prelu = /* @__PURE__ */ op({prelu_});

--- a/tfjs-core/src/ops/prod.ts
+++ b/tfjs-core/src/ops/prod.ts
@@ -73,4 +73,4 @@ function prod_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const prod = op({prod_});
+export const prod = /* @__PURE__ */ op({prod_});

--- a/tfjs-core/src/ops/ragged_gather.ts
+++ b/tfjs-core/src/ops/ragged_gather.ts
@@ -72,4 +72,4 @@ function raggedGather_(
   };
 }
 
-export const raggedGather = op({raggedGather_});
+export const raggedGather = /* @__PURE__ */ op({raggedGather_});

--- a/tfjs-core/src/ops/ragged_range.ts
+++ b/tfjs-core/src/ops/ragged_range.ts
@@ -60,4 +60,4 @@ function raggedRange_(
   };
 }
 
-export const raggedRange = op({raggedRange_});
+export const raggedRange = /* @__PURE__ */ op({raggedRange_});

--- a/tfjs-core/src/ops/ragged_tensor_to_tensor.ts
+++ b/tfjs-core/src/ops/ragged_tensor_to_tensor.ts
@@ -99,4 +99,4 @@ function raggedTensorToTensor_(
   return ENGINE.runKernel(RaggedTensorToTensor, inputs as {}, attrs as {});
 }
 
-export const raggedTensorToTensor = op({raggedTensorToTensor_});
+export const raggedTensorToTensor = /* @__PURE__ */ op({raggedTensorToTensor_});

--- a/tfjs-core/src/ops/rand.ts
+++ b/tfjs-core/src/ops/rand.ts
@@ -55,4 +55,4 @@ function rand_<R extends Rank>(
   return ENGINE.makeTensor(values, shape, dtype) as Tensor<R>;
 }
 
-export const rand = op({rand_});
+export const rand = /* @__PURE__ */ op({rand_});

--- a/tfjs-core/src/ops/random_gamma.ts
+++ b/tfjs-core/src/ops/random_gamma.ts
@@ -60,4 +60,4 @@ function randomGamma_<R extends Rank>(
   return res.toTensor();
 }
 
-export const randomGamma = op({randomGamma_});
+export const randomGamma = /* @__PURE__ */ op({randomGamma_});

--- a/tfjs-core/src/ops/random_normal.ts
+++ b/tfjs-core/src/ops/random_normal.ts
@@ -54,4 +54,4 @@ function randomNormal_<R extends Rank>(
   return res.toTensor();
 }
 
-export const randomNormal = op({randomNormal_});
+export const randomNormal = /* @__PURE__ */ op({randomNormal_});

--- a/tfjs-core/src/ops/random_standard_normal.ts
+++ b/tfjs-core/src/ops/random_standard_normal.ts
@@ -44,4 +44,4 @@ function randomStandardNormal_<R extends Rank>(
   return randomNormal(shape, 0, 1, dtype, seed);
 }
 
-export const randomStandardNormal = op({randomStandardNormal_});
+export const randomStandardNormal = /* @__PURE__ */ op({randomStandardNormal_});

--- a/tfjs-core/src/ops/random_uniform.ts
+++ b/tfjs-core/src/ops/random_uniform.ts
@@ -55,4 +55,4 @@ function randomUniform_<R extends Rank>(
   return res.toTensor();
 }
 
-export const randomUniform = op({randomUniform_});
+export const randomUniform = /* @__PURE__ */ op({randomUniform_});

--- a/tfjs-core/src/ops/real.ts
+++ b/tfjs-core/src/ops/real.ts
@@ -45,4 +45,4 @@ function real_<T extends Tensor>(input: T|TensorLike): T {
   return ENGINE.runKernel(Real, inputs as unknown as NamedTensorMap);
 }
 
-export const real = op({real_});
+export const real = /* @__PURE__ */ op({real_});

--- a/tfjs-core/src/ops/reciprocal.ts
+++ b/tfjs-core/src/ops/reciprocal.ts
@@ -42,4 +42,4 @@ function reciprocal_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: ReciprocalInputs = {x: $x};
   return ENGINE.runKernel(Reciprocal, inputs as unknown as NamedTensorMap);
 }
-export const reciprocal = op({reciprocal_});
+export const reciprocal = /* @__PURE__ */ op({reciprocal_});

--- a/tfjs-core/src/ops/relu.ts
+++ b/tfjs-core/src/ops/relu.ts
@@ -45,4 +45,4 @@ function relu_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(Relu, inputs as unknown as NamedTensorMap);
 }
 
-export const relu = op({relu_});
+export const relu = /* @__PURE__ */ op({relu_});

--- a/tfjs-core/src/ops/relu6.ts
+++ b/tfjs-core/src/ops/relu6.ts
@@ -45,4 +45,4 @@ function relu6_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(Relu6, inputs as unknown as NamedTensorMap);
 }
 
-export const relu6 = op({relu6_});
+export const relu6 = /* @__PURE__ */ op({relu6_});

--- a/tfjs-core/src/ops/reshape.ts
+++ b/tfjs-core/src/ops/reshape.ts
@@ -61,4 +61,4 @@ function reshape_<R extends Rank>(
       Reshape, inputs as unknown as NamedTensorMap,
       attrs as unknown as NamedAttrMap);
 }
-export const reshape = op({reshape_});
+export const reshape = /* @__PURE__ */ op({reshape_});

--- a/tfjs-core/src/ops/reverse.ts
+++ b/tfjs-core/src/ops/reverse.ts
@@ -68,4 +68,4 @@ function reverse_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const reverse = op({reverse_});
+export const reverse = /* @__PURE__ */ op({reverse_});

--- a/tfjs-core/src/ops/reverse_1d.ts
+++ b/tfjs-core/src/ops/reverse_1d.ts
@@ -35,4 +35,4 @@ function reverse1d_(x: Tensor1D|TensorLike): Tensor1D {
   return reverse($x, 0);
 }
 
-export const reverse1d = op({reverse1d_});
+export const reverse1d = /* @__PURE__ */ op({reverse1d_});

--- a/tfjs-core/src/ops/reverse_2d.ts
+++ b/tfjs-core/src/ops/reverse_2d.ts
@@ -37,4 +37,4 @@ function reverse2d_(x: Tensor2D|TensorLike, axis?: number|number[]): Tensor2D {
   return reverse($x, axis);
 }
 
-export const reverse2d = op({reverse2d_});
+export const reverse2d = /* @__PURE__ */ op({reverse2d_});

--- a/tfjs-core/src/ops/reverse_3d.ts
+++ b/tfjs-core/src/ops/reverse_3d.ts
@@ -37,4 +37,4 @@ function reverse3d_(x: Tensor3D|TensorLike, axis?: number|number[]): Tensor3D {
   return reverse($x, axis);
 }
 
-export const reverse3d = op({reverse3d_});
+export const reverse3d = /* @__PURE__ */ op({reverse3d_});

--- a/tfjs-core/src/ops/reverse_4d.ts
+++ b/tfjs-core/src/ops/reverse_4d.ts
@@ -37,4 +37,4 @@ function reverse4d_(x: Tensor4D|TensorLike, axis?: number|number[]): Tensor4D {
   return reverse($x, axis);
 }
 
-export const reverse4d = op({reverse4d_});
+export const reverse4d = /* @__PURE__ */ op({reverse4d_});

--- a/tfjs-core/src/ops/round.ts
+++ b/tfjs-core/src/ops/round.ts
@@ -44,4 +44,4 @@ function round_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(Round, inputs as unknown as NamedTensorMap);
 }
 
-export const round = op({round_});
+export const round = /* @__PURE__ */ op({round_});

--- a/tfjs-core/src/ops/rsqrt.ts
+++ b/tfjs-core/src/ops/rsqrt.ts
@@ -44,4 +44,4 @@ function rsqrt_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Rsqrt, inputs as unknown as NamedTensorMap);
 }
-export const rsqrt = op({rsqrt_});
+export const rsqrt = /* @__PURE__ */ op({rsqrt_});

--- a/tfjs-core/src/ops/scatter_nd.ts
+++ b/tfjs-core/src/ops/scatter_nd.ts
@@ -63,4 +63,4 @@ function scatterND_<R extends Rank>(
              attrs as unknown as NamedAttrMap) as Tensor<R>;
 }
 
-export const scatterND = op({scatterND_});
+export const scatterND = /* @__PURE__ */ op({scatterND_});

--- a/tfjs-core/src/ops/search_sorted.ts
+++ b/tfjs-core/src/ops/search_sorted.ts
@@ -113,4 +113,4 @@ function searchSorted_(
   return ENGINE.runKernel(SearchSorted, inputs as {}, attrs as {});
 }
 
-export const searchSorted = op({searchSorted_});
+export const searchSorted = /* @__PURE__ */ op({searchSorted_});

--- a/tfjs-core/src/ops/selu.ts
+++ b/tfjs-core/src/ops/selu.ts
@@ -46,4 +46,4 @@ function selu_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel(Selu, inputs as unknown as NamedTensorMap);
 }
 
-export const selu = op({selu_});
+export const selu = /* @__PURE__ */ op({selu_});

--- a/tfjs-core/src/ops/separable_conv2d.ts
+++ b/tfjs-core/src/ops/separable_conv2d.ts
@@ -136,4 +136,4 @@ function separableConv2d_<T extends Tensor3D|Tensor4D>(
   return res as T;
 }
 
-export const separableConv2d = op({separableConv2d_});
+export const separableConv2d = /* @__PURE__ */ op({separableConv2d_});

--- a/tfjs-core/src/ops/sigmoid.ts
+++ b/tfjs-core/src/ops/sigmoid.ts
@@ -43,4 +43,4 @@ function sigmoid_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Sigmoid, inputs as unknown as NamedTensorMap);
 }
-export const sigmoid = op({sigmoid_});
+export const sigmoid = /* @__PURE__ */ op({sigmoid_});

--- a/tfjs-core/src/ops/sign.ts
+++ b/tfjs-core/src/ops/sign.ts
@@ -41,4 +41,4 @@ function sign_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: SignInputs = {x: $x};
   return ENGINE.runKernel(Sign, inputs as unknown as NamedTensorMap);
 }
-export const sign = op({sign_});
+export const sign = /* @__PURE__ */ op({sign_});

--- a/tfjs-core/src/ops/signal/frame.ts
+++ b/tfjs-core/src/ops/signal/frame.ts
@@ -66,4 +66,4 @@ function frame_(
 
   return reshape(concat(output), [output.length, frameLength]);
 }
-export const frame = op({frame_});
+export const frame = /* @__PURE__ */ op({frame_});

--- a/tfjs-core/src/ops/signal/hamming_window.ts
+++ b/tfjs-core/src/ops/signal/hamming_window.ts
@@ -34,4 +34,4 @@ import {cosineWindow} from '../signal_ops_util';
 function hammingWindow_(windowLength: number): Tensor1D {
   return cosineWindow(windowLength, 0.54, 0.46);
 }
-export const hammingWindow = op({hammingWindow_});
+export const hammingWindow = /* @__PURE__ */ op({hammingWindow_});

--- a/tfjs-core/src/ops/signal/hann_window.ts
+++ b/tfjs-core/src/ops/signal/hann_window.ts
@@ -35,4 +35,4 @@ function hannWindow_(windowLength: number): Tensor1D {
   return cosineWindow(windowLength, 0.5, 0.5);
 }
 
-export const hannWindow = op({hannWindow_});
+export const hannWindow = /* @__PURE__ */ op({hannWindow_});

--- a/tfjs-core/src/ops/signal/stft.ts
+++ b/tfjs-core/src/ops/signal/stft.ts
@@ -51,4 +51,4 @@ function stft_(
   const windowedSignal = mul(framedSignal, windowFn(frameLength));
   return rfft(windowedSignal, fftLength);
 }
-export const stft = op({stft_});
+export const stft = /* @__PURE__ */ op({stft_});

--- a/tfjs-core/src/ops/sin.ts
+++ b/tfjs-core/src/ops/sin.ts
@@ -43,4 +43,4 @@ function sin_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Sin, inputs as unknown as NamedTensorMap);
 }
-export const sin = op({sin_});
+export const sin = /* @__PURE__ */ op({sin_});

--- a/tfjs-core/src/ops/sinh.ts
+++ b/tfjs-core/src/ops/sinh.ts
@@ -42,4 +42,4 @@ function sinh_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Sinh, inputs as unknown as NamedTensorMap);
 }
-export const sinh = op({sinh_});
+export const sinh = /* @__PURE__ */ op({sinh_});

--- a/tfjs-core/src/ops/slice.ts
+++ b/tfjs-core/src/ops/slice.ts
@@ -75,4 +75,4 @@ function slice_<R extends Rank, T extends Tensor<R>>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const slice = op({slice_});
+export const slice = /* @__PURE__ */ op({slice_});

--- a/tfjs-core/src/ops/slice1d.ts
+++ b/tfjs-core/src/ops/slice1d.ts
@@ -36,4 +36,4 @@ function slice1d_(
           `slice1d expects a rank-1 tensor, but got a rank-${$x.rank} tensor`);
   return slice($x, [begin], [size]);
 }
-export const slice1d = op({slice1d_});
+export const slice1d = /* @__PURE__ */ op({slice1d_});

--- a/tfjs-core/src/ops/slice2d.ts
+++ b/tfjs-core/src/ops/slice2d.ts
@@ -37,4 +37,4 @@ function slice2d_(
           `slice2d expects a rank-2 tensor, but got a rank-${$x.rank} tensor`);
   return slice($x, begin, size);
 }
-export const slice2d = op({slice2d_});
+export const slice2d = /* @__PURE__ */ op({slice2d_});

--- a/tfjs-core/src/ops/slice3d.ts
+++ b/tfjs-core/src/ops/slice3d.ts
@@ -37,4 +37,4 @@ function slice3d_(
           `slice3d expects a rank-3 tensor, but got a rank-${$x.rank} tensor`);
   return slice($x, begin, size);
 }
-export const slice3d = op({slice3d_});
+export const slice3d = /* @__PURE__ */ op({slice3d_});

--- a/tfjs-core/src/ops/slice4d.ts
+++ b/tfjs-core/src/ops/slice4d.ts
@@ -37,4 +37,4 @@ function slice4d_(
           `slice4d expects a rank-4 tensor, but got a rank-${$x.rank} tensor`);
   return slice($x, begin, size);
 }
-export const slice4d = op({slice4d_});
+export const slice4d = /* @__PURE__ */ op({slice4d_});

--- a/tfjs-core/src/ops/softmax.ts
+++ b/tfjs-core/src/ops/softmax.ts
@@ -66,4 +66,4 @@ function softmax_<T extends Tensor>(logits: T|TensorLike, dim = -1): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const softmax = op({softmax_});
+export const softmax = /* @__PURE__ */ op({softmax_});

--- a/tfjs-core/src/ops/softplus.ts
+++ b/tfjs-core/src/ops/softplus.ts
@@ -42,4 +42,4 @@ function softplus_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: SoftplusInputs = {x: $x};
   return ENGINE.runKernel(Softplus, inputs as unknown as NamedTensorMap);
 }
-export const softplus = op({softplus_});
+export const softplus = /* @__PURE__ */ op({softplus_});

--- a/tfjs-core/src/ops/space_to_batch_nd.ts
+++ b/tfjs-core/src/ops/space_to_batch_nd.ts
@@ -112,4 +112,4 @@ function spaceToBatchND_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const spaceToBatchND = op({spaceToBatchND_});
+export const spaceToBatchND = /* @__PURE__ */ op({spaceToBatchND_});

--- a/tfjs-core/src/ops/sparse/sparse_fill_empty_rows.ts
+++ b/tfjs-core/src/ops/sparse/sparse_fill_empty_rows.ts
@@ -124,4 +124,4 @@ function sparseFillEmptyRows_(
   };
 }
 
-export const sparseFillEmptyRows = op({sparseFillEmptyRows_});
+export const sparseFillEmptyRows = /* @__PURE__ */ op({sparseFillEmptyRows_});

--- a/tfjs-core/src/ops/sparse/sparse_reshape.ts
+++ b/tfjs-core/src/ops/sparse/sparse_reshape.ts
@@ -89,4 +89,4 @@ function sparseReshape_(
   return {outputIndices: result[0], outputShape: result[1]};
 }
 
-export const sparseReshape = op({sparseReshape_});
+export const sparseReshape = /* @__PURE__ */ op({sparseReshape_});

--- a/tfjs-core/src/ops/sparse/sparse_segment_mean.ts
+++ b/tfjs-core/src/ops/sparse/sparse_segment_mean.ts
@@ -87,4 +87,4 @@ function sparseSegmentMean_(
   return ENGINE.runKernel(SparseSegmentMean, inputs as {});
 }
 
-export const sparseSegmentMean = op({sparseSegmentMean_});
+export const sparseSegmentMean = /* @__PURE__ */ op({sparseSegmentMean_});

--- a/tfjs-core/src/ops/sparse/sparse_segment_sum.ts
+++ b/tfjs-core/src/ops/sparse/sparse_segment_sum.ts
@@ -87,4 +87,4 @@ function sparseSegmentSum_(
   return ENGINE.runKernel(SparseSegmentSum, inputs as {});
 }
 
-export const sparseSegmentSum = op({sparseSegmentSum_});
+export const sparseSegmentSum = /* @__PURE__ */ op({sparseSegmentSum_});

--- a/tfjs-core/src/ops/sparse_to_dense.ts
+++ b/tfjs-core/src/ops/sparse_to_dense.ts
@@ -93,4 +93,4 @@ function sparseToDense_<R extends Rank>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const sparseToDense = op({sparseToDense_});
+export const sparseToDense = /* @__PURE__ */ op({sparseToDense_});

--- a/tfjs-core/src/ops/spectral/fft.ts
+++ b/tfjs-core/src/ops/spectral/fft.ts
@@ -50,4 +50,4 @@ function fft_(input: Tensor): Tensor {
   return ENGINE.runKernel(FFT, inputs as unknown as NamedTensorMap);
 }
 
-export const fft = op({fft_});
+export const fft = /* @__PURE__ */ op({fft_});

--- a/tfjs-core/src/ops/spectral/ifft.ts
+++ b/tfjs-core/src/ops/spectral/ifft.ts
@@ -50,4 +50,4 @@ function ifft_(input: Tensor): Tensor {
   return ENGINE.runKernel(IFFT, inputs as unknown as NamedTensorMap);
 }
 
-export const ifft = op({ifft_});
+export const ifft = /* @__PURE__ */ op({ifft_});

--- a/tfjs-core/src/ops/spectral/irfft.ts
+++ b/tfjs-core/src/ops/spectral/irfft.ts
@@ -83,4 +83,4 @@ function irfft_(input: Tensor): Tensor {
   return ret;
 }
 
-export const irfft = op({irfft_});
+export const irfft = /* @__PURE__ */ op({irfft_});

--- a/tfjs-core/src/ops/spectral/rfft.ts
+++ b/tfjs-core/src/ops/spectral/rfft.ts
@@ -96,4 +96,4 @@ function rfft_(input: Tensor, fftLength?: number): Tensor {
       complex(realComplexConjugate[0], imagComplexConjugate[0]), outputShape);
 }
 
-export const rfft = op({rfft_});
+export const rfft = /* @__PURE__ */ op({rfft_});

--- a/tfjs-core/src/ops/split.ts
+++ b/tfjs-core/src/ops/split.ts
@@ -71,4 +71,4 @@ function split_<T extends Tensor>(
              attr as unknown as NamedAttrMap) as unknown as T[];
 }
 
-export const split = op({split_});
+export const split = /* @__PURE__ */ op({split_});

--- a/tfjs-core/src/ops/sqrt.ts
+++ b/tfjs-core/src/ops/sqrt.ts
@@ -43,4 +43,4 @@ function sqrt_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Sqrt, inputs as unknown as NamedTensorMap);
 }
-export const sqrt = op({sqrt_});
+export const sqrt = /* @__PURE__ */ op({sqrt_});

--- a/tfjs-core/src/ops/square.ts
+++ b/tfjs-core/src/ops/square.ts
@@ -39,4 +39,4 @@ function square_<T extends Tensor>(x: T|TensorLike): T {
   return ENGINE.runKernel('Square', {x: $x}, attrs);
 }
 
-export const square = op({square_});
+export const square = /* @__PURE__ */ op({square_});

--- a/tfjs-core/src/ops/squared_difference.ts
+++ b/tfjs-core/src/ops/squared_difference.ts
@@ -65,4 +65,4 @@ function squaredDifference_<T extends Tensor>(
       SquaredDifference, inputs as unknown as NamedTensorMap, attrs);
 }
 
-export const squaredDifference = op({squaredDifference_});
+export const squaredDifference = /* @__PURE__ */ op({squaredDifference_});

--- a/tfjs-core/src/ops/squeeze.ts
+++ b/tfjs-core/src/ops/squeeze.ts
@@ -43,4 +43,4 @@ function squeeze_<T extends Tensor>(x: Tensor|TensorLike, axis?: number[]): T {
   return reshape($x, squeezeShape($x.shape, axis).newShape) as T;
 }
 
-export const squeeze = op({squeeze_});
+export const squeeze = /* @__PURE__ */ op({squeeze_});

--- a/tfjs-core/src/ops/stack.ts
+++ b/tfjs-core/src/ops/stack.ts
@@ -62,4 +62,4 @@ function stack_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const stack = op({stack_});
+export const stack = /* @__PURE__ */ op({stack_});

--- a/tfjs-core/src/ops/step.ts
+++ b/tfjs-core/src/ops/step.ts
@@ -48,4 +48,4 @@ function step_<T extends Tensor>(x: T|TensorLike, alpha = 0.0): T {
       Step, inputs as unknown as NamedTensorMap,
       attrs as unknown as NamedAttrMap);
 }
-export const step = op({step_});
+export const step = /* @__PURE__ */ op({step_});

--- a/tfjs-core/src/ops/strided_slice.ts
+++ b/tfjs-core/src/ops/strided_slice.ts
@@ -81,4 +81,4 @@ function stridedSlice_(
       attrs as unknown as NamedAttrMap);
 }
 
-export const stridedSlice = op({stridedSlice_});
+export const stridedSlice = /* @__PURE__ */ op({stridedSlice_});

--- a/tfjs-core/src/ops/string/string_n_grams.ts
+++ b/tfjs-core/src/ops/string/string_n_grams.ts
@@ -96,4 +96,4 @@ function stringNGrams_(
   return {nGrams: result[0], nGramsSplits: result[1]};
 }
 
-export const stringNGrams = op({stringNGrams_});
+export const stringNGrams = /* @__PURE__ */ op({stringNGrams_});

--- a/tfjs-core/src/ops/string/string_split.ts
+++ b/tfjs-core/src/ops/string/string_split.ts
@@ -78,4 +78,4 @@ function stringSplit_(
   return {indices: result[0], values: result[1], shape: result[2]};
 }
 
-export const stringSplit = op({stringSplit_});
+export const stringSplit = /* @__PURE__ */ op({stringSplit_});

--- a/tfjs-core/src/ops/string/string_to_hash_bucket_fast.ts
+++ b/tfjs-core/src/ops/string/string_to_hash_bucket_fast.ts
@@ -57,4 +57,4 @@ function stringToHashBucketFast_(
   return ENGINE.runKernel(StringToHashBucketFast, inputs as {}, attrs as {});
 }
 
-export const stringToHashBucketFast = op({stringToHashBucketFast_});
+export const stringToHashBucketFast = /* @__PURE__ */ op({stringToHashBucketFast_});

--- a/tfjs-core/src/ops/sub.ts
+++ b/tfjs-core/src/ops/sub.ts
@@ -57,4 +57,4 @@ function sub_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   return ENGINE.runKernel(Sub, inputs as unknown as NamedTensorMap);
 }
 
-export const sub = op({sub_});
+export const sub = /* @__PURE__ */ op({sub_});

--- a/tfjs-core/src/ops/sum.ts
+++ b/tfjs-core/src/ops/sum.ts
@@ -70,4 +70,4 @@ function sum_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const sum = op({sum_});
+export const sum = /* @__PURE__ */ op({sum_});

--- a/tfjs-core/src/ops/tan.ts
+++ b/tfjs-core/src/ops/tan.ts
@@ -43,4 +43,4 @@ function tan_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Tan, inputs as unknown as NamedTensorMap);
 }
-export const tan = op({tan_});
+export const tan = /* @__PURE__ */ op({tan_});

--- a/tfjs-core/src/ops/tanh.ts
+++ b/tfjs-core/src/ops/tanh.ts
@@ -43,4 +43,4 @@ function tanh_<T extends Tensor>(x: T|TensorLike): T {
 
   return ENGINE.runKernel(Tanh, inputs as unknown as NamedTensorMap);
 }
-export const tanh = op({tanh_});
+export const tanh = /* @__PURE__ */ op({tanh_});

--- a/tfjs-core/src/ops/tile.ts
+++ b/tfjs-core/src/ops/tile.ts
@@ -66,4 +66,4 @@ function tile_<T extends Tensor>(x: T|TensorLike, reps: number[]): T {
       attrs as unknown as NamedAttrMap);
 }
 
-export const tile = op({tile_});
+export const tile = /* @__PURE__ */ op({tile_});

--- a/tfjs-core/src/ops/topk.ts
+++ b/tfjs-core/src/ops/topk.ts
@@ -77,4 +77,4 @@ function topk_<T extends Tensor>(
   return {values, indices};
 }
 
-export const topk = op({topk_});
+export const topk = /* @__PURE__ */ op({topk_});

--- a/tfjs-core/src/ops/transpose.ts
+++ b/tfjs-core/src/ops/transpose.ts
@@ -97,4 +97,4 @@ function transpose_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const transpose = op({transpose_});
+export const transpose = /* @__PURE__ */ op({transpose_});

--- a/tfjs-core/src/ops/truncated_normal.ts
+++ b/tfjs-core/src/ops/truncated_normal.ts
@@ -59,4 +59,4 @@ function truncatedNormal_<R extends Rank>(
   return res.toTensor();
 }
 
-export const truncatedNormal = op({truncatedNormal_});
+export const truncatedNormal = /* @__PURE__ */ op({truncatedNormal_});

--- a/tfjs-core/src/ops/unique.ts
+++ b/tfjs-core/src/ops/unique.ts
@@ -88,4 +88,4 @@ function unique_<T extends Tensor>(
   return {values, indices};
 }
 
-export const unique = op({unique_});
+export const unique = /* @__PURE__ */ op({unique_});

--- a/tfjs-core/src/ops/unsorted_segment_sum.ts
+++ b/tfjs-core/src/ops/unsorted_segment_sum.ts
@@ -59,4 +59,4 @@ function unsortedSegmentSum_<T extends Tensor>(
       attrs as unknown as NamedAttrMap);
 }
 
-export const unsortedSegmentSum = op({unsortedSegmentSum_});
+export const unsortedSegmentSum = /* @__PURE__ */ op({unsortedSegmentSum_});

--- a/tfjs-core/src/ops/unstack.ts
+++ b/tfjs-core/src/ops/unstack.ts
@@ -55,4 +55,4 @@ function unstack_(x: Tensor|TensorLike, axis = 0): Tensor[] {
       attrs as unknown as NamedAttrMap);
 }
 
-export const unstack = op({unstack_});
+export const unstack = /* @__PURE__ */ op({unstack_});

--- a/tfjs-core/src/ops/where.ts
+++ b/tfjs-core/src/ops/where.ts
@@ -71,4 +71,4 @@ function where_<T extends Tensor>(
   return ENGINE.runKernel(Select, inputs as unknown as NamedTensorMap);
 }
 
-export const where = op({where_});
+export const where = /* @__PURE__ */ op({where_});

--- a/tfjs-core/src/ops/zeros_like.ts
+++ b/tfjs-core/src/ops/zeros_like.ts
@@ -42,4 +42,4 @@ function zerosLike_<T extends Tensor>(x: T|TensorLike): T {
   const inputs: ZerosLikeInputs = {x: $x};
   return ENGINE.runKernel(ZerosLike, inputs as unknown as NamedTensorMap);
 }
-export const zerosLike = op({zerosLike_});
+export const zerosLike = /* @__PURE__ */ op({zerosLike_});


### PR DESCRIPTION
Mark calls to the `op()` function that creates the exported op as pure by using [`/* @__PURE__ */` annotations](https://esbuild.github.io/api/#ignore-annotations) (this also works for Rollup, but I can't find the docs). This comment instructs bundlers that the function call has no side-effects, so it can be removed if the result is not used.

This is okay for the `op` function because, although it references ENGINE, it does so [in a closure](https://github.com/tensorflow/tfjs/blob/master/tfjs-core/src/ops/operation.ts#L48-L61) that it never calls, so while its return value may cause side effects when called, it itself does not.

This has no immediate effect because we still maintain a list of `sideEffects` in the package.json, but it is a step towards removing that list.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7155)
<!-- Reviewable:end -->
