### PR TITLE
[Draft] Add dataCached and readCached

### DIFF
--- a/tfjs-backend-cpu/package.json
+++ b/tfjs-backend-cpu/package.json
@@ -42,14 +42,6 @@
     "util": false,
     "crypto": false
   },
-  "sideEffects": [
-    "./dist/register_all_kernels.js",
-    "./dist/base.js",
-    "./dist/index.js",
-    "./src/register_all_kernels.mjs",
-    "./src/base.mjs",
-    "./src/index.mjs"
-  ],
   "resolutions": {
     "minimist": "1.2.6"
   }

--- a/tfjs-backend-cpu/src/backend_cpu.ts
+++ b/tfjs-backend-cpu/src/backend_cpu.ts
@@ -142,6 +142,7 @@ export class MathBackendCPU extends KernelBackend {
     return util.convertBackendValuesAndArrayBuffer(
         this.data.get(dataId).values, dtype);
   }
+  override readCached = this.readSync;
 
   bufferSync<R extends Rank, D extends DataType>(t: TensorInfo):
       TensorBuffer<R, D> {

--- a/tfjs-backend-wasm/src/backend_wasm.ts
+++ b/tfjs-backend-wasm/src/backend_wasm.ts
@@ -132,6 +132,8 @@ export class BackendWasm extends KernelBackend {
     return typedArrayFromBuffer(bytes.buffer, dtype);
   }
 
+  override readCached = this.readSync;
+
   /**
    * Dispose the memory if the dataId has 0 refCount. Return true if the memory
    * is released, false otherwise.

--- a/tfjs-backend-wasm/src/setup_test.ts
+++ b/tfjs-backend-wasm/src/setup_test.ts
@@ -407,6 +407,7 @@ const TEST_FILTERS: TestFilter[] = [
   {include: 'diag '},
   {include: 'denseBincount '},
   {include: 'broadcastArgs '},
+  {include: 'dataCached'},
 ];
 
 const customInclude = (testName: string) => {

--- a/tfjs-backend-wasm/yarn.lock
+++ b/tfjs-backend-wasm/yarn.lock
@@ -17,11 +17,17 @@
 
 "@tensorflow/tfjs-backend-cpu@link:../link-package/node_modules/@tensorflow/tfjs-backend-cpu":
   version "0.0.0"
+  uid ""
 
 "@types/emscripten@~0.0.34":
   version "0.0.34"
   resolved "https://registry.yarnpkg.com/@types/emscripten/-/emscripten-0.0.34.tgz#12b4a344274fb102ff2f6c877b37587bc3e46008"
   integrity sha512-QSb9ojDincskc+uKMI0KXp8e1NALFINCrMlp8VGKGcTSxeEyRTTKyjWw75NYrCZHUsVEEEpr1tYHpbtaC++/sQ==
+
+"@types/seedrandom@^2.4.28":
+  version "2.4.30"
+  resolved "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.30.tgz#d2efe425869b84163c2d56e779dddadb9372cbfa"
+  integrity sha512-AnxLHewubLVzoF/A4qdxBGHCKifw8cY32iro3DQX9TPcetE95zBeVt3jnsvtvAUf1vwzMfwzp4t/L2yqPlnjkQ==
 
 async@^1.5.2:
   version "1.5.2"
@@ -145,6 +151,11 @@ resolve@^1.1.6:
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 wrappy@1:
   version "1.0.2"

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -419,6 +419,15 @@ export class MathBackendWebGL extends KernelBackend {
     return dTypeVals;
   }
 
+  override readCached(dataId: DataId): BackendValues | undefined {
+    const texData = this.texData.get(dataId);
+    const {values} = texData;
+    if (values != null) {
+      return this.convertAndCacheOnCPU(dataId);
+    }
+    return undefined;
+  }
+
   /**
    * Read tensor to a new texture that is densely packed for ease of use.
    * @param dataId The source tensor.

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -395,19 +395,21 @@ export class WebGPUBackend extends KernelBackend {
 
   // TODO: Remove once this is fixed:
   // https://github.com/tensorflow/tfjs/issues/1595
-  override readSync(dataId: object): BackendValues {
-    const tensorData = this.tensorMap.get(dataId);
-    const {values} = tensorData;
-
+  override readSync(dataId: DataId): BackendValues {
+    const values = this.readCached(dataId);
     if (values == null) {
       throw new Error(
           'WebGPU readSync is only available for CPU-resident tensors.');
     }
-
     return values;
   }
 
-  override async read(dataId: object): Promise<BackendValues> {
+  override readCached(dataId: DataId) {
+    const tensorData = this.tensorMap.get(dataId);
+    return tensorData.values;
+  }
+
+  override async read(dataId: DataId): Promise<BackendValues> {
     if (!this.tensorMap.has(dataId)) {
       throw new Error(`Tensor ${dataId} was not registered!`);
     }

--- a/tfjs-backend-webgpu/tsconfig.json
+++ b/tfjs-backend-webgpu/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig_base.json",
+  "extends": "../tsconfig",
   "include": [
     "src/"
   ],
@@ -7,9 +7,6 @@
     "node_modules/"
   ],
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {},
-    "outDir": "./dist",
-    "target": "es2017"
+    "outDir": "./dist"
   }
 }

--- a/tfjs-converter/src/operations/executors/transformation_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/transformation_executor_test.ts
@@ -55,7 +55,7 @@ describe('transformation', () => {
       it('should call tfOps.cast', () => {
         node.op = 'Cast';
         node.attrParams.dtype = createDtypeAttr('float32');
-        executeOp(node, {input1}, context, spyOpsAsTfOps);
+        executeOp(node, {input1}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.cast).toHaveBeenCalledWith(input1[0], 'float32');
       });
@@ -65,7 +65,7 @@ describe('transformation', () => {
         node.op = 'ExpandDims';
         node.attrParams.axis = createNumberAttr(1);
         spyOps.expandDims.and.returnValue({});
-        executeOp(node, {input1}, context, spyOpsAsTfOps);
+        executeOp(node, {input1}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.expandDims).toHaveBeenCalledWith(input1[0], 1);
       });
@@ -78,7 +78,7 @@ describe('transformation', () => {
         node.inputNames = ['input1', 'input3'];
         const input3 = [tfOps.tensor2d([1, 1, 2, 2], [2, 2])];
         spyOps.mirrorPad.and.returnValue({});
-        executeOp(node, {input1, input3}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input3}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.mirrorPad)
             .toHaveBeenCalledWith(input1[0], [[1, 1], [2, 2]], 'reflect');
@@ -92,7 +92,7 @@ describe('transformation', () => {
         node.inputNames = ['input1', 'input3'];
         const input3 = [tfOps.tensor2d([1, 1, 2, 2], [2, 2])];
         spyOps.pad.and.returnValue({});
-        executeOp(node, {input1, input3}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input3}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.pad).toHaveBeenCalledWith(input1[0], [[1, 1], [2, 2]], 1);
       });
@@ -105,7 +105,7 @@ describe('transformation', () => {
         node.inputNames = ['input1', 'input3'];
         const input3 = [tfOps.tensor2d([1, 1, 2, 2], [2, 2])];
         spyOps.pad.and.returnValue({});
-        executeOp(node, {input1, input3}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input3}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.pad).toHaveBeenCalledWith(input1[0], [[1, 1], [2, 2]], 1);
       });
@@ -116,7 +116,7 @@ describe('transformation', () => {
         node.inputParams.shape = createNumericArrayAttrFromIndex(1);
         node.inputNames = ['input1', 'input2'];
 
-        executeOp(node, {input1, input2}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input2}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.reshape).toHaveBeenCalledWith(input1[0], [1, 1]);
       });
@@ -126,7 +126,7 @@ describe('transformation', () => {
         node.op = 'Squeeze';
         node.attrParams.axis = createNumberAttr(1);
         spyOps.squeeze.and.returnValue({});
-        executeOp(node, {input1}, context, spyOpsAsTfOps);
+        executeOp(node, {input1}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.squeeze).toHaveBeenCalledWith(input1[0], 1);
       });
@@ -140,7 +140,7 @@ describe('transformation', () => {
         const input2 = [tfOps.tensor1d([1, 1, 2, 2])];
         const input3 = [tfOps.tensor2d([1, 2, 2, 3, 2, 3, 3, 4], [4, 2])];
         spyOps.spaceToBatchND.and.returnValue({});
-        executeOp(node, {input1, input2, input3}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input2, input3}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.spaceToBatchND)
             .toHaveBeenCalledWith(
@@ -156,7 +156,7 @@ describe('transformation', () => {
         const input2 = [tfOps.tensor1d([1, 1, 2, 2])];
         const input3 = [tfOps.tensor2d([1, 2, 2, 3, 2, 3, 3, 4], [4, 2])];
         spyOps.batchToSpaceND.and.returnValue({});
-        executeOp(node, {input1, input2, input3}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input2, input3}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.batchToSpaceND)
             .toHaveBeenCalledWith(
@@ -170,7 +170,7 @@ describe('transformation', () => {
         node.attrParams.dataFormat = createStrAttr('nhwc');
         node.inputNames = ['input1'];
         spyOps.depthToSpace.and.returnValue({});
-        executeOp(node, {input1}, context, spyOpsAsTfOps);
+        executeOp(node, {input1}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.depthToSpace).toHaveBeenCalledWith(input1[0], 1, 'NHWC');
       });
@@ -181,7 +181,7 @@ describe('transformation', () => {
         node.inputParams.shape = createNumericArrayAttrFromIndex(1);
         node.inputNames = ['input1', 'input2'];
 
-        executeOp(node, {input1, input2}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input2}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.broadcastTo).toHaveBeenCalledWith(input1[0], [1, 1]);
       });
@@ -195,7 +195,7 @@ describe('transformation', () => {
         const input1 = [tfOps.tensor1d([1, 1])];
         const input2 = [tfOps.tensor1d([1, 1])];
         spyOps.broadcastArgs.and.returnValue({});
-        executeOp(node, {input1, input2}, context, spyOpsAsTfOps);
+        executeOp(node, {input1, input2}, context, null, spyOpsAsTfOps);
 
         expect(spyOps.broadcastArgs).toHaveBeenCalledWith(input1[0], input2[0]);
       });

--- a/tfjs-converter/src/operations/operation_executor.ts
+++ b/tfjs-converter/src/operations/operation_executor.ts
@@ -97,8 +97,7 @@ export function executeOp(
           case 'string':
             return tidy(() => string.executeOp(node, tensorMap, context));
           case 'transformation':
-            return tidy(
-                () => transformation.executeOp(node, tensorMap, context));
+            return transformation.executeOp(node, tensorMap, context);
           case 'hash_table':
             return hashTable.executeOp(
                 node, tensorMap, context, resourceManager);

--- a/tfjs-converter/src/operations/operation_executor_test.ts
+++ b/tfjs-converter/src/operations/operation_executor_test.ts
@@ -75,14 +75,22 @@ describe('OperationExecutor', () => {
         });
     [arithmetic, basic_math, convolution, creation, evaluation, graph, image,
      logical, matrices, normalization, reduction, slice_join, sparse, spectral,
-     string, transformation]
+     string]
         .forEach(category => {
           it('should call tidy around executor', () => {
             const tidySpy = jasmine.createSpy('tidy spy', tfc.tidy);
 
             node.category = category.CATEGORY;
-            executeOp(node, {}, context, undefined, tidySpy as typeof tfc.tidy);
-            expect(tidySpy).toHaveBeenCalled();
+
+            try {
+              executeOp(node, {}, context, undefined,
+                        tidySpy as typeof tfc.tidy);
+            } finally {
+              // Put this expect in a finally block to make sure that its error
+              // appears. Otherwise, it throws a confusing 'node type const
+              // is not supported' error.
+              expect(tidySpy).toHaveBeenCalled();
+            }
           });
         });
 

--- a/tfjs-converter/src/operations/types.ts
+++ b/tfjs-converter/src/operations/types.ts
@@ -86,6 +86,12 @@ export interface InternalOpAsyncExecutor {
    resourceManager?: ResourceManager, ops?: typeof tfOps): Promise<Tensor[]>;
 }
 
+export interface InternalOpMaybeAsyncExecutor {
+  (node: Node, tensorMap: NamedTensorsMap, context: ExecutionContext,
+   resourceManager?: ResourceManager, ops?: typeof tfOps): Tensor[]
+    | Promise<Tensor[]>;
+}
+
 export declare interface OpMapper {
   tfOpName: string;
   category?: Category;

--- a/tfjs-core/package.json
+++ b/tfjs-core/package.json
@@ -52,26 +52,6 @@
     "crypto": false,
     "worker_threads": false
   },
-  "sideEffects": [
-    "./dist/index.js",
-    "./dist/engine.js",
-    "./dist/tensor.js",
-    "./dist/base_side_effects.js",
-    "./dist/flags.js",
-    "./dist/platforms/*.js",
-    "./dist/register_all_gradients.js",
-    "./dist/public/chained_ops/*.js",
-    "./dist/io/*.js",
-    "./src/index.mjs",
-    "./src/engine.mjs",
-    "./src/tensor.mjs",
-    "./src/base_side_effects.mjs",
-    "./src/flags.mjs",
-    "./src/platforms/*.mjs",
-    "./src/register_all_gradients.mjs",
-    "./src/public/chained_ops/*.mjs",
-    "./src/io/*.mjs"
-  ],
   "resolutions": {
     "minimist": "1.2.6"
   }

--- a/tfjs-core/src/backends/backend.ts
+++ b/tfjs-core/src/backends/backend.ts
@@ -116,6 +116,9 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   readSync(dataId: object): BackendValues {
     return notYetImplemented('readSync');
   }
+  readCached(dataId: object): BackendValues | undefined {
+    return notYetImplemented('readCached');
+  }
   readToGPU(dataId: object, options?: DataToGPUOptions): GPUData {
     return notYetImplemented('readToGPU');
   }

--- a/tfjs-core/src/backends/backend_test.ts
+++ b/tfjs-core/src/backends/backend_test.ts
@@ -16,6 +16,8 @@
  */
 import * as tf from '../index';
 import {ALL_ENVS, describeWithFlags} from '../jasmine_util';
+import {tensor1d} from '../ops/tensor1d';
+import {expectArraysEqual} from '../test_util';
 import {EPSILON_FLOAT16, EPSILON_FLOAT32} from './backend';
 
 describeWithFlags('epsilon', ALL_ENVS, () => {
@@ -28,5 +30,12 @@ describeWithFlags('epsilon', ALL_ENVS, () => {
 
   it('abs(epsilon) > 0', async () => {
     expect(await tf.abs(tf.backend().epsilon()).array()).toBeGreaterThan(0);
+  });
+});
+
+describeWithFlags('dataCached', ALL_ENVS, () => {
+  it('get data cached on CPU', () => {
+    const cachedTensor = tensor1d([1, 2, 3, 4]);
+    expectArraysEqual(cachedTensor.dataCached(), [1, 2, 3, 4]);
   });
 });

--- a/tfjs-core/src/engine.ts
+++ b/tfjs-core/src/engine.ts
@@ -1225,6 +1225,11 @@ export class Engine implements TensorTracker, DataMover {
     const info = this.state.tensorInfo.get(dataId);
     return info.backend.read(dataId);
   }
+  readCached(dataId: DataId): BackendValues | undefined {
+    // Route the read to the correct backend.
+    const info = this.state.tensorInfo.get(dataId);
+    return info.backend.readCached(dataId);
+  }
 
   readToGPU(dataId: DataId, options?: DataToGPUOptions): GPUData {
     // Route the read to the correct backend.

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -231,6 +231,8 @@ export class NodeJSKernelBackend extends KernelBackend {
     }
   }
 
+  override readCached = this.readSync;
+
   /**
    * Dispose the memory if the dataId has 0 refCount. Return true if the memory
    * is released, false otherwise.

--- a/tfjs/yarn.lock
+++ b/tfjs/yarn.lock
@@ -1760,23 +1760,32 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@tensorflow/tfjs-backend-cpu@link:../link-package/node_modules/@tensorflow/link-package/node_modules/@tensorflow/tfjs-backend-cpu":
+  version "0.0.0"
+
 "@tensorflow/tfjs-backend-cpu@link:../link-package/node_modules/@tensorflow/tfjs-backend-cpu":
   version "0.0.0"
+  uid ""
 
 "@tensorflow/tfjs-backend-webgl@link:../link-package/node_modules/@tensorflow/tfjs-backend-webgl":
   version "0.0.0"
+  uid ""
 
 "@tensorflow/tfjs-converter@link:../link-package/node_modules/@tensorflow/tfjs-converter":
   version "0.0.0"
+  uid ""
 
 "@tensorflow/tfjs-core@link:../link-package/node_modules/@tensorflow/tfjs-core":
   version "0.0.0"
+  uid ""
 
 "@tensorflow/tfjs-data@link:../link-package/node_modules/@tensorflow/tfjs-data":
   version "0.0.0"
+  uid ""
 
 "@tensorflow/tfjs-layers@link:../link-package/node_modules/@tensorflow/tfjs-layers":
   version "0.0.0"
+  uid ""
 
 "@types/argparse@^1.0.38":
   version "1.0.38"
@@ -1816,10 +1825,23 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.7.tgz#3fe583928ae0a22cdd34cedf930eeffeda2602fd"
   integrity sha512-RdbrPcW1aD78UmdLiDa9ZCKrbR5Go8PXh6GCpb4oIOkWVEusubSJJDrP4c5RYOu8m/CBz+ygZpicj6Pgms5a4Q==
 
+"@types/long@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
 "@types/minimatch@*":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
+
+"@types/node-fetch@^2.1.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>=10.0.0":
   version "18.11.9"
@@ -1831,12 +1853,27 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.56.tgz#010c9e047c3ff09ddcd11cbb6cf5912725cdc2b3"
   integrity sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w==
 
+"@types/offscreencanvas@~2019.3.0":
+  version "2019.3.0"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz#3336428ec7e9180cf4566dfea5da04eb586a6553"
+  integrity sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==
+
+"@types/offscreencanvas@~2019.7.0":
+  version "2019.7.0"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz#e4a932069db47bb3eabeb0b305502d01586fa90d"
+  integrity sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/seedrandom@^2.4.28":
+  version "2.4.30"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.30.tgz#d2efe425869b84163c2d56e779dddadb9372cbfa"
+  integrity sha512-AnxLHewubLVzoF/A4qdxBGHCKifw8cY32iro3DQX9TPcetE95zBeVt3jnsvtvAUf1vwzMfwzp4t/L2yqPlnjkQ==
 
 "@types/shelljs@^0.8.4":
   version "0.8.8"
@@ -1845,6 +1882,11 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/webgl-ext@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
+  integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -1857,6 +1899,11 @@
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@webgpu/types@0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.21.tgz#b181202daec30d66ccd67264de23814cfd176d3a"
+  integrity sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==
 
 accepts@~1.3.4:
   version "1.3.8"
@@ -1971,6 +2018,11 @@ async@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
   integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 available-typed-arrays@^1.0.2:
   version "1.0.2"
@@ -2384,6 +2436,13 @@ combine-source-map@^0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.12.1, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -2582,6 +2641,11 @@ define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -2869,6 +2933,15 @@ foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
   integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 from@~0:
   version "0.1.7"
@@ -3596,6 +3669,11 @@ log4js@^6.3.0, log4js@^6.4.1:
     rfdc "^1.3.0"
     streamroller "^3.0.2"
 
+long@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 magic-string@^0.25.2:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -3669,19 +3747,19 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-types@^2.1.12, mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
     mime-db "1.51.0"
-
-mime-types@~2.1.34:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
 
 mime@^2.5.2:
   version "2.6.0"
@@ -3746,6 +3824,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@~2.6.1:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.8.tgz#a68d30b162bc1d8fd71a367e81b997e1f4d4937e"
+  integrity sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-releases@^1.1.71:
   version "1.1.72"
@@ -4299,6 +4384,11 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -4632,6 +4722,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-node@~8.8.2:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.2.tgz#0b39e690bee39ea5111513a9d2bcdc0bc121755f"
@@ -4839,6 +4934,19 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add two new methods, `dataCached` (to backends) and `readCached` (to tensors), to enable synchronously reading a tensor's data if it's already cached on the CPU. If the data is not cached on the CPU, these methods return `undefined`. `dataCached` is necessary for ops like `reshape` that need a tensor's value immediately when they are called, and it avoids breaking existing models that pass constants to `reshape`.

For example, when `reshape` is executed in a graph model and it has a tensor value as the new shape, it does the following:
1. Calls `dataCached()` on the shape tensor and, if the value is available, returns the reshaped result immediately.
2.  If `dataCached()` returns `undefined`, then it calls `data()` on the shape tensor and returns the reshaped result in a promise.

Due to the synchronous check in (1), existing models that pass a constant tensor as the shape to `reshape` will still work synchronously.


To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.