### PR TITLE
Fine-tune packed BackpropInput

### DIFF
--- a/tfjs-backend-webgl/src/conv_backprop_gpu.ts
+++ b/tfjs-backend-webgl/src/conv_backprop_gpu.ts
@@ -59,16 +59,13 @@ export class Conv2DDerFilterProgram implements GPGPUProgram {
                 continue;
               }
 
-              if (${isChannelsLast}) {
-                float dyValue = getDy(b, yR, yC, d2);
-                float xValue = getX(b, xR, xC, d1);
-                dotProd += (xValue * dyValue);
-              } else {
-                float dyValue = getDy(b, d2, yR, yC);
-                float xValue = getX(b, d1, xR, xC);
-                dotProd += (xValue * dyValue);
-              }
-
+              ${isChannelsLast?
+             `float dyValue = getDy(b, yR, yC, d2);
+              float xValue = getX(b, xR, xC, d1);
+              dotProd += (xValue * dyValue);` :
+             `float dyValue = getDy(b, d2, yR, yC);
+              float xValue = getX(b, d1, xR, xC);
+              dotProd += (xValue * dyValue);`}
             }
           }
         }

--- a/tfjs-backend-webgl/src/conv_backprop_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/conv_backprop_packed_gpu.ts
@@ -116,4 +116,3 @@ export class Conv2DDerInputPackedProgram implements GPGPUProgram {
     `;
   }
 }
-


### PR DESCRIPTION
Originally, we use `idyCVal` and `idyCVal2` (could only be 0.0 or 1.0) to indicate if `result.xy` and `result.zw` are valid and `result.xy * idyCVal` and `result.zw * idyCVal2` could return the results to avoid checking through if-branches.

If stride is  1, both `idyCVal` and `idyCVal2` are always `1.0` and the original solution performs well. However, if stride is 2, whenever, only one of `idyCVal` and `idyCVal2` is `1.0`, which means either computing `result.xy` or `result.zw` is wasting of time.

As a result, this PR adds the if-branches to check `idyCVal` and `idyCVal2` before computing, instead of always computing `result.xy * idyCVal` and `result.zw * idyCVal2`. This improves Conv2DBackpropInput ops in ArPortraitDepth ~40% and ArPortraitDepth model is improved from 23ms to 18.5ms (Benchmarked on LENOVO P620 2021).

Before the PR:
![image](https://user-images.githubusercontent.com/40653845/219468947-94634fd4-52fe-477d-a38b-f6e3efa16946.png)


After the PR:
![image](https://user-images.githubusercontent.com/40653845/219468817-a0e6e680-899c-4d5e-83f8-7cb1ea1792cd.png)


Reference https://github.com/tensorflow/tfjs/pull/7371.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7386)
<!-- Reviewable:end -->
