### PR TITLE
[WebGPU] support dilation2d grad kernels

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -779,9 +779,9 @@ export class WebGPUBackend extends KernelBackend {
       const uniformsType = 'int32';
       bufferShapes.map(d => {
         programUniform.push({type: uniformsType, data: d});
+        const strides = util.computeStrides(d);
+        programUniform.push({type: uniformsType, data: strides});
       });
-      const strides = util.computeStrides(output.shape);
-      programUniform.push({type: uniformsType, data: strides});
       if (program.size) {
         const size = util.sizeFromShape(program.outputShape);
         programUniform.push({

--- a/tfjs-backend-webgpu/src/dilation_backprop_webgpu.ts
+++ b/tfjs-backend-webgpu/src/dilation_backprop_webgpu.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, DataType} from '@tensorflow/tfjs-core';
+
+import {atomicAddSnippet} from './shader_util';
+import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
+import {computeDispatch, flatDispatchLayout} from './webgpu_util';
+
+export class Dilation2DBackpropInputProgram implements WebGPUProgram {
+  outputShape: number[];
+  shaderKey: string;
+  dispatchLayout: {x: number[]};
+  dispatch: [number, number, number];
+  variableNames = ['x', 'w', 'dy'];
+  uniforms =
+      'filterDims: vec2<i32>, pads: vec2<i32>, strides: vec2<i32>, dilations: vec2<i32>, outSize: i32,';
+  workgroupSize: [number, number, number] = [64, 1, 1];
+  atomic = true;
+  type: DataType;
+
+  constructor(convInfo: backend_util.Conv2DInfo, outputDtype: DataType) {
+    this.outputShape = convInfo.inShape;
+    this.dispatchLayout = flatDispatchLayout(convInfo.outShape);
+    this.dispatch = computeDispatch(
+        this.dispatchLayout, convInfo.outShape, this.workgroupSize);
+
+    if (outputDtype !== 'float32' && outputDtype !== 'int32') {
+      throw new Error(`Dilation2DBackpropInput only supports float32 and int32
+          types, does not support ${outputDtype} type.`);
+    }
+    this.type = outputDtype;
+    this.shaderKey = `dilation2DBackpropInput_${this.type}`;
+  }
+
+  getUserCode(): string {
+    // This implementation follows the TF c++ cuda implementation:
+    // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/dilation_ops_gpu.cu.cc
+    const userCode = `
+       ${main('index')} {
+         if (index < uniforms.outSize) {
+           let d = index % uniforms.dyShape[3];
+           let out_idx2 = index / uniforms.dyShape[3];
+           let w_out = out_idx2 % uniforms.dyShape[2];
+           let out_idx3 = out_idx2 / uniforms.dyShape[2];
+           let h_out = out_idx3 % uniforms.dyShape[1];
+           let batch = out_idx3 / uniforms.dyShape[1];
+
+           let h_beg = h_out * uniforms.strides[0] - uniforms.pads[0];
+           let w_beg = w_out * uniforms.strides[1] - uniforms.pads[1];
+
+           var curVal = -3.4e38;  // neg_infinity
+           var h_in_max = select(h_beg, 0, h_beg < 0);
+           var w_in_max = select(w_beg, 0, w_beg < 0);
+
+           // In the case of multiple argmax branches, we only back-propagate
+           // along the last branch, i.e., the one with largest value of
+           // 'h * filter_cols + w', similarly to the max-pooling backward
+           // routines.
+           for (var h = 0; h < uniforms.filterDims[0]; h++) {
+             let h_in = h_beg + h * uniforms.dilations[0];
+
+             if (h_in >= 0 && h_in < uniforms.xShape[1]) {
+               for (var w = 0; w < uniforms.filterDims[1]; w++) {
+                 let w_in = w_beg + w * uniforms.dilations[1];
+
+                 if (w_in >= 0 && w_in < uniforms.xShape[2]) {
+                   let val = getX(batch, h_in, w_in, d) + getW(h, w, d);
+                   if (val > curVal) {
+                     curVal = val;
+                     h_in_max = h_in;
+                     w_in_max = w_in;
+                   }
+                 }
+               }
+             }
+           }
+
+           let flatIndexIn = d + uniforms.xShape[3] *
+               (w_in_max + uniforms.xShape[2] * (h_in_max + uniforms.xShape[1] * batch));
+           let value = getDy(batch, h_out, w_out, d);
+           ${
+        atomicAddSnippet(
+            '&result[flatIndexIn]', 'value', this.type as 'float32' | 'int32')}
+         }
+       }
+     `;
+    return userCode;
+  }
+}
+
+export class Dilation2DBackpropFilterProgram implements WebGPUProgram {
+  outputShape: number[];
+  shaderKey: string;
+  dispatchLayout: {x: number[]};
+  dispatch: [number, number, number];
+  variableNames = ['x', 'w', 'dy'];
+  uniforms =
+      'filterDims: vec2<i32>, pads: vec2<i32>, strides: vec2<i32>, dilations: vec2<i32>, outSize: i32,';
+  workgroupSize: [number, number, number] = [64, 1, 1];
+  atomic = true;
+  type: DataType;
+
+  constructor(
+      convInfo: backend_util.Conv2DInfo, shape: number[],
+      outputDtype: DataType) {
+    this.outputShape = convInfo.filterShape;
+    this.dispatchLayout = flatDispatchLayout(convInfo.outShape);
+    this.dispatch = computeDispatch(
+        this.dispatchLayout, convInfo.outShape, this.workgroupSize);
+
+    if (outputDtype !== 'float32' && outputDtype !== 'int32') {
+      throw new Error(`Dilation2DBackpropFilter only supports float32 and int32
+          types, does not support ${outputDtype} type.`);
+    }
+    this.type = outputDtype;
+    this.shaderKey = `dilation2DBackpropFilter_${this.type}`;
+  }
+
+  getUserCode(): string {
+    // This implementation follows the TF c++ cuda implementation:
+    // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/dilation_ops_gpu.cu.cc
+    const userCode = `
+       ${main('index')} {
+         if (index < uniforms.outSize) {
+           let d = index % uniforms.dyShape[3];
+           let out_idx2 = index / uniforms.dyShape[3];
+           let w_out = out_idx2 % uniforms.dyShape[2];
+           let out_idx3 = out_idx2 / uniforms.dyShape[2];
+           let h_out = out_idx3 % uniforms.dyShape[1];
+           let batch = out_idx3 / uniforms.dyShape[1];
+
+           let h_beg = h_out * uniforms.strides[0] - uniforms.pads[0];
+           let w_beg = w_out * uniforms.strides[1] - uniforms.pads[1];
+
+           var curVal = -3.4e38;  // neg_infinity
+           var h_w_max = 0;
+           var w_w_max = 0;
+
+           // In the case of multiple argmax branches, we only back-propagate
+           // along the last branch, i.e., the one with largest value of
+           // 'h * filter_cols + w', similarly to the max-pooling backward
+           // routines.
+           for (var h = 0; h < uniforms.filterDims[0]; h++) {
+             let h_in = h_beg + h * uniforms.dilations[0];
+
+             if (h_in >= 0 && h_in < uniforms.xShape[1]) {
+               for (var w = 0; w < uniforms.filterDims[1]; w++) {
+                 let w_in = w_beg + w * uniforms.dilations[1];
+
+                 if (w_in >= 0 && w_in < uniforms.xShape[2]) {
+                   let val = getX(batch, h_in, w_in, d) + getW(h, w, d);
+                   if (val > curVal) {
+                     curVal = val;
+                     h_w_max = h;
+                     w_w_max = w;
+                   }
+                 }
+               }
+             }
+           }
+
+           let flatIndexIn = d + uniforms.wShape[2] * (w_w_max + h_w_max * uniforms.wShape[1]);
+           let value = getDy(batch, h_out, w_out, d);
+           ${
+        atomicAddSnippet(
+            '&result[flatIndexIn]', 'value', this.type as 'float32' | 'int32')}
+         }
+       }
+     `;
+    return userCode;
+  }
+}

--- a/tfjs-backend-webgpu/src/kernels/Dilation2DBackpropFilter.ts
+++ b/tfjs-backend-webgpu/src/kernels/Dilation2DBackpropFilter.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Dilation2DAttrs, Dilation2DBackpropFilter, Dilation2DBackpropFilterInputs, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {Dilation2DBackpropFilterProgram} from '../dilation_backprop_webgpu';
+import {fill} from './Fill';
+
+export function dilation2DBackpropFilter(args: {
+  inputs: Dilation2DBackpropFilterInputs,
+  attrs: Dilation2DAttrs,
+  backend: WebGPUBackend
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x, filter, dy} = inputs;
+  const {strides, pad, dilations} = attrs;
+
+  const convInfo = backend_util.computeDilation2DInfo(
+      x.shape as [number, number, number, number],
+      filter.shape as [number, number, number], strides, pad,
+      'NHWC' /* dataFormat */, dilations);
+
+  const dtype = filter.dtype;
+  const program =
+      new Dilation2DBackpropFilterProgram(convInfo, filter.shape, dtype);
+  const uniformData = [
+    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
+    {type: 'int32', data: [convInfo.padInfo.top, convInfo.padInfo.left]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]},
+    {type: 'int32', data: [util.sizeFromShape(convInfo.outShape)]}
+  ];
+  const output = fill({backend, attrs: {shape: filter.shape, value: 0, dtype}});
+  return backend.runWebGPUProgram(
+      program, [x, filter, dy], dtype, uniformData, output);
+}
+
+export const dilation2DBackpropFilterConfig: KernelConfig = {
+  kernelName: Dilation2DBackpropFilter,
+  backendName: 'webgpu',
+  kernelFunc: dilation2DBackpropFilter as unknown as KernelFunc
+};

--- a/tfjs-backend-webgpu/src/kernels/Dilation2DBackpropInput.ts
+++ b/tfjs-backend-webgpu/src/kernels/Dilation2DBackpropInput.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {backend_util, Dilation2DAttrs, Dilation2DBackpropInput, Dilation2DBackpropInputInputs, KernelConfig, KernelFunc, TensorInfo, util} from '@tensorflow/tfjs-core';
+
+import {WebGPUBackend} from '../backend_webgpu';
+import {Dilation2DBackpropInputProgram} from '../dilation_backprop_webgpu';
+import {fill} from './Fill';
+
+export function dilation2DBackpropInput(args: {
+  inputs: Dilation2DBackpropInputInputs,
+  attrs: Dilation2DAttrs,
+  backend: WebGPUBackend
+}): TensorInfo {
+  const {inputs, backend, attrs} = args;
+  const {x, filter, dy} = inputs;
+  const {strides, pad, dilations} = attrs;
+
+  const convInfo = backend_util.computeDilation2DInfo(
+      x.shape as [number, number, number, number],
+      filter.shape as [number, number, number], strides, pad,
+      'NHWC' /* dataFormat */, dilations);
+
+  const dtype = x.dtype;
+  const program = new Dilation2DBackpropInputProgram(convInfo, dtype);
+  const uniformData = [
+    {type: 'int32', data: [convInfo.filterHeight, convInfo.filterWidth]},
+    {type: 'int32', data: [convInfo.padInfo.top, convInfo.padInfo.left]},
+    {type: 'int32', data: [convInfo.strideHeight, convInfo.strideWidth]},
+    {type: 'int32', data: [convInfo.dilationHeight, convInfo.dilationWidth]},
+    {type: 'int32', data: [util.sizeFromShape(convInfo.outShape)]}
+  ];
+  const output =
+      fill({backend, attrs: {shape: convInfo.inShape, value: 0, dtype}});
+  return backend.runWebGPUProgram(
+      program, [x, filter, dy], dtype, uniformData, output);
+}
+
+export const dilation2DBackpropInputConfig: KernelConfig = {
+  kernelName: Dilation2DBackpropInput,
+  backendName: 'webgpu',
+  kernelFunc: dilation2DBackpropInput as unknown as KernelFunc
+};

--- a/tfjs-backend-webgpu/src/register_all_kernels.ts
+++ b/tfjs-backend-webgpu/src/register_all_kernels.ts
@@ -62,6 +62,8 @@ import {depthwiseConv2dNativeBackpropFilterConfig} from './kernels/DepthwiseConv
 import {depthwiseConv2dNativeBackpropInputConfig} from './kernels/DepthwiseConv2dNativeBackpropInput';
 import {diagConfig} from './kernels/Diag';
 import {dilation2DConfig} from './kernels/Dilation2D';
+import {dilation2DBackpropFilterConfig} from './kernels/Dilation2DBackpropFilter';
+import {dilation2DBackpropInputConfig} from './kernels/Dilation2DBackpropInput';
 import {einsumConfig} from './kernels/Einsum';
 import {eluConfig} from './kernels/Elu';
 import {eluGradConfig} from './kernels/EluGrad';
@@ -219,6 +221,8 @@ const kernelConfigs: KernelConfig[] = [
   depthwiseConv2dNativeConfig,
   diagConfig,
   dilation2DConfig,
+  dilation2DBackpropFilterConfig,
+  dilation2DBackpropInputConfig,
   einsumConfig,
   eluConfig,
   eluGradConfig,

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -40,12 +40,6 @@ const TEST_FILTERS: TestFilter[] = [
     ]
   },
   {
-    startsWith: 'dilation2d ',
-    excludes: [
-      'gradient'  // gradient function not found.
-    ]
-  },
-  {
     startsWith: 'exp ',
     excludes: [
       'int32',  // TODO: fix precision problem.
@@ -89,7 +83,6 @@ const TEST_FILTERS: TestFilter[] = [
       'tensorScatterUpdate ',
       'unique ',
       'unsortedSegmentSum ',
-      'valueAndGradients ',
     ]
   },
 ];


### PR DESCRIPTION
This patch supports Dilation2DBackpropInput and
Dilation2DBackpropFilter kernels.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7455)
<!-- Reviewable:end -->
