### PR TITLE
Register optimizers in a centralized location

### DIFF
--- a/tfjs-core/src/index.ts
+++ b/tfjs-core/src/index.ts
@@ -17,5 +17,12 @@
 
 // Required side effectful code.
 import './base_side_effects';
+
+// TODO(mattSoulanille): Move this to base_side_effects.ts
+// It is here for now because custom bundles need to avoid calling it, and they
+// only replace the index.js file, not the base_side_effects file.
+import {registerOptimizers} from './optimizers/register_optimizers';
+registerOptimizers();
+
 // All exports from this package should be in base.
 export * from './base';

--- a/tfjs-core/src/optimizers/adadelta_optimizer.ts
+++ b/tfjs-core/src/optimizers/adadelta_optimizer.ts
@@ -23,7 +23,7 @@ import {mul} from '../ops/mul';
 import {sqrt} from '../ops/ops';
 import {square} from '../ops/square';
 import {zerosLike} from '../ops/zeros_like';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {NamedTensor, NamedVariableMap} from '../tensor_types';
 
 import {Optimizer, OptimizerVariable} from './optimizer';
@@ -147,4 +147,3 @@ export class AdadeltaOptimizer extends Optimizer {
     return new cls(config['learningRate'], config['rho'], config['epsilon']);
   }
 }
-registerClass(AdadeltaOptimizer);

--- a/tfjs-core/src/optimizers/adagrad_optimizer.ts
+++ b/tfjs-core/src/optimizers/adagrad_optimizer.ts
@@ -23,7 +23,7 @@ import {fill} from '../ops/fill';
 import {mul} from '../ops/mul';
 import {sqrt} from '../ops/sqrt';
 import {square} from '../ops/square';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {NamedTensor, NamedVariableMap} from '../tensor_types';
 
 import {Optimizer, OptimizerVariable} from './optimizer';
@@ -113,4 +113,3 @@ export class AdagradOptimizer extends Optimizer {
     return new cls(config['learningRate'], config['initialAccumulatorValue']);
   }
 }
-registerClass(AdagradOptimizer);

--- a/tfjs-core/src/optimizers/adam_optimizer.ts
+++ b/tfjs-core/src/optimizers/adam_optimizer.ts
@@ -26,7 +26,7 @@ import {sqrt} from '../ops/sqrt';
 import {square} from '../ops/square';
 import {sub} from '../ops/sub';
 import {zerosLike} from '../ops/zeros_like';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {Variable} from '../tensor';
 import {NamedTensor, NamedVariableMap} from '../tensor_types';
 
@@ -177,4 +177,3 @@ export class AdamOptimizer extends Optimizer {
         config['epsilon']);
   }
 }
-registerClass(AdamOptimizer);

--- a/tfjs-core/src/optimizers/adamax_optimizer.ts
+++ b/tfjs-core/src/optimizers/adamax_optimizer.ts
@@ -25,7 +25,7 @@ import {mul} from '../ops/mul';
 import {scalar} from '../ops/scalar';
 import {sub} from '../ops/sub';
 import {zerosLike} from '../ops/zeros_like';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {Variable} from '../tensor';
 import {NamedTensor, NamedVariableMap} from '../tensor_types';
 
@@ -155,4 +155,3 @@ export class AdamaxOptimizer extends Optimizer {
         config['epsilon'], config['decay']);
   }
 }
-registerClass(AdamaxOptimizer);

--- a/tfjs-core/src/optimizers/momentum_optimizer.ts
+++ b/tfjs-core/src/optimizers/momentum_optimizer.ts
@@ -21,7 +21,7 @@ import {add} from '../ops/add';
 import {mul} from '../ops/mul';
 import {scalar} from '../ops/scalar';
 import {zerosLike} from '../ops/zeros_like';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {Scalar, Tensor} from '../tensor';
 import {NamedTensor, NamedVariableMap} from '../tensor_types';
 
@@ -126,4 +126,3 @@ export class MomentumOptimizer extends SGDOptimizer {
         config['learningRate'], config['momentum'], config['useNesterov']);
   }
 }
-registerClass(MomentumOptimizer);

--- a/tfjs-core/src/optimizers/register_optimizers.ts
+++ b/tfjs-core/src/optimizers/register_optimizers.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {AdadeltaOptimizer} from './adadelta_optimizer';
+import {AdagradOptimizer} from './adagrad_optimizer';
+import {AdamOptimizer} from './adam_optimizer';
+import {AdamaxOptimizer} from './adamax_optimizer';
+import {MomentumOptimizer} from './momentum_optimizer';
+import {RMSPropOptimizer} from './rmsprop_optimizer';
+import {SGDOptimizer} from './sgd_optimizer';
+import {registerClass} from '../serialization';
+
+const OPTIMIZERS = [
+  AdadeltaOptimizer,
+  AdagradOptimizer,
+  AdamOptimizer,
+  AdamaxOptimizer,
+  MomentumOptimizer,
+  RMSPropOptimizer,
+  SGDOptimizer,
+];
+
+export function registerOptimizers() {
+  for (const optimizer of OPTIMIZERS) {
+    registerClass(optimizer);
+  }
+}

--- a/tfjs-core/src/optimizers/rmsprop_optimizer.ts
+++ b/tfjs-core/src/optimizers/rmsprop_optimizer.ts
@@ -24,7 +24,7 @@ import {sqrt} from '../ops/sqrt';
 import {square} from '../ops/square';
 import {sub} from '../ops/sub';
 import {zerosLike} from '../ops/zeros_like';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {NamedTensor, NamedTensorMap} from '../tensor_types';
 
 import {Optimizer, OptimizerVariable} from './optimizer';
@@ -207,4 +207,3 @@ export class RMSPropOptimizer extends Optimizer {
         config['epsilon'], config['centered']);
   }
 }
-registerClass(RMSPropOptimizer);

--- a/tfjs-core/src/optimizers/sgd_optimizer.ts
+++ b/tfjs-core/src/optimizers/sgd_optimizer.ts
@@ -20,7 +20,7 @@ import {keep, tidy} from '../globals';
 import {add} from '../ops/add';
 import {mul} from '../ops/mul';
 import {scalar} from '../ops/scalar';
-import {ConfigDict, registerClass, Serializable, SerializableConstructor} from '../serialization';
+import {ConfigDict, Serializable, SerializableConstructor} from '../serialization';
 import {Scalar} from '../tensor';
 import {NamedTensor, NamedTensorMap} from '../tensor_types';
 
@@ -93,4 +93,3 @@ export class SGDOptimizer extends Optimizer {
     return new cls(config['learningRate']);
   }
 }
-registerClass(SGDOptimizer);


### PR DESCRIPTION
Optimizers are currently registered in the same file they are defined in, which is a side effect. This would make it impossible to tree-shake them in a custom bundle when `sideEffects` is removed from the package.json.

This PR moves Optimizer registration to the `register_optimizers.ts` file. The files that the Optimizers are defined in no longer have side effects. To exclude Optimizers from a custom bundle, the `registerOptimizers` function is called from `index.ts`. Custom bundles replace `index.ts` with a different file that does not call this function.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7157)
<!-- Reviewable:end -->
