### PR TITLE
Migrate from dat.gui to lil.gui for local benchmark tool

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -19,7 +19,7 @@ limitations under the License.
   <title>TensorFlow.js Model Benchmark</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   <link href="./main.css" rel="stylesheet">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.7/dat.gui.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.18"></script>
   <script src="loader.js"></script>
   <link rel="shortcut icon"
         href="https://www.gstatic.com/devrel-devsite/prod/vf4ca28c48392b1412e7b030290622a0dd55b62dec1202c59f119b1e23227c988/tensorflow/images/favicon.png">
@@ -795,7 +795,7 @@ limitations under the License.
     }
 
     async function onPageLoad() {
-      const gui = new dat.gui.GUI({ width: 550 });
+      const gui = new lil.GUI({ width: 350 });
       gui.domElement.id = 'gui';
 
       urlState = getURLState(location.search);
@@ -819,15 +819,15 @@ limitations under the License.
         state.isModelChanged = true;
         state.isModelLoaded = false;
         if (modelArchitectureController !== null) {
-          modelParameterFolder.remove(modelArchitectureController);
+          modelArchitectureController.destroy();
           modelArchitectureController = null;
         }
         if (inputSizeController !== null) {
-          modelParameterFolder.remove(inputSizeController);
+          inputSizeController.destroy();
           inputSizeController = null;
         }
         if (inputTypeController !== null) {
-          modelParameterFolder.remove(inputTypeController);
+          inputTypeController.destroy();
           inputTypeController = null;
         }
 
@@ -908,7 +908,7 @@ limitations under the License.
             }
           }
         } else if (modelUrlController != null) {
-          modelFolder.remove(modelUrlController);
+          modelUrlController.destroy();
           modelUrlController = null;
         }
       });
