### PR TITLE
Adds function overloads to minimize.

### DIFF
--- a/tfjs-core/src/optimizers/optimizer.ts
+++ b/tfjs-core/src/optimizers/optimizer.ts
@@ -56,6 +56,9 @@ export abstract class Optimizer extends Serializable {
    *
    * @doc {heading: 'Training', subheading: 'Optimizers'}
    */
+  minimize(f: () => Scalar): null
+  minimize(f: () => Scalar, returnCost: true, varList?: Variable[]): Scalar
+  minimize(f: () => Scalar, returnCost: false, varList?: Variable[]): null
   minimize(f: () => Scalar, returnCost = false, varList?: Variable[]): Scalar
       |null {
     const {value, grads} = this.computeGradients(f, varList);


### PR DESCRIPTION
This will allow the caller to get correct type checking on the return values.

Note: This does not validate that the minimize function correctly returns the right type.  For example, if you changed `if (returnCost)` to `if (!returnCost)` you would not get a compiler error, so care must still be taken in ensuring this function does the right thing internally.

This change results in a number of tests failing to compile because they reuse variables (`let` instead of `const`).  I don't mind going through and fixing them all, but I wanted to get feedback on whether this is a desirable change first before I spend the time doing that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7212)
<!-- Reviewable:end -->
