### PR TITLE
Revert "Add a case for atanh when input is 1"

### DIFF
--- a/tfjs-core/src/ops/atanh_test.ts
+++ b/tfjs-core/src/ops/atanh_test.ts
@@ -65,14 +65,6 @@ describeWithFlags('atanh', ALL_ENVS, () => {
     expectArraysClose(await res.data(), [NaN, Math.atanh(0), NaN]);
   });
 
-  it('propagates 1.0 and -1.0', async () => {
-    const a = tf.tensor1d([0.5, 1.0, 0, -1.0]);
-    const res = tf.atanh(a);
-    expectArraysClose(
-        await res.data(),
-        [Math.atanh(0.5), Infinity, Math.atanh(0), -Infinity]);
-  });
-
   it('gradients: Scalar', async () => {
     const a = tf.scalar(0.5);
     const dy = tf.scalar(8);


### PR DESCRIPTION
Reverts tensorflow/tfjs#6964, since Browserstack Windows WebGL fails on it in nightly test. Sepcifically,  Browserstack Windows WebGL returns -88 for log(1.0 - 1.0) in WebGL. https://source.cloud.google.com/results/invocations/6db447d1-9f0f-4afd-9935-06d65adb7a0f/targets/%2F%2Ftfjs-backend-webgl:win_10_chrome_tfjs-backend-webgl2_test/log

Will add this test when the above problem is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7325)
<!-- Reviewable:end -->
