### PR TITLE
Fix topological sort for sync nodes execution order

### DIFF
--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -185,8 +185,7 @@ export class GraphExecutor implements FunctionExecutor {
           `[${inNames}]. Missing the following inputs: [${missingInputs}]`);
     }
 
-    const orderedNodes =
-        getNodesInTopologicalOrder(this.graph, this.weightMap, executionInfo);
+    const orderedNodes = getNodesInTopologicalOrder(this.graph, executionInfo);
     const nodeLiveUntilMap = getNodeLiveUntilMap(orderedNodes);
     return {orderedNodes, nodeLiveUntilMap};
   }

--- a/tfjs-converter/src/executor/graph_executor.ts
+++ b/tfjs-converter/src/executor/graph_executor.ts
@@ -165,7 +165,7 @@ export class GraphExecutor implements FunctionExecutor {
    *     tensors should be disposed after `x` is executed.
    */
   private compile(inputs: NamedTensorMap, outputs: Node[]):
-      {orderedNodes: Node[], nodeLiveUntilMap: Map<Node, Node[]>} {
+      {orderedNodes: Node[], nodeLiveUntilMap: Map<string, string[]>} {
     const executionInfo =
         getExecutionSubgraph(inputs, outputs, this.weightMap, this._initNodes);
     const {missingInputs, dynamicNode, syncInputs} = executionInfo;
@@ -306,7 +306,7 @@ export class GraphExecutor implements FunctionExecutor {
         }
         this.checkTensorForDisposalWithNodeLiveUntilInfo(
             node, tensorsMap, context, tensorsToKeep, outputNodeNameSet,
-            nodeLiveUntilMap.get(node));
+            nodeLiveUntilMap.get(node.name));
       }
 
       // dispose the context for the root executor
@@ -381,7 +381,7 @@ export class GraphExecutor implements FunctionExecutor {
   private checkTensorForDisposalWithNodeLiveUntilInfo(
       node: Node, tensorMap: NamedTensorsMap, context: ExecutionContext,
       tensorsToKeep: Set<number>, outputNodeNameSet: Set<string>,
-      liveUntilNodes?: Node[]) {
+      liveUntilNodes?: string[]) {
     // Skip output nodes and any control flow nodes, since its dependency is
     // tricky to track correctly.
     if (isControlFlow(node) || outputNodeNameSet.has(node.name)) {
@@ -391,9 +391,9 @@ export class GraphExecutor implements FunctionExecutor {
       return;
     }
 
-    for (const inputNode of liveUntilNodes) {
+    for (const inputNodeName of liveUntilNodes) {
       const tensors =
-          getTensorsForCurrentContext(inputNode.name, tensorMap, context);
+          getTensorsForCurrentContext(inputNodeName, tensorMap, context);
       for (const tensor of tensors) {
         if (!tensor || tensor.kept || tensorsToKeep.has(tensor.id)) {
           continue;

--- a/tfjs-converter/src/executor/graph_executor_test.ts
+++ b/tfjs-converter/src/executor/graph_executor_test.ts
@@ -37,11 +37,7 @@ const SIGNATURE: tensorflow.ISignatureDef = {
     x: {name: 'input', dtype: tensorflow.DataType.DT_INT32, tensorShape: {}}
   },
   outputs: {
-    add: {
-      name: 'output',
-      dtype: tensorflow.DataType.DT_FLOAT,
-      tensorShape: {}
-    }
+    add: {name: 'output', dtype: tensorflow.DataType.DT_FLOAT, tensorShape: {}}
   }
 };
 
@@ -419,11 +415,8 @@ describe('GraphExecutor', () => {
             },
             inputParams: {
               'cond': {'type': 'tensor', 'inputIndexStart': 0},
-              'args': {
-                'type': 'tensors',
-                'inputIndexStart': 1,
-                'inputIndexEnd': 0
-              }
+              'args':
+                  {'type': 'tensors', 'inputIndexStart': 1, 'inputIndexEnd': 0}
             }
           };
           inputNode.children.push(outputNode);
@@ -540,11 +533,8 @@ describe('GraphExecutor', () => {
               'body': {'value': 'bodyFunc', 'type': 'func'}
             },
             inputParams: {
-              'args': {
-                'type': 'tensors',
-                'inputIndexStart': 0,
-                'inputIndexEnd': 0
-              }
+              'args':
+                  {'type': 'tensors', 'inputIndexStart': 0, 'inputIndexEnd': 0}
             }
           };
           inputNode2.children.push(outputNode);

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -233,7 +233,7 @@ function validateNodesExecutionOrder(
     for (const child of node.children.filter(willBeExecuted)) {
       if (!nodeNameToOrder.has(child.name)) {
         throw new Error(`TopologicalSortError: Child ${child.name} of node ${
-            node.name}'s is unreachable.`);
+            node.name} is unreachable.`);
       }
       if (nodeNameToOrder.get(node.name) > nodeNameToOrder.get(child.name)) {
         throw new Error(`TopologicalSortError: Node ${

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -152,6 +152,9 @@ export function getNodesInTopologicalOrder(
     ...orderedNodes, ...inputNodes, ...graph.weights, ...(initNodes || [])
   ].filter(isUsed);
   for (const node of allNodes) {
+    if (!nodeNameToOrder.has(node.name)) {
+      throw new Error('Topological Sort Error: node is unreachable.');
+    }
     for (const child of node.children.filter(isUsed)) {
       if (!nodeNameToOrder.has(child.name)) {
         throw new Error('Topological Sort Error: child is unreachable.');

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -239,7 +239,7 @@ function validateNodesExecutionOrder(
       }
       if (nodeNameToOrder.get(node.name) > nodeNameToOrder.get(child.name)) {
         throw new Error(`TopologicalSortError: Node ${
-            node.name} has greater order than its child ${child.name}.`);
+            node.name} is scheduled to run after its child ${child.name}.`);
       }
     }
     if (!isPredefined(node)) {

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -181,12 +181,12 @@ export function getNodeLiveUntilMap(orderedNodes: Node[]): Map<Node, Node[]> {
   //           after `x` is executed.
   const liveUntilMap = new Map<Node, Node[]>();
   for (let nodeOrder = 0; nodeOrder < nNodes; ++nodeOrder) {
-    const iveUntilOrder = liveUntilOrders[nodeOrder];
-    if (iveUntilOrder === INF_LIFE) {
+    const liveUntilOrder = liveUntilOrders[nodeOrder];
+    if (liveUntilOrder === INF_LIFE) {
       continue;
     }
     const node = orderedNodes[nodeOrder];
-    const liveUntilNode = orderedNodes[iveUntilOrder];
+    const liveUntilNode = orderedNodes[liveUntilOrder];
     if (!liveUntilMap.has(liveUntilNode)) {
       liveUntilMap.set(liveUntilNode, []);
     }

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -157,7 +157,7 @@ export function getNodesInTopologicalOrder(
   }
 
   // Build a set for all nodes reachable by at least one predefined node.
-  // This can help us filter out redundant nodes from the return node order.
+  // This can help us filter out redundant nodes from the returned node list.
   // For example:
   // If we have four nodes with dependencies like this:
   //   a --> b --> c --> d
@@ -199,22 +199,22 @@ export function getNodesInTopologicalOrder(
     for (const node of filteredOrderedNodes) {
       for (const child of node.children.filter(willBeExecuted)) {
         if (!nodeNameToOrder.has(child.name)) {
-          throw new Error('Topological Sort Error: child is unreachable.');
+          throw new Error('TopologicalSortError: Child is unreachable.');
         }
         if (nodeNameToOrder.get(node.name) > nodeNameToOrder.get(child.name)) {
           throw new Error(
-              'Topological Sort Error: node has greater order than its child.');
+              'TopologicalSortError: Node has greater order than its child.');
         }
       }
       if (!isPredefined(node)) {
         for (const input of node.inputs) {
           if (!nodeNameToOrder.has(input.name)) {
-            throw new Error('Topological Sort Error: input is unreachable.');
+            throw new Error('TopologicalSortError: Input is unreachable.');
           }
           if (nodeNameToOrder.get(input.name) >
               nodeNameToOrder.get(node.name)) {
             throw new Error(
-                'Topological Sort Error: node has smaller order than its input.');
+                'TopologicalSortError: Node has smaller order than its input.');
           }
         }
       }
@@ -243,16 +243,15 @@ export function getNodeLiveUntilMap(orderedNodes: Node[]):
   // live forever since they're tricky to track correctly.
   const selfLifespans = orderedNodes.map(
       (node, nodeOrder) => isControlFlow(node) ? INF_LIFE : nodeOrder);
-  const getSelfLifeSpan =
-      (node: Node) => {
-        const selfLife = selfLifespans[nodeNameToOrder.get(node.name)!];
-        if (selfLife == null) {
-          // If nodeToOrder does not contain the node, it is unused or
-          // unreachable in graph.
-          return -1;
-        }
-        return selfLife;
-      }
+  const getSelfLifeSpan = (node: Node) => {
+    const selfLife = selfLifespans[nodeNameToOrder.get(node.name)!];
+    if (selfLife == null) {
+      // If nodeToOrder does not contain the node, it is unused or
+      // unreachable in graph.
+      return -1;
+    }
+    return selfLife;
+  };
 
   // `liveUntil[i]` points to the last node in the `orderedNodes` array that
   // may depend on tensors from node `i`. It indicates that all the

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -184,7 +184,8 @@ export function getNodesInTopologicalOrder(
           .map((name) => nameToNode.get(name)!);
 
   // Validates node orders
-  if (true) {
+  // TODO: Turn validation on/off with tf env flag.
+  {
     const nodeNameToOrder = new Map<string, number>(
         filteredOrderedNodes.map((node, order) => [node.name, order]));
     const predefinedNodeNames =

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -210,6 +210,12 @@ function filterPredefinedReachableNodes(
   return filteredOrderedNodes;
 }
 
+class NodesExecutionOrderError extends Error {
+  constructor(message: string) {
+    super(`NodesExecutionOrderError: ${message}`);
+  }
+}
+
 /**
  * This is a helper function of `getNodesInTopologicalOrder`.
  * Validates property: given nodes `a` and `b`, Order(a) > Order(b) if `a`
@@ -234,22 +240,22 @@ function validateNodesExecutionOrder(
   for (const node of orderedNodes) {
     for (const child of node.children.filter(willBeExecuted)) {
       if (!nodeNameToOrder.has(child.name)) {
-        throw new Error(`TopologicalSortError: Child ${child.name} of node ${
-            node.name} is unreachable.`);
+        throw new NodesExecutionOrderError(
+            `Child ${child.name} of node ${node.name} is unreachable.`);
       }
       if (nodeNameToOrder.get(node.name) > nodeNameToOrder.get(child.name)) {
-        throw new Error(`TopologicalSortError: Node ${
+        throw new NodesExecutionOrderError(`Node ${
             node.name} is scheduled to run after its child ${child.name}.`);
       }
     }
     if (!isPredefined(node)) {
       for (const input of node.inputs) {
         if (!nodeNameToOrder.has(input.name)) {
-          throw new Error(`TopologicalSortError: Input ${input.name} of node ${
-              node.name} is unreachable.`);
+          throw new NodesExecutionOrderError(
+              `Input ${input.name} of node ${node.name} is unreachable.`);
         }
         if (nodeNameToOrder.get(input.name) > nodeNameToOrder.get(node.name)) {
-          throw new Error(`TopologicalSortError: Node ${
+          throw new NodesExecutionOrderError(`Node ${
               node.name} is scheduled to run before its input ${input.name}.`);
         }
       }

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -261,8 +261,8 @@ function validateNodesExecutionOrder(
  *
  * @returns A map from node name to disposable node names after its
  *     execution. That is, for a node `x`, `nodeLiveUntilMap[x]` indicates
- * all nodes which their intermediate tensors should be disposed after `x`
- * being executed.
+ *     all nodes which their intermediate tensors should be disposed after `x`
+ *     being executed.
  */
 export function getNodeLiveUntilMap(orderedNodes: Node[]):
     Map<string, string[]> {

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -188,6 +188,8 @@ function filterPredefinedReachableNodes(
   // TODO: Filter out more nodes when >=2 nodes are predefined in a path.
   const stack = predefinedNodes.map((node) => node.name);
   const predefinedReachableNodeNames = new Set(stack);
+  // Perform a DFS starting from the set of all predefined nodes
+  // to find the set of all nodes reachable from the predefined nodes.
   while (stack.length > 0) {
     const nodeName = stack.pop();
     const node = nameToNode.get(nodeName)!;

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -104,65 +104,106 @@ export function getNodesInTopologicalOrder(
     graph: Graph, weightMap: NamedTensorsMap,
     executionInfo: ExecutionInfo): Node[] {
   const {usedNodes, inputs} = executionInfo;
-  const frontier: Node[] = [];
   const inputNodes = Object.keys(inputs)
                          .map(name => parseNodeName(name)[0])
                          .map(name => graph.nodes[name]);
   const initNodes = graph.initNodes;
 
-  inputNodes.forEach(input => {
-    if (usedNodes.has(input.name)) {
-      frontier.push(input);
-    }
+  const isUsed = (node: Node|string) =>
+      usedNodes.has(typeof node === 'string' ? node : node.name);
+  const frontier: Node[] = [
+    ...inputNodes,
+    ...graph.weights,
+    ...(initNodes || []),
+  ].filter(isUsed).filter((node) => {
+    // If predefined node has any inputs, skips it and waits until topological
+    // sort resolves its parents to add it to frontier.
+    return node.inputs.length === 0;
   });
-  graph.weights.forEach(weight => {
-    if (usedNodes.has(weight.name)) {
-      frontier.push(weight);
-    }
-  });
-  if (initNodes != null) {
-    initNodes.forEach(node => {
-      if (usedNodes.has(node.name)) {
-        frontier.push(node);
-      }
-    });
-  }
-  const seen = new Set<string>();
+
   const orderedNodes: Node[] = [];
+  const processedNodeNames = new Set<string>();
+  const isProcessed = (node: Node|string) =>
+      processedNodeNames.has(typeof node === 'string' ? node : node.name);
+
+  // TODO: Improve performance of the topological sort implementation.
   while (frontier.length > 0) {
     const node = frontier.pop();
-    seen.add(node.name);
-    if (!weightMap[node.name]) {
-      orderedNodes.push(node);
+    if (isProcessed(node)) {
+      continue;
     }
-    node.children.forEach(child => {
-      if (!seen.has(child.name) && usedNodes.has(child.name) &&
-          child.inputs.every(input => seen.has(input.name))) {
+    processedNodeNames.add(node.name);
+    orderedNodes.push(node);
+    for (const child of node.children.filter(isUsed)) {
+      if (isProcessed(child)) {
+        throw new Error(
+            'Topological Sort Error: child should not be processed.');
+      }
+      if (child.inputs.map((node) => node.name).every(isProcessed)) {
         frontier.push(child);
       }
-    });
+    }
   }
+
+  // Validates node orders
+  const nodeNameToOrder = new Map<string, number>(
+      orderedNodes.map((node, order) => [node.name, order]));
+  const allNodes = [
+    ...orderedNodes, ...inputNodes, ...graph.weights, ...(initNodes || [])
+  ].filter(isUsed);
+  for (const node of allNodes) {
+    for (const child of node.children.filter(isUsed)) {
+      if (!nodeNameToOrder.has(child.name)) {
+        throw new Error('Topological Sort Error: child is unreachable.');
+      }
+      if (nodeNameToOrder.get(node.name) > nodeNameToOrder.get(child.name)) {
+        throw new Error(
+            'Topological Sort Error: node has greater order than its child.');
+      }
+    }
+    for (const input of node.inputs) {
+      if (!nodeNameToOrder.has(input.name)) {
+        throw new Error('Topological Sort Error: input is unreachable.');
+      }
+      if (nodeNameToOrder.get(input.name) > nodeNameToOrder.get(node.name)) {
+        throw new Error(
+            'Topological Sort Error: node has smaller order than its input.');
+      }
+    }
+  }
+
   return orderedNodes;
 }
 
 /**
- * Given the execution info, return a map from node to the disposable node list
- * after its execution.
+ * Given the execution info, return a map from node name to the disposable node
+ * name list after its execution.
  *
- * @returns A map from node to disposable nodes after its
+ * @returns A map from node name to disposable node names after its
  *     execution. That is, for a node `x`, `nodeLiveUntilMap[x]` indicates all
  *     nodes which their intermediate tensors should be disposed after `x` being
  *     executed.
  */
-export function getNodeLiveUntilMap(orderedNodes: Node[]): Map<Node, Node[]> {
-  const nNodes = orderedNodes.length;
-  const nodeToOrder = new Map(orderedNodes.map((node, order) => [node, order]));
+export function getNodeLiveUntilMap(orderedNodes: Node[]):
+    Map<string, string[]> {
+  const nodeNameToOrder = new Map<string, number>(
+      orderedNodes.map((node, order) => [node.name, order]));
 
   const INF_LIFE = Number.MAX_SAFE_INTEGER;
   // Make control flow nodes (and consequently their direct parents)
   // live forever since they're tricky to track correctly.
   const selfLifespans = orderedNodes.map(
       (node, nodeOrder) => isControlFlow(node) ? INF_LIFE : nodeOrder);
+  const getSelfLifeSpan =
+      (node: Node) => {
+        const selfLife = selfLifespans[nodeNameToOrder.get(node.name)!];
+        if (selfLife == null) {
+          // If nodeToOrder does not contain the node, it is unused or
+          // unreachable in graph.
+          return -1;
+        }
+        return selfLife;
+      }
 
   // `liveUntil[i]` points to the last node in the `orderedNodes` array that
   // may depend on tensors from node `i`. It indicates that all the intermediate
@@ -171,26 +212,26 @@ export function getNodeLiveUntilMap(orderedNodes: Node[]): Map<Node, Node[]> {
   // A node lives long enough to pass on its tensors to its children.
   // It lives until at least `max(node's position, children's positions)`.
   const liveUntilOrders = orderedNodes.map((node, nodeOrder) => {
-    return node.children.map(node => selfLifespans[nodeToOrder.get(node)!])
+    return node.children.map(getSelfLifeSpan)
         .reduce((a, b) => Math.max(a, b), selfLifespans[nodeOrder]);
   });
 
   // liveUntilMap:
-  // - Key: A node `x`
+  // - Key: Name of a node `x`
   // - Values: All nodes whose intermediate tensors should be disposed
   //           after `x` is executed.
-  const liveUntilMap = new Map<Node, Node[]>();
-  for (let nodeOrder = 0; nodeOrder < nNodes; ++nodeOrder) {
+  const liveUntilMap = new Map<string, string[]>();
+  for (let nodeOrder = 0; nodeOrder < orderedNodes.length; ++nodeOrder) {
     const liveUntilOrder = liveUntilOrders[nodeOrder];
     if (liveUntilOrder === INF_LIFE) {
       continue;
     }
     const node = orderedNodes[nodeOrder];
     const liveUntilNode = orderedNodes[liveUntilOrder];
-    if (!liveUntilMap.has(liveUntilNode)) {
-      liveUntilMap.set(liveUntilNode, []);
+    if (!liveUntilMap.has(liveUntilNode.name)) {
+      liveUntilMap.set(liveUntilNode.name, []);
     }
-    liveUntilMap.get(liveUntilNode)!.push(node);
+    liveUntilMap.get(liveUntilNode.name)!.push(node.name);
   }
   return liveUntilMap;
 }

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -133,7 +133,7 @@ export function getNodesInTopologicalOrder(
       // When the child is unused, set in counts to infinity so that it will
       // never be decreased to 0 and added to the execution list.
       if (!isUsed(child)) {
-        inCounts[child.name] = Number.MAX_SAFE_INTEGER;
+        inCounts[child.name] = Number.POSITIVE_INFINITY;
       }
       inCounts[child.name] = (inCounts[child.name] || 0) + 1;
     }
@@ -148,7 +148,7 @@ export function getNodesInTopologicalOrder(
   while (frontier.length > 0) {
     const nodeName = frontier.pop();
     const node = nameToNode.get(nodeName)!;
-    for (const child of node.children) {
+    for (const child of node.children.filter(isUsed)) {
       if (--inCounts[child.name] === 0) {
         orderedNodeNames.push(child.name);
         frontier.push(child.name);
@@ -169,7 +169,7 @@ export function getNodesInTopologicalOrder(
   while (stack.length > 0) {
     const nodeName = stack.pop();
     const node = nameToNode.get(nodeName)!;
-    for (const child of node.children) {
+    for (const child of node.children.filter(isUsed)) {
       if (predefinedReachableNodeNames.has(child.name)) {
         continue;
       }

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -168,7 +168,7 @@ export function getNodesInTopologicalOrder(
 
 /**
  * This is a helper function of `getNodesInTopologicalOrder`.
- * Build a set for all nodes reachable by at least one predefined node.
+ * Returns ordered nodes reachable by at least one predefined node.
  * This can help us filter out redundant nodes from the returned node list.
  * For example:
  * If we have four nodes with dependencies like this:
@@ -210,7 +210,7 @@ function filterPredefinedReachableNodes(
 
 /**
  * This is a helper function of `getNodesInTopologicalOrder`.
- * Validates property: given node `a` and node `b`, Order(a) > Order(b) if `a`
+ * Validates property: given nodes `a` and `b`, Order(a) > Order(b) if `a`
  * is a child of `b`. This function throws an error if validation fails.
  *
  * @param orderedNodes Graph nodes in execution order.

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -250,7 +250,7 @@ function validateNodesExecutionOrder(
         }
         if (nodeNameToOrder.get(input.name) > nodeNameToOrder.get(node.name)) {
           throw new Error(`TopologicalSortError: Node ${
-              node.name} has smaller order than its input ${input.name}.`);
+              node.name} is scheduled to run before its input ${input.name}.`);
         }
       }
     }

--- a/tfjs-converter/src/executor/model_analysis.ts
+++ b/tfjs-converter/src/executor/model_analysis.ts
@@ -170,7 +170,7 @@ export function getNodeLiveUntilMap(orderedNodes: Node[]): Map<Node, Node[]> {
   // `orderedNodes[liveUntil[i]]` is executed.
   // A node lives long enough to pass on its tensors to its children.
   // It lives until at least `max(node's position, children's positions)`.
-  const liveUntil = orderedNodes.map((node, nodeOrder) => {
+  const liveUntilOrders = orderedNodes.map((node, nodeOrder) => {
     return node.children.map(node => selfLifespans[nodeToOrder.get(node)!])
         .reduce((a, b) => Math.max(a, b), selfLifespans[nodeOrder]);
   });
@@ -181,12 +181,12 @@ export function getNodeLiveUntilMap(orderedNodes: Node[]): Map<Node, Node[]> {
   //           after `x` is executed.
   const liveUntilMap = new Map<Node, Node[]>();
   for (let nodeOrder = 0; nodeOrder < nNodes; ++nodeOrder) {
-    const nodeLiveUntil = liveUntil[nodeOrder];
-    if (nodeLiveUntil === INF_LIFE) {
+    const iveUntilOrder = liveUntilOrders[nodeOrder];
+    if (iveUntilOrder === INF_LIFE) {
       continue;
     }
     const node = orderedNodes[nodeOrder];
-    const liveUntilNode = orderedNodes[nodeLiveUntil];
+    const liveUntilNode = orderedNodes[iveUntilOrder];
     if (!liveUntilMap.has(liveUntilNode)) {
       liveUntilMap.set(liveUntilNode, []);
     }


### PR DESCRIPTION
This PR rewrites the algorithm to determine execution order of sync graph nodes:
1. The new algorithm guarantees that  `OrderParent < OrderChild`  if `parent -> child` always holds. The old implementation does not guarantee this when `child` is predefined (given with an input tensor, is weight, etc), which will lead to some error in execution-order based tensor disposal plan.
2. Improve the time complexity from `O(NE)` to `O(E)`.

Verified with sample models (localbenchmark) and diffuser

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7431)
<!-- Reviewable:end -->
