### PR TITLE
[prototype] Record-Replay API and implementation for production

### DIFF
--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -180,6 +180,7 @@ export class MathBackendWebGL extends KernelBackend {
 
   // Writes a new entry to the data store with a WebGL texture, and registers it
   // to the texture manager.
+  @NoCommandRecording()
   writeTexture(
       texture: WebGLTexture, shape: number[], dtype: DataType,
       texHeight: number, texWidth: number, channels: string): DataId {
@@ -270,6 +271,7 @@ export class MathBackendWebGL extends KernelBackend {
     this.disposeData(tensorInfo.dataId);
   }
 
+  @NoCommandRecording()
   override readSync(dataId: DataId): BackendValues {
     const texData = this.texData.get(dataId);
     const {values, dtype, complexTensorInfos, slice, shape, isPacked} = texData;
@@ -319,6 +321,7 @@ export class MathBackendWebGL extends KernelBackend {
     return this.convertAndCacheOnCPU(dataId, result);
   }
 
+  @NoCommandRecording()
   override async read(dataId: DataId): Promise<BackendValues> {
     if (this.pendingRead.has(dataId)) {
       const subscribers = this.pendingRead.get(dataId);
@@ -428,6 +431,7 @@ export class MathBackendWebGL extends KernelBackend {
    *     customTexShape: Optional. If set, will use the user defined texture
    *     shape to create the texture.
    */
+  @NoCommandRecording()
   override readToGPU(dataId: DataId, options: DataToGPUWebGLOption = {}):
       GPUData {
     const texData = this.texData.get(dataId);
@@ -507,6 +511,7 @@ export class MathBackendWebGL extends KernelBackend {
     }
   }
 
+  @NoCommandRecording()
   private getValuesFromTexture(dataId: DataId): Float32Array {
     const {shape, dtype, isPacked} = this.texData.get(dataId);
     const size = util.sizeFromShape(shape);
@@ -845,6 +850,7 @@ export class MathBackendWebGL extends KernelBackend {
     return {dataId: output.dataId, shape: afterShape, dtype: output.dtype};
   }
 
+  @NoCommandRecording()
   private decode(dataId: DataId, customTexShape?: [number, number]):
       TensorInfo {
     const texData = this.texData.get(dataId);
@@ -881,11 +887,11 @@ export class MathBackendWebGL extends KernelBackend {
       customUniformValues?: number[][], preventEagerUnpackingOfOutput = false,
       customTexShape?: [number, number]): TensorInfo {
     const output = WebGLProgramCommand.record<TensorInfo>(
-        program, inputs, outputDtype, customUniformValues,
-        preventEagerUnpackingOfOutput, customTexShape);
+        this, program, inputs, outputDtype, customUniformValues,
+        customTexShape);
     const outData = this.texData.get(output.dataId);
 
-    const glFlushThreshold = Number(env().get('WEBGL_FLUSH_THRESHOLD'));
+    const glFlushThreshold = env().get('WEBGL_FLUSH_THRESHOLD') as number;
     // Manually GL flush requested
     if (glFlushThreshold > 0) {
       const time = util.now();

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -19,7 +19,7 @@
 import './flags_webgl';
 
 import * as tf from '@tensorflow/tfjs-core';
-import {backend_util, BackendValues, buffer, DataId, DataStorage, DataToGPUWebGLOption, DataType, engine, env, GPUData, kernel_impls, KernelBackend, MemoryInfo, nextFrame, NoCommandRecording, NumericDataType, Rank, RecursiveArray, scalar, ShapeMap, Tensor, Tensor2D, TensorBuffer, TensorInfo, tidy, TimingInfo, TypedArray, util, WebGLData} from '@tensorflow/tfjs-core';
+import {backend_util, BackendValues, buffer, DataId, DataStorage, DataToGPUWebGLOption, DataType, engine, env, GPUData, kernel_impls, KernelBackend, MemoryInfo, nextFrame, NoCommandRecordingMethod, NumericDataType, Rank, RecursiveArray, scalar, ShapeMap, Tensor, Tensor2D, TensorBuffer, TensorInfo, tidy, TimingInfo, TypedArray, util, WebGLData} from '@tensorflow/tfjs-core';
 
 import {getWebGLContext} from './canvas_util';
 import {WebGLProgramCommand} from './commands';
@@ -180,7 +180,7 @@ export class MathBackendWebGL extends KernelBackend {
 
   // Writes a new entry to the data store with a WebGL texture, and registers it
   // to the texture manager.
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   writeTexture(
       texture: WebGLTexture, shape: number[], dtype: DataType,
       texHeight: number, texWidth: number, channels: string): DataId {
@@ -271,7 +271,7 @@ export class MathBackendWebGL extends KernelBackend {
     this.disposeData(tensorInfo.dataId);
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   override readSync(dataId: DataId): BackendValues {
     const texData = this.texData.get(dataId);
     const {values, dtype, complexTensorInfos, slice, shape, isPacked} = texData;
@@ -321,7 +321,7 @@ export class MathBackendWebGL extends KernelBackend {
     return this.convertAndCacheOnCPU(dataId, result);
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   override async read(dataId: DataId): Promise<BackendValues> {
     if (this.pendingRead.has(dataId)) {
       const subscribers = this.pendingRead.get(dataId);
@@ -431,7 +431,7 @@ export class MathBackendWebGL extends KernelBackend {
    *     customTexShape: Optional. If set, will use the user defined texture
    *     shape to create the texture.
    */
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   override readToGPU(dataId: DataId, options: DataToGPUWebGLOption = {}):
       GPUData {
     const texData = this.texData.get(dataId);
@@ -511,7 +511,7 @@ export class MathBackendWebGL extends KernelBackend {
     }
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   private getValuesFromTexture(dataId: DataId): Float32Array {
     const {shape, dtype, isPacked} = this.texData.get(dataId);
     const size = util.sizeFromShape(shape);
@@ -811,13 +811,13 @@ export class MathBackendWebGL extends KernelBackend {
                this.makeTensorInfo(shape, dtype, values), this) as T;
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   unpackTensor(input: TensorInfo): TensorInfo {
     const program = new UnpackProgram(input.shape);
     return this.runWebGLProgram(program, [input], input.dtype);
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   packTensor(input: TensorInfo): TensorInfo {
     const program = new PackProgram(input.shape);
     const preventEagerUnpackingOutput = true;
@@ -826,7 +826,7 @@ export class MathBackendWebGL extends KernelBackend {
         preventEagerUnpackingOutput);
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   packedReshape(input: TensorInfo, afterShape: number[]): TensorInfo {
     const input3DShape = [
       webgl_util.getBatchDim(input.shape),
@@ -850,7 +850,7 @@ export class MathBackendWebGL extends KernelBackend {
     return {dataId: output.dataId, shape: afterShape, dtype: output.dtype};
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   private decode(dataId: DataId, customTexShape?: [number, number]):
       TensorInfo {
     const texData = this.texData.get(dataId);
@@ -988,7 +988,7 @@ export class MathBackendWebGL extends KernelBackend {
     return this.floatPrecision() === 32 ? EPSILON_FLOAT32 : EPSILON_FLOAT16;
   }
 
-  @NoCommandRecording()
+  @NoCommandRecordingMethod()
   uploadToGPU(dataId: DataId): tex_util.TextureData {
     const texData = this.texData.get(dataId);
     const {shape, dtype, values, texture, usage, isPacked} = texData;

--- a/tfjs-backend-webgl/src/backend_webgl.ts
+++ b/tfjs-backend-webgl/src/backend_webgl.ts
@@ -20,6 +20,7 @@ import './flags_webgl';
 
 import * as tf from '@tensorflow/tfjs-core';
 import {backend_util, BackendValues, buffer, DataId, DataStorage, DataToGPUWebGLOption, DataType, engine, env, GPUData, kernel_impls, KernelBackend, MemoryInfo, nextFrame, NumericDataType, Rank, RecursiveArray, scalar, ShapeMap, Tensor, Tensor2D, TensorBuffer, TensorInfo, tidy, TimingInfo, TypedArray, util, WebGLData} from '@tensorflow/tfjs-core';
+
 import {getWebGLContext} from './canvas_util';
 import {DecodeMatrixProgram} from './decode_matrix_gpu';
 import {DecodeMatrixPackedProgram} from './decode_matrix_packed_gpu';

--- a/tfjs-backend-webgl/src/commands.ts
+++ b/tfjs-backend-webgl/src/commands.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {ClosureCommand, CommandBuildOutput, DataType, KernelCommand, TensorInfo, util} from '@tensorflow/tfjs-core';
+import {MathBackendWebGL} from './backend_webgl';
+import {getUniformLocations, GPGPUBinary, GPGPUProgram, TensorData} from './gpgpu_math';
+import * as tex_util from './tex_util';
+
+export class RunWebGLProgramCommand extends KernelCommand {
+  static override build(
+      backend: MathBackendWebGL, program: GPGPUProgram, inputs: TensorInfo[],
+      outputDtype: DataType, customUniformValues?: number[][],
+      customTexShape?: [number, number]):
+      CommandBuildOutput<RunWebGLProgramCommand, TensorInfo> {
+    const output = backend.makeTensorInfo(program.outputShape, outputDtype);
+    const outData = backend.texData.get(output.dataId);
+    if (program.packedOutput) {
+      outData.isPacked = true;
+    }
+    if (program.outPackingScheme === tex_util.PackingScheme.DENSE) {
+      const texelShape = customTexShape != null ?
+          customTexShape :
+          tex_util.getDenseTexShape(program.outputShape);
+      // For a densely packed output, we explicitly set texShape
+      // so it doesn't get assigned later according to our typical packing
+      // scheme wherein a single texel can only contain values from adjacent
+      // rows/cols.
+      outData.texShape = texelShape.map(d => d * 2) as [number, number];
+    }
+    if (program.outTexUsage != null) {
+      outData.usage = program.outTexUsage;
+    }
+
+    if (util.sizeFromShape(output.shape) === 0) {
+      // Short-circuit the computation since the result is empty (has 0 in its
+      // shape).
+      outData.values =
+          util.getTypedArrayFromDType(output.dtype as 'float32', 0);
+      return output;
+    }
+
+    const dataToDispose: TensorInfo[] = [];
+    const inputsData: TensorData[] = inputs.map(input => {
+      if (input.dtype === 'complex64') {
+        throw new Error(
+            `GPGPUProgram does not support complex64 input. For complex64 ` +
+            `dtypes, please separate the program into real and imaginary ` +
+            `parts.`);
+      }
+
+      let texData = this.texData.get(input.dataId);
+
+      if (texData.texture == null) {
+        if (!program.packedInputs &&
+            util.sizeFromShape(input.shape) <=
+                env().getNumber('WEBGL_SIZE_UPLOAD_UNIFORM')) {
+          // Upload small tensors that live on the CPU as uniforms, not as
+          // textures. Do this only when the environment supports 32bit floats
+          // due to problems when comparing 16bit floats with 32bit floats.
+          // TODO(https://github.com/tensorflow/tfjs/issues/821): Make it
+          // possible for packed shaders to sample from uniforms.
+          return {
+            shape: input.shape,
+            texData: null,
+            isUniform: true,
+            uniformValues: texData.values as TypedArray
+          };
+        }
+
+        // This ensures that if a packed program's inputs have not yet been
+        // uploaded to the GPU, they get uploaded as packed right off the bat.
+        if (program.packedInputs) {
+          texData.isPacked = true;
+          texData.shape = input.shape;
+        }
+      }
+
+      this.uploadToGPU(input.dataId);
+      if (!!texData.isPacked !== !!program.packedInputs) {
+        input = texData.isPacked ? this.unpackTensor(input) :
+                                   this.packTensor(input);
+        dataToDispose.push(input);
+        texData = this.texData.get(input.dataId);
+      } else if (
+          texData.isPacked &&
+          !webgl_util.isReshapeFree(texData.shape, input.shape)) {
+        // This is a special case where a texture exists for a tensor
+        // but the shapes are incompatible (due to packing constraints) because
+        // the tensor did not have a chance to go through the packed reshape
+        // shader. This only happens when we reshape the *same* tensor to form
+        // *distinct* inputs to an op, e.g. dotting a vector with itself. This
+        // case will disappear once packed uploading is the default.
+
+        const savedInput = input;
+        const targetShape = input.shape;
+
+        input.shape = texData.shape;
+        input = this.packedReshape(input as Tensor, targetShape);
+        dataToDispose.push(input);
+        texData = this.texData.get(input.dataId);
+
+        savedInput.shape = targetShape;
+      }
+
+      return {shape: input.shape, texData, isUniform: false};
+    });
+
+    backend.uploadToGPU(output.dataId);
+    const outputData:
+        TensorData = {shape: output.shape, texData: outData, isUniform: false};
+    const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
+    const binary = override.getAndSaveBinary(key, () => {
+      return gpgpu_math.compileProgram(
+          this.gpgpu, program, inputsData, outputData);
+    });
+    const shouldTimeProgram = this.activeTimers != null;
+    let query: WebGLQuery|CPUTimerQuery;
+    if (shouldTimeProgram) {
+      query = this.startTimer();
+    }
+
+    if (!env().get('ENGINE_COMPILE_ONLY')) {
+      gpgpu_math.runProgram(
+          this.gpgpu, binary, inputsData, outputData, customUniformValues);
+    }
+  }
+
+  execute() {}
+}

--- a/tfjs-backend-webgl/src/commands.ts
+++ b/tfjs-backend-webgl/src/commands.ts
@@ -14,21 +14,189 @@
  * limitations under the License.
  * =============================================================================
  */
-import {ClosureCommand, CommandBuildOutput, DataType, KernelCommand, TensorInfo, util} from '@tensorflow/tfjs-core';
-import {MathBackendWebGL} from './backend_webgl';
-import {getUniformLocations, GPGPUBinary, GPGPUProgram, TensorData} from './gpgpu_math';
-import * as tex_util from './tex_util';
+import {CommandBuildOutput, DataId, DataType, env, KernelCommand, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
-export class RunWebGLProgramCommand extends KernelCommand {
-  static override build(
+import {CPUTimerQuery, MathBackendWebGL} from './backend_webgl';
+import * as gpgpu_math from './gpgpu_math';
+import {GPGPUBinary, GPGPUProgram} from './gpgpu_math';
+import * as tex_util from './tex_util';
+import * as webgl_util from './webgl_util';
+
+const WEBGL_PACKED = 'WEBGL_PACKED';
+const WEBGL_UNPACKED = 'WEBGL_UNPACKED';
+
+export class WebGLProgramCommand extends KernelCommand {
+  public outDataTemplate: Partial<tex_util.TextureData> = {};
+  public isOutputAlwaysEmpty: boolean = false;
+  public binary?: GPGPUBinary;
+
+  constructor(
+      public backend: MathBackendWebGL, public program: GPGPUProgram,
+      public customUniformValues?: number[][],
+      public customTexShape?: [number, number]) {
+    super();
+  }
+
+  public override pushInput(...tensors: TensorInfo[]): void {
+    for (const tensor of tensors) {
+      if (tensor.dtype === 'complex64') {
+        throw new Error(
+            `GPGPUProgram does not support complex64 input. For complex64 ` +
+            `dtypes, please separate the program into real and imaginary ` +
+            `parts.`);
+      }
+    }
+    super.pushInput(...tensors);
+  }
+
+  programPackTag() {
+    return !!this.program.packedInputs ? WEBGL_PACKED : WEBGL_UNPACKED;
+  }
+
+  prepareOutputData() {
+    // WebGLProgramCommand always has one output tensor only.
+    const placeholder = this.outputs[0];
+    const output = this.backend.makeTensorInfo(
+        placeholder.template.shape, placeholder.template.dtype);
+    const tag = !!this.program.packedOutput ? WEBGL_PACKED : WEBGL_UNPACKED;
+    // Increase the ref by one since it's set with two tags.
+    this.backend.incRef(output.dataId);
+    placeholder.set(output, this.backend);
+    placeholder.set(output, this.backend, /*tag=*/tag);
+
+    const outData = this.backend.texData.get(placeholder.get().dataId);
+    Object.assign(outData, this.outDataTemplate);
+    this.backend.uploadToGPU(output.dataId);
+    return {shape: output.shape, texData: outData, isUniform: false};
+  }
+
+  prepareInputsData() {
+    return this.inputs.map((placeholder) => {
+      let input = placeholder.getNoNotFoundError(this.programPackTag());
+      let texData;
+      let dataIdToDispose: DataId|null = null;
+
+      if (input != null) {
+        texData = this.backend.texData.get(input.dataId);
+      } else {
+        // Use the default one, upload to gpu and pack/unpack if necessary.
+        input = placeholder.get();
+        let texData = this.backend.texData.get(input.dataId);
+        if (texData.texture == null) {
+          if (!this.program.packedInputs &&
+              util.sizeFromShape(input.shape) <=
+                  env().getNumber('WEBGL_SIZE_UPLOAD_UNIFORM')) {
+            // Upload small tensors that live on the CPU as uniforms, not as
+            // textures. Do this only when the environment supports 32bit
+            // floats due to problems when comparing 16bit floats with 32bit
+            // floats.
+            // TODO(https://github.com/tensorflow/tfjs/issues/821): Make it
+            // possible for packed shaders to sample from uniforms.
+            return {
+              shape: input.shape,
+              texData: null,
+              isUniform: true,
+              uniformValues: texData.values as TypedArray
+            };
+          }
+
+          // This ensures that if a packed program's inputs have not yet
+          // been uploaded to the GPU, they get uploaded as packed right off
+          // the bat.
+          if (this.program.packedInputs) {
+            texData.isPacked = true;
+            texData.shape = input.shape;
+          }
+        }
+
+        this.backend.uploadToGPU(input.dataId);
+        if (!!texData.isPacked !== !!this.program.packedInputs) {
+          const newInput = this.program.packedInputs ?
+              this.backend.packTensor(input) :
+              this.backend.unpackTensor(input);
+          // Store the packed/unpacked tensor as additional value in
+          // placeholder for reuse.
+          placeholder.set(newInput, this.backend, this.programPackTag())
+          texData = this.backend.texData.get(newInput.dataId);
+        }
+      }
+
+      if (texData.isPacked &&
+          !webgl_util.isReshapeFree(texData.shape, input.shape)) {
+        // This is a special case where a texture exists for a tensor
+        // but the shapes are incompatible (due to packing constraints)
+        // because the tensor did not have a chance to go through the packed
+        // reshape shader. This only happens when we reshape the *same*
+        // tensor to form *distinct* inputs to an op, e.g. dotting a vector
+        // with itself. This case will disappear once packed uploading is
+        // the default.
+        const savedInput = input;
+        const targetShape = input.shape;
+
+        input.shape = texData.shape;
+        const newInput = this.backend.packedReshape(input, targetShape);
+        texData = this.backend.texData.get(input.dataId);
+        dataIdToDispose = newInput;
+
+        savedInput.shape = targetShape;
+      }
+      return {shape: input.shape, texData, isUniform: false, dataIdToDispose};
+    });
+  }
+
+  runProgram(
+      inputsData: ReturnType<typeof this.prepareInputsData>,
+      outputData: ReturnType<typeof this.prepareOutputData>) {
+    const activeTimers = this.backend.activeTimers;
+    const shouldTimeProgram = activeTimers != null;
+    let query: WebGLQuery|CPUTimerQuery;
+    if (shouldTimeProgram) {
+      query = this.backend.startTimer();
+    }
+
+    if (!env().get('ENGINE_COMPILE_ONLY')) {
+      gpgpu_math.runProgram(
+          this.backend.gpgpu, this.binary!, inputsData, outputData,
+          this.customUniformValues);
+    }
+
+    if (shouldTimeProgram) {
+      query = this.backend.endTimer(query);
+      this.backend.activeTimers.push({
+        name: this.program.constructor.name,
+        query: this.backend.getQueryTime(query)
+      });
+    }
+  }
+
+  override execute() {
+    const outData = this.prepareOutputData();
+    if (this.isOutputAlwaysEmpty) {
+      return;
+    }
+    const inputsData = this.prepareInputsData();
+    this.runProgram(inputsData, outData);
+    for (const {dataIdToDispose} of inputsData) {
+      if (dataIdToDispose != null) {
+        this.backend.disposeData(dataIdToDispose);
+      }
+    }
+  }
+
+  static override build<TensorInfo>(
       backend: MathBackendWebGL, program: GPGPUProgram, inputs: TensorInfo[],
       outputDtype: DataType, customUniformValues?: number[][],
-      customTexShape?: [number, number]):
-      CommandBuildOutput<RunWebGLProgramCommand, TensorInfo> {
+      customTexShape?: [number, number]): CommandBuildOutput<TensorInfo> {
+    const command = new WebGLProgramCommand(
+        backend, program, customUniformValues, customTexShape);
+
+    // Make output tensor
     const output = backend.makeTensorInfo(program.outputShape, outputDtype);
-    const outData = backend.texData.get(output.dataId);
+    command.pushOutput(output);
+
+    // Prepare output data
     if (program.packedOutput) {
-      outData.isPacked = true;
+      command.outDataTemplate.isPacked = true;
     }
     if (program.outPackingScheme === tex_util.PackingScheme.DENSE) {
       const texelShape = customTexShape != null ?
@@ -38,105 +206,51 @@ export class RunWebGLProgramCommand extends KernelCommand {
       // so it doesn't get assigned later according to our typical packing
       // scheme wherein a single texel can only contain values from adjacent
       // rows/cols.
-      outData.texShape = texelShape.map(d => d * 2) as [number, number];
+      command.outDataTemplate.texShape =
+          texelShape.map(d => d * 2) as [number, number];
     }
     if (program.outTexUsage != null) {
-      outData.usage = program.outTexUsage;
+      command.outDataTemplate.usage = program.outTexUsage;
     }
 
     if (util.sizeFromShape(output.shape) === 0) {
       // Short-circuit the computation since the result is empty (has 0 in its
       // shape).
-      outData.values =
+      command.outDataTemplate.values =
           util.getTypedArrayFromDType(output.dtype as 'float32', 0);
-      return output;
+      command.isOutputAlwaysEmpty = true;
+      const outData = backend.texData.get(output.dataId);
+      Object.assign(outData, command.outDataTemplate);
+      return {command, outputs: output as TensorInfo};
     }
 
-    const dataToDispose: TensorInfo[] = [];
-    const inputsData: TensorData[] = inputs.map(input => {
-      if (input.dtype === 'complex64') {
-        throw new Error(
-            `GPGPUProgram does not support complex64 input. For complex64 ` +
-            `dtypes, please separate the program into real and imaginary ` +
-            `parts.`);
-      }
+    command.pushInput(...(inputs as any));
 
-      let texData = this.texData.get(input.dataId);
+    // The output of record is generated by executing the command. Prepare the
+    // inputs and output with tensors we have.
+    for (let i = 0; i < command.inputs.length; ++i) {
+      command.inputs[i].set(inputs[i] as any, backend);
+    }
+    command.outputs[0].set(output, backend);
 
-      if (texData.texture == null) {
-        if (!program.packedInputs &&
-            util.sizeFromShape(input.shape) <=
-                env().getNumber('WEBGL_SIZE_UPLOAD_UNIFORM')) {
-          // Upload small tensors that live on the CPU as uniforms, not as
-          // textures. Do this only when the environment supports 32bit floats
-          // due to problems when comparing 16bit floats with 32bit floats.
-          // TODO(https://github.com/tensorflow/tfjs/issues/821): Make it
-          // possible for packed shaders to sample from uniforms.
-          return {
-            shape: input.shape,
-            texData: null,
-            isUniform: true,
-            uniformValues: texData.values as TypedArray
-          };
-        }
+    const inputsData = command.prepareInputsData();
+    const outputData = command.prepareOutputData();
 
-        // This ensures that if a packed program's inputs have not yet been
-        // uploaded to the GPU, they get uploaded as packed right off the bat.
-        if (program.packedInputs) {
-          texData.isPacked = true;
-          texData.shape = input.shape;
-        }
-      }
-
-      this.uploadToGPU(input.dataId);
-      if (!!texData.isPacked !== !!program.packedInputs) {
-        input = texData.isPacked ? this.unpackTensor(input) :
-                                   this.packTensor(input);
-        dataToDispose.push(input);
-        texData = this.texData.get(input.dataId);
-      } else if (
-          texData.isPacked &&
-          !webgl_util.isReshapeFree(texData.shape, input.shape)) {
-        // This is a special case where a texture exists for a tensor
-        // but the shapes are incompatible (due to packing constraints) because
-        // the tensor did not have a chance to go through the packed reshape
-        // shader. This only happens when we reshape the *same* tensor to form
-        // *distinct* inputs to an op, e.g. dotting a vector with itself. This
-        // case will disappear once packed uploading is the default.
-
-        const savedInput = input;
-        const targetShape = input.shape;
-
-        input.shape = texData.shape;
-        input = this.packedReshape(input as Tensor, targetShape);
-        dataToDispose.push(input);
-        texData = this.texData.get(input.dataId);
-
-        savedInput.shape = targetShape;
-      }
-
-      return {shape: input.shape, texData, isUniform: false};
-    });
-
-    backend.uploadToGPU(output.dataId);
-    const outputData:
-        TensorData = {shape: output.shape, texData: outData, isUniform: false};
     const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
-    const binary = override.getAndSaveBinary(key, () => {
+    const binary = backend.getAndSaveBinary(key, () => {
       return gpgpu_math.compileProgram(
-          this.gpgpu, program, inputsData, outputData);
+          backend.gpgpu, program, inputsData, outputData);
     });
-    const shouldTimeProgram = this.activeTimers != null;
-    let query: WebGLQuery|CPUTimerQuery;
-    if (shouldTimeProgram) {
-      query = this.startTimer();
+    command.binary = binary;
+
+    command.runProgram(inputsData, outputData);
+
+    // Cleanup input and output placeholders used to generate recording output.
+    const buildOutput = command.outputs[0].release();
+    for (const placeholder of command.inputs) {
+      placeholder.reset();
     }
 
-    if (!env().get('ENGINE_COMPILE_ONLY')) {
-      gpgpu_math.runProgram(
-          this.gpgpu, binary, inputsData, outputData, customUniformValues);
-    }
+    return {command, outputs: buildOutput as any};
   }
-
-  execute() {}
 }

--- a/tfjs-backend-webgl/src/commands.ts
+++ b/tfjs-backend-webgl/src/commands.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {CommandBuildOutput, DataType, env, KernelCommand, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+import {Command, CommandBuildOutput, DataType, env, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {CPUTimerQuery, MathBackendWebGL} from './backend_webgl';
 import * as gpgpu_math from './gpgpu_math';
@@ -30,7 +30,7 @@ interface WebGLProgramTensorData extends gpgpu_math.TensorData {
   readonly disposeTensorInfoAfterRunProgram?: boolean;
 }
 
-export class WebGLProgramCommand extends KernelCommand {
+export class WebGLProgramCommand extends Command {
   public isOutputAlwaysEmpty = false;
 
   private constructor(

--- a/tfjs-backend-webgl/src/kernel_utils/kernel_funcs_utils.ts
+++ b/tfjs-backend-webgl/src/kernel_utils/kernel_funcs_utils.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import { backend_util, BinaryInputs, DataType, env, KernelFunc, TypedArray, UnaryInputs, upcastType} from '@tensorflow/tfjs-core';
+import {backend_util, BinaryInputs, DataType, env, KernelFunc, TypedArray, UnaryInputs, upcastType} from '@tensorflow/tfjs-core';
 
 import {MathBackendWebGL} from '../backend_webgl';
 import {BinaryOpProgram} from '../binaryop_gpu';

--- a/tfjs-backend-webgl/src/kernels/Add.ts
+++ b/tfjs-backend-webgl/src/kernels/Add.ts
@@ -32,5 +32,8 @@ export const addKernelFunc = binaryKernelFunc({
 export const addConfig: KernelConfig = {
   kernelName: Add,
   backendName: 'webgl',
-  kernelFunc: addKernelFunc
+  kernelFunc: addKernelFunc,
+  // NOTE: Mark builtin recording since we manually check all paths in
+  // `binaryKernelFunc` are builtin recording.
+  isRecordingBuiltin: true,
 };

--- a/tfjs-core/src/base.ts
+++ b/tfjs-core/src/base.ts
@@ -55,7 +55,7 @@ export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
 export {DataToGPUOptions, DataToGPUWebGLOption, GPUData, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer, Variable} from './tensor';
 export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
-export {BackendValues, DataType, DataTypeMap, DataTypeFor, DataValues, NumericDataType, PixelData, Rank, RecursiveArray, ScalarLike, ShapeMap, sumOutType, TensorLike, TypedArray, upcastType, WebGLData, WebGPUData} from './types';
+export {BackendValues, DataType, DataTypeFor, DataTypeMap, DataValues, NumericDataType, PixelData, Rank, RecursiveArray, ScalarLike, ShapeMap, sumOutType, TensorLike, TypedArray, upcastType, WebGLData, WebGPUData} from './types';
 
 export * from './ops/ops';
 export {Reduction} from './ops/loss_ops_utils';
@@ -67,6 +67,9 @@ export {TensorInfo, DataId} from './tensor_info';
 export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} from './gradients';
 
 export {TimingInfo, MemoryInfo, ForwardFunc} from './engine';
+// Record/Replay types
+export {Command, UnInitCommand, ClosureCommand, KernelCommand, CommandBuildOutput, TensorPlaceholder} from './engine';
+
 export {Environment, env, ENV} from './environment';
 export {Platform} from './platforms/platform';
 

--- a/tfjs-core/src/base.ts
+++ b/tfjs-core/src/base.ts
@@ -68,7 +68,7 @@ export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} fro
 
 export {TimingInfo, MemoryInfo, ForwardFunc} from './engine';
 // Record/Replay types
-export {Command, ClosureCommand, KernelCommand, CommandBuildOutput, TensorPlaceholder} from './engine';
+export {Command, ClosureCommand, CommandBuildOutput, TensorPlaceholder} from './engine';
 
 export {Environment, env, ENV} from './environment';
 export {Platform} from './platforms/platform';

--- a/tfjs-core/src/base.ts
+++ b/tfjs-core/src/base.ts
@@ -68,7 +68,7 @@ export {customGrad, grad, grads, valueAndGrad, valueAndGrads, variableGrads} fro
 
 export {TimingInfo, MemoryInfo, ForwardFunc} from './engine';
 // Record/Replay types
-export {Command, UnInitCommand, ClosureCommand, KernelCommand, CommandBuildOutput, TensorPlaceholder} from './engine';
+export {Command, ClosureCommand, KernelCommand, CommandBuildOutput, TensorPlaceholder} from './engine';
 
 export {Environment, env, ENV} from './environment';
 export {Platform} from './platforms/platform';

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -90,7 +90,7 @@ export function engine(): Engine {
  * This is a decorator to wrap a function in noCommandRecordingScope of the
  * current state.activeCommandTape.
  */
-export function NoCommandRecording<Cls, T>() {
+export function NoCommandRecordingMethod<Cls, T>() {
   return function(
       target: unknown, propertyKey: string,
       descriptor: TypedPropertyDescriptor<T>) {
@@ -108,6 +108,20 @@ export function NoCommandRecording<Cls, T>() {
       } as T;
     }
   }
+}
+
+export function noCommandRecording<T extends(...args: unknown[]) => unknown>(
+    fn: T): T {
+  return function(...args: unknown[]) {
+    const activeCommandTape = engine().state.activeCommandTape;
+
+    if (activeCommandTape != null) {
+      return activeCommandTape.noCommandRecordingScope(() => {
+        return fn(...args);
+      });
+    }
+    return fn(...args);
+  } as T;
 }
 
 /**

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -87,23 +87,24 @@ export function engine(): Engine {
 }
 
 /**
- * This is a decorator to wrap a function in noCommandScope of the current
- * state.activeCommandTape.
+ * This is a decorator to wrap a function in noCommandRecordingScope of the
+ * current state.activeCommandTape.
  */
-export function NoCommandRecording<T>() {
-  return (target: unknown, propertyKey: string,
-          descriptor: TypedPropertyDescriptor<T>) => {
+export function NoCommandRecording<Cls, T>() {
+  return function(
+      target: unknown, propertyKey: string,
+      descriptor: TypedPropertyDescriptor<T>) {
     const fn = descriptor.value;
     if (typeof fn === 'function') {
-      descriptor.value = function(...args: any[]) {
+      descriptor.value = function(this: Cls, ...args: any[]) {
         const activeCommandTape = engine().state.activeCommandTape;
 
         if (activeCommandTape != null) {
-          return activeCommandTape.noCommandScope(() => {
-            return fn.apply(target, args);
+          return activeCommandTape.noCommandRecordingScope(() => {
+            return fn.apply(this, args);
           });
         }
-        return fn.apply(target, args);
+        return fn.apply(this, args);
       } as T;
     }
   }

--- a/tfjs-core/src/globals.ts
+++ b/tfjs-core/src/globals.ts
@@ -87,6 +87,29 @@ export function engine(): Engine {
 }
 
 /**
+ * This is a decorator to wrap a function in noCommandScope of the current
+ * state.activeCommandTape.
+ */
+export function NoCommandRecording<T>() {
+  return (target: unknown, propertyKey: string,
+          descriptor: TypedPropertyDescriptor<T>) => {
+    const fn = descriptor.value;
+    if (typeof fn === 'function') {
+      descriptor.value = function(...args: any[]) {
+        const activeCommandTape = engine().state.activeCommandTape;
+
+        if (activeCommandTape != null) {
+          return activeCommandTape.noCommandScope(() => {
+            return fn.apply(target, args);
+          });
+        }
+        return fn.apply(target, args);
+      } as T;
+    }
+  }
+}
+
+/**
  * Returns memory info at the current time in the program. The result is an
  * object with the following properties:
  *
@@ -96,14 +119,14 @@ export function engine(): Engine {
  *   (undisposed) at this time, which is ≤ the number of tensors
  *   (e.g. `a.reshape(newShape)` makes a new Tensor that shares the same
  *   data buffer with `a`).
- * - `unreliable`: True if the memory usage is unreliable. See `reasons` when
- *    `unreliable` is true.
+ * - `unreliable`: True if the memory usage is unreliable. See `reasons`
+ * when `unreliable` is true.
  * - `reasons`: `string[]`, reasons why the memory is unreliable, present if
  *    `unreliable` is true.
  *
  * WebGL Properties:
- * - `numBytesInGPU`: Number of bytes allocated (undisposed) in the GPU only at
- *     this time.
+ * - `numBytesInGPU`: Number of bytes allocated (undisposed) in the GPU only
+ * at this time.
  *
  * @doc {heading: 'Performance', subheading: 'Memory'}
  */

--- a/tfjs-core/src/kernel_registry.ts
+++ b/tfjs-core/src/kernel_registry.ts
@@ -22,29 +22,28 @@ import {Tensor} from './tensor';
 import {TensorInfo} from './tensor_info';
 import {RecursiveArray} from './types';
 
-const kernelRegistry =
-  getGlobal('kernelRegistry', () => new Map<`${string}_${string}`,
-    KernelConfig>());
+const kernelRegistry = getGlobal(
+    'kernelRegistry', () => new Map<`${string}_${string}`, KernelConfig>());
 const gradRegistry =
-  getGlobal('gradRegistry', () => new Map<string, GradConfig>());
+    getGlobal('gradRegistry', () => new Map<string, GradConfig>());
 
 type AttributeValue =
-  number | number[] | boolean | boolean[] | string | string[] | NamedAttrMap;
+    number|number[]|boolean|boolean[]|string|string[]|NamedAttrMap;
 
 /** These are extra non-tensor/primitive params passed to kernel functions. */
-export type Attribute = AttributeValue | RecursiveArray<AttributeValue>;
+export type Attribute = AttributeValue|RecursiveArray<AttributeValue>;
 
 /** Specifies the code to run when executing a kernel. */
 export type KernelFunc = (params: {
   inputs: NamedTensorInfoMap,
   backend: {},
   attrs?: NamedAttrMap,
-}) => TensorInfo | TensorInfo[];
+}) => TensorInfo|TensorInfo[];
 
 /** The function to run when computing a gradient during backprop. */
 export type GradFunc =
-  (dy: Tensor | Tensor[], saved: Tensor[], attrs: NamedAttrMap) =>
-    NamedGradientMap;
+    (dy: Tensor|Tensor[], saved: Tensor[], attrs: NamedAttrMap) =>
+        NamedGradientMap;
 
 /** Function that gets called after the backend initializes. */
 export type KernelSetupFunc = (backend: {}) => void;
@@ -58,6 +57,7 @@ export interface KernelConfig {
   kernelFunc: KernelFunc;
   setupFunc?: KernelSetupFunc;
   disposeFunc?: KernelDisposeFunc;
+  isRecordingBuiltin?: boolean;
 }
 
 /** Config object for registering a gradient in the global registry. */
@@ -203,7 +203,7 @@ export function copyRegisteredKernels(
   });
 }
 
-function makeKey(kernelName: string,
-                 backendName: string): `${string}_${string}` {
+function makeKey(
+    kernelName: string, backendName: string): `${string}_${string}` {
   return `${backendName}_${kernelName}`;
 }

--- a/tfjs-core/src/ops/add.ts
+++ b/tfjs-core/src/ops/add.ts
@@ -57,4 +57,6 @@ function add_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   return ENGINE.runKernel(Add, inputs as unknown as NamedTensorMap);
 }
 
-export const add = /* @__PURE__ */ op({add_});
+export const add = /* @__PURE__ */ op({add_}, /*recording=*/() => {
+  return ENGINE.isKernelRecordingBuiltin(Add) ? 'builtin' : 'auto';
+});

--- a/tfjs-core/src/ops/operation.ts
+++ b/tfjs-core/src/ops/operation.ts
@@ -121,6 +121,7 @@ export function op<T extends Function>(
   };
 
   let recorder: (...args: unknown[]) => unknown;
+  let allowKernelCommands: boolean = true;
   switch (record) {
     case 'none':
       recorder = () => {
@@ -129,13 +130,16 @@ export function op<T extends Function>(
       break;
     case 'builtin':
       recorder = f2;
+      allowKernelCommands = true;
       break;
     case 'auto':
       recorder = buildOpAutoRecorder(f2);
+      allowKernelCommands = false;
+      break;
   }
 
   const recordFn = (...args: unknown[]) => {
-    ENGINE.state.activateCommandTape = new CommandTape();
+    ENGINE.state.activateCommandTape = new CommandTape({allowKernelCommands});
     const outputs = recorder(...args);
     const result = {
       tape: ENGINE.state.activateCommandTape,

--- a/tfjs-core/src/ops/operation.ts
+++ b/tfjs-core/src/ops/operation.ts
@@ -160,6 +160,6 @@ export function op<T extends Function>(
 
   Object.defineProperty(opFn, 'name', {value: opName, configurable: true});
   Object.defineProperty(
-      opFn, 'record', {value: recordOpFn, configurable: false});
+      opFn, '_record', {value: recordOpFn, configurable: false});
   return opFn as unknown as T;
 }

--- a/tsconfig_base.json
+++ b/tsconfig_base.json
@@ -24,7 +24,8 @@
     "noFallthroughCasesInSwitch": true,
     "allowUnreachableCode": false,
     "noImplicitOverride": true,
-    "incremental": true
+    "incremental": true,
+    "experimentalDecorators": true
   },
   "include": [
     "**/src/"

--- a/tsconfig_base.json
+++ b/tsconfig_base.json
@@ -11,7 +11,7 @@
     "declaration": true,
     "target": "es2017",
     "lib": [
-      "es2019",
+      "esnext",
       "dom"
     ],
     "outDir": "./dist",


### PR DESCRIPTION
### TODO: 
#### General
- [x] Make basic command types and tfjs-core level recording
- [x] Make `TensorPlaceholder`: a tensor/tensor info holder for passing tensors between commands
  - `TensorPlaceholder` naturally solves the issue of how to dispose/reuse/detach tensors. Those are no longer issues since tensors in TensorPlaceholder should be different (have different id) across multiple runs.
- [x] Make WebGLProgrammCommand to record most webgl
- [x] Make mechanism to let op select whether to use auto recorder or built-in recorder, depending on recording support of kernel 
- [ ] Modify sync graph executor to use `tf.<op>._record(...)` to record commands in graph execution

#### Benchmark
- [x] Benchmark non-recording model inference time (no performance loss in MobileNetV3)
- [ ] Benchmark MobileNetV3 with recording (use builtin recorder for all ops and assume correct)
- [ ] Benchmark MobileNetV3 with recording (use auto recorder for all ops, and make sure no performance loss with ClosureCommand) 

#### Compatibility
- [x] Make sure model inference without recording works with new tfjs-core and old backend (and vice versa)
- [ ] Make sure model inference without recording works with new tfjs-converter and old tfjs-core
- [ ] Make sure all combinations work

#### JIT prototype and exploration
- [ ] (JIT) Cache and reuse packed/unpacked versions of the same tensor in TensorPlaceholder to avoid redundant pack/unpack computations.
- [ ] (JIT) Options to record input/output pack/unpack state to make recorded command faster
- [ ] (JIT) Build simple model inference memory plan with static analysis (based on command in/out TensorPlaceholders)
- [ ] (JIT) Simple `WebGLProgramCommand` dynamic fuser


### Usage:
Remember to use local core and backend-webgl builds (of course you can use only one to test compatibility).
You may also set `tf.env().set('WEBGL_CPU_FORWARD', false)`. In that case `tf.add._record(x, y)` would produce different command, since the cpu forwarded one produces `ClosureCommand` for CPU computations while the non-forwarded one produces `WebGLProgramCommand`.
Currently only `tf.add` has builtin recording mode (conditionally used based on your choice of backend). All the other ops use auto recorder.
```js
x = tf.tensor1d([1, 1]);
y = tf.tensor1d([2, 2]);
let {tape, outputs} = tf.add._record(x, y);
outputs.print(); // Tensor[3, 3]. `outputs` is the output of `tf.add(x, y)`, it can be used as a normal tensor.

cmd = rec.tape.commands[0];
console.log('*** Recorded command: ***', cmd);

cmd.inputs[0].set(x);
cmd.inputs[1].set(tf.tensor1d([10, 20]));
cmd.execute();
cmd.outputs[0].toTensor().print(); // Tensor[11, 21]
cmd.outputs[0].reset() // Dispose tensor(s) held in the placeholder

cmd.inputs[0].set(tf.tensor1d([5, 5]))
cmd.execute();
cmd.outputs[0].toTensor().print(); // Tensor[15, 25]
x = cmd.outputs[0].releaseTensor(); 

// Now the output placeholder no longer holds the tensor.
// x can be used as a regular, independent tensor
```