### PR TITLE
[WebGPU] support conv3d backprop kernels

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/Conv3DBackpropFilterV2.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv3DBackpropFilterV2.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Conv3DBackpropFilterV2, Conv3DBackpropFilterV2Attrs, Conv3DBackpropFilterV2Inputs, KernelConfig, KernelFunc, TensorInfo} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {Conv3DDerFilterProgram} from '../conv_backprop_webgpu';
+
+export function conv3DBackpropFilterV2(args: {
+  inputs: Conv3DBackpropFilterV2Inputs,
+  attrs: Conv3DBackpropFilterV2Attrs,
+  backend: WebGPUBackend,
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x, dy} = inputs;
+  const {strides, pad, filterShape} = attrs;
+
+  const convInfo = backend_util.computeConv3DInfo(
+      x.shape as [number, number, number, number, number], filterShape, strides,
+      1 /* dilations */, pad);
+
+  const program = new Conv3DDerFilterProgram(convInfo);
+  const uniformData = [
+    {
+      type: 'int32',
+      data:
+          [convInfo.padInfo.front, convInfo.padInfo.top, convInfo.padInfo.left]
+    },
+    {
+      type: 'int32',
+      data: [convInfo.strideDepth, convInfo.strideHeight, convInfo.strideWidth]
+    },
+    {type: 'int32', data: [convInfo.batchSize]},
+    {type: 'int32', data: [convInfo.outDepth]},
+    {type: 'int32', data: [convInfo.outHeight]},
+    {type: 'int32', data: [convInfo.outWidth]},
+    {type: 'int32', data: [convInfo.inDepth]},
+    {type: 'int32', data: [convInfo.inHeight]},
+    {type: 'int32', data: [convInfo.inWidth]}
+  ];
+  return backend.runWebGPUProgram(program, [x, dy], dy.dtype, uniformData);
+}
+
+export const conv3DBackpropFilterV2Config: KernelConfig = {
+  kernelName: Conv3DBackpropFilterV2,
+  backendName: 'webgpu',
+  kernelFunc: conv3DBackpropFilterV2 as unknown as KernelFunc
+};

--- a/tfjs-backend-webgpu/src/kernels/Conv3DBackpropInputV2.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv3DBackpropInputV2.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Conv3DBackpropInputV2, Conv3DBackpropInputV2Attrs, Conv3DBackpropInputV2Inputs, KernelConfig, KernelFunc, TensorInfo} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {Conv3DDerInputProgram} from '../conv_backprop_webgpu';
+
+export function conv3DBackpropInputV2(args: {
+  inputs: Conv3DBackpropInputV2Inputs,
+  attrs: Conv3DBackpropInputV2Attrs,
+  backend: WebGPUBackend
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {dy, filter} = inputs;
+  const {strides, pad, inputShape} = attrs;
+
+  const convInfo = backend_util.computeConv3DInfo(
+      inputShape, filter.shape as [number, number, number, number, number],
+      strides, 1 /* dilations */, pad);
+
+  const program = new Conv3DDerInputProgram(convInfo);
+  const uniformData = [
+    {
+      type: 'int32',
+      data: [convInfo.filterDepth, convInfo.filterHeight, convInfo.filterWidth]
+    },
+    {
+      type: 'int32',
+      data: [
+        convInfo.filterDepth - 1 - convInfo.padInfo.front,
+        convInfo.filterHeight - 1 - convInfo.padInfo.top,
+        convInfo.filterWidth - 1 - convInfo.padInfo.left
+      ]
+    },
+    {
+      type: 'int32',
+      data: [convInfo.strideDepth, convInfo.strideHeight, convInfo.strideWidth]
+    },
+    {type: 'int32', data: [convInfo.outDepth]},
+    {type: 'int32', data: [convInfo.outHeight]},
+    {type: 'int32', data: [convInfo.outWidth]},
+    {type: 'int32', data: [convInfo.outChannels]}
+  ];
+
+  return backend.runWebGPUProgram(program, [dy, filter], dy.dtype, uniformData);
+}
+
+export const conv3DBackpropInputV2Config: KernelConfig = {
+  kernelName: Conv3DBackpropInputV2,
+  backendName: 'webgpu',
+  kernelFunc: conv3DBackpropInputV2 as unknown as KernelFunc,
+};

--- a/tfjs-backend-webgpu/src/register_all_kernels.ts
+++ b/tfjs-backend-webgpu/src/register_all_kernels.ts
@@ -47,6 +47,8 @@ import {conv2DConfig} from './kernels/Conv2D';
 import {conv2DBackpropFilterConfig} from './kernels/Conv2DBackpropFilter';
 import {conv2DBackpropInputConfig} from './kernels/Conv2DBackpropInput';
 import {conv3DConfig} from './kernels/Conv3D';
+import {conv3DBackpropFilterV2Config} from './kernels/Conv3DBackpropFilterV2';
+import {conv3DBackpropInputV2Config} from './kernels/Conv3DBackpropInputV2';
 import {cosConfig} from './kernels/Cos';
 import {coshConfig} from './kernels/Cosh';
 import {cropAndResizeConfig} from './kernels/CropAndResize';
@@ -201,6 +203,8 @@ const kernelConfigs: KernelConfig[] = [
   conv2DBackpropFilterConfig,
   conv2DBackpropInputConfig,
   conv3DConfig,
+  conv3DBackpropFilterV2Config,
+  conv3DBackpropInputV2Config,
   cosConfig,
   coshConfig,
   cropAndResizeConfig,

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -34,12 +34,6 @@ const TEST_FILTERS: TestFilter[] = [
     ]
   },
   {
-    startsWith: 'conv3d ',
-    excludes: [
-      'gradient',  // Not yet implemented.
-    ]
-  },
-  {
     startsWith: 'cumsum ',
     excludes: [
       'gradient',  // gradient function not found.
@@ -82,7 +76,6 @@ const TEST_FILTERS: TestFilter[] = [
     include: ' webgpu ',
     excludes: [
       'avgPool3dBackprop ',
-      'conv3dTranspose ',
       'raggedGather ',
       'raggedRange ',
       'raggedTensorToTensor ',


### PR DESCRIPTION
This patch supports Conv3DBackpropFilterV2
and Conv3DBackpropInputV2 kernels.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7434)
<!-- Reviewable:end -->
