### PR TITLE
[webgpu] Further tweak vectorized NaN handling in binary ops

### DIFF
--- a/tfjs-backend-webgpu/src/binary_op_util.ts
+++ b/tfjs-backend-webgpu/src/binary_op_util.ts
@@ -46,8 +46,9 @@ const CHECK_NAN_SNIPPET = `
   `;
 
 const CHECK_NAN_SNIPPET_VEC4 = `
-  let isNaN = isnanVec4(a) | isnanVec4(b);
-  resultTemp = select(resultTemp, vec4<f32>(valueForNaN), isNaN);
+  resultTemp = select(
+      resultTemp, vec4<f32>(valueForNaN),
+      vec4<bool>(isNaN) | isnanVec4(a) | isnanVec4(b));
   `;
 
 const ADD = 'return a + b;';
@@ -117,22 +118,10 @@ const MOD = `
   }
 `;
 const MOD_VEC4 = `
+  let isNaN = !vec4<bool>(b);
   let valueForNaN = uniforms.NAN;
   var resultTemp = vec4<f32>(a % b);
   ${CHECK_NAN_SNIPPET_VEC4}
-
-  if (b[0] == 0.) {
-    resultTemp[0] = uniforms.NAN;
-  }
-  if (b[1] == 0.) {
-    resultTemp[1] = uniforms.NAN;
-  }
-  if (b[2] == 0.) {
-    resultTemp[2] = uniforms.NAN;
-  }
-  if (b[3] == 0.) {
-    resultTemp[3] = uniforms.NAN;
-  }
 
   if (!((a[0] < 0. && b[0] < 0.) || (a[0] >= 0. && b[0] > 0.))) {
     resultTemp[0] = (resultTemp[0] + b[0]) % b[0];
@@ -197,7 +186,9 @@ const POW_VEC4 = `
     resultTemp.a = 1.0;
   }
   let isNaN = (a < vec4<f32>(0.0)) & (floor(b) < b);
-  return select(resultTemp, vec4<f32>(uniforms.NAN), isNaN);
+  let valueForNaN = uniforms.NAN;
+  ${CHECK_NAN_SNIPPET_VEC4}
+  return resultTemp;
 `;
 
 const PRELU = `if (a < 0.0) { return b * a; }  return a;`;

--- a/tfjs-backend-webgpu/src/binary_op_webgpu.ts
+++ b/tfjs-backend-webgpu/src/binary_op_webgpu.ts
@@ -87,7 +87,10 @@ export class BinaryOpProgram implements WebGPUProgram {
     const dType = this.isVec4 ? 'vec4<f32>' : 'f32';
     const opFnStr = `
     fn binaryOperation(a : ${dType}, b : ${dType}) -> ${dType} {
-      ${getBinaryOpString(this.op, this.isVec4)}
+      let isNaN = false;
+      {
+        ${getBinaryOpString(this.op, this.isVec4)}
+      }
     };
     `;
 


### PR DESCRIPTION
The big picture will be:

```
  fn binaryOperation(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
    let isNaN = false;
    {
      // op-specific code begins
      let result = ...;
      let isNaN = ...;  // optional, declare this only if the op defines
                        // its own extra rules about NaN, say mod(0, 0)
      // op-specific code ends

      return select(result, vec4<f32>(valueForNaN),
                    vec4<bool>(isNaN) | isnanVec4(a) | isnanVec4(b));
    }
  }
```

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7185)
<!-- Reviewable:end -->
