### PR TITLE
Use static getters to get optimizer class names

### DIFF
--- a/tfjs-core/src/optimizers/adadelta_optimizer.ts
+++ b/tfjs-core/src/optimizers/adadelta_optimizer.ts
@@ -31,7 +31,12 @@ import {Optimizer, OptimizerVariable} from './optimizer';
 /** @doclink Optimizer */
 export class AdadeltaOptimizer extends Optimizer {
   /** @nocollapse */
-  static className = 'Adadelta';  // Name matters for Python compatibility.
+  static get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'Adadelta';
+  }
   private accumulatedGrads: OptimizerVariable[] = [];
   private accumulatedUpdates: OptimizerVariable[] = [];
 

--- a/tfjs-core/src/optimizers/adagrad_optimizer.ts
+++ b/tfjs-core/src/optimizers/adagrad_optimizer.ts
@@ -31,7 +31,12 @@ import {Optimizer, OptimizerVariable} from './optimizer';
 /** @doclink Optimizer */
 export class AdagradOptimizer extends Optimizer {
   /** @nocollapse */
-  static className = 'Adagrad';  // Note: Name matters for Python compatibility.
+  static get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'Adagrad';
+  }
 
   private accumulatedGrads: OptimizerVariable[] = [];
 

--- a/tfjs-core/src/optimizers/adam_optimizer.ts
+++ b/tfjs-core/src/optimizers/adam_optimizer.ts
@@ -34,7 +34,12 @@ import {Optimizer, OptimizerVariable} from './optimizer';
 
 export class AdamOptimizer extends Optimizer {
   /** @nocollapse */
-  static className = 'Adam';  // Note: Name matters for Python compatibility.
+  static get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'Adam';
+  }
   private accBeta1: Variable;
   private accBeta2: Variable;
 

--- a/tfjs-core/src/optimizers/adamax_optimizer.ts
+++ b/tfjs-core/src/optimizers/adamax_optimizer.ts
@@ -33,7 +33,12 @@ import {Optimizer, OptimizerVariable} from './optimizer';
 
 export class AdamaxOptimizer extends Optimizer {
   /** @nocollapse */
-  static className = 'Adamax';  // Note: Name matters for Python compatbility.
+  static get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'Adamax';
+  }
   private accBeta1: Variable;
   private iteration: Variable;
 

--- a/tfjs-core/src/optimizers/momentum_optimizer.ts
+++ b/tfjs-core/src/optimizers/momentum_optimizer.ts
@@ -32,7 +32,12 @@ import {SGDOptimizer} from './sgd_optimizer';
 export class MomentumOptimizer extends SGDOptimizer {
   /** @nocollapse */
   // Name matters for Python compatibility.
-  static override className = 'Momentum';
+  static override get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'Momentum';
+  }
   private m: Scalar;
   private accumulations: OptimizerVariable[] = [];
 

--- a/tfjs-core/src/optimizers/rmsprop_optimizer.ts
+++ b/tfjs-core/src/optimizers/rmsprop_optimizer.ts
@@ -32,7 +32,12 @@ import {Optimizer, OptimizerVariable} from './optimizer';
 /** @doclink Optimizer */
 export class RMSPropOptimizer extends Optimizer {
   /** @nocollapse */
-  static className = 'RMSProp';  // Note: Name matters for Python compatibility.
+  static get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'RMSProp';
+  }
   private centered: boolean;
 
   private accumulatedMeanSquares: OptimizerVariable[] = [];

--- a/tfjs-core/src/optimizers/sgd_optimizer.ts
+++ b/tfjs-core/src/optimizers/sgd_optimizer.ts
@@ -29,7 +29,12 @@ import {Optimizer} from './optimizer';
 /** @doclink Optimizer */
 export class SGDOptimizer extends Optimizer {
   /** @nocollapse */
-  static className = 'SGD';  // Note: Name matters for Python compatibility.
+  static get className() {
+    // Name matters for Python compatibility.
+    // This is a getter instead of a property because when it's a property, it
+    // prevents the entire class from being tree-shaken.
+    return 'SGD';
+  }
   protected c: Scalar;
 
   constructor(protected learningRate: number) {


### PR DESCRIPTION
Each `Optimizer` lists its class name as a static property of the class so it can be serialized and deserialized. This prevents the class from being tree-shaken because bundlers will compile it like this:

```ts
class SomeOptimizer {
  ...
}

// The bundler can not remove this assignment because
// SomeOptimizer.className could be a setter with a side effect.
SomeOptimizer.className = 'SomeOptimizer';
```

This PR uses a static getter for the class name instead, which bundlers can tree-shake properly.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7168)
<!-- Reviewable:end -->
