### PR TITLE
[webgpu] Inline `CHECK_NAN_SNIPPET_VEC4_INNER`

### DIFF
--- a/tfjs-backend-webgpu/src/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/binary_op_util.ts
@@ -45,13 +45,9 @@ const CHECK_NAN_SNIPPET = `
   if (isnan(b)) { return b; }
   `;
 
-const CHECK_NAN_SNIPPET_VEC4_INNER = `
-  resultTemp = select(resultTemp, vec4<f32>(valueForNaN), isNaN);
-  `;
-
 const CHECK_NAN_SNIPPET_VEC4 = `
   let isNaN = isnanVec4(a) | isnanVec4(b);
-  ${CHECK_NAN_SNIPPET_VEC4_INNER}
+  resultTemp = select(resultTemp, vec4<f32>(valueForNaN), isNaN);
   `;
 
 const ADD = 'return a + b;';
@@ -201,9 +197,7 @@ const POW_VEC4 = `
     resultTemp.a = 1.0;
   }
   let isNaN = (a < vec4<f32>(0.0)) & (floor(b) < b);
-  let valueForNaN = uniforms.NAN;
-  ${CHECK_NAN_SNIPPET_VEC4_INNER}
-  return resultTemp;
+  return select(resultTemp, vec4<f32>(uniforms.NAN), isNaN);
 `;
 
 const PRELU = `if (a < 0.0) { return b * a; }  return a;`;


### PR DESCRIPTION
What the heck is the `_INNER` suffix? How does it differ from `CHECK_NAN_SNIPPET_VEC4`? Why there isn't a `CHECK_NAN_SNIPPET_INNER`?

I think this just creates more readability obstacles than it solves now.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7178)
<!-- Reviewable:end -->
