### PR TITLE
Propagate errors from indexedDB database.put

### DIFF
--- a/tfjs-core/src/io/indexed_db.ts
+++ b/tfjs-core/src/io/indexed_db.ts
@@ -162,18 +162,31 @@ export class BrowserIndexedDB implements IOHandler {
           // First, put ModelArtifactsInfo into info store.
           const infoTx = db.transaction(INFO_STORE_NAME, 'readwrite');
           let infoStore = infoTx.objectStore(INFO_STORE_NAME);
-          const putInfoRequest =
+          let putInfoRequest: IDBRequest<IDBValidKey>;
+          try {
+            putInfoRequest =
               infoStore.put({modelPath: this.modelPath, modelArtifactsInfo});
+          } catch (error) {
+            reject(error);
+            return;
+          }
           let modelTx: IDBTransaction;
           putInfoRequest.onsuccess = () => {
             // Second, put model data into model store.
             modelTx = db.transaction(MODEL_STORE_NAME, 'readwrite');
             const modelStore = modelTx.objectStore(MODEL_STORE_NAME);
-            const putModelRequest = modelStore.put({
-              modelPath: this.modelPath,
-              modelArtifacts,
-              modelArtifactsInfo
-            });
+            let putModelRequest: IDBRequest<IDBValidKey>;
+            try {
+              putModelRequest = modelStore.put({
+                modelPath: this.modelPath,
+                modelArtifacts,
+                modelArtifactsInfo
+              });
+            } catch (error) {
+              // Sometimes, the serialized value is too large to store.
+              reject(error);
+              return;
+            }
             putModelRequest.onsuccess = () => resolve({modelArtifactsInfo});
             putModelRequest.onerror = error => {
               // If the put-model request fails, roll back the info entry as


### PR DESCRIPTION
database.put can sometimes throw an error if the data being stored is too large. Propagate that error to the promise instead of letting it escape the callback.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.