### PR TITLE
Implement the RandomUniformInt op

### DIFF
--- a/tfjs-converter/python/tensorflowjs/op_list/creation.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/creation.json
@@ -215,6 +215,42 @@
     ]
   },
   {
+    "tfOpName": "RandomUniformInt",
+    "category": "creation",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "shape",
+        "type": "number[]"
+      }
+    ],
+    "attrs": [
+      {
+        "tfName": "minval",
+        "name": "minval",
+        "type": "number"
+      },
+      {
+        "tfName": "maxval",
+        "name": "maxval",
+        "type": "number"
+      },
+      {
+        "tfName": "seed",
+        "name": "seed",
+        "type": "number",
+        "defaultValue": 0
+      },
+      {
+        "tfName": "seed2",
+        "name": "seed2",
+        "type": "number",
+        "defaultValue": 0,
+        "notSupported": true
+      }
+    ]
+  },
+  {
     "tfOpName": "Range",
     "category": "creation",
     "inputs": [

--- a/tfjs-converter/src/operations/executors/creation_executor.ts
+++ b/tfjs-converter/src/operations/executors/creation_executor.ts
@@ -92,6 +92,13 @@ export const executeOp: InternalOpExecutor =
               getParamValue('maxval', node, tensorMap, context) as number,
               getParamValue('dtype', node, tensorMap, context) as DataType)];
         }
+        case 'RandomUniformInt': {
+          return [ops.randomUniformInt(
+              getParamValue('shape', node, tensorMap, context) as number[],
+              getParamValue('minval', node, tensorMap, context) as number,
+              getParamValue('maxval', node, tensorMap, context) as number,
+              getParamValue('seed', node, tensorMap, context) as number)];
+        }
         case 'Range': {
           const start =
               getParamValue('start', node, tensorMap, context) as number;

--- a/tfjs-converter/src/operations/executors/creation_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/creation_executor_test.ts
@@ -228,6 +228,31 @@ describe('creation', () => {
         expect(validateParam(node, creation.json)).toBeTruthy();
       });
     });
