### PR TITLE
[tfjs-node] fixed summary writer memory leak 

### DIFF
--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -542,9 +542,10 @@ export class NodeJSKernelBackend extends KernelBackend {
       }
       const opAttrs: TFEOpAttr[] =
           [{name: 'T', type: this.binding.TF_ATTR_TYPE, value: typeAttr}];
-
-      this.binding.executeOp(
-          'WriteScalarSummary', opAttrs, this.getInputTensorIds(inputArgs), 0);
+      const ids = this.getInputTensorIds(inputArgs);
+      this.binding.executeOp('WriteScalarSummary', opAttrs, ids, 0);
+      // release the tensorflow tensor for Int64Scalar value of step
+      this.binding.deleteTensor(ids[1]);
     });
   }
 
@@ -594,8 +595,10 @@ export class NodeJSKernelBackend extends KernelBackend {
       const typeAttr = this.typeAttributeFromTensor(buckets);
       const opAttrs: TFEOpAttr[] =
           [{name: 'T', type: this.binding.TF_ATTR_TYPE, value: typeAttr}];
-      this.binding.executeOp(
-          'WriteSummary', opAttrs, this.getInputTensorIds(inputArgs), 0);
+      const ids = this.getInputTensorIds(inputArgs);
+      this.binding.executeOp('WriteSummary', opAttrs, ids, 0);
+      // release the tensorflow tensor for Int64Scalar value of step
+      this.binding.deleteTensor(ids[1]);
     });
   }
 

--- a/tfjs-node/src/tensorboard_test.ts
+++ b/tfjs-node/src/tensorboard_test.ts
@@ -90,6 +90,16 @@ describe('tensorboard', () => {
       expect(fileNames.length).toEqual(1);
     });
 
+    it('Writing tf.Scalar no memory leak', () => {
+      const writer = tfn.node.summaryFileWriter(tmpLogDir);
+      const beforeNumTFTensors = writer.backend.getNumOfTFTensors();
+      const value = scalar(42);
+      writer.scalar('foo', value, 0);
+      writer.flush();
+      value.dispose();
+      expect(writer.backend.getNumOfTFTensors()).toBe(beforeNumTFTensors);
+    });
+
     it('No crosstalk between two summary writers', () => {
       const logDir1 = path.join(tmpLogDir, '1');
       const writer1 = tfn.node.summaryFileWriter(logDir1);
@@ -180,6 +190,15 @@ describe('tensorboard', () => {
       expect(fileSize2 - fileSize1).toEqual(2 * incrementPerScalar);
     });
 
+    it('summaryFileWriter no memory leak', () => {
+      const writer = tfn.node.summaryFileWriter(tmpLogDir);
+      const beforeNumTFTensors = writer.backend.getNumOfTFTensors();
+      const value = tensor1d([1, 2, 3, 4, 5], 'int32');
+      writer.histogram('foo', value, 0, 5);
+      writer.flush();
+      value.dispose();
+      expect(writer.backend.getNumOfTFTensors()).toBe(beforeNumTFTensors);
+    });
     it('Can create multiple normal distribution', () => {
       const writer = tfn.node.summaryFileWriter(tmpLogDir);
       tf.tidy(() => {


### PR DESCRIPTION
This is due to the step Int64Scalar interna tensor not deleted after use.
fixed https://github.com/tensorflow/tfjs/issues/7432

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.