### PR TITLE
webgpu: Switch back to old karma reporter

### DIFF
--- a/tfjs-backend-webgpu/karma.conf.js
+++ b/tfjs-backend-webgpu/karma.conf.js
@@ -18,17 +18,13 @@
 const karmaTypescriptConfig = {
   tsconfig: 'tsconfig.test.json',
   // Disable coverage reports and instrumentation by default for tests
-  coverageOptions: {
-    instrumentation: false
-  },
+  coverageOptions: {instrumentation: false},
   reports: {},
   bundlerOptions: {
     transforms: [require('karma-typescript-es6-transform')({
       presets: [
         // ensure we get es5 by adding IE 11 as a target
-        ['@babel/env', {
-          'targets': { 'ie': '11' }, 'loose': true
-        }]
+        ['@babel/env', {'targets': {'ie': '11'}, 'loose': true}]
       ]
     })],
     // worker_node_test in tfjs-core contains a conditional require statement
@@ -40,21 +36,15 @@ const karmaTypescriptConfig = {
 const devConfig = {
   frameworks: ['jasmine', 'karma-typescript'],
   files: [
-    {
-      pattern: './node_modules/@babel/polyfill/dist/polyfill.js'
-    },
+    {pattern: './node_modules/@babel/polyfill/dist/polyfill.js'},
     'src/setup_test.ts',
-    {
-      pattern: 'src/**/*.ts'
-    },
+    {pattern: 'src/**/*.ts'},
   ],
-  preprocessors: {
-    'src/**/*.ts': ['karma-typescript']
-  },
+  preprocessors: {'src/**/*.ts': ['karma-typescript']},
   karmaTypescriptConfig,
 };
 
-module.exports = function (config) {
+module.exports = function(config) {
   const args = [];
   if (config.grep) {
     args.push('--grep', config.grep);
@@ -69,7 +59,7 @@ module.exports = function (config) {
 
   config.set({
     ...devConfig,
-    reporters: ['kjhtml'],
+    reporters: ['dots', 'karma-typescript'],
     plugins: [
       require('karma-chrome-launcher'),
       require('karma-typescript'),
@@ -91,11 +81,6 @@ module.exports = function (config) {
         ],
       }
     },
-    client: {
-      jasmine: {
-        random: false
-      },
-      args: args
-    }
+    client: {jasmine: {random: false}, args: args}
   })
 }

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -119,7 +119,7 @@ if (typeof __karma__ !== 'undefined') {
 // tslint:disable-next-line:no-imports-from-dist
 // tslint:disable-next-line:no-require-imports
 require('@tensorflow/tfjs-core/dist/tests');
-// Import and run tests from webgl.
+// Import and run tests from webgpu.
 // tslint:disable-next-line:no-imports-from-dist
 // tslint:disable-next-line:no-require-imports
 require('./tests');


### PR DESCRIPTION
With karma-jasmine-html-report, we don't know how many cases are skipped. The result looks like below:
TOTAL: 37 SUCCESS

The old report provides more info as below:
Chrome 113.0.0.0 (Windows 10): Executed 37 of 4559 (skipped 4522) SUCCESS (1.045 secs / 0.395 secs)

This PR also fixes a comment typo in setup_test.ts

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7449)
<!-- Reviewable:end -->
