### PR TITLE
Update date for nightly benchmark

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -107,9 +107,9 @@ The following are supported options arguments which trigger options features:
     node app.js --period=15
     ```
   * --date
-    - Set the date for selecting models and this works only if `--period` is set. The value could be -1 (the day will the date at the runtime) or 1~31.
+    - Set the date for selecting models and this works only if `--period` is set. The value could be 1~31. If it is not declared, the date will the real date at runtime.
     ``` shell
-    node app.js --period=15 --date=-1
+    node app.js --period=15 --date=1
     ```
   * --maxBenchmarks
     - Sets maximum for number of benchmarks run in parallel. Expects a positive integer.

--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -101,10 +101,15 @@ The following are supported options arguments which trigger options features:
     ``` shell
     node app.js --help
     ```
-  * --weeklyCycleRun
-    - Runs a part of models specified in `--benchmarks`'s file in a weekly cycle and the part of models to run is determined by the day of a week. The value could be -1 (the day will the day at the runtime) or 0~6 (representing Sunday to Saturday). This argument takes effect only if `--benchmarks` is set.
+  * --period
+    - Runs a part of models specified in `--benchmarks`'s file in a cycle and the part of models to run is determined by the date of a month. The value could be or 1~31 (representing Sunday to Saturday). This argument takes effect only if `--benchmarks` is set.
     ``` shell
