### PR TITLE
Move nightly verdaccio tests to a separate cloudbuild file

### DIFF
--- a/cloudbuild-verdaccio.yml
+++ b/cloudbuild-verdaccio.yml
@@ -1,0 +1,35 @@
+steps:
+# Install top-level deps.
+- name: 'gcr.io/learnjs-174218/release'
+  entrypoint: 'yarn'
+  id: 'yarn-common'
+  args: ['install']
+
+# Run verdaccio nightly publishing tests.
+- name: 'gcr.io/learnjs-174218/release'
+  entrypoint: 'bash'
+  id: 'nightly-verdaccio-test'
+  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'RELEASE=true']
+  secretEnv: ['BROWSERSTACK_KEY']
+  waitFor: ['yarn-common']
+  args:
+    - '-eEuo'
+    - 'pipefail'
+    - '-c'
+    - |-
+      yarn release-tfjs --dry --guess-version release --use-local-changes --force
+      cd /tmp/tfjs-release/tfjs/e2e/
+      bash scripts/release-e2e.sh
+
+secrets:
+- kmsKeyName: projects/learnjs-174218/locations/global/keyRings/tfjs/cryptoKeys/enc
+  secretEnv:
+    BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
+timeout: 7200s
+logsBucket: 'gs://tfjs-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  machineType: 'N1_HIGHCPU_32'
+  substitution_option: 'ALLOW_LOOSE'

--- a/scripts/cloudbuild_general_config.yml
+++ b/scripts/cloudbuild_general_config.yml
@@ -52,29 +52,6 @@ steps:
     - 'NIGHTLY=$_NIGHTLY'
   secretEnv: ['BROWSERSTACK_KEY']
 
-# Run verdaccio nightly publishing tests.
-- name: 'gcr.io/learnjs-174218/release'
-  entrypoint: 'bash'
-  id: 'nightly-verdaccio-test'
-  env: ['BROWSERSTACK_USERNAME=deeplearnjs1', 'RELEASE=true']
-  secretEnv: ['BROWSERSTACK_KEY']
-  # TODO(mattsoulanille): Remove `bazel-tests` from the waitFor list once CI
-  # can run on remote builds. Right now, running these both at the same time
-  # causes Bazel tests to terminate abruptly, presumably from OOM killer.
-  waitFor: ['yarn-common', 'bazel-tests']
-  nightlyOnly: true
-  # Verdaccio tests change the yarn registry, so other package tests must wait
-  # for them to finish before starting.
-  waitedForByPackages: true
-  args:
-    - '-eEuo'
-    - 'pipefail'
-    - '-c'
-    - |-
-      yarn release-tfjs --dry --guess-version release --use-local-changes --force
-      cd /tmp/tfjs-release/tfjs/e2e/
-      bash scripts/release-e2e.sh
-
 # The following step builds the link package, which is a temporary package
 # that helps packages that don't build with Bazel load outputs from packages
 # that build with Bazel.

--- a/scripts/generate_cloudbuild_test.ts
+++ b/scripts/generate_cloudbuild_test.ts
@@ -40,28 +40,4 @@ describe('generateCloudbuild', () => {
                                           /* print */ false);
     expect(cloudbuild).toEqual(expectedCloudbuild as CloudbuildYaml);
   });
-
-  it('filters nightlyOnly steps when running presubmit tests', () => {
-    const cloudbuild = generateCloudbuild(['e2e'], /* nightly */ false,
-                                          /* print */ false);
-    expect(cloudbuild.steps).not.toContain(jasmine.objectContaining({
-      id: 'nightly-verdaccio-test',
-    }));
-  });
-
-  it('includes nightlyOnly steps when running nightly tests', () => {
-    const cloudbuild = generateCloudbuild(['e2e'], /* nightly */ true,
-                                          /* print */ false);
-    expect(cloudbuild.steps).toContain(jasmine.objectContaining({
-      id: 'nightly-verdaccio-test',
-    }));
-  });
-
-  it('removes the nightlyOnly property from the generated steps', () => {
-    const cloudbuild = generateCloudbuild(['e2e'], /* nightly */ true,
-                                          /* print */ false);
-    for (let step of cloudbuild.steps) {
-      expect(Object.keys(step)).not.toContain('nightlyOnly');
-    }
-  });
 });


### PR DESCRIPTION
Verdaccio tests, which test TFJS's release process, take a long time and are sometimes flaky. When they fail, they prevent the rest of the nightly tests from running. Separate Verdaccio tests from the other nightly tests and run them in a different cloudbuild instance.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7584)
<!-- Reviewable:end -->
