### PR TITLE
webgpu: Unify the way to acquire and release buffers

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -665,7 +665,7 @@ export class WebGPUBackend extends KernelBackend {
             stagingBuffer, 0, buffer, 0, size);
 
         this.stagingPendingDisposal.push({
-          size: size,
+          size,
           usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
           buffer: stagingBuffer
         });

--- a/tfjs-backend-webgpu/src/buffer_manager.ts
+++ b/tfjs-backend-webgpu/src/buffer_manager.ts
@@ -26,69 +26,63 @@ export class BufferManager {
 
   constructor(private device: GPUDevice) {}
 
-  // The upload buffer is not reusable.
-  acquireUploadBuffer(size: number, usage: GPUBufferUsageFlags) {
-    this.numBytesAllocated += size;
-    return this.device.createBuffer({size, usage, mappedAtCreation: true});
-  }
-
   acquireBuffer(
-      size: number, usage: GPUBufferUsageFlags, mappedAtCreation = false) {
+      size: number, usage: GPUBufferUsageFlags, mappedAtCreation = false,
+      reuse = true) {
+    let buffer;
     const key = getBufferKey(size, usage);
-    if (!this.freeBuffers.has(key)) {
-      this.freeBuffers.set(key, []);
+
+    if (reuse) {
+      if (!this.freeBuffers.has(key)) {
+        this.freeBuffers.set(key, []);
+      }
+
+      if (this.freeBuffers.get(key).length > 0) {
+        buffer = this.freeBuffers.get(key).shift();
+        this.numFreeBuffers--;
+      } else {
+        buffer = this.device.createBuffer({size, usage, mappedAtCreation});
+        this.numBytesAllocated += size;
+      }
+    } else {
+      buffer = this.device.createBuffer({size, usage, mappedAtCreation});
+      this.numBytesAllocated += size;
     }
 
     if (!this.usedBuffers.has(key)) {
       this.usedBuffers.set(key, []);
     }
-
-    this.numBytesUsed += size;
+    this.usedBuffers.get(key).push(buffer);
     this.numUsedBuffers++;
+    this.numBytesUsed += size;
 
-    if (this.freeBuffers.get(key).length > 0) {
-      this.numFreeBuffers--;
-
-      const newBuffer = this.freeBuffers.get(key).shift();
-      this.usedBuffers.get(key).push(newBuffer);
-      return newBuffer;
-    }
-
-    this.numBytesAllocated += size;
-    const newBuffer = this.device.createBuffer({size, usage, mappedAtCreation});
-    this.usedBuffers.get(key).push(newBuffer);
-
-    return newBuffer;
+    return buffer;
   }
 
-  releaseBuffer(buffer: GPUBuffer, size: number, usage: GPUBufferUsageFlags) {
+  releaseBuffer(
+      buffer: GPUBuffer, size: number, usage: GPUBufferUsageFlags,
+      reuse = true) {
     if (this.freeBuffers.size === 0) {
       return;
     }
 
     const key = getBufferKey(size, usage);
-    if (!this.freeBuffers.has(key)) {
-      this.freeBuffers.set(key, []);
-    }
-
-    this.freeBuffers.get(key).push(buffer);
-    this.numFreeBuffers++;
-    this.numUsedBuffers--;
-
     const bufferList = this.usedBuffers.get(key);
     const bufferIndex = bufferList.indexOf(buffer);
     if (bufferIndex < 0) {
-      throw new Error(
-          'Cannot release a buffer that was never provided by this ' +
-          'buffer manager');
+      throw new Error('Cannot find the buffer in buffer manager');
     }
     bufferList.splice(bufferIndex, 1);
+    this.numUsedBuffers--;
     this.numBytesUsed -= size;
-  }
 
-  releaseUploadBuffer(buffer: GPUBuffer) {
-    this.numBytesAllocated -= buffer.size;
-    buffer.destroy();
+    if (reuse) {
+      this.freeBuffers.get(key).push(buffer);
+      this.numFreeBuffers++;
+    } else {
+      buffer.destroy();
+      this.numBytesAllocated -= size;
+    }
   }
 
   getNumUsedBuffers(): number {

--- a/tfjs-backend-webgpu/src/buffer_manager.ts
+++ b/tfjs-backend-webgpu/src/buffer_manager.ts
@@ -38,7 +38,7 @@ export class BufferManager {
       }
 
       if (this.freeBuffers.get(key).length > 0) {
-        buffer = this.freeBuffers.get(key).shift();
+        buffer = this.freeBuffers.get(key).pop();
         this.numFreeBuffers--;
       } else {
         buffer = this.device.createBuffer({size, usage, mappedAtCreation});
@@ -67,12 +67,13 @@ export class BufferManager {
     }
 
     const key = getBufferKey(size, usage);
-    const bufferList = this.usedBuffers.get(key);
-    const bufferIndex = bufferList.indexOf(buffer);
-    if (bufferIndex < 0) {
+    const bufferArray = this.usedBuffers.get(key);
+    const index = bufferArray.indexOf(buffer);
+    if (index < 0) {
       throw new Error('Cannot find the buffer in buffer manager');
     }
-    bufferList.splice(bufferIndex, 1);
+    bufferArray[index] = bufferArray[bufferArray.length - 1];
+    bufferArray.pop();
     this.numUsedBuffers--;
     this.numBytesUsed -= size;
 


### PR DESCRIPTION
This is to remove dedicated functions for upload to GPU, to unify the usages to acquire and release buffers.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7552)
<!-- Reviewable:end -->
