### PR TITLE
webgpu: Optimize softmax

### DIFF
--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -121,7 +121,8 @@ const TEST_FILTERS: TestFilter[] = [
   {
     startsWith: 'softmax ',
     excludes: [
-      'underflow',  // Actual: NaN,NaN. Expected: 0.5,0.5.
+      'underflow',        // Actual: NaN,NaN. Expected: 0.5,0.5.
+      'Propagates NaNs',  // Failing on MacOS
     ],
   },
 

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -121,7 +121,6 @@ const TEST_FILTERS: TestFilter[] = [
   {
     startsWith: 'softmax ',
     excludes: [
-      'underflow',        // Actual: NaN,NaN. Expected: 0.5,0.5.
       'Propagates NaNs',  // Failing on MacOS
     ],
   },

--- a/tfjs-backend-webgpu/src/setup_test.ts
+++ b/tfjs-backend-webgpu/src/setup_test.ts
@@ -66,55 +66,62 @@ const TEST_FILTERS: TestFilter[] = [
   {
     startsWith: 'cos ',
     excludes: [
-      'gradients', // Failing on MacOS
-      'gradient with clones', // Failing on MacOS
+      'gradients',             // Failing on MacOS
+      'gradient with clones',  // Failing on MacOS
     ],
   },
   {
     startsWith: 'tan ',
     excludes: [
-      'gradients', // Failing on MacOS
+      'gradients',  // Failing on MacOS
       //'gradient with clones', // Failing on MacOS
     ],
   },
   {
     startsWith: 'acosh ',
     excludes: [
-      'propagates NaNs', // Failing on MacOS
-      'gradient with clones', // Failing on MacOS
+      'propagates NaNs',       // Failing on MacOS
+      'gradient with clones',  // Failing on MacOS
     ],
   },
   {
     startsWith: 'asinh ',
     excludes: [
-      'propagates NaNs', // Failing on MacOS
+      'propagates NaNs',  // Failing on MacOS
       //'gradient with clones', // Failing on MacOS
     ],
   },
   {
     startsWith: 'atanh ',
     excludes: [
-      'propagates NaNs', // Failing on MacOS
+      'propagates NaNs',  // Failing on MacOS
       //'gradient with clones', // Failing on MacOS
     ],
   },
   {
     startsWith: 'sigmoid ',
     excludes: [
-      'propagates NaNs', // Failing on MacOS
+      'propagates NaNs',  // Failing on MacOS
       //'gradient with clones', // Failing on MacOS
     ],
   },
   {
     startsWith: 'unsortedSegmentSum ',
     excludes: [
-      'ignores negative segmentIds', // Failing on MacOS
+      'ignores negative segmentIds',  // Failing on MacOS
     ],
   },
   {
     startsWith: 'log ',
     excludes: [
-      'log propagates NaNs', // Failing on MacOS
+      'log propagates NaNs',  // Failing on MacOS
+    ],
+  },
+
+  {
+    startsWith: 'softmax ',
+    excludes: [
+      'underflow',  // Actual: NaN,NaN. Expected: 0.5,0.5.
     ],
   },
 

--- a/tfjs-backend-webgpu/src/softmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/softmax_webgpu.ts
@@ -49,7 +49,7 @@ export class SoftmaxProgram implements WebGPUProgram {
       let tid = i32(localId.x);
       let cols = uniforms.outShape[1];
 
-      var threadMax = -1.0 / 1e-20;
+      var threadMax = -3.402823e+38f;
       for (var col = tid; col < cols; col += blockSize) {
         let value = getLogits(row, col);
         threadMax = max(threadMax, value);
@@ -77,9 +77,7 @@ export class SoftmaxProgram implements WebGPUProgram {
         let subExp = exp(getLogits(row, col) - rowMaxShared);
         threadSum += subExp;
       }
-      if (tid < cols) {
-        buf[tid] = threadSum;
-      }
+      buf[tid] = threadSum;
       workgroupBarrier();
 
       for (var currSize = blockSize >> 1;  currSize > 0; currSize = currSize >> 1) {

--- a/tfjs-backend-webgpu/src/softmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/softmax_webgpu.ts
@@ -54,15 +54,13 @@ export class SoftmaxProgram implements WebGPUProgram {
         let value = getLogits(row, col);
         threadMax = max(threadMax, value);
       }
-      if (tid < cols)
-      {
+      if (tid < cols) {
         buf[tid] = threadMax;
       }
       workgroupBarrier();
 
       let reduceSize = min(cols, blockSize);
-      for (var currSize = reduceSize >> 1;  currSize > 0; currSize = currSize >> 1)
-      {
+      for (var currSize = reduceSize >> 1;  currSize > 0; currSize = currSize >> 1) {
         if (tid < currSize) {
           buf[tid] = max(buf[tid], buf[tid + currSize]);
         }
@@ -79,14 +77,12 @@ export class SoftmaxProgram implements WebGPUProgram {
         let subExp = exp(getLogits(row, col) - rowMaxShared);
         threadSum += subExp;
       }
-      if (tid < cols)
-      {
+      if (tid < cols) {
         buf[tid] = threadSum;
       }
       workgroupBarrier();
 
-      for (var currSize = blockSize >> 1;  currSize > 0; currSize = currSize >> 1)
-      {
+      for (var currSize = blockSize >> 1;  currSize > 0; currSize = currSize >> 1) {
         if (tid < currSize) {
           buf[tid] = buf[tid] + buf[tid + currSize];
         }

--- a/tfjs-backend-webgpu/src/softmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/softmax_webgpu.ts
@@ -16,36 +16,92 @@
  */
 
 import {getMainHeaderString as main, WebGPUProgram} from './webgpu_program';
-import {computeDispatch, flatDispatchLayout} from './webgpu_util';
+import {flatDispatchLayout} from './webgpu_util';
 
-// This kernel in fact is a combination of sub, exp.
 export class SoftmaxProgram implements WebGPUProgram {
-  variableNames = ['a', 'b'];
+  variableNames = ['logits'];
   outputShape: number[];
   shaderKey: string;
   dispatchLayout: {x: number[]};
   dispatch: [number, number, number];
-  workgroupSize: [number, number, number] = [64, 1, 1];
-  size = true;
+  workgroupSize: [number, number, number];
 
   constructor(outputShape: number[]) {
-    this.outputShape = outputShape;
+    this.outputShape = outputShape;  // [rows, cols]
     this.dispatchLayout = flatDispatchLayout(this.outputShape);
-    this.dispatch = computeDispatch(
-        this.dispatchLayout, this.outputShape, this.workgroupSize);
+    this.dispatch = [this.outputShape[0], 1, 1];
+    if (this.outputShape[1] >= 4096) {
+      this.workgroupSize = [256, 1, 1];
+    } else {
+      this.workgroupSize = [64, 1, 1]
+    }
     this.shaderKey = 'softmax';
   }
 
   getUserCode(): string {
     const userCode = `
-      ${main('index')} {
-        if (index < uniforms.size) {
-          let a = getAByOutputIndex(index);
-          let b = getBByOutputIndex(index);
-          let value = a - b;
-          setOutputAtIndex(index, exp(value));
-        }
+    var<workgroup> buf : array<f32, ${this.workgroupSize[0]}>;
+    var<workgroup> rowMaxShared : f32;
+    var<workgroup> rowSumShared : f32;
+    const block_size = ${this.workgroupSize[0]};
+    ${main('index')} {
+      let row = index / block_size;
+      let tid = i32(localId.x);
+      let cols = uniforms.outShape[1];
+
+      var thread_max = -1.0 / 1e-20;
+      for (var col = tid; col < cols; col += block_size) {
+        let pack = getLogits(row, col);
+        thread_max = max(thread_max, pack);
       }
+      if (tid < cols)
+      {
+        buf[tid] = thread_max;
+      }
+      workgroupBarrier();
+
+      for (var currSize = block_size >> 1;  currSize > 0; currSize = currSize >> 1)
+      {
+        if (tid < currSize) {
+          buf[tid] = max(buf[tid], buf[tid + currSize]);
+        }
+        workgroupBarrier();
+      }
+
+      if (tid == 0) {
+        rowMaxShared = buf[0];
+      }
+      workgroupBarrier();
+
+      var thread_sum = 0.0;
+      for (var col = tid; col < cols; col += block_size) {
+        let subExp = exp(getLogits(row, col) - rowMaxShared);
+        thread_sum += subExp;
+      }
+      if (tid < cols)
+      {
+        buf[tid] = thread_sum;
+      }
+      workgroupBarrier();
+
+      for (var currSize = block_size >> 1;  currSize > 0; currSize = currSize >> 1)
+      {
+        if (tid < currSize) {
+          buf[tid] = buf[tid] + buf[tid + currSize];
+        }
+        workgroupBarrier();
+      }
+
+      if (tid == 0) {
+        rowSumShared = buf[0];
+      }
+      workgroupBarrier();
+
+      for (var col = tid; col < cols; col += block_size) {
+        let pack = exp(getLogits(row, col) - rowMaxShared) / rowSumShared;
+        setOutputAtCoords(row, col, pack);
+      }
+  }
     `;
     return userCode;
   }

--- a/tfjs-backend-webgpu/src/softmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/softmax_webgpu.ts
@@ -60,7 +60,8 @@ export class SoftmaxProgram implements WebGPUProgram {
       }
       workgroupBarrier();
 
-      for (var currSize = blockSize >> 1;  currSize > 0; currSize = currSize >> 1)
+      let reduceSize = min(cols, blockSize);
+      for (var currSize = reduceSize >> 1;  currSize > 0; currSize = currSize >> 1)
       {
         if (tid < currSize) {
           buf[tid] = max(buf[tid], buf[tid + currSize]);
@@ -69,7 +70,7 @@ export class SoftmaxProgram implements WebGPUProgram {
       }
 
       if (tid == 0) {
-        rowMaxShared = buf[0];
+        rowMaxShared = max(buf[0], buf[reduceSize - 1]);
       }
       workgroupBarrier();
 

--- a/tfjs-backend-webgpu/src/softmax_webgpu.ts
+++ b/tfjs-backend-webgpu/src/softmax_webgpu.ts
@@ -33,7 +33,7 @@ export class SoftmaxProgram implements WebGPUProgram {
     if (this.outputShape[1] >= 4096) {
       this.workgroupSize = [256, 1, 1];
     } else {
-      this.workgroupSize = [64, 1, 1]
+      this.workgroupSize = [64, 1, 1];
     }
     this.shaderKey = 'softmax';
   }


### PR DESCRIPTION
PERF

Previously, the softmax was implemented by the naive method, which
includes five (max, sub, exp, sum, div) basic kernels. Even we fused sub
and exp, it sill needs 4 compute shaders. This PR utilizes shared memory
to implement everything in one shader and avoids the intermediate
buffers reading/writing, which greatly reduces the I/O accessing time.

softmax time in stable diffusion: 74ms -> 16ms

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs/7588)
<!-- Reviewable:end -->
