### PR TITLE
Use verdaccio on 127.0.0.1 instead of localhost to avoid ipv6

### DIFF
--- a/e2e/scripts/verdaccio.yaml
+++ b/e2e/scripts/verdaccio.yaml
@@ -33,3 +33,6 @@ packages:
 # Log settings.
 logs:
   - {type: stdout, format: pretty, level: http}
+
+listen:
+  - 127.0.0.1:4873

--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -32,7 +32,7 @@ import * as child_process from 'child_process';
 import {BAZEL_PACKAGES} from './bazel_packages';
 
 const TMP_DIR = '/tmp/tfjs-publish';
-const VERDACCIO_REGISTRY = 'http://localhost:4873';
+const VERDACCIO_REGISTRY = 'http://127.0.0.1:4873';
 const NPM_REGISTRY = 'https://registry.npmjs.org/';
 
 // This script can not publish the tfjs website


### PR DESCRIPTION
Fix an intermittent bug in the npm publishing script that causes the script to depend on the network configuration of the host. I think what's happening is that when ipv6 is available, sometimes Verdaccio binds [::1]:5783 instead of 127.0.0.1:5783, but npm tries to publish to 127.0.0.1:5783. Explicitly specifying the loopback address 127.0.0.1 fixes this.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7491)
<!-- Reviewable:end -->
