### PR TITLE
[Local benchmark] Fix run button

### DIFF
--- a/e2e/benchmarks/local-benchmark/index.html
+++ b/e2e/benchmarks/local-benchmark/index.html
@@ -167,7 +167,7 @@ limitations under the License.
         correctnessButton.domElement.click();
       }
       if (runButton != null && task == 'performance') {
-        runButton.domElement.click();
+        runButton.$button.click();
       }
     }
 


### PR DESCRIPTION
Since lil.gui migration, `runButton.domElement` no longer refer to a button element, but `runButton.$button` refer to it.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.