### PR TITLE
Simplify how Optimizers are re-exported in train.ts

### DIFF
--- a/tfjs-core/src/train.ts
+++ b/tfjs-core/src/train.ts
@@ -15,26 +15,6 @@
  * =============================================================================
  */
 
-// So typings can propagate.
-import {AdadeltaOptimizer} from './optimizers/adadelta_optimizer';
-import {AdagradOptimizer} from './optimizers/adagrad_optimizer';
-import {AdamOptimizer} from './optimizers/adam_optimizer';
-import {AdamaxOptimizer} from './optimizers/adamax_optimizer';
-import {MomentumOptimizer} from './optimizers/momentum_optimizer';
 import {OptimizerConstructors} from './optimizers/optimizer_constructors';
-import {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
-import {SGDOptimizer} from './optimizers/sgd_optimizer';
 
-// tslint:disable-next-line:no-unused-expression
-[MomentumOptimizer, SGDOptimizer, AdadeltaOptimizer, AdagradOptimizer,
- RMSPropOptimizer, AdamaxOptimizer, AdamOptimizer];
-
-export const train = {
-  sgd: OptimizerConstructors.sgd,
-  momentum: OptimizerConstructors.momentum,
-  adadelta: OptimizerConstructors.adadelta,
-  adagrad: OptimizerConstructors.adagrad,
-  rmsprop: OptimizerConstructors.rmsprop,
-  adamax: OptimizerConstructors.adamax,
-  adam: OptimizerConstructors.adam
-};
+export const train = OptimizerConstructors;


### PR DESCRIPTION
`train.ts` exports optimizers by copying them from the `OptimizerConstructors` class onto a `train` object. This is unnecessary because the `OptimizerConstructors` class constructor is a subtype of the `train` object's type (i.e. it has all the properties that `train` has). Instead of creating a new `train` object, this PR re-exports `OptimizerConstructors` as `train`.

This has no direct effect now, but if / when we remove the `sideEffects` field from `package.json`, it helps some bundlers (esbuild) do tree-shaking.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7156)
<!-- Reviewable:end -->
