### PR TITLE
Add an error message for webgpu backend setup

### DIFF
--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -143,6 +143,9 @@ import {makeTensor} from './tensor_ops_util';
  *   return gpuReadBuffer;
  * }
  *
+ * await tf.setBackend('webgpu').catch(
+ *     () => {throw new Error(
+ *         'Failed to use WebGPU backend. Please use Chrome Canary to run.')});
  * const dtype = 'float32';
  * const device = tf.backend().device;
  * const aData = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];


### PR DESCRIPTION
For https://github.com/tensorflow/tfjs/issues/7289

This PR would give users a more meaningful error message when users use the gpudataToTensor API in the API website.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7366)
<!-- Reviewable:end -->
