### PR TITLE
Update dependency to the latest version of TF-DecisionForests

### DIFF
--- a/tfjs-tfdf/tfdf_repositories.bzl
+++ b/tfjs-tfdf/tfdf_repositories.bzl
@@ -15,9 +15,10 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def tfdf_repositories(version = "1.1.0"):
+def tfdf_repositories(version = "1.3.0"):
     versions = {
         "1.1.0": "36b6974996d899589ba99ee95fb56699bf34c582f71e2d98475d7db4bce43b5b",
+        "1.3.0": "ca903f36893a6a9bd59bf3128f51cb0588f6e4f6430863b0c4d3235a168f1b7d",
     }
 
     if not version in versions:


### PR DESCRIPTION
TF.js currently depends on Yggdrasil Decision Forests 1.1.0 (which is equivalent to TF Decision Forests 1.1.0).
This change updates TF.js to Yggdrasil Decision Forests 1.3.0 (which is equivalent to TF Decision Forests 1.2.0).

This update notably adds support for categorical-set splits.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.