### PR TITLE
Support tfjs converter options in JAX conversion

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -322,6 +322,20 @@ See
 [here](https://github.com/google/jax/tree/main/jax/experimental/jax2tf#shape-polymorphic-conversion)
 for more details on the exact syntax for this argument.
 
+When converting JAX models, you can also pass any [options that
+`convert_tf_saved_model`
+uses](https://github.com/tensorflow/tfjs/blob/master/tfjs-converter/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py#L951-L974).
+For example, to quantize a model's weights, pass the `quantization_dtype_map`
+option listing the weights that should be quantized.
+
+```py
+jax_conversion.convert_jax(
+  apply_fn=module.apply,
+  params=params,
+  input_signatures=[((3, 4), np.float32)],
+  model_dir=tfjs_model_dir,
+  quantization_dtype_map={'float16': '*'})
+```
 
 ## Step 2: Loading and running in the browser
 

--- a/tfjs-converter/python/tensorflowjs/converters/jax_conversion.py
+++ b/tfjs-converter/python/tensorflowjs/converters/jax_conversion.py
@@ -60,7 +60,8 @@ def convert_jax(
     *,
     input_signatures: Sequence[Tuple[Sequence[Union[int, None]], DType]],
     model_dir: str,
-    polymorphic_shapes: Optional[Sequence[Union[str, PolyShape]]] = None):
+    polymorphic_shapes: Optional[Sequence[Union[str, PolyShape]]] = None,
+    **tfjs_converter_params):
   """Converts a JAX function `jax_apply_fn` and model parameters to a TensorflowJS model.
 
   Example usage for a Flax Module:
@@ -146,4 +147,5 @@ def convert_jax(
         saved_model_dir,
         signatures=signatures,
         options=saved_model_options)
-    saved_model_conversion.convert_tf_saved_model(saved_model_dir, model_dir)
+    saved_model_conversion.convert_tf_saved_model(saved_model_dir, model_dir,
+                                                  **tfjs_converter_params)


### PR DESCRIPTION
Support configuring the options, such as quantization, passed to tfjs converter during conversion of a jax model.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7331)
<!-- Reviewable:end -->
