### PR TITLE
Fix wasm backend test segment faults

### DIFF
--- a/tfjs-backend-wasm/src/cc/kernels/BatchMatMul_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/BatchMatMul_test.cc
@@ -39,7 +39,7 @@ TEST(BATCH_MATMUL, xnn_operator_lifetime) {
   size_t* b_shape_ptr = b_shape.data();
 
   size_t out_id = 5;
-  float out_values[2] = {0, 0};
+  float out_values[4] = {};
 
   tfjs::wasm::register_tensor(a0_id, size, a_values);
   tfjs::wasm::register_tensor(a1_id, size, a_values);

--- a/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul_test.cc
+++ b/tfjs-backend-wasm/src/cc/kernels/_FusedMatMul_test.cc
@@ -39,7 +39,7 @@ TEST(_FUSED_MATMUL, xnn_operator_lifetime) {
   size_t* b_shape_ptr = b_shape.data();
 
   size_t out_id = 5;
-  float out_values[2] = {0, 0};
+  float out_values[4] = {};
 
   tfjs::wasm::register_tensor(a0_id, size, a_values);
   tfjs::wasm::register_tensor(a1_id, size, a_values);


### PR DESCRIPTION
Fixed the segment faults in matmul wasm backend tests. 

The cause of these segment faults is the output buffer's incorrect buffer size - the matmul output of shape [2,1] and [1,2] should be shape [2,2], 4 elements there.

After this PR, the wasm backend tests should always pass without remote build.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7258)
<!-- Reviewable:end -->
