### PR TITLE
[e2e] Ignore golden tests in some nightly tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,28 +5,34 @@ This package contains integration and e2e tests for TensorFlow.js.
 ## To run the tests in local:
 
 ### Filter tests by tag:
+
 ```js
-export TAGS=#SMOKE,#REGRESSION
+export TAGS=#SMOKE,#REGRESSION,#GOLDEN
 yarn test
 ```
 
 ### Filter tests by grep:
+
 ```js
 yarn test --grep cpu
 ```
 
 ## Add new tests:
+
 When creating new test, add at least one tag to the test description.
 
 Supported tags:
-- # SMOKE:
-    Smoke tests should be light weight. Run in every PR and nightly
-    builds. Criteria for smoke test is that the test should run fast and only
-    test critical CUJ.
 
-- # REGRESSION:
-    Regression tests compare results across backends, previous
-    builds, with other platform, etc. Run in nightly builds. Need additional
-    steps to run in local.
+- **SMOKE**:
+  Smoke tests should be light weight. Run in every PR and nightly
+  builds. Criteria for smoke test is that the test should run fast and only
+  test critical CUJ.
+- **REGRESSION**:
+  Regression tests compare results across backends, previous
+  builds, with other platform, etc. Run in nightly builds. Need additional
+  steps to run in local.
+- **GOLDEN**:
+  Golden tests validate pretrained model outputs against the prebuilt golden
+  outputs. Need additional steps to run in local.
 
 To add a new tag: Extend the TAGS list in integration_tests/util

--- a/e2e/integration_tests/constants.ts
+++ b/e2e/integration_tests/constants.ts
@@ -19,9 +19,12 @@
 export const SMOKE = '#SMOKE';
 /** Regression tests run in nightly builds. */
 export const REGRESSION = '#REGRESSION';
+// TODO: Make golden tests part of regression tests.
+/** Golden regression tests */
+export const GOLDEN = '#GOLDEN';
 
 /** Testing tags. */
-export const TAGS = [SMOKE, REGRESSION];
+export const TAGS = [SMOKE, REGRESSION, GOLDEN];
 
 /** Testing backends. */
 export const BACKENDS = ['cpu', 'webgl'];

