### PR TITLE
Improve assertAndGetBroadcastShape

### DIFF
--- a/tfjs-core/src/ops/broadcast_util.ts
+++ b/tfjs-core/src/ops/broadcast_util.ts
@@ -62,25 +62,25 @@ export function assertAndGetBroadcastShape(
   const result: number[] = [];
   const l = Math.max(shapeA.length, shapeB.length);
 
-  for (let i = 0; i < l; i++) {
-    let a = shapeA[shapeA.length - i - 1];
+  for (let i = l - 1; i >= 0; i--) {
+    let a = shapeA[i];
     if (a == null) {
       a = 1;
     }
-    let b = shapeB[shapeB.length - i - 1];
+    let b = shapeB[i];
     if (b == null) {
       b = 1;
     }
     if (a === 1) {
-      result.unshift(b);
+      result.push(b);
     } else if (b === 1) {
-      result.unshift(a);
+      result.push(a);
     } else if (a !== b) {
       const errMsg = `Operands could not be broadcast together with shapes ` +
           `${shapeA} and ${shapeB}.`;
       throw Error(errMsg);
     } else {
-      result.unshift(a);
+      result.push(a);
     }
   }
   return result;

--- a/tfjs-core/src/ops/broadcast_util.ts
+++ b/tfjs-core/src/ops/broadcast_util.ts
@@ -59,28 +59,28 @@ export function getReductionAxes(
 
 export function assertAndGetBroadcastShape(
     shapeA: number[], shapeB: number[]): number[] {
-  const result: number[] = [];
   const l = Math.max(shapeA.length, shapeB.length);
+  const result = new Array(l);
 
-  for (let i = l - 1; i >= 0; i--) {
-    let a = shapeA[i];
+  for (let i = 0; i < l; i++) {
+    let a = shapeA[shapeA.length - i - 1];
     if (a == null) {
       a = 1;
     }
-    let b = shapeB[i];
+    let b = shapeB[shapeB.length - i - 1];
     if (b == null) {
       b = 1;
     }
     if (a === 1) {
-      result.push(b);
+      result[l - i - 1] = b;
     } else if (b === 1) {
-      result.push(a);
+      result[l - i - 1] = a;
     } else if (a !== b) {
       const errMsg = `Operands could not be broadcast together with shapes ` +
           `${shapeA} and ${shapeB}.`;
       throw Error(errMsg);
     } else {
-      result.push(a);
+      result[l - i - 1] = a;
     }
   }
   return result;


### PR DESCRIPTION
According to https://jsbench.me/bmlehvit9v/1, push is far faster than unshift.

![image](https://user-images.githubusercontent.com/40653845/221072104-4541adae-ca73-4367-8eb2-64e126165203.png)
`assertAndGetBroadcastShape2` is after this PR.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7413)
<!-- Reviewable:end -->
