### PR TITLE
[WebGPU] support pool3d kernels

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/AvgPool3D.ts
+++ b/tfjs-backend-webgpu/src/kernels/AvgPool3D.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {AvgPool3D, AvgPool3DAttrs, AvgPool3DInputs, backend_util, KernelConfig, KernelFunc, TensorInfo} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {Pool3DProgram} from '../pool_webgpu';
+
+export function avgPool3D(args: {
+  inputs: AvgPool3DInputs,
+  backend: WebGPUBackend,
+  attrs: AvgPool3DAttrs
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x} = inputs;
+  const {filterSize, strides, pad, dataFormat, dimRoundingMode} = attrs;
+  const dilations: [number, number, number] = [1, 1, 1];
+
+  const convInfo = backend_util.computePool3DInfo(
+      x.shape as [number, number, number, number, number], filterSize, strides,
+      dilations, pad, dimRoundingMode, dataFormat);
+  const maxPoolProgram = new Pool3DProgram(convInfo, 'avg');
+  const dimensions = [
+    {
+      type: 'int32',
+      data: [convInfo.strideDepth, convInfo.strideHeight, convInfo.strideWidth]
+    },
+    {
+      type: 'int32',
+      data:
+          [convInfo.padInfo.front, convInfo.padInfo.top, convInfo.padInfo.left]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
+      ]
+    },
+    {
+      type: 'int32',
+      data: [convInfo.inDepth, convInfo.inHeight, convInfo.inWidth]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.effectiveFilterDepth, convInfo.effectiveFilterHeight,
+        convInfo.effectiveFilterWidth
+      ]
+    }
+  ];
+  return backend.runWebGPUProgram(maxPoolProgram, [x], x.dtype, dimensions);
+}
+
+export const avgPool3DConfig: KernelConfig = {
+  kernelName: AvgPool3D,
+  backendName: 'webgpu',
+  kernelFunc: avgPool3D as unknown as KernelFunc
+};

