### PR TITLE
Do not run docker interactively in tfjs-node publish

### DIFF
--- a/tfjs-node/scripts/build-and-upload-addon.sh
+++ b/tfjs-node/scripts/build-and-upload-addon.sh
@@ -28,7 +28,7 @@ NAPI_VERSION=`node -p "process.versions.napi"`
 # remove the pre-built addon tarball if it already exist
 rm -f $PACKAGE_NAME
 # Build the native binding in docker to use a known version of GLIBC
-docker run -it --rm --mount type=bind,source=$(pwd),target=/tfjs-node/ --user "$(id -u):$(id -g)" gcr.io/learnjs-174218/release  bash -c "cd tfjs-node && yarn build-addon-from-source"
+docker run --rm --mount type=bind,source=$(pwd),target=/tfjs-node/ --user "$(id -u):$(id -g)" gcr.io/learnjs-174218/release  bash -c "cd tfjs-node && yarn build-addon-from-source"
 if [ "$1" = "publish" ]; then
   # build a new pre-built addon tarball
   tar -czvf $PACKAGE_NAME -C lib napi-v$NAPI_VERSION/tfjs_binding.node


### PR DESCRIPTION
tfjs-node's publishing script does not provide a TTY for docker's interactive mode, so don't run docker interactively.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7227)
<!-- Reviewable:end -->
