### PR TITLE
webgpu: Make staging buffer disposable and create buffer with mapping when needed

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -508,10 +508,7 @@ export class WebGPUBackend extends KernelBackend {
     }
 
     const size = (resourceInfo as BufferInfo).size;
-    const buffer = this.bufferManager.acquireBuffer(
-        size,
-        GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC |
-            GPUBufferUsage.COPY_DST);
+    const buffer = this.bufferManager.acquireBuffer(size, resourceInfo.usage);
     this.ensureCommandEncoderReady();
     this.ensureComputePassEnded();
     this.currentCommandEncoder.copyBufferToBuffer(
@@ -523,7 +520,8 @@ export class WebGPUBackend extends KernelBackend {
     const tensorRef = engine().makeTensorFromTensorInfo(tensorInfo);
 
     const tensorData = this.tensorMap.get(tensorInfo.dataId);
-    tensorData.resourceInfo = {size, usage: buffer.usage, buffer};
+    tensorData
+        .resourceInfo = {size, usage: this.defaultGpuBufferUsage(), buffer};
 
     return {tensorRef, buffer, bufSize: size};
   }

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -137,7 +137,7 @@ describeWebGPU('backend webgpu', () => {
     const usedBuffersAfterFirstMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul)
         .toEqual(1);  // from released uniform
-    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(3);
+    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(2);
 
     const a2 = tf.tensor2d([2, 4, 6, 8], [2, 2]);
     const b2 = tf.tensor2d([0.5, 0.5, 0.5, 0.5], [2, 2]);
@@ -147,14 +147,14 @@ describeWebGPU('backend webgpu', () => {
     const usedBuffersAfterSecondMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul)
         .toEqual(0);  // released a uniform buffer and reused a buffer
-    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(5);
+    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(3);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     tf.matMul(c2, f2);
     const freeBuffersAfterSecondMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMatMul - freeBuffersAfterSecondMul).toEqual(0);
-    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(3);
+    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(2);
     tf.env().set('WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE', savedFlag);
   });
 
@@ -177,7 +177,7 @@ describeWebGPU('backend webgpu', () => {
     const freeBuffersAfterFirstMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterFirstMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterFirstMatMul - freeBuffersAfterFirstMul).toEqual(0);
-    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(4);
+    expect(usedBuffersAfterFirstMatMul - usedBuffersAfterFirstMul).toEqual(3);
 
     const a2 = tf.tensor2d([2, 4, 6, 8], [2, 2]);
     const b2 = tf.tensor2d([0.5, 0.5, 0.5, 0.5], [2, 2]);
@@ -186,14 +186,14 @@ describeWebGPU('backend webgpu', () => {
     const freeBuffersAfterSecondMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMul - freeBuffersAfterFirstMatMul).toEqual(0);
-    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(6);
+    expect(usedBuffersAfterSecondMul - usedBuffersAfterFirstMatMul).toEqual(4);
 
     const f2 = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const c3 = tf.matMul(c2, f2);
     const freeBuffersAfterSecondMatMul = bufferManager.getNumFreeBuffers();
     const usedBuffersAfterSecondMatMul = bufferManager.getNumUsedBuffers();
     expect(freeBuffersAfterSecondMatMul - freeBuffersAfterSecondMul).toEqual(0);
-    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(4);
+    expect(usedBuffersAfterSecondMatMul - usedBuffersAfterSecondMul).toEqual(3);
 
     // Tests happen within a tidy so we need to read a tensor at the end of a
     // test in delayed mode in order to force flush the disposal queue.
@@ -241,9 +241,7 @@ describeWebGPU('backendWebGPU', () => {
     expect(bufferManager.getNumUsedBuffers()).toBe(0);
 
     backend.uploadToGPU(t.dataId);
-    expect(bufferManager.getNumUsedBuffers())
-        .toBe(
-            2);  // One is the storage buffer, the other is the staging buffer.
+    expect(bufferManager.getNumUsedBuffers()).toBe(1);
   });
 });
 

--- a/tfjs-backend-webgpu/src/buffer_manager.ts
+++ b/tfjs-backend-webgpu/src/buffer_manager.ts
@@ -26,10 +26,6 @@ export class BufferManager {
 
   constructor(private device: GPUDevice) {}
 
-  acquireUploadBuffer(size: number, usage: GPUBufferUsageFlags) {
-    return this.acquireBuffer(size, usage, true);
-  }
-
   acquireBuffer(
       size: number, usage: GPUBufferUsageFlags, mappedAtCreation = false) {
     const key = getBufferKey(size, usage);
@@ -44,7 +40,7 @@ export class BufferManager {
     this.numBytesUsed += size;
     this.numUsedBuffers++;
 
-    if (this.freeBuffers.get(key).length > 0) {
+    if (!mappedAtCreation && this.freeBuffers.get(key).length > 0) {
       this.numFreeBuffers--;
 
       const newBuffer = this.freeBuffers.get(key).shift();
@@ -82,18 +78,6 @@ export class BufferManager {
     }
     bufferList.splice(bufferIndex, 1);
     this.numBytesUsed -= size;
-  }
-
-  releaseUploadBuffer(
-      buffer: GPUBuffer, size: number, usage: GPUBufferUsageFlags) {
-    buffer.mapAsync(GPUMapMode.WRITE)
-        .then(
-            () => {
-              this.releaseBuffer(buffer, size, usage);
-            },
-            (err) => {
-                // Do nothing;
-            });
   }
 
   getNumUsedBuffers(): number {

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -82,9 +82,3 @@ ENV.registerFlag('WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL', () => 0);
  * Whether we will run im2col as a separate shader for convolution.
  */
 ENV.registerFlag('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', () => false);
-
-/**
- * When running a very large model, disable buffer mappedAtCreation can save
- * memory.
- */
-ENV.registerFlag('WEBGPU_DISABLE_BUFFER_MAPPED_AT_CREATION', () => false);

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -82,3 +82,9 @@ ENV.registerFlag('WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL', () => 0);
  * Whether we will run im2col as a separate shader for convolution.
  */
 ENV.registerFlag('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', () => false);
+
+/**
+ * When running a very large model, disable buffer mappedAtCreation can save
+ * memory.
+ */
+ENV.registerFlag('WEBGPU_DISABLE_BUFFER_MAPPED_AT_CREATION', () => false);


### PR DESCRIPTION
To improve the perf of uploading data, we introduced the staging buffer, which is created with mapped. To reuse the allocated staging buffers, we always keep the buffer mapped, which occupies a lot of cpu memory for a large model. That results webgpu context lost when cpu is exhausted.

In fact, we can't efficiently reuse the staging buffer since it's in an asyn method `mapAsync`. Considering this, this PR makes the staging buffer disposable. Meanwhile,  try to create the storage buffer with mapped directly if there are data needed to be uploaded. Once the uploading is done, unmap it immediately. This change resolves too many cpu memories used issue and still keeps the efficient way to upload data.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7524)
<!-- Reviewable:end -->