+    describe('RandomUniformInt', () => {
+      it('should call tfOps.randomUniformInt', () => {
+        node.op = 'RandomUniformInt';
+        node.inputParams['shape'] = createNumericArrayAttrFromIndex(0);
+        node.inputNames = ['input1'];
+        node.attrParams['maxval'] = createNumberAttr(1);
+        node.attrParams['minval'] = createNumberAttr(0);
+        node.attrParams['seed'] = createNumberAttr(456);
+
+        executeOp(node, {input1}, context, spyOpsAsTfOps);
+
+        expect(spyOps.randomUniformInt)
+            .toHaveBeenCalledWith([1, 2, 3], 0, 1, 456);
+      });
+      it('should match json def', () => {
+        node.op = 'RandomUniformInt';
+        node.inputParams['shape'] = createNumericArrayAttrFromIndex(0);
+        node.inputNames = ['input1'];
+        node.attrParams['maxval'] = createNumberAttr(1);
+        node.attrParams['minval'] = createNumberAttr(0);
+        node.attrParams['seed'] = createNumberAttr(456);
+
+        expect(validateParam(node, creation.json)).toBeTruthy();
+      });
+    });
     describe('TruncatedNormal', () => {
       it('should call tfOps.truncatedNormal', () => {
         node.op = 'TruncatedNormal';

--- a/tfjs-core/src/ops/ops.ts
+++ b/tfjs-core/src/ops/ops.ts
@@ -143,6 +143,7 @@ export {randomGamma} from './random_gamma';
 export {randomNormal} from './random_normal';
 export {randomStandardNormal} from './random_standard_normal';
 export {randomUniform} from './random_uniform';
+export {randomUniformInt} from './random_uniform_int';
 export {range} from './range';
 export {real} from './real';
 export {reciprocal} from './reciprocal';

--- a/tfjs-core/src/ops/random_uniform.ts
+++ b/tfjs-core/src/ops/random_uniform.ts
@@ -40,6 +40,9 @@ import {UniformRandom} from './rand_util';
  * @param maxval The upper bound on the range of random values to generate.
  *   Defaults to 1.
  * @param dtype The data type of the output tensor. Defaults to 'float32'.
+ * @param seed An optional int. Defaults to 0. If seed is set to be non-zero,
+ *   the random number generator is seeded by the given seed. Otherwise, it is
+ *   seeded by a random seed.
  *
  * @doc {heading: 'Tensors', subheading: 'Random'}
  */

--- a/tfjs-core/src/ops/random_uniform_int.ts
+++ b/tfjs-core/src/ops/random_uniform_int.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Tensor} from '../tensor';
+import {Rank, ShapeMap} from '../types';
+import {op} from './operation';
+import {randomUniform} from './random_uniform';
+
+/**
+ * Creates a `tf.Tensor` with integers sampled from a uniform distribution.
+ *
+ * The generated values are uniform integers in the range [minval, maxval). The
+ * lower bound minval is included in the range, while the upper bound maxval is
+ * excluded.
+ *
+ * ```js
+ * tf.randomUniformInt([2, 2], 0, 10).print();
+ * ```
+ *
+ * @param shape An array of integers defining the output tensor shape.
+ * @param minval Inclusive lower bound on the generated integers.
+ * @param maxval Exclusive upper bound on the generated integers.
+ * @param seed An optional int. Defaults to 0. If seed is set to be non-zero,
+ *   the random number generator is seeded by the given seed. Otherwise, it is
+ *   seeded by a random seed.
+ *
+ * @doc {heading: 'Tensors', subheading: 'Random'}
+ */
+function randomUniformInt_<R extends Rank>(
+  shape: ShapeMap[R], minval: number, maxval: number,
+    seed?: number|string): Tensor<R> {
+  // TODO(mattsoulanille): Handle optional seed2 input.
+  return randomUniform(shape, minval, maxval, 'int32', seed);
+}
+
+export const randomUniformInt = /* @__PURE__ */ op({randomUniformInt_});

--- a/tfjs-core/src/ops/random_uniform_int_test.ts
+++ b/tfjs-core/src/ops/random_uniform_int_test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../index';
+import {ALL_ENVS, describeWithFlags} from '../jasmine_util';
+import { expectArraysEqual, expectValuesInRange} from '../test_util';
+
+describeWithFlags('randomUniformInt', ALL_ENVS, () => {
+  it('should return a random 1D int32 array', async () => {
+    const shape: [number] = [10];
+    const result = tf.randomUniformInt(shape, 0, 2);
+    expect(result.dtype).toBe('int32');
+    expectValuesInRange(await result.data(), 0, 2);
+  });
+
+  it('should return a random 2D int32 array', async () => {
+    const shape: [number, number] = [3, 4];
+    const result = tf.randomUniformInt(shape, 0, 2);
+    expect(result.dtype).toBe('int32');
+    expectValuesInRange(await result.data(), 0, 2);
+  });
+
+  it('should return a random 3D int32 array', async () => {
+    const shape: [number, number, number] = [3, 4, 5];
+    const result = tf.randomUniformInt(shape, 0, 2);
+    expect(result.dtype).toBe('int32');
+    expectValuesInRange(await result.data(), 0, 2);
+  });
+
+  it('should return a random 4D int32 array', async () => {
+    const shape: [number, number, number, number] = [3, 4, 5, 6];
+    const result = tf.randomUniformInt(shape, 0, 2);
+    expect(result.dtype).toBe('int32');
+    expectValuesInRange(await result.data(), 0, 2);
+  });
+
+  it('should return a random 5D int32 array', async () => {
+    const shape: [number, number, number, number, number] = [2, 3, 4, 5, 6];
+    const result = tf.randomUniformInt(shape, 0, 2);
+    expect(result.dtype).toBe('int32');
+    expectValuesInRange(await result.data(), 0, 2);
+  });
+
+  it('should throw error when shape is not integer', () => {
+    expect(() => tf.randomUniformInt([2, 2.22, 3.33], 0, 1)).toThrow();
+  });
+
+  it('should return the same result when seed is specified', async () => {
+    const seed = 123;
+    const shape = [4, 4];
+    const result1 = tf.randomUniformInt(shape, 0, 1000, seed);
+    const result2 = tf.randomUniformInt(shape, 0, 1000, seed);
+    expectArraysEqual(await result1.data(), await result2.data());
+  });
+});


### PR DESCRIPTION
Implement the [RandomUniformInt](https://www.tensorflow.org/api_docs/python/tf/raw_ops/RandomUniformInt) op.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.