### PR TITLE
SharedArrayBuffer is not GPU data

### DIFF
--- a/tfjs-core/src/ops/tensor_ops_util.ts
+++ b/tfjs-core/src/ops/tensor_ops_util.ts
@@ -17,7 +17,7 @@
 
 import {ENGINE} from '../engine';
 import {Tensor} from '../tensor';
-import {TensorLike, TypedArray, WebGLData, WebGPUData} from '../types';
+import {getGPUDataType, GPUDataType, TensorLike, TypedArray, WebGLData, WebGPUData} from '../types';
 import {DataType} from '../types';
 import {assert, assertNonNegativeIntegerDimensions, flatten, inferDtype, isTypedArray, sizeFromShape, toTypedArray} from '../util';
 
@@ -33,9 +33,7 @@ export function makeTensor(
         `Please use tf.complex(real, imag).`);
   }
 
-  if (typeof values === 'object' &&
-      ('texture' in values ||
-       ('buffer' in values && !(values.buffer instanceof ArrayBuffer)))) {
+  if (getGPUDataType(values) !== GPUDataType.Unknown) {
     if (dtype !== 'float32' && dtype !== 'int32') {
       throw new Error(
           `Creating tensor from GPU data only supports ` +

--- a/tfjs-core/src/ops/tensor_ops_util.ts
+++ b/tfjs-core/src/ops/tensor_ops_util.ts
@@ -17,7 +17,7 @@
 
 import {ENGINE} from '../engine';
 import {Tensor} from '../tensor';
-import {getGPUDataType, GPUDataType, TensorLike, TypedArray, WebGLData, WebGPUData} from '../types';
+import {isWebGLData, isWebGPUData, TensorLike, TypedArray, WebGLData, WebGPUData} from '../types';
 import {DataType} from '../types';
 import {assert, assertNonNegativeIntegerDimensions, flatten, inferDtype, isTypedArray, sizeFromShape, toTypedArray} from '../util';
 
@@ -33,7 +33,7 @@ export function makeTensor(
         `Please use tf.complex(real, imag).`);
   }
 
-  if (getGPUDataType(values) !== GPUDataType.Unknown) {
+  if (isWebGPUData(values) || isWebGLData(values)) {
     if (dtype !== 'float32' && dtype !== 'int32') {
       throw new Error(
           `Creating tensor from GPU data only supports ` +

--- a/tfjs-core/src/ops/tensor_ops_util.ts
+++ b/tfjs-core/src/ops/tensor_ops_util.ts
@@ -40,7 +40,7 @@ export function makeTensor(
           `'float32'|'int32' dtype, while the dtype is ${dtype}.`);
     }
     return ENGINE.backend.createTensorFromGPUData(
-        values as WebGLData | WebGPUData, shape || inferredShape, dtype);
+        values, shape || inferredShape, dtype);
   }
 
   if (!isTypedArray(values) && !Array.isArray(values) &&

--- a/tfjs-core/src/tensor_util_env.ts
+++ b/tfjs-core/src/tensor_util_env.ts
@@ -30,7 +30,6 @@ export function inferShape(
     return dtype === 'string' ? [] : [val.length];
   }
 
-  const gpuDataType = getGPUDataType(val);
   if (isWebGLData(val)) {
     const usedChannels = val.channels || 'RGBA';
     return [val.height, val.width * usedChannels.length];

--- a/tfjs-core/src/tensor_util_env.ts
+++ b/tfjs-core/src/tensor_util_env.ts
@@ -18,7 +18,7 @@
 import {ENGINE} from './engine';
 import {env} from './environment';
 import {Tensor} from './tensor';
-import {DataType, TensorLike, WebGLData, WebGPUData} from './types';
+import {DataType, getGPUDataType, GPUDataType, TensorLike, WebGLData, WebGPUData} from './types';
 import {assert, flatten, inferDtype, isTypedArray, toTypedArray} from './util';
 import {bytesPerElement} from './util_base';
 
@@ -29,14 +29,18 @@ export function inferShape(
   if (isTypedArray(val)) {
     return dtype === 'string' ? [] : [val.length];
   }
-  const isObject = typeof val === 'object';
-  if (isObject) {
-    if ('texture' in val) {
-      const usedChannels = val.channels || 'RGBA';
-      return [val.height, val.width * usedChannels.length];
-    } else if ('buffer' in val && !(val.buffer instanceof ArrayBuffer)) {
-      return [val.buffer.size / (dtype == null ? 4 : bytesPerElement(dtype))];
-    }
+
+  const gpuDataType = getGPUDataType(val);
+  if (gpuDataType === GPUDataType.WebGL) {
+    const usedChannels = (val as WebGLData).channels || 'RGBA';
+    return [
+      (val as WebGLData).height, (val as WebGLData).width * usedChannels.length
+    ];
+  } else if (gpuDataType === GPUDataType.WebGPU) {
+    return [
+      (val as WebGPUData).buffer.size /
+      (dtype == null ? 4 : bytesPerElement(dtype))
+    ];
   }
   if (!Array.isArray(val)) {
     return [];  // Scalar.

--- a/tfjs-core/src/tensor_util_env.ts
+++ b/tfjs-core/src/tensor_util_env.ts
@@ -18,7 +18,7 @@
 import {ENGINE} from './engine';
 import {env} from './environment';
 import {Tensor} from './tensor';
-import {DataType, getGPUDataType, GPUDataType, TensorLike, WebGLData, WebGPUData} from './types';
+import {DataType, isWebGLData, isWebGPUData, TensorLike, WebGLData, WebGPUData} from './types';
 import {assert, flatten, inferDtype, isTypedArray, toTypedArray} from './util';
 import {bytesPerElement} from './util_base';
 
@@ -31,16 +31,11 @@ export function inferShape(
   }
 
   const gpuDataType = getGPUDataType(val);
-  if (gpuDataType === GPUDataType.WebGL) {
-    const usedChannels = (val as WebGLData).channels || 'RGBA';
-    return [
-      (val as WebGLData).height, (val as WebGLData).width * usedChannels.length
-    ];
-  } else if (gpuDataType === GPUDataType.WebGPU) {
-    return [
-      (val as WebGPUData).buffer.size /
-      (dtype == null ? 4 : bytesPerElement(dtype))
-    ];
+  if (isWebGLData(val)) {
+    const usedChannels = val.channels || 'RGBA';
+    return [val.height, val.width * usedChannels.length];
+  } else if (isWebGPUData(val)) {
+    return [val.buffer.size / (dtype == null ? 4 : bytesPerElement(dtype))];
   }
   if (!Array.isArray(val)) {
     return [];  // Scalar.

--- a/tfjs-core/src/types.ts
+++ b/tfjs-core/src/types.ts
@@ -197,25 +197,16 @@ export interface WebGPUData {
   zeroCopy?: boolean;
 }
 
-export enum GPUDataType {
-  Unknown = 0,
-  WebGL = 1,
-  WebGPU = 2,
+export function isWebGLData(values: unknown): values is WebGLData {
+  return values != null 
+      && typeof values === 'object' 
+      && 'texture' in values
+      && values.texture instanceof WebGLTexture;
 }
-
-export function getGPUDataType(values: TensorLike|WebGLData|
-                               WebGPUData): GPUDataType {
-  if (typeof values !== 'object') {
-    // Unknown data type.
-    return GPUDataType.Unknown;
-  }
-  if ('texture' in values && values.texture instanceof WebGLTexture) {
-    return GPUDataType.WebGL;
-  } else if (
-      'buffer' in values && typeof GPUBuffer !== 'undefined' &&
-      values.buffer instanceof GPUBuffer) {
-    return GPUDataType.WebGPU;
-  } else {
-    return GPUDataType.Unknown;
-  }
+export function isWebGPUData(values: unknown): values is WebGPUData {
+  return typeof GPUBuffer !== 'undefined'
+      && values != null
+      && typeof values === 'object'
+      && 'buffer' in values 
+      && values.buffer instanceof GPUBuffer;
 }

--- a/tfjs-core/src/types.ts
+++ b/tfjs-core/src/types.ts
@@ -196,3 +196,26 @@ export interface WebGPUData {
   buffer: GPUBuffer;
   zeroCopy?: boolean;
 }
+
+export enum GPUDataType {
+  Unknown = 0,
+  WebGL = 1,
+  WebGPU = 2,
+}
+
+export function getGPUDataType(values: TensorLike|WebGLData|
+                               WebGPUData): GPUDataType {
+  if (typeof values !== 'object') {
+    // Unknown data type.
+    return GPUDataType.Unknown;
+  }
+  if ('texture' in values && values.texture instanceof WebGLTexture) {
+    return GPUDataType.WebGL;
+  } else if (
+      'buffer' in values && typeof GPUBuffer !== 'undefined' &&
+      values.buffer instanceof GPUBuffer) {
+    return GPUDataType.WebGPU;
+  } else {
+    return GPUDataType.Unknown;
+  }
+}


### PR DESCRIPTION
Bug: https://github.com/tensorflow/tfjs/issues/7343

TODO: Add test case for ShardArrayBuffer.
```
describeWithFlags('tensor from ShardArrayBuffer', ALL_ENVS, () => {
  it('float32 tensor from ShardArrayBuffer', async () => {
    let length = 4;
    // ReferenceError: SharedArrayBuffer is not defined.
    let sharedFloats = new Float32Array(new SharedArrayBuffer(length * 4));
    let expected = [];
    for (let i = 0; i < length; i++) {
      sharedFloats[i] = i;
      expected[i] = i;
    }
    const a = tf.tensor(sharedFloats);
    tf.test_util.expectArraysEqual(await a.data(), expected);
  });
});

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7344)
<!-- Reviewable:end -->
