### PR TITLE
Make converter hashtable test not overly specific

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -542,7 +542,6 @@ class ConvertTest(tf.test.TestCase):
     self.assertIn('LookupTableImportV2', initializer_ops)
 
     weights_manifest = model_json['weightsManifest'][0]
-    weights_manifest = model_json['weightsManifest'][0]
     self.assertEqual(weights_manifest['paths'], ['group1-shard1of1.bin'])
     self.assertEqual(weights_manifest['weights'][0],
                      {'name': 'unknown_0', 'shape': [], 'dtype': 'int32'})

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -551,7 +551,6 @@ class ConvertTest(tf.test.TestCase):
     self.assertEqual(weights_manifest['weights'][2]['shape'], [2])
     self.assertEqual(weights_manifest['weights'][2]['dtype'], 'int32')
 
-    self.assertEqual(weights_manifest, expected_weights_manifest)
     # Check meta-data in the artifact JSON.
     self.assertEqual(model_json['format'], 'graph-model')
     self.assertEqual(

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -513,14 +513,6 @@ class ConvertTest(tf.test.TestCase):
       }
     }
 
-    expected_weights_manifest = [{
-        'paths': ['group1-shard1of1.bin'],
-        'weights': [
-            {'name': 'unknown_0', 'shape': [], 'dtype': 'int32'},
-            {'name': '4609', 'shape': [2], 'dtype': 'string'},
-            {'name': '4611', 'shape': [2], 'dtype': 'int32'}
-        ]}]
-
     tfjs_path = os.path.join(self._tmp_dir, SAVED_MODEL_DIR, 'js')
     # Check model.json and weights manifest.
     with open(os.path.join(tfjs_path, 'model.json'), 'rt') as f:

--- a/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -549,7 +549,17 @@ class ConvertTest(tf.test.TestCase):
     self.assertIn('HashTableV2', initializer_ops)
     self.assertIn('LookupTableImportV2', initializer_ops)
 
-    weights_manifest = model_json['weightsManifest']
+    weights_manifest = model_json['weightsManifest'][0]
+    weights_manifest = model_json['weightsManifest'][0]
+    self.assertEqual(weights_manifest['paths'], ['group1-shard1of1.bin'])
+    self.assertEqual(weights_manifest['weights'][0],
+                     {'name': 'unknown_0', 'shape': [], 'dtype': 'int32'})
+    # Only check weights and dtype since name may vary between TF versions.
+    self.assertEqual(weights_manifest['weights'][1]['shape'], [2])
+    self.assertEqual(weights_manifest['weights'][1]['dtype'], 'string')
+    self.assertEqual(weights_manifest['weights'][2]['shape'], [2])
+    self.assertEqual(weights_manifest['weights'][2]['dtype'], 'int32')
+
     self.assertEqual(weights_manifest, expected_weights_manifest)
     # Check meta-data in the artifact JSON.
     self.assertEqual(model_json['format'], 'graph-model')


### PR DESCRIPTION
tfjs-converter's saved model conversion test for hashtable depends on the exact names of the hashtable weights it saves, but these names are generated and may change between versions of TF. This was observed when syncing into google3, which is using tf 2.12. This PR prevents the test from checking the name of the hashtable weights.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7249)
<!-- Reviewable:end -->
