### PR TITLE
Update date for nightly benchmark

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/package.json
+++ b/e2e/benchmarks/browserstack-benchmark/package.json
@@ -34,7 +34,7 @@
     "build-all-link-packages": "cd ../../../ && yarn && cd ./link-package && yarn build",
     "build-individual-link-package": "cd ../../../ && yarn && cd ./link-package && yarn build-deps-for",
     "run-cloud-benchmarks": "node app.js --benchmark='./preconfigured_browser.json' --cloud --maxBenchmarks=12 --firestore",
-    "run-cloud-benchmarks-half-month-cycle": "yarn run-cloud-benchmarks --period=15 --date=-1"
+    "run-cloud-benchmarks-half-month-cycle": "yarn run-cloud-benchmarks --period=15"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Currently `undefined` date means the date at runtime, instead of `-1`.

Tried a cloud build: https://pantheon.corp.google.com/cloud-build/builds/75ac3eb9-bde8-473b-bcb1-c4ae905c7533;step=1?project=learnjs-174218

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7184)
<!-- Reviewable:end -->
