### PR TITLE
Fix release script not updating all package.jsons

### DIFF
--- a/e2e/scripts/test-ci.sh
+++ b/e2e/scripts/test-ci.sh
@@ -16,8 +16,10 @@
 
 set -e
 
-./scripts/run-custom-builds.sh # Generate custom bundle files for tests
+# Generate custom bundle files and model files for tests
+parallel ::: ./scripts/run-custom-builds.sh \
+  ./scripts/create-python-models.sh
 
-parallel ::: ./scripts/create-python-models.sh \
-  ./scripts/run-browserstack-tests.sh \
+# Run browserstack tests (and webpack test)
+parallel ::: ./scripts/run-browserstack-tests.sh \
   "cd webpack_test && yarn --mutex network && yarn build"

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -38,26 +38,6 @@ steps:
   args: ['lint']
   waitFor: ['yarn-common']
 
-# Run verdaccio nightly publishing tests.
-- name: 'gcr.io/learnjs-174218/release'
-  entrypoint: 'bash'
-  id: 'nightly-verdaccio-test'
-  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'RELEASE=true']
-  secretEnv: ['BROWSERSTACK_KEY']
-  waitFor: ['yarn-common']
-  nightlyOnly: true
-  # Verdaccio tests change the yarn registry, so other package tests must wait
-  # for them to finish before starting.
-  waitedForByPackages: true
-  args:
-    - '-eEuo'
-    - 'pipefail'
-    - '-c'
-    - |-
-      yarn release-tfjs --dry --guess-version release --use-local-changes --force
-      cd /tmp/tfjs-release/tfjs/e2e/
-      bash scripts/release-e2e.sh
-
 # Bazel tests
 # These use a remote cache and only re-run if changes occurred, so we run them
 # in every build.
@@ -71,6 +51,29 @@ steps:
     - 'BROWSERSTACK_USERNAME=deeplearnjs1'
     - 'NIGHTLY=$_NIGHTLY'
   secretEnv: ['BROWSERSTACK_KEY']
+
+# Run verdaccio nightly publishing tests.
+- name: 'gcr.io/learnjs-174218/release'
+  entrypoint: 'bash'
+  id: 'nightly-verdaccio-test'
+  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'RELEASE=true']
+  secretEnv: ['BROWSERSTACK_KEY']
+  # TODO(mattsoulanille): Remove `bazel-tests` from the waitFor list once CI
+  # can run on remote builds. Right now, running these both at the same time
+  # causes Bazel tests to terminate abruptly, presumably from OOM killer.
+  waitFor: ['yarn-common', 'bazel-tests']
+  nightlyOnly: true
+  # Verdaccio tests change the yarn registry, so other package tests must wait
+  # for them to finish before starting.
+  waitedForByPackages: true
+  args:
+    - '-eEuo'
+    - 'pipefail'
+    - '-c'
+    - |-
+      yarn release-tfjs --dry --guess-version release --use-local-changes --force
+      cd /tmp/tfjs-release/tfjs/e2e/
+      bash scripts/release-e2e.sh
 
 # The following step builds the link package, which is a temporary package
 # that helps packages that don't build with Bazel load outputs from packages

--- a/scripts/release-tfjs.ts
+++ b/scripts/release-tfjs.ts
@@ -227,6 +227,8 @@ async function main() {
             .split('\n');
       for (const packageJsonPath of subpackages) {
         const pkg = fs.readFileSync(packageJsonPath, 'utf8');
+        console.log(chalk.magenta.bold(
+            `~~~ Update dependency versions for ${packageJsonPath} ~~~`));
         const updated = updateTFJSDependencyVersions(pkg, versions, phase.deps || []);
         fs.writeFileSync(packageJsonPath, updated);
       }

--- a/scripts/release-tfjs.ts
+++ b/scripts/release-tfjs.ts
@@ -207,18 +207,29 @@ async function main() {
     for (const packageName of phase.packages) {
       shell.cd(packageName);
 
-      // Update the version.
-      const packageJsonPath = `${dir}/${packageName}/package.json`;
-      let pkg = `${fs.readFileSync(packageJsonPath)}`;
+      // Update the version number of the package.json
+      const packagePath = path.join(dir, packageName);
+      const packageJsonPath = path.join(packagePath, 'package.json');
+      let pkg = fs.readFileSync(packageJsonPath, 'utf8');
       const parsedPkg = JSON.parse(`${pkg}`);
 
       console.log(chalk.magenta.bold(`~~~ Processing ${packageName} ~~~`));
       const newVersion = versions.get(packageName);
       pkg = `${pkg}`.replace(
           `"version": "${parsedPkg.version}"`, `"version": "${newVersion}"`);
-      pkg = updateTFJSDependencyVersions(pkg, versions, phase.deps || []);
 
       fs.writeFileSync(packageJsonPath, pkg);
+
+      // Update dependency versions of all package.json files found in the
+      // package to use the new verison numbers (except ones in node_modules).
+      const subpackages =
+            $(`find ${packagePath} -name package.json -not -path \'*/node_modules/*\'`)
+            .split('\n');
+      for (const packageJsonPath of subpackages) {
+        const pkg = fs.readFileSync(packageJsonPath, 'utf8');
+        const updated = updateTFJSDependencyVersions(pkg, versions, phase.deps || []);
+        fs.writeFileSync(packageJsonPath, updated);
+      }
 
       shell.cd('..');
 

--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -348,7 +348,6 @@ export async function updateDependency(
 export function updateTFJSDependencyVersions(
     pkg: string, versions: Map<string, string>,
     depsToReplace = [...versions.keys()]): string {
-  console.log(chalk.magenta.bold(`~~~ Update dependency versions ~~~`));
 
   const parsedPkg = JSON.parse(pkg);
 

--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -350,8 +350,8 @@ export function updateTFJSDependencyVersions(
     depsToReplace = [...versions.keys()]): string {
   console.log(chalk.magenta.bold(`~~~ Update dependency versions ~~~`));
 
-  const parsedPkg = JSON.parse(`${pkg}`);
-  JSON.parse(pkg);
+  const parsedPkg = JSON.parse(pkg);
+
   for (const dep of depsToReplace) {
     const newVersion = versions.get(dep);
     if (!newVersion) {


### PR DESCRIPTION
release-tfjs updated only the root package.json of each package, but e2e tests have some other package.json files that must be updated as well. Fix this by updating all package.json files in each package so that they use the npm release versions instead of `link:` dependencies.

Also fix e2e running integration tests at the same time as generating files for integration tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7542)
<!-- Reviewable:end -->