@@ -958,7 +958,7 @@ limitations under the License.
         }
         if (isTflite()) {
           // Remove the "Test correctness" button which doesn't apply to tfjs-tflite.
-          correctnessButton.remove();
+          correctnessButton.destroy();
           correctnessButton = null;
 
           // Update models drop down to only show models that support tflite.
@@ -1017,7 +1017,7 @@ limitations under the License.
 
     function updateModelsDropdown(newValues) {
       const tfliteBenchmarksHtml = newValues.map(name => `<option value="${name}">${name}</option>`);
-      modelController.domElement.children[0].innerHTML = tfliteBenchmarksHtml;
+      modelController.domElement.children[1].children[0].innerHTML = tfliteBenchmarksHtml;
     }
 
     onPageLoad();

--- a/e2e/benchmarks/local-benchmark/index.js
+++ b/e2e/benchmarks/local-benchmark/index.js
@@ -35,7 +35,7 @@ const BACKEND_FLAGS_MAP = {
 };
 if (tf.engine().backendNames().includes('webgpu')) {
   BACKEND_FLAGS_MAP['webgpu'] =
-      ['WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE', 'KEEP_INTERMEDIATE_TENSORS'];
+    ['WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE', 'KEEP_INTERMEDIATE_TENSORS'];
 }
 
 const TUNABLE_FLAG_NAME_MAP = {
@@ -55,7 +55,7 @@ const TUNABLE_FLAG_NAME_MAP = {
 };
 if (tf.engine().backendNames().includes('webgpu')) {
   TUNABLE_FLAG_NAME_MAP['WEBGPU_DEFERRED_SUBMIT_BATCH_SIZE'] =
-      'deferred submit batch size';
+    'deferred submit batch size';
 }
 
 /**
@@ -75,28 +75,27 @@ let TUNABLE_FLAG_DEFAULT_VALUE_MAP;
  * @param {string} backendName
  */
 async function showFlagSettingsAndReturnTunableFlagControllers(
-    folderController, backendName) {
+  folderController, backendName) {
   // Determine wether it is the first call.
   if (TUNABLE_FLAG_DEFAULT_VALUE_MAP == null) {
     await initDefaultValueMap();
     showBackendFlagSettingsAndReturnTunableFlagControllers(
-        folderController, 'general');
+      folderController, 'general');
   } else {
     // Clean up flag settings for the previous backend.
     // The first constroller under the `folderController` is the backend
     // setting.
     const fixedSelectionCount = BACKEND_FLAGS_MAP.general.length + 1;
-    while (folderController.__controllers.length > fixedSelectionCount) {
-      folderController.remove(
-          folderController
-              .__controllers[folderController.__controllers.length - 1]);
+    while (folderController.controllers.length > fixedSelectionCount) {
+      folderController
+        .controllers[folderController.controllers.length - 1].destroy();
     }
   }
 
   // Show flag settings for the new backend and return the tunable flags
   // controllers.
   return showBackendFlagSettingsAndReturnTunableFlagControllers(
-      folderController, backendName);
+    folderController, backendName);
 }
 
 const stringValueMap = {};
@@ -108,14 +107,14 @@ const stringValueMap = {};
  * @param {string} backendName
  */
 function showBackendFlagSettingsAndReturnTunableFlagControllers(
-    folderController, backendName) {
+  folderController, backendName) {
   const tunableFlags = BACKEND_FLAGS_MAP[backendName];
   const tunableFlagControllers = {};
 
   // Remove it once we figure out how to correctly read the tensor data
   // before the tensor is disposed in profiling mode.
   if (backendName === 'webgpu' &&
-      state.flags['CHECK_COMPUTATION_FOR_ERRORS'] === true) {
+    state.flags['CHECK_COMPUTATION_FOR_ERRORS'] === true) {
     state.flags['CHECK_COMPUTATION_FOR_ERRORS'] = false;
     state.isFlagChanged = true;
   }
@@ -130,8 +129,8 @@ function showBackendFlagSettingsAndReturnTunableFlagControllers(
     // Heuristically consider a flag with at least two options as tunable.
     if (flagValueRange.length < 2) {
       console.warn(
-          `The ${flag} is considered as untunable, ` +
-          `because its value range is [${flagValueRange}].`);
+        `The ${flag} is considered as untunable, ` +
+        `because its value range is [${flagValueRange}].`);
       continue;
     }
     let flagController;
@@ -147,7 +146,7 @@ function showBackendFlagSettingsAndReturnTunableFlagControllers(
       // Show dropdown for other types of flags.
       try {
         flagController =
-            folderController.add(state.flags, flag, flagValueRange);
+          folderController.add(state.flags, flag, flagValueRange);
       } catch (ex) {
         console.warn(ex.message);
         continue;
@@ -213,8 +212,8 @@ async function initDefaultValueMap() {
 function getTunableRange(flag) {
   const defaultValue = TUNABLE_FLAG_DEFAULT_VALUE_MAP[flag];
   if (flag === 'WEBGL_FORCE_F16_TEXTURES' ||
-      flag === 'WEBGL_PACK_DEPTHWISECONV' ||
-      flag === 'KEEP_INTERMEDIATE_TENSORS') {
+    flag === 'WEBGL_PACK_DEPTHWISECONV' ||
+    flag === 'KEEP_INTERMEDIATE_TENSORS') {
     return [false, true];
   } else if (flag === 'WEBGL_VERSION') {
     const tunableRange = [];
@@ -230,8 +229,8 @@ function getTunableRange(flag) {
     return tunableRange;
   } else if (typeof defaultValue === 'boolean') {
     return defaultValue || flag === 'WEBGL_USE_SHAPES_UNIFORMS' ?
-        [false, true] :
-        [false];
+      [false, true] :
+      [false];
   } else if (TUNABLE_FLAG_VALUE_RANGE_MAP[flag] != null) {
     return TUNABLE_FLAG_VALUE_RANGE_MAP[flag];
   } else {

--- a/e2e/benchmarks/local-benchmark/main.css
+++ b/e2e/benchmarks/local-benchmark/main.css
@@ -142,12 +142,20 @@ th:first-child {
   padding-left: 16px;
 }
 
+#gui input{
+  text-align:center;
+}
+
 #gui select {
   width: 100%;
 }
 
+#gui .display {
+  width: 100%;
+  text-align:center;
+}
+
 #gui input[type=checkbox] {
-  margin: 7 auto;
   width: 100%;
 }
 


### PR DESCRIPTION
Since Dat.gui is updated a year ago and migration to Lil.gui is almost drop-in, this PR does:
1. Changes API usage according to API changes, https://lil-gui.georgealways.com/#Migrating.
2. Tuned the style for new UI.

New UI would be like:
![image](https://user-images.githubusercontent.com/40653845/229247263-f81bed9e-dd9f-45c6-b622-ce5e82859468.png)



To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7538)
<!-- Reviewable:end -->
