### PR TITLE
Fix latest npm package version retrieval in scripts

### DIFF
--- a/scripts/release-tfjs.ts
+++ b/scripts/release-tfjs.ts
@@ -25,6 +25,7 @@
 
 import * as argparse from 'argparse';
 import chalk from 'chalk';
+import semver from 'semver';
 import * as fs from 'fs';
 import * as shell from 'shelljs';
 import {TMP_DIR, $, question, makeReleaseDir, createPR, TFJS_RELEASE_UNIT, updateTFJSDependencyVersions, ALPHA_RELEASE_UNIT, getMinorUpdateVersion, getPatchUpdateVersion, E2E_PHASE, getReleaseBlockers, getNightlyVersion} from './release-util';
@@ -57,8 +58,8 @@ parser.addArgument(['--commit-hash', '--hash'], {
 
 parser.addArgument(['--use-local-changes'], {
   action: 'storeTrue',
-  help: 'Use local changes to the repo instead of a remote branch. Only for'
-      + ' testing and debugging.',
+  help: 'Use local changes to the repo instead of a remote branch. Only for' +
+      ' testing and debugging.',
 });
 
 parser.addArgument('--force', {
@@ -66,15 +67,17 @@ parser.addArgument('--force', {
   help: 'Force a release even if there are release blockers.',
 });
 
-async function getNewVersion(packageName: string,
-                             incrementVersion: (version: string) => string,
-                             ask = true) {
-
-  let newVersion: string | undefined;
+async function getNewVersion(
+    packageName: string, incrementVersion: (version: string) => string,
+    ask = true) {
+  let newVersion: string|undefined;
   try {
-    const latestVersion =
-      $(`npm view @tensorflow/${packageName} dist-tags.latest`);
-    newVersion = incrementVersion(latestVersion);
+    const versions: string[] =
+        JSON.parse($(`npm view @tensorflow/${packageName} versions --json`));
+    if (Array.isArray(versions) && versions.length !== 0) {
+      const latestVersion = semver.rsort(versions)[0];
+      newVersion = incrementVersion(latestVersion);
+    }
   } catch (e) {
     // Suppress errors when guessing the version.
   }
@@ -83,34 +86,36 @@ async function getNewVersion(packageName: string,
     if (!ask) {
       return newVersion;
     }
-    newVersion = await question(
-      `New version for ${packageName} (leave empty for ${newVersion}): `)
-      || newVersion;
+    newVersion = await question(`New version for ${
+                     packageName} (leave empty for ${newVersion}): `) ||
+        newVersion;
     return newVersion;
   }
 
   if (!ask) {
-    console.warn('Guessing version 0.0.1 for unpublished package '
-      + `${packageName}`);
+    console.warn(
+        'Guessing version 0.0.1 for unpublished package ' +
+        `${packageName}`);
     return '0.0.1';
   }
 
   // Repeat until the user answers.
   while (true) {
     newVersion = await question(
-      `New Version for ${packageName} (no current version found on npm): `);
+        `New Version for ${packageName} (no current version found on npm): `);
     if (newVersion !== '') {
       return newVersion;
     }
-    console.log(`${packageName} has no version on npm. `
-      + 'Please provide an initial version.');
+    console.log(
+        `${packageName} has no version on npm. ` +
+        'Please provide an initial version.');
   }
 }
 
 async function main() {
   const args = parser.parseArgs();
 
-  let incrementVersion: ((version: string) => string) | undefined;
+  let incrementVersion: ((version: string) => string)|undefined;
   if (args.guess_version === 'nightly') {
     incrementVersion = v => getNightlyVersion(getMinorUpdateVersion(v));
   }
@@ -161,7 +166,7 @@ async function main() {
     if (!commit) {
       commit = await question(
           'Commit of release candidate (the last ' +
-            'successful nightly build): ');
+          'successful nightly build): ');
     }
     if (commit === '') {
       console.log(chalk.red('Commit cannot be empty.'));
@@ -177,8 +182,8 @@ async function main() {
   if (args.use_local_changes) {
     shell.cd(path.join(__dirname, '../'));
     console.log(chalk.magenta.bold(
-        '~~~ Copying current changes to a new release branch'
-         + ` ${releaseBranch} ~~~`));
+        '~~~ Copying current changes to a new release branch' +
+        ` ${releaseBranch} ~~~`));
     // Avoid copying `.git/` because this script will `git push`
     // to origin, which it expects to be the tfjs repo as was set
     // up when the script ran 'git clone' above.
@@ -196,9 +201,8 @@ async function main() {
   }
 
   // Update versions in package.json files.
-  const phases = [
-    ...TFJS_RELEASE_UNIT.phases, ...ALPHA_RELEASE_UNIT.phases, E2E_PHASE
-  ];
+  const phases =
+      [...TFJS_RELEASE_UNIT.phases, ...ALPHA_RELEASE_UNIT.phases, E2E_PHASE];
   for (const phase of phases) {
     for (const packageName of phase.packages) {
       shell.cd(packageName);
@@ -211,7 +215,7 @@ async function main() {
       console.log(chalk.magenta.bold(`~~~ Processing ${packageName} ~~~`));
       const newVersion = versions.get(packageName);
       pkg = `${pkg}`.replace(
-        `"version": "${parsedPkg.version}"`, `"version": "${newVersion}"`);
+          `"version": "${parsedPkg.version}"`, `"version": "${newVersion}"`);
       pkg = updateTFJSDependencyVersions(pkg, versions, phase.deps || []);
 
       fs.writeFileSync(packageJsonPath, pkg);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -98,8 +98,10 @@ async function main() {
 
   if (phaseInt !== 0) {
     // Phase0 should be published and release branch should have been created.
-    const firstPackageLatestVersion =
-        $(`npm view @tensorflow/${phases[0].packages[0]} dist-tags.latest`);
+    const firstPackageVersions: string[] = JSON.parse(
+        $(`npm view @tensorflow/${phases[0].packages[0]} versions --json`));
+    const firstPackageLatestVersion = semver.rsort(firstPackageVersions)[0];
+
     releaseBranch = `${name}_${firstPackageLatestVersion}`;
 
     $(`git clone -b ${releaseBranch} ${urlBase}tensorflow/tfjs ${

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -28,6 +28,7 @@
 
 import * as argparse from 'argparse';
 import chalk from 'chalk';
+import semver from 'semver';
 import * as fs from 'fs';
 import * as shell from 'shelljs';
 import {RELEASE_UNITS, WEBSITE_RELEASE_UNIT, TMP_DIR, $, question, printReleaseUnit, printPhase, makeReleaseDir, updateDependency, prepareReleaseBuild, createPR, getPatchUpdateVersion, ALPHA_RELEASE_UNIT} from './release-util';
@@ -120,8 +121,9 @@ async function main() {
     const packageJsonPath = `${dir}/${packageName}/package.json`;
     let pkg = `${fs.readFileSync(packageJsonPath)}`;
     const parsedPkg = JSON.parse(`${pkg}`);
-    const latestVersion =
-        $(`npm view @tensorflow/${packageName} dist-tags.latest`);
+    const packageVersions: string[] =
+        JSON.parse($(`npm view @tensorflow/${packageName} versions --json`));
+    const latestVersion = semver.rsort(packageVersions)[0];
 
     console.log(chalk.magenta.bold(
         `~~~ Processing ${packageName} (${latestVersion}) ~~~`));


### PR DESCRIPTION
This PR is for fixing the nightly tests.
Since our scripts use command `npm view <pkg> dist-tags.latest` to get the latest version in npm, they can only get the version with the "latest" tag instead of the one with the largest version number. It leads to some problems since our latest version (4.3.0) is deprecated and the "latest" tag is associated to an older version (4.2.0). This PR fix the latest version retrieval to get the global maximum version number instead of one with latest tag.

This PR is not verified with all release/ci scripts. I/we will send separate PRs if we have other problems with versioning when running the release/ci.

Nightly passed: https://pantheon.corp.google.com/cloud-build/builds;region=global/c27e24d2-ca5d-46d2-9f0c-875f66a2a5cb?project=learnjs-174218

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7511)
<!-- Reviewable:end -->
