### PR TITLE
Switch CI to e2-highcpu-32

### DIFF
--- a/scripts/cloudbuild_e2e_expected.yml
+++ b/scripts/cloudbuild_e2e_expected.yml
@@ -223,5 +223,5 @@ substitutions:
   _NIGHTLY: ''
 options:
   logStreamingOption: STREAM_ON
-  machineType: N1_HIGHCPU_32
+  machineType: E2_HIGHCPU_32
   substitution_option: ALLOW_LOOSE

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -102,5 +102,5 @@ substitutions:
   _NIGHTLY: ''
 options:
   logStreamingOption: 'STREAM_ON'
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_32'
   substitution_option: 'ALLOW_LOOSE'

--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -237,5 +237,5 @@ substitutions:
   _NIGHTLY: ''
 options:
   logStreamingOption: STREAM_ON
-  machineType: N1_HIGHCPU_32
+  machineType: E2_HIGHCPU_32
   substitution_option: ALLOW_LOOSE


### PR DESCRIPTION
e2 highcpu has slightly more memory (32 vs 28.8) and is the same price. See https://cloud.google.com/build/pricing for details.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7537)
<!-- Reviewable:end -->
