### PR TITLE
Add '.bazel' to make-version.js's python build file path

### DIFF
--- a/scripts/make-version.js
+++ b/scripts/make-version.js
@@ -19,9 +19,10 @@
 // Where DIR_NAME is the directory name for the package you want to make a
 // version for.
 const fs = require('fs');
+const path = require('path');
 
 const dirName = process.argv[2];
-const packageJsonFile = dirName + '/package.json';
+const packageJsonFile = path.join(dirName, 'package.json');
 if (!fs.existsSync(packageJsonFile)) {
   console.log(
       packageJsonFile, 'does not exist. Please call this script as follows:');
@@ -38,7 +39,7 @@ const version = '${version}';
 export {version};
 `
 
-fs.writeFile(dirName + '/src/version.ts', versionCode, err => {
+fs.writeFile(path.join(dirName, 'src/version.ts'), versionCode, err => {
   if (err) {
     throw new Error(`Could not save version file ${version}: ${err}`);
   }
@@ -53,7 +54,8 @@ version = '${version}'
 `;
 
   fs.writeFile(
-      dirName + '/python/tensorflowjs/version.py', pipVersionCode, err => {
+      path.join(dirName, '/python/tensorflowjs/version.py'),
+      pipVersionCode, err => {
         if (err != null) {
           throw new Error(`Could not save pip version file ${version}: ${err}`);
         }
@@ -61,7 +63,7 @@ version = '${version}'
             `Version file for pip version ${version} saved sucessfully.`);
       });
 
-  const buildFilename = dirName + '/python/BUILD.bazel';
+  const buildFilename = path.join(dirName, '/python/BUILD.bazel');
   fs.readFile(buildFilename, 'utf-8', function(err, data) {
     if (err != null) {
       throw new Error(`Could not update the BUILD.bazel file: ${err}`);

--- a/scripts/make-version.js
+++ b/scripts/make-version.js
@@ -61,10 +61,10 @@ version = '${version}'
             `Version file for pip version ${version} saved sucessfully.`);
       });
 
-  const buildFilename = dirName + '/python/BUILD';
+  const buildFilename = dirName + '/python/BUILD.bazel';
   fs.readFile(buildFilename, 'utf-8', function(err, data) {
     if (err != null) {
-      throw new Error(`Could not update the BUILD file: ${err}`);
+      throw new Error(`Could not update the BUILD.bazel file: ${err}`);
     }
 
     const newValue = data.replace(
@@ -72,6 +72,6 @@ version = '${version}'
     fs.writeFileSync(buildFilename, newValue, 'utf-8');
 
     console.log(
-        `pip version ${version} for BUILD file is updated sucessfully.`);
+        `pip version ${version} for BUILD.bazel file is updated sucessfully.`);
   });
 }


### PR DESCRIPTION
Fix make-version.js to work with the changes made in #7253.

Tested locally with `yarn release-tfjs --git-protocol --dry --use-local-changes --force` since the release tests only run in nightly.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7263)
<!-- Reviewable:end -->
