### PR TITLE
Remove Array.at usage

### DIFF
--- a/tfjs-converter/src/operations/executors/utils.ts
+++ b/tfjs-converter/src/operations/executors/utils.ts
@@ -32,9 +32,10 @@ export function getParamValue(
         undefined :
         (inputParam.inputIndexEnd === undefined ? start + 1 :
                                                   inputParam.inputIndexEnd);
+    const shiftedStart = start < 0 ? node.inputNames.length + start : start;
     if (inputParam.type === 'tensor') {
       return getTensor(
-          node.inputNames.at(start), tensorMap, context, resourceManager);
+          node.inputNames[shiftedStart], tensorMap, context, resourceManager);
     }
     if (inputParam.type === 'tensors') {
       const inputs = node.inputNames.slice(start, end);
@@ -43,7 +44,7 @@ export function getParamValue(
           name => getTensor(name, tensorMap, context, resourceManager));
     }
     const tensor = getTensor(
-        node.inputNames.at(start), tensorMap, context, resourceManager);
+        node.inputNames[shiftedStart], tensorMap, context, resourceManager);
     const data = tensor.dataSync();
     return inputParam.type === 'number' ?
         data[0] :


### PR DESCRIPTION
`Array.at(..)` is not supported in Mac.
Behavior change: originally the tensor name lookup is done by `nodeNames.slice(start)[0]`, which returns the first element when `start < -nodeNames.length`. It now returns `undefined`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7409)
<!-- Reviewable:end -->
