### PR TITLE
webgpu: Tune reduce workgroupSize

### DIFF
--- a/tfjs-backend-webgpu/src/base.ts
+++ b/tfjs-backend-webgpu/src/base.ts
@@ -55,6 +55,9 @@ if (isWebGPUSupported()) {
           adapterLimits.maxComputeWorkgroupsPerDimension,
       'maxStorageBufferBindingSize': adapterLimits.maxStorageBufferBindingSize,
       'maxBufferSize': adapterLimits.maxBufferSize,
+      'maxComputeWorkgroupSizeX': adapterLimits.maxComputeWorkgroupSizeX,
+      'maxComputeInvocationsPerWorkgroup':
+          adapterLimits.maxComputeInvocationsPerWorkgroup,
     };
 
     const device: GPUDevice = await adapter.requestDevice(deviceDescriptor);

--- a/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
+++ b/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
@@ -83,7 +83,8 @@ export function reduce(
     const uniformData = [
       {type: 'int32', data: [inSize]},
     ];
-    const program = new ReduceProgram(reduceInfo, reduceType);
+    const program = new ReduceProgram(
+        reduceInfo, reduceType, backend.device.limits.maxComputeWorkgroupSizeX);
     const reduced =
         backend.runWebGPUProgram(program, [input], dtype, uniformData);
     toDispose.push(reduced);

--- a/tfjs-backend-webgpu/src/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/reduce_webgpu.ts
@@ -24,7 +24,7 @@ export class ReduceProgram implements WebGPUProgram {
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workgroupSize: [number, number, number] = [64, 1, 1];
+  workgroupSize: [number, number, number];
   variableNames = ['x'];
   uniforms = 'reduceSize : i32,';
   reduceType: 'all'|'any'|'max'|'mean'|'min'|'prod'|'sum';
@@ -47,6 +47,8 @@ export class ReduceProgram implements WebGPUProgram {
       this.workgroupSize = [512, 1, 1];
     } else if (reduceInfo.inSize >= 4096) {
       this.workgroupSize = [256, 1, 1];
+    } else {
+      this.workgroupSize = [64, 1, 1];
     }
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     // A work group only outputs a data, so we transfer [1, 1, 1] to compute

--- a/tfjs-backend-webgpu/src/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/reduce_webgpu.ts
@@ -33,12 +33,17 @@ export class ReduceProgram implements WebGPUProgram {
 
   constructor(
       reduceInfo: backend_util.ReduceInfo,
-      reduceType: 'all'|'any'|'max'|'mean'|'min'|'prod'|'sum') {
+      reduceType: 'all'|'any'|'max'|'mean'|'min'|'prod'|'sum',
+      maxComputeWorkgroupSizeX: number) {
     this.inputShape = [reduceInfo.batchSize, reduceInfo.inSize];
     const [outputShape, ] =
         backend_util.computeOutAndReduceShapes(this.inputShape, [1]);
     this.outputShape = outputShape.length === 0 ? [1] : outputShape;
-
+    if (reduceInfo.inSize >= 32768 && maxComputeWorkgroupSizeX >= 512) {
+      this.workgroupSize = [512, 1, 1];
+    } else if (reduceInfo.inSize >= 4096) {
+      this.workgroupSize = [256, 1, 1];
+    }
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
     // A work group only outputs a data, so we transfer [1, 1, 1] to compute
     // dispatch size.

--- a/tfjs-backend-webgpu/src/reduce_webgpu.ts
+++ b/tfjs-backend-webgpu/src/reduce_webgpu.ts
@@ -39,6 +39,10 @@ export class ReduceProgram implements WebGPUProgram {
     const [outputShape, ] =
         backend_util.computeOutAndReduceShapes(this.inputShape, [1]);
     this.outputShape = outputShape.length === 0 ? [1] : outputShape;
+    // If reduceSize |reduceInfo.inSize| is very large, the I/O accessing will
+    // become the bottleneck. Increasing workgroupSize can reduce the times of
+    // accessing global memory. The threshold value is just to make sure the
+    // reduceSize is large enough for a bigger workgroupSize.
     if (reduceInfo.inSize >= 32768 && maxComputeWorkgroupSizeX >= 512) {
       this.workgroupSize = [512, 1, 1];
     } else if (reduceInfo.inSize >= 4096) {


### PR DESCRIPTION
PERF

Increase the workgroupSize when the reduce length is very large. See great improvement of Mean in stable diffusion. Mean in stable diffusion: 16ms -> 8ms
Mean in decoder: 165ms -> 35.92ms

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7559)
<!-- Reviewable:end -->