--- a/tfjs-backend-webgpu/src/kernels/AvgPool3D.ts
+++ b/tfjs-backend-webgpu/src/kernels/AvgPool3D.ts
@@ -32,7 +32,7 @@ export function avgPool3D(args: {
   const convInfo = backend_util.computePool3DInfo(
       x.shape as [number, number, number, number, number], filterSize, strides,
       dilations, pad, dimRoundingMode, dataFormat);
-  const maxPoolProgram = new Pool3DProgram(convInfo, 'avg');
+  const avgPoolProgram = new Pool3DProgram(convInfo, 'avg');
   const dimensions = [
     {
       type: 'int32',
@@ -42,12 +42,6 @@ export function avgPool3D(args: {
       type: 'int32',
       data:
           [convInfo.padInfo.front, convInfo.padInfo.top, convInfo.padInfo.left]
-    },
-    {
-      type: 'int32',
-      data: [
-        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
-      ]
     },
     {
       type: 'int32',
@@ -61,7 +55,7 @@ export function avgPool3D(args: {
       ]
     }
   ];
-  return backend.runWebGPUProgram(maxPoolProgram, [x], x.dtype, dimensions);
+  return backend.runWebGPUProgram(avgPoolProgram, [x], x.dtype, dimensions);
 }
 
 export const avgPool3DConfig: KernelConfig = {

--- a/tfjs-backend-webgpu/src/kernels/MaxPool3D.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPool3D.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {backend_util, KernelConfig, KernelFunc, MaxPool3D, MaxPool3DAttrs, MaxPool3DInputs, TensorInfo} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {Pool3DProgram} from '../pool_webgpu';
+
+export function maxPool3d(args: {
+  inputs: MaxPool3DInputs,
+  backend: WebGPUBackend,
+  attrs: MaxPool3DAttrs
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x} = inputs;
+  const {filterSize, strides, pad, dataFormat, dimRoundingMode} = attrs;
+  const dilations: [number, number, number] = [1, 1, 1];
+
+  const convInfo = backend_util.computePool3DInfo(
+      x.shape as [number, number, number, number, number], filterSize, strides,
+      dilations, pad, dimRoundingMode, dataFormat);
+  const maxPoolProgram = new Pool3DProgram(convInfo, 'max');
+  const dimensions = [
+    {
+      type: 'int32',
+      data: [convInfo.strideDepth, convInfo.strideHeight, convInfo.strideWidth]
+    },
+    {
+      type: 'int32',
+      data:
+          [convInfo.padInfo.front, convInfo.padInfo.top, convInfo.padInfo.left]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
+      ]
+    },
+    {
+      type: 'int32',
+      data: [convInfo.inDepth, convInfo.inHeight, convInfo.inWidth]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.effectiveFilterDepth, convInfo.effectiveFilterHeight,
+        convInfo.effectiveFilterWidth
+      ]
+    }
+  ];
+  return backend.runWebGPUProgram(maxPoolProgram, [x], x.dtype, dimensions);
+}
+
+export const maxPool3DConfig: KernelConfig = {
+  kernelName: MaxPool3D,
+  backendName: 'webgpu',
+  kernelFunc: maxPool3d as unknown as KernelFunc
+};

--- a/tfjs-backend-webgpu/src/kernels/MaxPool3D.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPool3D.ts
@@ -45,12 +45,6 @@ export function maxPool3d(args: {
     },
     {
       type: 'int32',
-      data: [
-        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
-      ]
-    },
-    {
-      type: 'int32',
       data: [convInfo.inDepth, convInfo.inHeight, convInfo.inWidth]
     },
     {

--- a/tfjs-backend-webgpu/src/kernels/MaxPool3DGrad.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPool3DGrad.ts
@@ -50,12 +50,6 @@ export function maxPool3DGrad(args: {
     },
     {
       type: 'int32',
-      data: [
-        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
-      ]
-    },
-    {
-      type: 'int32',
       data: [convInfo.inDepth, convInfo.inHeight, convInfo.inWidth]
     },
     {
@@ -81,12 +75,6 @@ export function maxPool3DGrad(args: {
         convInfo.effectiveFilterDepth - 1 - convInfo.padInfo.front,
         convInfo.effectiveFilterHeight - 1 - convInfo.padInfo.top,
         convInfo.effectiveFilterWidth - 1 - convInfo.padInfo.left
-      ]
-    },
-    {
-      type: 'int32',
-      data: [
-        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
       ]
     },
     {

--- a/tfjs-backend-webgpu/src/kernels/MaxPool3DGrad.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPool3DGrad.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, KernelConfig, KernelFunc, MaxPool3DGrad, MaxPool3DGradAttrs, MaxPool3DGradInputs, TensorInfo} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {MaxPool3DBackpropProgram} from '../max_pool_backprop_webgpu';
+import {Pool3DProgram} from '../pool_webgpu';
+
+export function maxPool3DGrad(args: {
+  inputs: MaxPool3DGradInputs,
+  backend: WebGPUBackend,
+  attrs: MaxPool3DGradAttrs
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {dy, input} = inputs;
+  const x = input;
+  const {filterSize, strides, pad, dimRoundingMode} = attrs;
+  const dilations: [number, number, number] = [1, 1, 1];
+
+  const convInfo = backend_util.computePool3DInfo(
+      x.shape as [number, number, number, number, number], filterSize, strides,
+      dilations, pad, dimRoundingMode);
+
+  const maxPool3dPositionsProgram =
+      new Pool3DProgram(convInfo, 'max', true /* get positions */);
+  let uniformData = [
+    {
+      type: 'int32',
+      data: [convInfo.strideDepth, convInfo.strideHeight, convInfo.strideWidth]
+    },
+    {
+      type: 'int32',
+      data:
+          [convInfo.padInfo.front, convInfo.padInfo.top, convInfo.padInfo.left]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
+      ]
+    },
+    {
+      type: 'int32',
+      data: [convInfo.inDepth, convInfo.inHeight, convInfo.inWidth]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.effectiveFilterDepth, convInfo.effectiveFilterHeight,
+        convInfo.effectiveFilterWidth
+      ]
+    }
+  ];
+  const maxPool3dPositions = backend.runWebGPUProgram(
+      maxPool3dPositionsProgram, [x], 'int32', uniformData);
+
+  const maxPool3dBackpropProgram = new MaxPool3DBackpropProgram(convInfo);
+  uniformData = [
+    {
+      type: 'int32',
+      data: [convInfo.strideDepth, convInfo.strideHeight, convInfo.strideWidth]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.effectiveFilterDepth - 1 - convInfo.padInfo.front,
+        convInfo.effectiveFilterHeight - 1 - convInfo.padInfo.top,
+        convInfo.effectiveFilterWidth - 1 - convInfo.padInfo.left
+      ]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.dilationDepth, convInfo.dilationHeight, convInfo.dilationWidth
+      ]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.effectiveFilterDepth, convInfo.effectiveFilterHeight,
+        convInfo.effectiveFilterWidth
+      ]
+    },
+    {type: 'int32', data: [convInfo.outDepth]},
+    {type: 'int32', data: [convInfo.outHeight]},
+    {type: 'int32', data: [convInfo.outWidth]}
+  ];
+  const result = backend.runWebGPUProgram(
+      maxPool3dBackpropProgram, [dy, maxPool3dPositions], x.dtype, uniformData);
+  backend.disposeData(maxPool3dPositions.dataId);
+
+  return result;
+}
+
+export const maxPool3DGradConfig: KernelConfig = {
+  kernelName: MaxPool3DGrad,
+  backendName: 'webgpu',
+  kernelFunc: maxPool3DGrad as unknown as KernelFunc
+};

--- a/tfjs-backend-webgpu/src/kernels/MaxPoolGrad.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPoolGrad.ts
@@ -18,8 +18,8 @@
 import {backend_util, KernelConfig, KernelFunc, MaxPoolGrad, MaxPoolGradAttrs, MaxPoolGradInputs, TensorInfo} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {MaxPool2DBackpropProgram} from '../max_pool2d_backprop_webgpu';
-import {Pool2DProgram} from '../pool2d_webgpu';
+import {MaxPool2DBackpropProgram} from '../max_pool_backprop_webgpu';
+import {Pool2DProgram} from '../pool_webgpu';
 import {assertNotComplex} from '../webgpu_util';
 
 export function maxPoolGrad(args: {

--- a/tfjs-backend-webgpu/src/kernels/MaxPoolWithArgmax.ts
+++ b/tfjs-backend-webgpu/src/kernels/MaxPoolWithArgmax.ts
@@ -19,7 +19,7 @@ import {MaxPoolWithArgmax, MaxPoolWithArgmaxAttrs, MaxPoolWithArgmaxInputs} from
 import {backend_util, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {Pool2DProgram} from '../pool2d_webgpu';
+import {Pool2DProgram} from '../pool_webgpu';
 
 export function maxPoolWithArgmax(args: {
   inputs: MaxPoolWithArgmaxInputs,

--- a/tfjs-backend-webgpu/src/kernels/Pool_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/Pool_impl.ts
@@ -17,8 +17,8 @@
 import {backend_util, TensorInfo, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
-import {Pool2DProgram} from '../pool2d_webgpu';
 import {PoolWithFilterSizeEqualsOneProgram} from '../pool_filtersizeone_webgpu';
+import {Pool2DProgram} from '../pool_webgpu';
 
 import {identity} from './Identity';
 import {max} from './Max';

--- a/tfjs-backend-webgpu/src/max_pool_backprop_webgpu.ts
+++ b/tfjs-backend-webgpu/src/max_pool_backprop_webgpu.ts
@@ -66,7 +66,7 @@ export class MaxPool2DBackpropProgram implements WebGPUProgram {
           }
           let idyR = i32(dyR);
 
-          for (var wC = 0; wC < uniforms.filterDims[1]; wC++) {
+          for (var wC = 0; wC < uniforms.filterDims[1]; wC += uniforms.dilations[1]) {
             let dyC = f32(dyCCorner + wC) / f32(uniforms.strides[1]);
 
             if (dyC < 0.0 || dyC >= f32(uniforms.outWidth) || fract(dyC) > 0.0) {
@@ -98,8 +98,7 @@ export class MaxPool3DBackpropProgram implements WebGPUProgram {
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
   variableNames = ['dy', 'maxPos'];
-  uniforms =
-      `strides : vec3<i32>, pads : vec3<i32>, dilations : vec3<i32>, filterDims : vec3<i32>,
+  uniforms = `strides : vec3<i32>, pads : vec3<i32>, filterDims : vec3<i32>,
       outDepth : i32, outHeight : i32, outWidth : i32`;
   workgroupSize: [number, number, number] = [64, 1, 1];
   size = true;
@@ -134,7 +133,7 @@ export class MaxPool3DBackpropProgram implements WebGPUProgram {
         var dotProd = 0.0;
         let lastIndex = uniforms.filterDims[0] * uniforms.filterDims[1] * uniforms.filterDims[2] - 1;
 
-        for (var wD = 0; wD < uniforms.filterDims[0]; wD += uniforms.dilations[0]) {
+        for (var wD = 0; wD < uniforms.filterDims[0]; wD++) {
           let dyD = f32(dyDCorner + wD) / f32(uniforms.strides[0]);
 
           if (dyD < 0.0 || dyD >= f32(uniforms.outDepth) || fract(dyD) > 0.0) {
@@ -142,7 +141,7 @@ export class MaxPool3DBackpropProgram implements WebGPUProgram {
           }
           let idyD = i32(dyD);
 
-          for (var wR = 0; wR < uniforms.filterDims[1]; wR += uniforms.dilations[1]) {
+          for (var wR = 0; wR < uniforms.filterDims[1]; wR++) {
             let dyR = f32(dyRCorner + wR) / f32(uniforms.strides[1]);
 
             if (dyR < 0.0 || dyR >= f32(uniforms.outHeight) || fract(dyR) > 0.0) {

--- a/tfjs-backend-webgpu/src/pool_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pool_webgpu.ts
@@ -128,3 +128,119 @@ export class Pool2DProgram implements WebGPUProgram {
     return userCode;
   }
 }
+
+export class Pool3DProgram implements WebGPUProgram {
+  outputShape: number[];
+  shaderKey: string;
+  dispatchLayout: {x: number[]};
+  dispatch: [number, number, number];
+  variableNames = ['x'];
+  uniforms =
+      `strides : vec3<i32>, pads : vec3<i32>, dilations : vec3<i32>, convDims : vec3<i32>, filterDims : vec3<i32>,`;
+  workgroupSize: [number, number, number] = [128, 1, 1];
+  poolType: 'max'|'avg';
+  size = true;
+  computePositions: boolean;
+  flattenPositions: boolean;
+  includeBatchIndex: boolean;
+
+  constructor(
+      convInfo: backend_util.Conv3DInfo, poolType: 'max'|'avg',
+      computePositions = false, flattenPositions = false,
+      includeBatchIndex = false) {
+    if (poolType === 'avg' && computePositions) {
+      throw new Error('Cannot compute positions for average pool.');
+    }
+
+    this.outputShape = convInfo.outShape;
+    this.dispatchLayout = flatDispatchLayout(this.outputShape);
+    this.dispatch = computeDispatch(
+        this.dispatchLayout, this.outputShape, this.workgroupSize);
+
+    this.poolType = poolType;
+    this.computePositions = computePositions;
+    this.flattenPositions = flattenPositions;
+    this.includeBatchIndex = includeBatchIndex;
+    this.shaderKey = `pool3D_${poolType}_${computePositions}_${
+        flattenPositions}_${includeBatchIndex}`;
+  }
+
+  getUserCode(): string {
+    let updateSnippet: string;
+    if (this.poolType === 'avg') {
+      updateSnippet = `resultValue += value; count += 1.0;`;
+    } else if (this.computePositions) {
+      const positionStr = this.flattenPositions ?
+          (this.includeBatchIndex ?
+               `(((batch * uniforms.xShape.y + xD) * uniforms.xShape.z + xR) * uniforms.xShape.w + xC) * uniforms.xShape.u + ch` :
+               `((xD * uniforms.xShape.z + xR) * uniforms.xShape.w + xC) * uniforms.xShape.u + ch`) :
+          `wD * uniforms.filterDims.y * uniforms.filterDims.y + wR * uniforms.filterDims.z + wC`;
+      updateSnippet = `let currMaxValue = mix(value, maxValue, maxValueFound);
+      if (value >= currMaxValue) {
+        maxValue = value;
+        maxValueFound = 1.0;
+        maxPosition = ${positionStr};
+      }`;
+    } else {
+      updateSnippet = `resultValue = max(value, resultValue);`;
+    }
+
+    let returnValue = `resultValue`;
+    if (this.poolType === 'avg') {
+      returnValue = `resultValue / max(count, 1.0)`;
+    }
+
+    const userCode = `
+      ${main('index')} {
+        if (index < uniforms.size) {
+          let coords = getCoordsFromIndex(index);
+          let batch = coords.x;
+          let ch = coords.u;
+
+          let xCorner = vec3<i32>(coords.y, coords.z, coords.w) * uniforms.strides - uniforms.pads;
+          let xDCorner = xCorner.x;
+          let xRCorner = xCorner.y;
+          let xCCorner = xCorner.z;
+
+          ${
+        this.computePositions ?
+            `var maxValue = 0.0;
+            var maxValueFound = 0.0;
+            var maxPosition = 0;` :
+            `var resultValue = ${
+                this.poolType === 'avg' ? '0.0' : '-1.0 / pow(10.0, -20.0)'};`}
+
+          var count = 0.0;
+          for (var wD = 0; wD < uniforms.filterDims.x; wD += uniforms.dilations.x) {
+            let xD = xDCorner + wD;
+            if (xD < 0 || xD >= uniforms.convDims.x) {
+              continue;
+            }
+
+            for (var wR = 0; wR < uniforms.filterDims.y; wR += uniforms.dilations.y) {
+              let xR = xRCorner + wR;
+              if (xR < 0 || xR >= uniforms.convDims.y) {
+                continue;
+              }
+
+              for (var wC = 0; wC < uniforms.filterDims.z; wC += uniforms.dilations.z) {
+                let xC = xCCorner + wC;
+                if (xC < 0 || xC >= uniforms.convDims.z) {
+                  continue;
+                }
+
+                let value = getX(batch, xD, xR, xC, ch);
+                ${updateSnippet}
+              }
+            }
+          }
+
+          ${
+        this.computePositions ? `setOutputAtIndexI32(index, maxPosition);` :
+                                `setOutputAtIndex(index, ${returnValue});`}
+        }
+      }
+    `;
+    return userCode;
+  }
+}

--- a/tfjs-backend-webgpu/src/pool_webgpu.ts
+++ b/tfjs-backend-webgpu/src/pool_webgpu.ts
@@ -136,7 +136,7 @@ export class Pool3DProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['x'];
   uniforms =
-      `strides : vec3<i32>, pads : vec3<i32>, dilations : vec3<i32>, convDims : vec3<i32>, filterDims : vec3<i32>,`;
+      `strides : vec3<i32>, pads : vec3<i32>, convDims : vec3<i32>, filterDims : vec3<i32>,`;
   workgroupSize: [number, number, number] = [128, 1, 1];
   poolType: 'max'|'avg';
   size = true;
@@ -211,19 +211,19 @@ export class Pool3DProgram implements WebGPUProgram {
                 this.poolType === 'avg' ? '0.0' : '-1.0 / pow(10.0, -20.0)'};`}
 
           var count = 0.0;
-          for (var wD = 0; wD < uniforms.filterDims.x; wD += uniforms.dilations.x) {
+          for (var wD = 0; wD < uniforms.filterDims.x; wD++) {
             let xD = xDCorner + wD;
             if (xD < 0 || xD >= uniforms.convDims.x) {
               continue;
             }
 
-            for (var wR = 0; wR < uniforms.filterDims.y; wR += uniforms.dilations.y) {
+            for (var wR = 0; wR < uniforms.filterDims.y; wR++) {
               let xR = xRCorner + wR;
               if (xR < 0 || xR >= uniforms.convDims.y) {
                 continue;
               }
 
-              for (var wC = 0; wC < uniforms.filterDims.z; wC += uniforms.dilations.z) {
+              for (var wC = 0; wC < uniforms.filterDims.z; wC++) {
                 let xC = xCCorner + wC;
                 if (xC < 0 || xC >= uniforms.convDims.z) {
                   continue;

--- a/tfjs-backend-webgpu/src/register_all_kernels.ts
+++ b/tfjs-backend-webgpu/src/register_all_kernels.ts
@@ -32,6 +32,7 @@ import {atanConfig} from './kernels/Atan';
 import {atan2Config} from './kernels/Atan2';
 import {atanhConfig} from './kernels/Atanh';
 import {avgPoolConfig} from './kernels/AvgPool';
+import {avgPool3DConfig} from './kernels/AvgPool3D';
 import {avgPoolGradConfig} from './kernels/AvgPoolGrad';
 import {batchMatMulConfig} from './kernels/BatchMatMul';
 import {batchToSpaceNDConfig} from './kernels/BatchToSpaceND';
@@ -99,6 +100,8 @@ import {lrnGradConfig} from './kernels/LRNGrad';
 import {maxConfig} from './kernels/Max';
 import {maximumConfig} from './kernels/Maximum';
 import {maxPoolConfig} from './kernels/MaxPool';
+import {maxPool3DConfig} from './kernels/MaxPool3D';
+import {maxPool3DGradConfig} from './kernels/MaxPool3DGrad';
 import {maxPoolGradConfig} from './kernels/MaxPoolGrad';
 import {maxPoolWithArgmaxConfig} from './kernels/MaxPoolWithArgmax';
 import {meanConfig} from './kernels/Mean';
@@ -183,6 +186,7 @@ const kernelConfigs: KernelConfig[] = [
   atan2Config,
   atanhConfig,
   avgPoolConfig,
+  avgPool3DConfig,
   avgPoolGradConfig,
   batchMatMulConfig,
   batchToSpaceNDConfig,
@@ -251,6 +255,8 @@ const kernelConfigs: KernelConfig[] = [
   maximumConfig,
   maxPoolConfig,
   maxPoolGradConfig,
+  maxPool3DConfig,
+  maxPool3DGradConfig,
   maxPoolWithArgmaxConfig,
   meanConfig,
   minConfig,

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -81,11 +81,8 @@ const TEST_FILTERS: TestFilter[] = [
   {
     include: ' webgpu ',
     excludes: [
-      'avgPool3d ',
       'avgPool3dBackprop ',
       'conv3dTranspose ',
-      'maxPool3d ',
-      'maxPool3dBackprop ',
       'raggedGather ',
       'raggedRange ',
       'raggedTensorToTensor ',


### PR DESCRIPTION
This patch supports AvgPool3D, MaxPool3D and
MaxPool3DGrad kernels.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7405)
<!-- Reviewable:end -->