--- a/e2e/integration_tests/graph_model_golden_tests.ts
+++ b/e2e/integration_tests/graph_model_golden_tests.ts
@@ -22,7 +22,7 @@ import * as tfc from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
 import {ALL_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
-import {KARMA_SERVER, REGRESSION} from './constants';
+import {GOLDEN, KARMA_SERVER} from './constants';
 import * as GOLDEN_MODEL_DATA_FILENAMES from './graph_model_golden_data/filenames.json';
 import {GraphModeGoldenData, TensorDetail} from './types';
 
@@ -32,7 +32,7 @@ const DATA_URL = 'graph_model_golden_data';
 const INTERMEDIATE_NODE_TESTS_NUM = 5;
 
 
-describeWithFlags(`${REGRESSION} graph_model_golden`, ALL_ENVS, () => {
+describeWithFlags(`${GOLDEN} graph_model_golden`, ALL_ENVS, () => {
   let originalTimeout: number;
 
   beforeAll(() => {
@@ -84,8 +84,9 @@ describeWithFlags(`${REGRESSION} graph_model_golden`, ALL_ENVS, () => {
              const goldens = targetNodeNames.map((name) => {
                const details = modelGolden.intermediateDetails[name];
                if (details == null) {
-                 throw new Error(`Golden file is missing tensor details for ` +
-                   `${name}`);
+                 throw new Error(
+                     `Golden file is missing tensor details for ` +
+                     `${name}`);
                }
                return details;
              });

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -18,6 +18,7 @@ set -e
 
 # Smoke and regression tests run in PR and nightly builds.
 TAGS="#SMOKE,#REGRESSION"
+TAGS_WITH_GOLDEN+=",#GOLDEN"
 
 # Generate canonical layers models and inputs.
 ./scripts/create_save_predict.sh
@@ -49,18 +50,19 @@ yarn
 yarn build
 cd ..
 
-node ../scripts/run_flaky.js "yarn run-browserstack --browsers=win_10_chrome --tags '$TAGS'"
+node ../scripts/run_flaky.js "yarn run-browserstack --browsers=win_10_chrome --tags '$TAGS_WITH_GOLDEN'"
 
 # Test script tag bundles
 node ../scripts/run_flaky.js "karma start ./script_tag_tests/tfjs/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js"
 
 # Additional tests to run in nightly only.
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
+  #TODO: Run golden tests on all devices.
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_ios_12 --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
 
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac --tags '$TAGS'"
-  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS_WITH_GOLDEN'"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_android_10 --tags '$TAGS'"
 
   # Test script tag bundles

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -18,7 +18,7 @@ set -e
 
 # Smoke and regression tests run in PR and nightly builds.
 TAGS="#SMOKE,#REGRESSION"
-TAGS_WITH_GOLDEN+=",#GOLDEN"
+TAGS_WITH_GOLDEN="$TAGS,#GOLDEN"
 
 # Generate canonical layers models and inputs.
 ./scripts/create_save_predict.sh

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -46,7 +46,7 @@ cd ..
 
 # Test webpack
 COMMANDS+=("cd webpack_test && yarn && yarn build && cd ..")
-COMMANDS+=("yarn run-browserstack --browsers=win_10_chrome --tags '$TAGS'")
+COMMANDS+=("yarn run-browserstack --browsers=win_10_chrome --tags '$TAGS_WITH_GOLDEN'")
 
 # Test script tag bundles
 COMMANDS+=("karma start ./script_tag_tests/tfjs/karma.conf.js --browserstack --browsers=bs_chrome_mac --testBundle tf.min.js")
@@ -55,7 +55,7 @@ COMMANDS+=("karma start ./script_tag_tests/tfjs/karma.conf.js --browserstack --b
 if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   #TODO: Run golden tests on all devices.
   COMMANDS+=(
-    "yarn run-browserstack --browsers=bs_ios_12 --tags '$TAGS_WITH_GOLDEN' --testEnv webgl --flags '{\"\\"\"WEBGL_VERSION\"\\"\": 1, \"\\"\"WEBGL_CPU_FORWARD\"\\"\": false, \"\\"\"WEBGL_SIZE_UPLOAD_UNIFORM\"\\"\": 0}'"
+    "yarn run-browserstack --browsers=bs_ios_12 --tags '$TAGS' --testEnv webgl --flags '{\"\\"\"WEBGL_VERSION\"\\"\": 1, \"\\"\"WEBGL_CPU_FORWARD\"\\"\": false, \"\\"\"WEBGL_SIZE_UPLOAD_UNIFORM\"\\"\": 0}'"
     "yarn run-browserstack --browsers=bs_safari_mac --tags '$TAGS' --testEnv webgl --flags '{\"\\"\"WEBGL_VERSION\"\\"\": 1, \"\\"\"WEBGL_CPU_FORWARD\"\\"\": false, \"\\"\"WEBGL_SIZE_UPLOAD_UNIFORM\"\\"\": 0}'"
     "yarn run-browserstack --browsers=bs_firefox_mac --tags '$TAGS'"
     "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS'"
@@ -64,7 +64,6 @@ if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
     "karma start ./script_tag_tests/tfjs-core-cpu/karma.conf.js --browserstack --browsers=bs_chrome_mac"
   )
 fi
-  #TODO: Run golden tests on all devices.
 
 for command in "${COMMANDS[@]}"; do
   TO_RUN+=("node ../scripts/run_flaky.js \"$command\"")

--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -62,7 +62,7 @@ if [[ "$NIGHTLY" = true || "$RELEASE" = true ]]; then
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_safari_mac --tags '$TAGS' --testEnv webgl --flags '{"\""WEBGL_VERSION"\"": 1, "\""WEBGL_CPU_FORWARD"\"": false, "\""WEBGL_SIZE_UPLOAD_UNIFORM"\"": 0}'"
 
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_firefox_mac --tags '$TAGS'"
-  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS_WITH_GOLDEN'"
+  node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_chrome_mac --tags '$TAGS'"
   node ../scripts/run_flaky.js "yarn run-browserstack --browsers=bs_android_10 --tags '$TAGS'"
 
   # Test script tag bundles

--- a/e2e/scripts/test.sh
+++ b/e2e/scripts/test.sh
@@ -26,11 +26,11 @@ if [[ -z "$TAGS" ]]; then
 fi
 
 if [[ "$NIGHTLY" = true ]]; then
-    TAGS="${TAGS},#REGRESSION"
+  TAGS="${TAGS},#GOLDEN,#REGRESSION"
 fi
 
 # Additional setup for regression tests.
-if [[ "$TAGS" == *"#REGRESSION"*  ]]; then
+if [[ "$TAGS" == *"#REGRESSION"* ]]; then
   # Generate canonical layers models and inputs.
   ./scripts/create_save_predict.sh
 
@@ -65,4 +65,3 @@ fi
 
 echo "Karma tests."
 yarn karma start --tags $TAGS
-


### PR DESCRIPTION
Add a new e2e test tag `#GOLDEN` and only enable golden tests in limited scenarios.

As @mattsoulanille said, the golden tests freeze on android and ios for some browserstack issues/limits, and they can take too much time in nightly tests. Therefore the golden tests are only enabled on windows.

nightly trial run passed: https://pantheon.corp.google.com/cloud-build/builds;region=global/60b9af1c-5a1f-404d-a9c0-3536d7b59ca0;step=5?project=learnjs-174218

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7532)
<!-- Reviewable:end -->
