### PR TITLE
[layers] allow conversion of weight only keras H5 file that lacks keras version info

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion.py
@@ -183,7 +183,11 @@ def h5_merged_saved_model_to_tfjs_format(h5file, split_by_layer=False):
     ValueError: If the Keras version of the HDF5 file is not supported.
   """
   h5file = _ensure_h5file(h5file)
-  _check_version(h5file)
+  try:
+    _check_version(h5file)
+  except ValueError:
+    print("""failed to lookup keras version from the file,
+    this is likely a weight only file""")
   model_json = _initialize_output_dictionary(h5file)
 
   model_json['model_config'] = _ensure_json_dict(
@@ -230,7 +234,11 @@ def h5_weights_to_tfjs_format(h5file, split_by_layer=False):
     ValueError: If the Keras version of the HDF5 file is not supported
   """
   h5file = _ensure_h5file(h5file)
-  _check_version(h5file)
+  try:
+    _check_version(h5file)
+  except ValueError:
+    print("""failed to lookup keras version from the file,
+    this is likely a weight only file""")
 
   groups = [] if split_by_layer else [[]]
 


### PR DESCRIPTION
fixed https://github.com/tensorflow/tfjs/issues/7349

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7359)
<!-- Reviewable:end -->
