### PR TITLE
Fix comment in tile.ts

### DIFF
--- a/tfjs-core/src/ops/tile.ts
+++ b/tfjs-core/src/ops/tile.ts
@@ -38,13 +38,13 @@ import {op} from './operation';
  * ```js
  * const a = tf.tensor1d([1, 2]);
  *
- * a.tile([2]).print();    // or a.tile([2])
+ * a.tile([2]).print();    // or tf.tile(a, [2])
  * ```
  *
  * ```js
  * const a = tf.tensor2d([1, 2, 3, 4], [2, 2]);
  *
- * a.tile([1, 2]).print();  // or a.tile([1, 2])
+ * a.tile([1, 2]).print();  // or tf.tile(a, [1,2])
  * ```
  * @param x The tensor to tile.
  * @param reps Determines the number of replications per dimension.


### PR DESCRIPTION
Fixed comment to show different expression from examples

Hi, I visited [api docs](https://js.tensorflow.org/api/4.2.0/) to learn about tensorflow.js and found a bit ackward comment in tile part. I think it's not the way you intend so I tried to fix it in a better way !

Thanks :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7298)
<!-- Reviewable:end -->
