### PR TITLE
[webgpu] Enable parallel compilation

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -373,9 +373,9 @@ export class WebGPUBackend extends KernelBackend {
 
   public async getBufferData(buffer: GPUBuffer, size: number):
       Promise<ArrayBuffer> {
-    if (env().getBool('ENGINE_COMPILE_ONLY')) {
+    if (env().getBool('WEBGPU_ENGINE_COMPILE_ONLY')) {
       console.warn(
-          'The data may be invalid since ENGINE_COMPILE_ONLY is true, this can only be called when ENGINE_COMPILE_ONLY is false');
+          'The data may be invalid since WEBGPU_ENGINE_COMPILE_ONLY is true, this can only be called when WEBGPU_ENGINE_COMPILE_ONLY is false');
       return null;
     }
     const staging = this.bufferManager.acquireBuffer(
@@ -929,7 +929,7 @@ export class WebGPUBackend extends KernelBackend {
     program.shaderKey =
         webgpu_program.makeShaderKey(program, inputsData, output);
 
-    const parallelCompilation = env().getBool('ENGINE_COMPILE_ONLY');
+    const parallelCompilation = env().getBool('WEBGPU_ENGINE_COMPILE_ONLY');
     if (!(program.shaderKey in this.pipelineCache)) {
       this.pipelineCache[program.shaderKey] = webgpu_program.compileProgram(
           this.device, program, inputsData, output, parallelCompilation);

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -129,7 +129,8 @@ export class WebGPUBackend extends KernelBackend {
   private dummyContext: GPUCanvasContext;
   private tensorDataPendingDisposal: DataId[] = [];
   private static nextDataId = 0;
-  private pipelineCache: {[key: string]: GPUComputePipeline};
+  private pipelineCache:
+      {[key: string]: GPUComputePipeline|Promise<GPUComputePipeline>};
   private programTimersStack: TimerNode[];
   private querySet: GPUQuerySet;
   private stagingPendingDisposal: BufferInfo[] = [];
@@ -356,8 +357,27 @@ export class WebGPUBackend extends KernelBackend {
     return this.currentComputePass;
   }
 
+  // Check if parallel compilation is done.
+  async checkCompileCompletionAsync() {
+    let pipelines: GPUComputePipeline[];
+    try {
+      pipelines = await Promise.all(Object.values(this.pipelineCache));
+    } catch (e) {
+      // TODO: Add test case to catch this exception.
+      throw new Error(e.message);
+    }
+    Object.keys(this.pipelineCache).map((key, i) => {
+      this.pipelineCache[key] = pipelines[i];
+    });
+  }
+
   public async getBufferData(buffer: GPUBuffer, size: number):
       Promise<ArrayBuffer> {
+    if (env().getBool('ENGINE_COMPILE_ONLY')) {
+      console.warn(
+          'The data may be invalid since ENGINE_COMPILE_ONLY is true, this can only be called when ENGINE_COMPILE_ONLY is false');
+      return null;
+    }
     const staging = this.bufferManager.acquireBuffer(
         size, GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ);
     this.ensureCommandEncoderReady();
@@ -888,6 +908,47 @@ export class WebGPUBackend extends KernelBackend {
     this.uploadToGPU(output.dataId);
     program.dispatch = reshapeDispatch(this.device, program);
 
+    const inputsData = inputs.map((input: TensorInfo, i: number) => {
+      if (input.dtype === 'complex64') {
+        throw new Error(
+            `GPGPUProgram does not support complex64 input. For complex64 ` +
+            `dtypes, please separate the program into real and imaginary ` +
+            `parts.`);
+      }
+      this.uploadToGPU(input.dataId);
+
+      return {
+        // Returning dtype from tensorMap because it reflects dtype
+        // of underlying buffer, rather than abstract dtype.
+        dtype: this.tensorMap.get(input.dataId).dtype,
+        shape: input.shape,
+        name: program.variableNames[i]
+      };
+    });
+
+    program.shaderKey =
+        webgpu_program.makeShaderKey(program, inputsData, output);
+
+    const parallelCompilation = env().getBool('ENGINE_COMPILE_ONLY');
+    if (!(program.shaderKey in this.pipelineCache)) {
+      this.pipelineCache[program.shaderKey] = webgpu_program.compileProgram(
+          this.device, program, inputsData, output, parallelCompilation);
+    }
+    program.pipeline = this.pipelineCache[program.shaderKey];
+
+    if (!parallelCompilation) {
+      this.recordAndSubmit(program, output, inputs, programDefinedUniform);
+    }
+    return output;
+  }
+
+  private recordAndSubmit(
+      program: webgpu_program.WebGPUProgram, output: TensorInfo,
+      inputs: TensorInfo[], programDefinedUniform?: ProgramUniform) {
+    if (program.pipeline instanceof Promise<GPUComputePipeline>) {
+      throw new Error(
+          'Please call checkCompileCompletionAsync to ensure parallel compilation is done!');
+    }
     // There are six kinds of uniforms: NAN, INFINITY, shapes, shape strides,
     // program size, program defined uniforms.
     let programUniform: ProgramUniform = [];
@@ -912,36 +973,6 @@ export class WebGPUBackend extends KernelBackend {
       }
     }
 
-    const inputsData = inputs.map((input: TensorInfo, i: number) => {
-      if (input.dtype === 'complex64') {
-        throw new Error(
-            `GPGPUProgram does not support complex64 input. For complex64 ` +
-            `dtypes, please separate the program into real and imaginary ` +
-            `parts.`);
-      }
-      this.uploadToGPU(input.dataId);
-
-      return {
-        // Returning dtype from tensorMap because it reflects dtype
-        // of underlying buffer, rather than abstract dtype.
-        dtype: this.tensorMap.get(input.dataId).dtype,
-        shape: input.shape,
-        name: program.variableNames[i]
-      };
-    });
-
-    const shaderKey =
-        webgpu_program.makeShaderKey(program, bufferShapes, inputsData, output);
-
-    let pipeline;
-    if (shaderKey in this.pipelineCache) {
-      pipeline = this.pipelineCache[shaderKey];
-    } else {
-      pipeline = webgpu_program.compileProgram(
-          this.device, program, inputsData, output, shaderKey);
-      this.pipelineCache[shaderKey] = pipeline;
-    }
-
     if (programDefinedUniform) {
       programUniform = [...programUniform, ...programDefinedUniform];
     }
@@ -950,49 +981,45 @@ export class WebGPUBackend extends KernelBackend {
       this.makeUniforms(programUniform)
     ];
 
-    const bindGroup = this.device.createBindGroup({
-      layout: pipeline.getBindGroupLayout(0),
-      entries: bindings.map((b, i) => ({binding: i, resource: b})),
-    });
-
-    this.ensureCommandEncoderReady();
-    const pass = this.getComputePass();
-    const shouldTimeProgram = this.activeTimers != null;
-    if (shouldTimeProgram) {
-      if (this.supportTimeQuery) {
-        // tslint:disable-next-line:no-any
-        (pass as any).writeTimestamp(this.querySet, 0);
-      }
-    }
-    pass.setPipeline(pipeline);
-    pass.setBindGroup(0, bindGroup);
-    pass.dispatchWorkgroups(
-        program.dispatch[0], program.dispatch[1], program.dispatch[2]);
-    if (shouldTimeProgram) {
-      if (this.supportTimeQuery) {
-        // tslint:disable-next-line:no-any
-        (pass as any).writeTimestamp(this.querySet, 1);
-      }
-    }
-    this.dispatchNumberInEncoder++;
-
     inputs.forEach(input => {
       this.commandQueueOwnedIds.add(input.dataId);
     });
     this.commandQueueOwnedIds.add(output.dataId);
 
+    const bindGroup = this.device.createBindGroup({
+      layout: program.pipeline.getBindGroupLayout(0),
+      entries: bindings.map((b, i) => ({binding: i, resource: b})),
+    });
+    this.ensureCommandEncoderReady();
+    const pass = this.getComputePass();
+
+    const shouldTimeProgram = this.activeTimers != null;
+    if (shouldTimeProgram && this.supportTimeQuery) {
+      // tslint:disable-next-line:no-any
+      (pass as any).writeTimestamp(this.querySet, 0);
+    }
+
+    pass.setPipeline(program.pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(
+        program.dispatch[0], program.dispatch[1], program.dispatch[2]);
+
+    if (shouldTimeProgram && this.supportTimeQuery) {
+      // tslint:disable-next-line:no-any
+      (pass as any).writeTimestamp(this.querySet, 1);
+    }
+    this.dispatchNumberInEncoder++;
+
     if (env().get('WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE') as
         number <= this.dispatchNumberInEncoder) {
       this.submitQueue();
     }
-
     if (shouldTimeProgram) {
       this.activeTimers.push({
         name: program.constructor.name,
         query: this.getQueryTime(this.querySet)
       });
     }
-    return output;
   }
 
   async getTimeFromQuerySet(querySet: GPUQuerySet) {

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -362,12 +362,12 @@ async function parallelCompilationCommon(webGPUBackend: WebGPUBackend) {
   const b1 = tf.tensor1d([1, 1, 1]);
 
   // Parallel compile.
-  tf.env().set('ENGINE_COMPILE_ONLY', true);
+  tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', true);
   const c1 = tf.add(a1, b1);
   await webGPUBackend.checkCompileCompletionAsync();
 
   // Actual inference.
-  tf.env().set('ENGINE_COMPILE_ONLY', false);
+  tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', false);
   const c2 = tf.add(a1, b1);
   expectArraysEqual(await c2.data(), [2, 2, 2]);
 
@@ -406,14 +406,15 @@ describeWebGPU('parallel compilation', () => {
     tf.setBackend('test-parallel');
 
     savedWebGPUCPUForward = tf.env().get('WEBGPU_CPU_FORWARD') as boolean;
-    savedEngineCompileOnly = tf.env().get('ENGINE_COMPILE_ONLY') as boolean;
+    savedEngineCompileOnly =
+        tf.env().get('WEBGPU_ENGINE_COMPILE_ONLY') as boolean;
     tf.env().set('WEBGPU_CPU_FORWARD', false);
     await tf.ready();
   });
 
   afterEach(() => {
     tf.env().set('WEBGPU_CPU_FORWARD', savedWebGPUCPUForward);
-    tf.env().set('ENGINE_COMPILE_ONLY', savedEngineCompileOnly);
+    tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', savedEngineCompileOnly);
     tf.setBackend(prevBackend);
     tf.removeBackend(customWebGPUBackendName);
   });
@@ -451,11 +452,11 @@ describeWebGPU('parallel compilation', () => {
 
     // Parallel compile but not call await (tf.backend() as
     // WebGPUBackend).checkCompileCompletionAsync().
-    tf.env().set('ENGINE_COMPILE_ONLY', true);
+    tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', true);
     tf.add(a1, b1);
 
     // Actual inference.
-    tf.env().set('ENGINE_COMPILE_ONLY', false);
+    tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', false);
     expect(() => tf.add(a1, b1))
         .toThrowError(
             'Please call checkCompileCompletionAsync to ensure parallel compilation is done!');
@@ -466,7 +467,7 @@ describeWebGPU('parallel compilation', () => {
     const b1 = tf.tensor1d([1, 1, 1]);
 
     // Parallel compile.
-    tf.env().set('ENGINE_COMPILE_ONLY', true);
+    tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', true);
     const c1 = tf.add(a1, b1);
     await (tf.backend() as WebGPUBackend).checkCompileCompletionAsync();
     // Read data is invalid.
@@ -478,7 +479,7 @@ describeWebGPU('parallel compilation', () => {
        const a1 = tf.tensor1d([1, 1, 1]);
        const b1 = tf.tensor1d([1, 1, 1]);
        // If parallel compilation is false, checkCompileCompletionAsync is nop.
-       tf.env().set('ENGINE_COMPILE_ONLY', false);
+       tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', false);
        const c1 = tf.add(a1, b1);
        await (tf.backend() as WebGPUBackend).checkCompileCompletionAsync();
        expectArraysClose(await c1.data(), [2, 2, 2]);

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -91,4 +91,4 @@ ENV.registerFlag('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', () => false);
 ENV.registerFlag('WEBGPU_PRINT_SHADER', () => '');
 
 /** Experimental flag, whether enter compile only phase. */
-ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);
+ENV.registerFlag('WEBGPU_ENGINE_COMPILE_ONLY', () => false);

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -89,3 +89,6 @@ ENV.registerFlag('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', () => false);
  * etc.). 'unary,conv2d' to print both unary and conv2d.
  */
 ENV.registerFlag('WEBGPU_PRINT_SHADER', () => '');
+
+/** Experimental flag, whether enter compile only phase. */
+ENV.registerFlag('ENGINE_COMPILE_ONLY', () => false);

--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, DataType, env, Rank, ShapeMap, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {backend_util, DataType, DataTypeMap, env, Rank, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {symbolicallyComputeStrides} from './shader_util';
 
@@ -49,21 +49,18 @@ export interface WebGPUProgram {
   // Each thread writes to workPerThread * workPerThread locations in the output
   // buffer.
   workPerThread?: number;
+  pipeline?: GPUComputePipeline|Promise<GPUComputePipeline>;
   getUserCode: () => string;
 }
 
 export const compileProgram =
     (device: GPUDevice, program: WebGPUProgram, inputsData: InputInfo[],
-     output: TensorInfo, shaderKey: string): GPUComputePipeline => {
+     output: TensorInfo, parallelCompilation: boolean): GPUComputePipeline|
+    Promise<GPUComputePipeline> => {
       const outputData = {dtype: output.dtype, shape: output.shape};
       const source = makeShader(inputsData, outputData, program);
       const module = device.createShaderModule(
           {code: source, label: program.constructor.name});
-      const pipeline = device.createComputePipeline({
-        compute: {module, entryPoint: '_start'},
-        label: program.constructor.name,
-        layout: 'auto'
-      });
 
       let printShaderString = env().get('WEBGPU_PRINT_SHADER') as string;
       if (printShaderString !== '') {
@@ -71,13 +68,26 @@ export const compileProgram =
         const printShaderArray = printShaderString.split(',');
         if (printShaderString === 'all' ||
             printShaderArray.some(
-                item => shaderKey.toLowerCase().includes(item))) {
-          console.group(shaderKey);
+                item => program.shaderKey.toLowerCase().includes(item))) {
+          console.group(program.shaderKey);
           console.debug(source);
           console.groupEnd();
         }
       }
-      return pipeline;
+
+      if (parallelCompilation) {
+        return device.createComputePipelineAsync({
+          compute: {module, entryPoint: '_start'},
+          label: program.constructor.name,
+          layout: 'auto'
+        });
+      } else {
+        return device.createComputePipeline({
+          compute: {module, entryPoint: '_start'},
+          label: program.constructor.name,
+          layout: 'auto'
+        });
+      }
     };
 
 export const typeSnippet = (component: number, type = 'f32') => {
@@ -326,14 +336,22 @@ function makeShader(
 }
 
 export function makeShaderKey<R extends Rank>(
-    program: WebGPUProgram, shapes: Array<ShapeMap[R]>, inputsData: InputInfo[],
+    program: WebGPUProgram, inputsData: InputInfo[],
     output: TensorInfo): string {
   let key = program.shaderKey;
   if (program.isFromPixels) {
     return key;
   }
 
-  const types = inputsData.map(d => d.dtype).concat(output.dtype);
+  const shapes: number[][] = [];
+  const types: Array<keyof DataTypeMap> = [];
+  inputsData.forEach(element => {
+    shapes.push(element.shape);
+    types.push(element.dtype);
+  });
+  shapes.push(output.shape);
+  types.push(output.dtype);
+
   const broadcastDims =
       inputsData.map(d => backend_util.getBroadcastDims(d.shape, output.shape));
   const inputShapesEqualsOutShape =


### PR DESCRIPTION
Example:
```
  // Parallel compile.
  tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', true);
  const result1 = predict(model);
  await tf.backend().checkCompileCompletionAsync();
  tf.dispose(result1);
  // Actual inference.
  tf.env().set('WEBGPU_ENGINE_COMPILE_ONLY', false);
  const result2 = predict(model);
  await result2.data();
  tf.dispose(result2);
```

This change is based on: https://github.com/tensorflow/tfjs/pull/5815

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7191)
<!-- Reviewable:end -->
