### PR TITLE
Turn off CHECK_COMPUTATION_FOR_ERRORS by default

### DIFF
--- a/tfjs-core/src/flags.ts
+++ b/tfjs-core/src/flags.ts
@@ -72,7 +72,7 @@ ENV.registerFlag('DEPRECATION_WARNINGS_ENABLED', () => true);
 ENV.registerFlag('IS_TEST', () => false);
 
 /** Whether to check computation result for errors. */
-ENV.registerFlag('CHECK_COMPUTATION_FOR_ERRORS', () => true);
+ENV.registerFlag('CHECK_COMPUTATION_FOR_ERRORS', () => ENV.getBool('DEBUG'));
 
 /** Whether the backend needs to wrap input to imageBitmap. */
 ENV.registerFlag('WRAP_TO_IMAGEBITMAP', () => false);


### PR DESCRIPTION
The flag is on by default, causing GPU-to-CPU downloading when profiling kernels. As a result, GPU frequency is reduced and the benchmarked kernel times would be slower than the normal (even 2x slower).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7367)
<!-- Reviewable:end -->