-    node app.js --weeklyCycleRun=-1
+    node app.js --period=15
+    ```
+  * --date
+    - Set the date for selecting models and this works only if `--period` is set. The value could be -1 (the day will the date at the runtime) or 1~31.
+    ``` shell
+    node app.js --period=15 --date=-1
     ```
   * --maxBenchmarks
     - Sets maximum for number of benchmarks run in parallel. Expects a positive integer.

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -362,12 +362,19 @@ function setupHelpMessage() {
     help: 'runs GCP compatible version of benchmarking system',
     action: 'store_true'
   });
-  parser.add_argument('--weeklyCycleRun', {
+  parser.add_argument('--period', {
     help: 'runs a part of models specified in --benchmarks\'s file in a ' +
-      'weekly cycle and the part of models to run is determined by the day ' +
-      'of a week. The value could be -1 (the day will the day at the ' +
-      'runtime) or 0~6 (representing Sunday to Saturday).',
+      'cycle and the part of models to run is determined by the date ' +
+      'of a month. The value could be 1~31.',
     type: 'int',
+    action: 'store'
+  });
+  parser.add_argument('--date', {
+    help: 'set the date for selecting models and this works only if period ' +
+      'is set. The value could be -1 (the day will the date at the runtime) ' +
+      'or 1~31.',
+    type: 'int',
+    default: -1,
     action: 'store'
   });
   parser.add_argument('--maxBenchmarks', {
@@ -411,22 +418,27 @@ function setupHelpMessage() {
 
 /**
  * Get the models to benchmark for the day running the script. (All models are
- * spilted to 7 buckets, associated with the day of the week, and the function
- * returns a certain bucket.)
+ * spilted to n buckets and n === period, associated with the date of the month,
+ * and the function returns a certain bucket.)
  *
  * @param models The models to schedule.
- * @param day The value could be -1 or 0~6, and it determines the models to
- *    benchmark. If value is -1, the day will be the day at the runtime.
+ * @param period The period to run all models.
+ * @param date The value could be -1 or 1~31, and it determines the models to
+ *    benchmark. If value is -1, the date will be the date at the runtime.
  */
-function scheduleModels(models, day) {
-  if (day === -1) {
-    const date = new Date();
-    day = date.getDay();
-  } else if (day < 0 || day > 6) {
-    throw new Error('--weeklyCycleRun must be an integer of -1 or 0~6.');
+function scheduleModels(models, period, date) {
+  if (period < 1 || period > 31) {
+    throw new Error('--period must be an integer of 1~31.');
   }
-  const bucketSize = Math.ceil(models.length / 7);
-  return models.slice(day * bucketSize, (day + 1) * bucketSize);
+  if (date === -1) {
+    const date = new Date();
+    date = date.getDate();
+  } else if (date <= 0 || date > 31) {
+    throw new Error('--date must be an integer of -1 or 1~31.');
+  }
+  date = (date - 1) % period;
+  const bucketSize = Math.ceil(models.length / period);
+  return models.slice(date * bucketSize, (date + 1) * bucketSize);
 }
 
 /**
@@ -438,8 +450,8 @@ function scheduleModels(models, day) {
 async function runBenchmarkFromFile(file, runBenchmark = benchmarkAll) {
   console.log('Running a preconfigured benchmark...');
   const { benchmark, browsers } = file;
-  if (cliArgs?.weeklyCycleRun != null) {
-    benchmark.model = scheduleModels(benchmark.model, cliArgs.weeklyCycleRun);
+  if (cliArgs?.period != null) {
+    benchmark.model = scheduleModels(benchmark.model, cliArgs.period, cliArgs.date);
     console.log(
       `\nWill benchmark the following models: \n\t` +
       `${benchmark.model.join('\n\t')} \n`);

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -372,8 +372,7 @@ function setupHelpMessage() {
   parser.add_argument('--date', {
     help: 'set the date for selecting models and this works only if period ' +
       'is set. The value could be 1~31. If it is not set, the date would be ' +
-      'the date at runtime) ' +
-      'or ',
+      'the date at runtime).',
     type: 'int',
     action: 'store'
   });

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -371,10 +371,10 @@ function setupHelpMessage() {
   });
   parser.add_argument('--date', {
     help: 'set the date for selecting models and this works only if period ' +
-      'is set. The value could be -1 (the day will the date at the runtime) ' +
-      'or 1~31.',
+      'is set. The value could be 1~31. If it is not set, the date would be ' +
+      'the date at runtime) ' +
+      'or ',
     type: 'int',
-    default: -1,
     action: 'store'
   });
   parser.add_argument('--maxBenchmarks', {
@@ -423,18 +423,15 @@ function setupHelpMessage() {
  *
  * @param models The models to schedule.
  * @param period The period to run all models.
- * @param date The value could be -1 or 1~31, and it determines the models to
- *    benchmark. If value is -1, the date will be the date at the runtime.
+ * @param date The value could be 1~31, and it determines the models to
+ *    benchmark. By default, the date would be the date at runtime.
  */
-function scheduleModels(models, period, date) {
+function scheduleModels(models, period, date = new Date().getDate()) {
   if (period < 1 || period > 31) {
     throw new Error('--period must be an integer of 1~31.');
   }
-  if (date === -1) {
-    const date = new Date();
-    date = date.getDate();
-  } else if (date <= 0 || date > 31) {
-    throw new Error('--date must be an integer of -1 or 1~31.');
+  if (date <= 0 || date > 31) {
+    throw new Error('--date must be an integer of 1~31.');
   }
   date = (date - 1) % period;
   const bucketSize = Math.ceil(models.length / period);

--- a/e2e/benchmarks/browserstack-benchmark/app_node_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_node_test.js
@@ -367,7 +367,7 @@ describe('schedule models', () => {
     );
   });
 
-  fit('scheduling models works for half-month', () => {
+  it('scheduling models works for half-month', () => {
     models = Array.from(Array(25).keys());
     const res = scheduleModels(models, 15, 6);
     expect(res).toEqual(
@@ -375,7 +375,7 @@ describe('schedule models', () => {
     );
   });
 
-  fit('scheduling models works for default date', () => {
+  it('scheduling models works for default date', () => {
     jasmine.clock().install();
 
     const baseTime = new Date(2022, 12, 6);

--- a/e2e/benchmarks/browserstack-benchmark/app_node_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_node_test.js
@@ -342,28 +342,37 @@ describe('promise queue', () => {
 });
 
 
-describe('weekly schedule', () => {
-  it('scheduling models works for Sun', () => {
+describe('schedule models', () => {
+  it('scheduling models works for the first day of a period', () => {
     models = Array.from(Array(25).keys());
-    const res = scheduleModels(models, 0);
+    const res = scheduleModels(models, 7, 1);
     expect(res).toEqual(
       [0, 1, 2, 3]
     );
   });
 
-  it('scheduling models works', () => {
+  it('scheduling models works for weekly period', () => {
     models = Array.from(Array(25).keys());
-    const res = scheduleModels(models, 3);
+    const res = scheduleModels(models, 7, 4);
     expect(res).toEqual(
       [12, 13, 14, 15]
     );
   });
 
-  it('scheduling models works for Sat', () => {
+  it('scheduling models works for the last day of a period', () => {
     models = Array.from(Array(25).keys());
-    const res = scheduleModels(models, 6);
+    const res = scheduleModels(models, 7, 7);
     expect(res).toEqual(
       [24]
+    );
+  });
+
+
+  it('scheduling models works for half-month', () => {
+    models = Array.from(Array(25).keys());
+    const res = scheduleModels(models, 15, 6);
+    expect(res).toEqual(
+      [10, 11]
     );
   });
 });

--- a/e2e/benchmarks/browserstack-benchmark/app_node_test.js
+++ b/e2e/benchmarks/browserstack-benchmark/app_node_test.js
@@ -367,12 +367,27 @@ describe('schedule models', () => {
     );
   });
 
-
-  it('scheduling models works for half-month', () => {
+  fit('scheduling models works for half-month', () => {
     models = Array.from(Array(25).keys());
     const res = scheduleModels(models, 15, 6);
     expect(res).toEqual(
       [10, 11]
     );
+  });
+
+  fit('scheduling models works for default date', () => {
+    jasmine.clock().install();
+
+    const baseTime = new Date(2022, 12, 6);
+    jasmine.clock().mockDate(baseTime);
+    expect(new Date().getDate()).toEqual(6);
+
+    models = Array.from(Array(25).keys());
+    const res = scheduleModels(models, 15);
+    expect(res).toEqual(
+      [10, 11]
+    );
+
+    jasmine.clock().uninstall();
   });
 });

--- a/e2e/benchmarks/browserstack-benchmark/cloudbuild.yml
+++ b/e2e/benchmarks/browserstack-benchmark/cloudbuild.yml
@@ -12,7 +12,7 @@ steps:
   dir: 'e2e/benchmarks/browserstack-benchmark'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['run-cloud-benchmarks-weekly-cycle']
+  args: ['run-cloud-benchmarks-half-month-cycle']
   env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'NIGHTLY=$_NIGHTLY']
   secretEnv: ['BROWSERSTACK_ACCESS_KEY', 'FIREBASE_KEY']
   waitFor: ['yarn']

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -34,7 +34,7 @@
     "build-all-link-packages": "cd ../../../ && yarn && cd ./link-package && yarn build",
     "build-individual-link-package": "cd ../../../ && yarn && cd ./link-package && yarn build-deps-for",
     "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=12 --firestore",
-    "run-cloud-benchmarks-weekly-cycle": "yarn run-cloud-benchmarks --weeklyCycleRun=-1"
+    "run-cloud-benchmarks-half-month-cycle": "yarn run-cloud-benchmarks --period=15 --date=-1"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -34,7 +34,7 @@
     "build-all-link-packages": "cd ../../../ && yarn && cd ./link-package && yarn build",
     "build-individual-link-package": "cd ../../../ && yarn && cd ./link-package && yarn build-deps-for",
     "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=12 --firestore",
-    "run-cloud-benchmarks-half-month-cycle": "yarn run-cloud-benchmarks --period=15 --date=-1"
+    "run-cloud-benchmarks-half-month-cycle": "yarn run-cloud-benchmarks --period=15"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/tfjs-backend-webgpu/src/matmul_test.ts
+++ b/tfjs-backend-webgpu/src/matmul_test.ts
@@ -1219,6 +1219,17 @@ function matmulTest(programType: MatMulProgramType) {
       ]);
     });
 
+    it('A x B with large K. [16,2048]x[2048,16]', async () => {
+      const a = tf.tensor2d(new Array(16 * 2048).fill(1), [16, 2048]);
+      const b = tf.tensor2d(new Array(2048 * 16).fill(1), [2048, 16]);
+
+      const c = tf.matMul(a, b);
+      const cData = await c.data();
+
+      expect(c.shape).toEqual([16, 16]);
+      expectArraysClose(cData, new Array(16 * 16).fill(2048));
+    });
+
     it('matmul followed by mul', async () => {
       const a = tf.tensor2d([1, 2, 3, 4], [2, 2]);
       const b = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);


### PR DESCRIPTION
Currently `undefined` date means the date at runtime, instead of `-1`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7183)
<!-- Reviewable:end -->
