### PR TITLE
Temporarily pin flax to <0.6.3 to fix circular dep build issue

### DIFF
--- a/tfjs-converter/python/BUILD
+++ b/tfjs-converter/python/BUILD
@@ -48,7 +48,7 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     requires = [
-        "flax>=0.5.3",
+        "flax<0.6.3,>=0.5.3",
         "importlib_resources>=5.9.0",
         "jax>=0.3.16",
         "protobuf<3.20,>=3.9.2",

--- a/tfjs-converter/python/requirements.txt
+++ b/tfjs-converter/python/requirements.txt
@@ -1,4 +1,4 @@
-flax>=0.5.3
+flax<0.6.3,>=0.5.3
 jax>=0.3.16
 importlib_resources>=5.9.0
 protobuf<3.20,>=3.9.2


### PR DESCRIPTION
Flax 0.6.3 seems to cause a circular dependency issue with Bazel. Pin it to <0.6.3 for now.

```
ERROR: /usr/local/google/home/msoulanille/.cache/bazel/_bazel_msoulanille/9633cfa0c28af5f24d900dd13e6bc5b8/external/tensorflowjs_dev_deps/pypi__flax/BUILD.bazel:22:11: in py_library rule @tensorflowjs_dev_deps//pypi__flax:pypi__flax: cycle in dependency graph:
    //tfjs-converter/python/tensorflowjs/converters:jax_conversion_test (1ac704f01a0ba260bfb1a01d72a5e91827144d78836864b5710509d3d9d956a2)
    //tfjs-converter/python/tensorflowjs:expect_flax_installed (c57eef692cab50e751ca54fdd64a9d8b7f624d9bccb12be15778f5c2d8865e6c)
.-> @tensorflowjs_dev_deps//pypi__flax:pypi__flax (c57eef692cab50e751ca54fdd64a9d8b7f624d9bccb12be15778f5c2d8865e6c)
|   @tensorflowjs_dev_deps//pypi__orbax:pypi__orbax (c57eef692cab50e751ca54fdd64a9d8b7f624d9bccb12be15778f5c2d8865e6c)
`-- @tensorflowjs_dev_deps//pypi__flax:pypi__flax (c57eef692cab50e751ca54fdd64a9d8b7f624d9bccb12be15778f5c2d8865e6c)
```
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7158)
<!-- Reviewable:end -->
