### PR TITLE
[tfjs-node] Encode jpeg

### DIFF
--- a/tfjs-node/binding/tfjs_backend.cc
+++ b/tfjs-node/binding/tfjs_backend.cc
@@ -1208,7 +1208,6 @@ napi_value TFJSBackend::RunSavedModel(napi_env env,
   return output_tensor_infos;
 }
 
-
 napi_value TFJSBackend::GetNumOfSavedModels(napi_env env) {
   napi_status nstatus;
   napi_value num_saved_models;

--- a/tfjs-node/binding/tfjs_backend.cc
+++ b/tfjs-node/binding/tfjs_backend.cc
@@ -804,6 +804,15 @@ void TFJSBackend::DeleteTensor(napi_env env, napi_value tensor_id_value) {
   tfe_handle_map_.erase(tensor_entry);
 }
 
+napi_value TFJSBackend::GetNumOfTensors(napi_env env) {
+  napi_status nstatus;
+  napi_value num_of_tensors;
+  nstatus =
+      napi_create_int32(env, tfe_handle_map_.size(), &num_of_tensors);
+  ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+  return num_of_tensors;
+}
+
 napi_value TFJSBackend::GetTensorData(napi_env env,
                                       napi_value tensor_id_value) {
   int32_t tensor_id;
@@ -1198,6 +1207,7 @@ napi_value TFJSBackend::RunSavedModel(napi_env env,
 
   return output_tensor_infos;
 }
+
 
 napi_value TFJSBackend::GetNumOfSavedModels(napi_env env) {
   napi_status nstatus;

--- a/tfjs-node/binding/tfjs_backend.h
+++ b/tfjs-node/binding/tfjs_backend.h
@@ -85,6 +85,9 @@ class TFJSBackend {
   // Get number of loaded SavedModel in the backend:
   napi_value GetNumOfSavedModels(napi_env env);
 
+  // Get number of tensor handles in the backend:
+  napi_value GetNumOfTensors(napi_env env);
+
  private:
   TFJSBackend(napi_env env);
 

--- a/tfjs-node/binding/tfjs_binding.cc
+++ b/tfjs-node/binding/tfjs_binding.cc
@@ -260,6 +260,13 @@ static napi_value RunSavedModel(napi_env env, napi_callback_info info) {
   return backend->RunSavedModel(env, args[0], args[1], args[2], args[3]);
 }
 
+static napi_value GetNumOfTensors(napi_env env, napi_callback_info info) {
+  TFJSBackend *const backend = GetTFJSBackend(env);
+  if (!backend) return nullptr;
+  // Delete SavedModel takes 0 param;
+  return backend->GetNumOfTensors(env);
+}
+
 static napi_value GetNumOfSavedModels(napi_env env, napi_callback_info info) {
   TFJSBackend *const backend = GetTFJSBackend(env);
   if (!backend) return nullptr;
@@ -314,6 +321,9 @@ static napi_value InitTFNodeJSBinding(napi_env env, napi_value exports) {
        napi_default, nullptr},
       {"getNumOfSavedModels", nullptr, GetNumOfSavedModels, nullptr, nullptr,
        nullptr, napi_default, nullptr},
+      {"getNumOfTensors", nullptr, GetNumOfTensors, nullptr, nullptr,
+       nullptr, napi_default, nullptr},
+
   };
   nstatus = napi_define_properties(env, exports, ARRAY_SIZE(exports_properties),
                                    exports_properties);

--- a/tfjs-node/src/image_test.ts
+++ b/tfjs-node/src/image_test.ts
@@ -266,14 +266,16 @@ describe('decode images', () => {
 });
 
 describe('encode images', () => {
-  it('encodeJpeg', async () => {
+  fit('encodeJpeg', async () => {
     const imageTensor = tf.tensor3d(
         new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]),
         [2, 2, 3]);
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors = tf.backend().getNumOfTFTensors();
     const jpegEncodedData = await tf.node.encodeJpeg(imageTensor);
     expect(memory().numTensors).toBe(beforeNumTensors);
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
+    expect(tf.backend().getNumOfTFTensors()).toBe(beforeNumTFTensors);
     imageTensor.dispose();
   });
 

--- a/tfjs-node/src/image_test.ts
+++ b/tfjs-node/src/image_test.ts
@@ -22,12 +22,15 @@ import {promisify} from 'util';
 
 import {getImageType, ImageType} from './image';
 import * as tf from './index';
+import {NodeJSKernelBackend} from './nodejs_kernel_backend';
 
 const readFile = promisify(fs.readFile);
 
 describe('decode images', () => {
   it('decode png', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/image_png_test.png');
     const imageTensor = tf.node.decodePng(uint8array);
@@ -38,10 +41,14 @@ describe('decode images', () => {
         await imageTensor.data(),
         [238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode png 1 channels', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/image_png_test.png');
     const imageTensor = tf.node.decodeImage(uint8array, 1);
@@ -49,10 +56,14 @@ describe('decode images', () => {
     expect(imageTensor.shape).toEqual([2, 2, 1]);
     test_util.expectArraysEqual(await imageTensor.data(), [130, 50, 59, 124]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode png 3 channels', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/image_png_test.png');
     const imageTensor = tf.node.decodeImage(uint8array);
@@ -62,10 +73,14 @@ describe('decode images', () => {
         await imageTensor.data(),
         [238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode png 4 channels', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array = await getUint8ArrayFromImage(
         'test_objects/images/image_png_4_channel_test.png');
     const imageTensor = tf.node.decodeImage(uint8array, 4);
@@ -75,10 +90,14 @@ describe('decode images', () => {
       238, 101, 0, 255, 50, 50, 50, 255, 100, 50, 0, 255, 200, 100, 50, 255
     ]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode bmp', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/image_bmp_test.bmp');
     const imageTensor = tf.node.decodeBmp(uint8array);
@@ -88,10 +107,14 @@ describe('decode images', () => {
         await imageTensor.data(),
         [238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode bmp through decodeImage', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/image_bmp_test.bmp');
     const imageTensor = tf.node.decodeImage(uint8array);
@@ -101,10 +124,15 @@ describe('decode images', () => {
         await imageTensor.data(),
         [238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode jpg', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
+
     const uint8array = await getUint8ArrayFromImage(
         'test_objects/images/image_jpeg_test.jpeg');
     const imageTensor = tf.node.decodeJpeg(uint8array);
@@ -114,6 +142,8 @@ describe('decode images', () => {
         await imageTensor.data(),
         [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode jpeg node bindings do not leak', async () => {
@@ -142,6 +172,9 @@ describe('decode images', () => {
 
   it('decode jpg 1 channel', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
+
     const uint8array = await getUint8ArrayFromImage(
         'test_objects/images/image_jpeg_test.jpeg');
     const imageTensor = tf.node.decodeImage(uint8array, 1);
@@ -149,10 +182,14 @@ describe('decode images', () => {
     expect(imageTensor.shape).toEqual([2, 2, 1]);
     test_util.expectArraysEqual(await imageTensor.data(), [130, 47, 56, 121]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode jpg 3 channels', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array = await getUint8ArrayFromImage(
         'test_objects/images/image_jpeg_test.jpeg');
     const imageTensor = tf.node.decodeImage(uint8array, 3);
@@ -162,12 +199,16 @@ describe('decode images', () => {
         await imageTensor.data(),
         [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode jpg with 0 channels, use the number of channels in the ' +
          'JPEG-encoded image',
      async () => {
        const beforeNumTensors = memory().numTensors;
+       const beforeNumTFTensors =
+           (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
        const uint8array = await getUint8ArrayFromImage(
            'test_objects/images/image_jpeg_test.jpeg');
        const imageTensor = tf.node.decodeImage(uint8array);
@@ -177,10 +218,14 @@ describe('decode images', () => {
            await imageTensor.data(),
            [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]);
        expect(memory().numTensors).toBe(beforeNumTensors + 1);
+       expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+           .toBe(beforeNumTFTensors + 1);
      });
 
   it('decode jpg with downscale', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array = await getUint8ArrayFromImage(
         'test_objects/images/image_jpeg_test.jpeg');
     const imageTensor = tf.node.decodeJpeg(uint8array, 0, 2);
@@ -188,10 +233,14 @@ describe('decode images', () => {
     expect(imageTensor.shape).toEqual([1, 1, 3]);
     test_util.expectArraysEqual(await imageTensor.data(), [147, 75, 25]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode gif', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/gif_test.gif');
     const imageTensor = tf.node.decodeImage(uint8array);
@@ -202,10 +251,15 @@ describe('decode images', () => {
       200, 100, 50, 34, 68, 102, 170, 0,  102, 255, 255, 255
     ]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('decode gif with no expandAnimation', async () => {
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
+
     const uint8array =
         await getUint8ArrayFromImage('test_objects/images/gif_test.gif');
     const imageTensor = tf.node.decodeImage(uint8array, 3, 'int32', false);
@@ -215,6 +269,8 @@ describe('decode images', () => {
         await imageTensor.data(),
         [238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]);
     expect(memory().numTensors).toBe(beforeNumTensors + 1);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors + 1);
   });
 
   it('throw error if request non int32 dtype', async done => {
@@ -266,25 +322,31 @@ describe('decode images', () => {
 });
 
 describe('encode images', () => {
-  fit('encodeJpeg', async () => {
+  it('encodeJpeg', async () => {
     const imageTensor = tf.tensor3d(
         new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]),
         [2, 2, 3]);
     const beforeNumTensors = memory().numTensors;
-    const beforeNumTFTensors = tf.backend().getNumOfTFTensors();
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const jpegEncodedData = await tf.node.encodeJpeg(imageTensor);
     expect(memory().numTensors).toBe(beforeNumTensors);
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
-    expect(tf.backend().getNumOfTFTensors()).toBe(beforeNumTFTensors);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors);
     imageTensor.dispose();
   });
 
   it('encodeJpeg grayscale', async () => {
     const imageTensor = tf.tensor3d(new Uint8Array([239, 0, 47, 0]), [2, 2, 1]);
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const jpegEncodedData = await tf.node.encodeJpeg(imageTensor, 'grayscale');
     expect(memory().numTensors).toBe(beforeNumTensors);
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors);
     imageTensor.dispose();
   });
 
@@ -302,10 +364,14 @@ describe('encode images', () => {
     const yDensity = 500;
 
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const jpegEncodedData = await tf.node.encodeJpeg(
         imageTensor, format, quality, progressive, optimizeSize,
         chromaDownsampling, densityUnit, xDensity, yDensity);
     expect(memory().numTensors).toBe(beforeNumTensors);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors);
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
     imageTensor.dispose();
   });
@@ -315,11 +381,15 @@ describe('encode images', () => {
         new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]),
         [2, 2, 3]);
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const pngEncodedData = await tf.node.encodePng(imageTensor);
     const pngDecodedTensor = await tf.node.decodePng(pngEncodedData);
     const pngDecodedData = await pngDecodedTensor.data();
     pngDecodedTensor.dispose();
     expect(memory().numTensors).toBe(beforeNumTensors);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors);
     expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
     test_util.expectArraysEqual(await imageTensor.data(), pngDecodedData);
     imageTensor.dispose();
@@ -328,8 +398,12 @@ describe('encode images', () => {
   it('encodePng grayscale', async () => {
     const imageTensor = tf.tensor3d(new Uint8Array([239, 0, 47, 0]), [2, 2, 1]);
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const pngEncodedData = await tf.node.encodePng(imageTensor);
     expect(memory().numTensors).toBe(beforeNumTensors);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors);
     expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
     imageTensor.dispose();
   });
@@ -341,8 +415,12 @@ describe('encode images', () => {
     const compression = 4;
 
     const beforeNumTensors = memory().numTensors;
+    const beforeNumTFTensors =
+        (tf.backend() as NodeJSKernelBackend).getNumOfTFTensors();
     const pngEncodedData = await tf.node.encodePng(imageTensor, compression);
     expect(memory().numTensors).toBe(beforeNumTensors);
+    expect((tf.backend() as NodeJSKernelBackend).getNumOfTFTensors())
+        .toBe(beforeNumTFTensors);
     expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
     imageTensor.dispose();
   });

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -120,8 +120,8 @@ export class NodeJSKernelBackend extends KernelBackend {
     // We can then change the return type from Tensor to TensorInfo.
     // return {dataId: newId, shape: metadata.shape, dtype};
 
-    const tensorInfo: TensorInfo = {
-      dataId: newId, shape: metadata.shape, dtype};
+    const tensorInfo:
+        TensorInfo = {dataId: newId, shape: metadata.shape, dtype};
     return tf.engine().makeTensorFromTensorInfo(tensorInfo);
   }
 
@@ -393,6 +393,7 @@ export class NodeJSKernelBackend extends KernelBackend {
         this.binding.createTensor(imageShape, this.binding.TF_UINT8, imageData);
     const outputMetadata =
         this.binding.executeOp(name, opAttrs, [inputTensorId], 1);
+    this.binding.deleteTensor(inputTensorId);
     const outputTensorInfo = outputMetadata[0];
     // prevent the tensor data from being converted to a UTF8 string, since
     // the encoded data is not valid UTF8

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -680,6 +680,10 @@ export class NodeJSKernelBackend extends KernelBackend {
   getNumOfSavedModels() {
     return this.binding.getNumOfSavedModels();
   }
+
+  getNumOfTFTensors() {
+    return this.binding.getNumOfTensors();
+  }
 }
 
 /** Returns an instance of the Node.js backend. */

--- a/tfjs-node/src/tfjs_binding.ts
+++ b/tfjs-node/src/tfjs_binding.ts
@@ -61,7 +61,7 @@ export interface TFJSBinding {
       outputOpNames: string): TensorMetadata[];
 
   getNumOfSavedModels(): number;
-
+  getNumOfTensors(): number;
   isUsingGpuDevice(): boolean;
 
   // TF Types


### PR DESCRIPTION
fixed https://github.com/tensorflow/tfjs/issues/7459
ensure TF tensors are disposed after encode image op is called.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7484)
<!-- Reviewable:end -->
