### PR TITLE
Support batch-benchmark on local device

### DIFF
--- a/e2e/benchmarks/browserstack-benchmark/README.md
+++ b/e2e/benchmarks/browserstack-benchmark/README.md
@@ -58,6 +58,7 @@ The following are supported options arguments which trigger options features:
         "backend": ["backend_name"] //List of one or more backends to be benchmarked
       },
       "browsers": {
+        "local": {},  // Benchmark on your local device
         "unique_identifier_laptop_or_desktop": {
           "base": "BrowserStack",
           "browser": "browser_name",

--- a/e2e/benchmarks/browserstack-benchmark/app.js
+++ b/e2e/benchmarks/browserstack-benchmark/app.js
@@ -88,6 +88,9 @@ function runServer() {
 function setupBenchmarkEnv(config) {
   // Write the map (tabId - browser setting) to `./browsers.json`.
   for (const tabId in config.browsers) {
+    if (tabId === 'local') {
+      continue;
+    }
     const browser = config.browsers[tabId];
     browser.base = 'BrowserStack';
     // For mobile devices, we would use real devices instead of emulators.
@@ -274,7 +277,10 @@ async function getOneBenchmarkResult(
  */
 function runBrowserStackBenchmark(tabId) {
   return new Promise((resolve, reject) => {
-    const args = ['test', '--browserstack', `--browsers=${tabId}`];
+    const args = ['test'];
+    if (tabId !== 'local') {
+      args.push('--browserstack', `--browsers=${tabId}`);
+    }
     if (cliArgs.localBuild) {
       args.push(`--localBuild=${cliArgs.localBuild}`)
     };


### PR DESCRIPTION
Enable the browserstack-benchmark tool to benchmark on local devices.
If the tabId is `local`, then spawn a command line as `yarn test`; otherwise, as originally, `yarn test --browserstack --browsers=...`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7228)
<!-- Reviewable:end -->
