### PR TITLE
Add cache for parseNodeName

### DIFF
--- a/tfjs-converter/src/executor/execution_context.ts
+++ b/tfjs-converter/src/executor/execution_context.ts
@@ -39,6 +39,8 @@ export interface ExecutionContextInfo {
  * For model with branch logic, TensorFLow will generate Switch/Merge ops.
  */
 export class ExecutionContext {
+  public readonly parseNodeNameCache =
+      new Map<string, [string, number, string?]>();
   private rootContext = {id: 0, frameName: '', iterationId: 0};
   private contexts: ExecutionContextInfo[] = [this.rootContext];
   private lastId = 0;

--- a/tfjs-converter/src/executor/execution_context.ts
+++ b/tfjs-converter/src/executor/execution_context.ts
@@ -39,8 +39,6 @@ export interface ExecutionContextInfo {
  * For model with branch logic, TensorFLow will generate Switch/Merge ops.
  */
 export class ExecutionContext {
-  public readonly parseNodeNameCache =
-      new Map<string, [string, number, string?]>();
   private rootContext = {id: 0, frameName: '', iterationId: 0};
   private contexts: ExecutionContextInfo[] = [this.rootContext];
   private lastId = 0;
@@ -50,7 +48,8 @@ export class ExecutionContext {
       readonly weightMap: NamedTensorsMap = {},
       readonly tensorArrayMap: TensorArrayMap = {},
       readonly tensorListMap: TensorListMap = {},
-      readonly functionMap: {[key: string]: FunctionExecutor} = {}) {
+      readonly functionMap: {[key: string]: FunctionExecutor} = {},
+      readonly parseNodeNameCache?: Map<string, [string, number, string?]>) {
     this.generateCurrentContextIds();
   }
 

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -265,7 +265,7 @@ export class GraphExecutor implements FunctionExecutor {
       }
 
       Object.keys(inputs).forEach(name => {
-        const [nodeName, index] = parseNodeName(name);
+        const [nodeName, index] = parseNodeName(name, context);
         const tensors: Tensor[] = [];
         tensors[index] = inputs[name];
         tensorsMap[nodeName] = tensors;

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -19,7 +19,7 @@ import {DataType, env, keep, NamedTensorMap, Tensor, tidy, util} from '@tensorfl
 
 import {ISignatureDef} from '../data/compiled_api';
 import {NamedTensorsMap, TensorArrayMap, TensorInfo, TensorListMap} from '../data/types';
-import {getNodeNameAndIndex, getParamValue, getTensor, getTensorsForCurrentContenxt, parseNodeName} from '../operations/executors/utils';
+import {getNodeNameAndIndex, getParamValue, getTensor, getTensorsForCurrentContext, parseNodeName} from '../operations/executors/utils';
 import {executeOp} from '../operations/operation_executor';
 import {Graph, Node} from '../operations/types';
 
@@ -34,7 +34,8 @@ interface NodeWithContexts {
 }
 
 export class GraphExecutor implements FunctionExecutor {
-  private compiledMap: Map<string, Node[]> = new Map();
+  private compiledMap = new Map<string, Node[]>();
+  private parseNodeNameCache = new Map<string, [string, number, string?]>();
   private _weightMap: NamedTensorsMap = {};
   private _weightIds: number[];
   private _signature: ISignatureDef;
@@ -258,7 +259,7 @@ export class GraphExecutor implements FunctionExecutor {
     return tidy(() => {
       const context = new ExecutionContext(
           this.weightMap, tensorArrayMap, tensorListMap,
-          this.functionExecutorMap);
+          this.functionExecutorMap, this.parseNodeNameCache);
       const tensorsMap: NamedTensorsMap = {...this.weightMap};
       if (this.keepIntermediateTensors) {
         this.clonedTensorsMap = this.cloneTensorMap(this.weightMap);
@@ -338,7 +339,7 @@ export class GraphExecutor implements FunctionExecutor {
       // correctly.
       if (input.category !== 'control') {
         const tensors =
-            getTensorsForCurrentContenxt(input.name, tensorMap, context);
+            getTensorsForCurrentContext(input.name, tensorMap, context);
         if (tensors != null) {
           tensors.forEach(tensor => {
             if (tensor && !tensor.kept && !tensorsToKeep.has(tensor.id)) {
@@ -428,8 +429,8 @@ export class GraphExecutor implements FunctionExecutor {
     }
 
     const context = new ExecutionContext(
-        this.weightMap, tensorArrayMap, tensorListMap,
-        this.functionExecutorMap);
+        this.weightMap, tensorArrayMap, tensorListMap, this.functionExecutorMap,
+        this.parseNodeNameCache);
 
     if (this.keepIntermediateTensors) {
       this.clonedTensorsMap = this.cloneTensorMap(this.weightMap);

--- a/tfjs-converter/src/operations/executors/utils.ts
+++ b/tfjs-converter/src/operations/executors/utils.ts
@@ -34,7 +34,7 @@ export function getParamValue(
                                                   inputParam.inputIndexEnd);
     if (inputParam.type === 'tensor') {
       return getTensor(
-          node.inputNames[start], tensorMap, context, resourceManager);
+          node.inputNames.at(start), tensorMap, context, resourceManager);
     }
     if (inputParam.type === 'tensors') {
       const inputs = node.inputNames.slice(start, end);
@@ -42,8 +42,8 @@ export function getParamValue(
       return inputs.map(
           name => getTensor(name, tensorMap, context, resourceManager));
     }
-    const tensor =
-        getTensor(node.inputNames[start], tensorMap, context, resourceManager);
+    const tensor = getTensor(
+        node.inputNames.at(start), tensorMap, context, resourceManager);
     const data = tensor.dataSync();
     return inputParam.type === 'number' ?
         data[0] :

--- a/tfjs-converter/src/operations/executors/utils.ts
+++ b/tfjs-converter/src/operations/executors/utils.ts
@@ -117,8 +117,8 @@ function getNodeNameWithContextId(name: string, contextId?: string): string {
 export function parseNodeName(
     name: string, context?: ExecutionContext): [string, number, string?] {
   if (name === '') {
-    return ['', 0, undefined]
-  };
+    return ['', 0, undefined];
+  }
 
   const isCacheEnabled = context != null && context.parseNodeNameCache != null;
   if (isCacheEnabled) {


### PR DESCRIPTION
This PR adds cache for parseNodeName - an expensive string manipulation function in graph executor. The time saved is around 2% to 3% for MobileNetV3 (tested on my laptop, may be imprecise).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7391)
<!-- Reviewable:end -->
