### PR TITLE
[e2e] Move tflite backend to worker thread

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -307,7 +307,7 @@ limitations under the License.
     const parameterTable = document.querySelector('#parameters tbody');
     const modelInputsTable = document.querySelector('#modelInputs tbody');
 
-    let model, predict, chartWidth;
+    let model, tfliteModel, worker, tfliteWorkerAPI, predict, chartWidth;
 
     async function showMsg(message) {
       if (message != null) {
@@ -442,7 +442,7 @@ limitations under the License.
       }
       let needInputShape = false;
       const modelInputsElement = document.getElementById('modelInputs');
-      const inputs = isTflite() ? await tfliteModel.getInputs() : model.inputs;
+      const inputs = isTflite() ? await tfliteModel.inputs : model.inputs;
       if (inputs == null) {
         modelInputsElement.style.display = 'none';
       } else {
@@ -549,7 +549,7 @@ limitations under the License.
         model = await benchmark.load(inputSize, state.architecture, state.inputType);
       }
       state.inputs = [];
-      const inputs = isTflite() ? await tfliteModel.getInputs() : model.inputs;
+      const inputs = isTflite() ? await tfliteModel.inputs : model.inputs;
       if (inputs) {
         // construct the input state for the model
         for (let modelInputIndex = 0; modelInputIndex < inputs.length; modelInputIndex++) {
@@ -1002,10 +1002,17 @@ limitations under the License.
     }
 
     async function loadTfliteModel(enableProfiling = false) {
+      if (!worker) {
+        worker = new Worker('./tflite_worker.js');
+        tfliteWorkerAPI = Comlink.wrap(worker);
+      }
+      if (tfliteModel) {
+        await tfliteModel.cleanUp();
+      }
       state.shouldReloadTfliteModel = false;
       const benchmark = benchmarks[state.benchmark];
 
-      await benchmark.loadTflite(enableProfiling, state.architecture);
+      tfliteModel = await benchmark.loadTflite(enableProfiling, state.architecture);
     }
 
     function updateModelsDropdown(newValues) {

--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -295,7 +295,8 @@ limitations under the License.
       flags: {},
       isFlagChanged: false,
       isModelLoaded: false,
-      inputs: {}
+      inputs: {},
+      shouldReloadTfliteModel: false
     };
 
     const modalDiv = document.getElementById('modal-msg');
@@ -306,7 +307,7 @@ limitations under the License.
     const parameterTable = document.querySelector('#parameters tbody');
     const modelInputsTable = document.querySelector('#modelInputs tbody');
 
-    let model, tfliteModel, predict, chartWidth;
+    let model, predict, chartWidth;
 
     async function showMsg(message) {
       if (message != null) {
@@ -420,7 +421,7 @@ limitations under the License.
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
           timeInfo = isTflite() ?
-              await timeInference(()=>predict(input), numWarmups) :
+              await timeInference(() => predict(undefined, input), numWarmups) :
               await timeModelInference(model, input, numWarmups);
         } finally {
           tf.dispose(input);
@@ -441,7 +442,7 @@ limitations under the License.
       }
       let needInputShape = false;
       const modelInputsElement = document.getElementById('modelInputs');
-      const inputs = isTflite() ? tfliteModel.inputs : model.inputs;
+      const inputs = isTflite() ? await tfliteModel.getInputs() : model.inputs;
       if (inputs == null) {
         modelInputsElement.style.display = 'none';
       } else {
@@ -479,7 +480,7 @@ limitations under the License.
               const maxInput = createRangeInput(state.inputs[inputIndex].range,
                 1);
               const seperator = document.createElement('span');
-              seperator.textContent = ' - '
+              seperator.textContent = ' - ';
               const div = document.createElement('div');
               div.appendChild(minInput);
               div.appendChild(seperator);
@@ -548,7 +549,7 @@ limitations under the License.
         model = await benchmark.load(inputSize, state.architecture, state.inputType);
       }
       state.inputs = [];
-      const inputs = isTflite() ? tfliteModel.inputs : model.inputs
+      const inputs = isTflite() ? await tfliteModel.getInputs() : model.inputs;
       if (inputs) {
         // construct the input state for the model
         for (let modelInputIndex = 0; modelInputIndex < inputs.length; modelInputIndex++) {
@@ -605,7 +606,7 @@ limitations under the License.
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
           timeInfo = isTflite() ?
-              await timeInference(()=>predict(input), numRuns) :
+              await timeInference(()=>predict(undefined, input), numRuns) :
               await timeModelInference(model, input, numRuns);
         } finally {
           tf.dispose(input);
@@ -638,8 +639,7 @@ limitations under the License.
         //
         // Without this, the model with profiling *enabled* will continued to be used to measure
         // the total run time when "Run benchmark" is clicked, which is not accurate.
-        state.isModelChanged = true;
-        state.isModelLoaded = false;
+        state.shouldReloadTfliteModel = true;
       }
 
       const start = performance.now();
@@ -649,7 +649,11 @@ limitations under the License.
       if (state.benchmark === 'custom') {
         const input = generateInputFromDef(state.inputs, model instanceof tf.GraphModel);
         try {
-          profileInfo = await profileModelInference(model, input, isTflite(), numProfiles);
+          if (isTflite()) {
+            profileInfo = await profileInference(() => predict(undefined, input), true, numProfiles);
+          } else {
+            profileInfo = await profileModelInference(model, input, numProfiles);
+          }
         } finally {
           tf.dispose(input);
         }
@@ -726,7 +730,8 @@ limitations under the License.
     }
 
     async function loadModel() {
-      if (state.isModelChanged || !state.isModelLoaded || state.isFlagChanged) {
+      if (state.isModelChanged || !state.isModelLoaded || state.isFlagChanged ||
+          (isTflite() && state.shouldReloadTfliteModel)) {
         await loadModelAndRecordTime();
         state.isModelLoaded = true;
         const needInputShape = await showInputs();
@@ -997,11 +1002,10 @@ limitations under the License.
     }
 
     async function loadTfliteModel(enableProfiling = false) {
-      if (tfliteModel) {
-        tfliteModel.modelRunner.cleanUp();
-      }
+      state.shouldReloadTfliteModel = false;
       const benchmark = benchmarks[state.benchmark];
-      tfliteModel = await benchmark.loadTflite(enableProfiling, state.architecture);
+
+      await benchmark.loadTflite(enableProfiling, state.architecture);
     }
 
     function updateModelsDropdown(newValues) {

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -213,7 +213,8 @@ async function initDefaultValueMap() {
 function getTunableRange(flag) {
   const defaultValue = TUNABLE_FLAG_DEFAULT_VALUE_MAP[flag];
   if (flag === 'WEBGL_FORCE_F16_TEXTURES' ||
-      flag === 'WEBGL_PACK_DEPTHWISECONV' || 'KEEP_INTERMEDIATE_TENSORS') {
+      flag === 'WEBGL_PACK_DEPTHWISECONV' ||
+      flag === 'KEEP_INTERMEDIATE_TENSORS') {
     return [false, true];
   } else if (flag === 'WEBGL_VERSION') {
     const tunableRange = [];

--- a/e2e/benchmarks/local-benchmark/loader.js
+++ b/e2e/benchmarks/local-benchmark/loader.js
@@ -61,9 +61,6 @@ async function loadTFJS(localBuild) {
     'https://cdn.jsdelivr.net/npm/@tensorflow-models/posenet@2',
     'https://cdn.jsdelivr.net/npm/@tensorflow-models/body-pix@2',
     'https://cdn.jsdelivr.net/npm/@tensorflow-models/pose-detection',
-    // Load tfjs-tflite from jsdelivr because it correctly sets the
-    // "cross-origin-resource-policy" header.
-    'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-tflite@latest/dist/tf-tflite.js',
     '../model_config.js',
     '../benchmark_util.js',
     './util.js',

--- a/e2e/benchmarks/local-benchmark/loader.js
+++ b/e2e/benchmarks/local-benchmark/loader.js
@@ -61,6 +61,7 @@ async function loadTFJS(localBuild) {
     'https://cdn.jsdelivr.net/npm/@tensorflow-models/posenet@2',
     'https://cdn.jsdelivr.net/npm/@tensorflow-models/body-pix@2',
     'https://cdn.jsdelivr.net/npm/@tensorflow-models/pose-detection',
+    'https://cdn.jsdelivr.net/npm/comlink@latest/dist/umd/comlink.js',
     '../model_config.js',
     '../benchmark_util.js',
     './util.js',

--- a/e2e/benchmarks/local-benchmark/tflite_worker.js
+++ b/e2e/benchmarks/local-benchmark/tflite_worker.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+importScripts("https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core/");
+importScripts("https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-cpu/");
+// Load tfjs-tflite from jsdelivr because it correctly sets the
+// "cross-origin-resource-policy" header.
+importScripts('https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-tflite/dist/tf-tflite.js');
+
+let tfliteModel, inputs;
+
+// Receive message from the main thread
+onmessage = async (message) => {
+  if (message) {
+    switch (message.data.actionType) {
+      case 'load':
+        if (tfliteModel) {
+          tfliteModel.modelRunner.cleanUp();
+        }
+        tflite.setWasmPath('https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-tflite/dist/');
+        let options = message.data.options;
+        // Load tflite model.
+        try {
+          tfliteModel = await tflite.loadTFLiteModel(message.data.url, options);
+          inputs = tfliteModel.inputs;
+          postMessage('OK');                
+        } catch(e) {
+          postMessage({ error: e.message });
+        }
+        break;
+      case 'getInputs':
+        postMessage(inputs);
+        break;
+      case 'getProfilingResults':
+        postMessage(tfliteModel.getProfilingResults());
+        break;
+      case 'predict':
+        const inputTensorArray = [];
+        let outputTensor;
+        try {
+          let inputData = message.data.inputData;
+          if (!inputData[0].length) {
+            // Single input, move it into an arrary
+            inputData = [inputData];
+          }
+          for (let i = 0; i< inputs.length; i++) {
+            const inputTensor = tf.tensor(
+                inputData[i], inputs[i].shape, inputs[i].dtype);
+            inputTensorArray.push(inputTensor);
+          }
+          outputTensor = tfliteModel.predict(inputTensorArray);
+          if (tfliteModel.outputs.length > 1) {
+            // Multiple outputs
+            let outputData = [];
+            for (let tensorName in outputTensor) {
+              outputData.push(outputTensor[tensorName].dataSync());
+            }
+          } else {
+            // Single output
+            const outputData = outputTensor.dataSync();
+          }
+          // We encourage user processing output data in worker thread
+          // rather than posting output data to main thread directly, as
+          // which would bring much overhead if the output size is huge.
+          // From this perspective, we don't post output data to main thread
+          // in this benchmark.
+          postMessage('OK');
+        } catch(e) {
+          postMessage({ error: e.message });
+        } finally {
+          // dispose input and output tensors
+          tf.dispose(inputTensorArray);
+          tf.dispose(outputTensor);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+};

--- a/e2e/benchmarks/local-benchmark/tflite_worker.js
+++ b/e2e/benchmarks/local-benchmark/tflite_worker.js
@@ -62,9 +62,9 @@ const tfliteWorkerAPI = {
         // dispose input and output tensors
         tf.dispose(inputTensorArray);
         tf.dispose(outputTensor);
-        // We encourage user processing output data in worker thread
+        // We encourage the user to process output data in the worker thread
         // rather than posting output data to main thread directly, as
-        // which would bring much overhead if the output size is huge.
+        // this would bring much overhead if the output size is huge.
         // From this perspective, we don't post output data to main thread
         // in this benchmark.
         return 'OK';

--- a/e2e/benchmarks/model_config.js
+++ b/e2e/benchmarks/model_config.js
@@ -91,7 +91,7 @@ const benchmarks = {
         enableProfiling = false, modelArchitecture = 'small_075') => {
       const url = `https://tfhub.dev/google/lite-model/imagenet/mobilenet_v3_${
           modelArchitecture}_224/classification/5/metadata/1`;
-      return tfliteWorkerAPI.loadTFLiteModel(url, {enableProfiling});
+      return await tfliteWorkerAPI.loadTFLiteModel(url, {enableProfiling});
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
@@ -135,7 +135,7 @@ const benchmarks = {
     loadTflite: async (enableProfiling = false) => {
       const url =
           'https://tfhub.dev/tensorflow/lite-model/mobilenet_v2_1.0_224/1/metadata/1';
-      return tfliteWorkerAPI.loadTFLiteModel(url, {enableProfiling});
+      return await tfliteWorkerAPI.loadTFLiteModel(url, {enableProfiling});
     },
     predictFunc: () => {
       const input = tf.randomNormal([1, 224, 224, 3]);
@@ -518,7 +518,7 @@ const benchmarks = {
       return loadModelByUrlWithState(state.modelUrl, {}, state);
     },
     loadTflite: async (enableProfiling = false) => {
-      return tfliteWorkerAPI.loadTFLiteModel(state.modelUrl, {enableProfiling});
+      return await tfliteWorkerAPI.loadTFLiteModel(state.modelUrl, {enableProfiling});
     },
     predictFunc: () => {
       return async (model, customInput) => {


### PR DESCRIPTION
This PR moves all operations of tflite backend to worker thread in order to make preparation for WebNN external delegate integration because the WebNN spec restricts its Sync API in the worker thread. Besides, this PR also fixes some minor issues.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7453)
<!-- Reviewable:end -->
