### PR TITLE
webgpu: Change the Chrome macOS flags in BrowserStack

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -83,11 +83,17 @@ const CUSTOM_LAUNCHERS = {
     os_version: 'High Sierra',
     flags: [
       '--enable-unsafe-webgpu',
+      '--disable-vulkan-surface',
+
+      '--disable-vulkan-fallback-to-gl-for-testing',
+      '--disable-features=VaapiVideoDecoder',
+      '--ignore-gpu-blocklist',
+
       '--enable-features=vulkan',
       '--use-angle=swiftshader',
       '--use-vulkan=swiftshader',
       '--use-webgpu-adapter=swiftshader',
-      '--disable-vulkan-surface',
+
     ],
   },
   chrome_with_swift_shader: {

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -89,7 +89,7 @@ const CUSTOM_LAUNCHERS = {
       '--use-angle=swiftshader', '--use-vulkan=swiftshader',
 
       // more tests
-      //'--disable-vulkan-fallback-to-gl-for-testing',
+      '--disable-vulkan-fallback-to-gl-for-testing',
       //'--disable-features=VaapiVideoDecoder',
 
     ],

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -83,7 +83,6 @@ const CUSTOM_LAUNCHERS = {
     os_version: 'High Sierra',
     flags: [
       '--enable-unsafe-webgpu',  // Can be removed after WebGPU release
-      //'--enable-features=Vulkan',
       '--use-webgpu-adapter=swiftshader',
 
       // https://github.com/tensorflow/tfjs/issues/7631

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -83,7 +83,7 @@ const CUSTOM_LAUNCHERS = {
     os_version: 'High Sierra',
     flags: [
       '--enable-unsafe-webgpu',  // Can be removed after WebGPU release
-      '--enable-features=Vulkan',
+      //'--enable-features=Vulkan',
       '--use-webgpu-adapter=swiftshader',
 
       // https://github.com/tensorflow/tfjs/issues/7631

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -82,17 +82,12 @@ const CUSTOM_LAUNCHERS = {
     os: 'OS X',
     os_version: 'High Sierra',
     flags: [
-      // mandatory flags
-      '--enable-unsafe-webgpu',
+      '--enable-unsafe-webgpu',  // Can be removed after WebGPU release
       '--enable-features=Vulkan',
       '--use-webgpu-adapter=swiftshader',
 
-      //'--use-angle=swiftshader',
-      //'--use-vulkan=swiftshader',
-
-      // more tests
+      // https://github.com/tensorflow/tfjs/issues/7631
       '--disable-vulkan-fallback-to-gl-for-testing',
-
     ],
   },
   chrome_with_swift_shader: {

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -83,13 +83,11 @@ const CUSTOM_LAUNCHERS = {
     os_version: 'High Sierra',
     flags: [
       '--enable-unsafe-webgpu',
-      '--disable-vulkan-fallback-to-gl-for-testing',
+      '--enable-features=vulkan',
+      '--use-angle=swiftshader',
+      '--use-vulkan=swiftshader',
+      '--use-webgpu-adapter=swiftshader',
       '--disable-vulkan-surface',
-      '--disable-features=VaapiVideoDecoder',
-      '--ignore-gpu-blocklist',
-      // For some reason, the tests fail without this flag, even though macos
-      // does not use Vulkan.
-      '--use-angle=vulkan',
     ],
   },
   chrome_with_swift_shader: {
@@ -155,14 +153,16 @@ module.exports = function(config) {
     const username = process.env.BROWSERSTACK_USERNAME;
     const accessKey = process.env.BROWSERSTACK_KEY;
     if (!username) {
-      console.error('No browserstack username found. Please set the'
-                    + ' environment variable "BROWSERSTACK_USERNAME" to your'
-                    + ' browserstack username');
+      console.error(
+          'No browserstack username found. Please set the' +
+          ' environment variable "BROWSERSTACK_USERNAME" to your' +
+          ' browserstack username');
     }
     if (!accessKey) {
-      console.error('No browserstack access key found. Please set the'
-                    + ' environment variable "BROWSERSTACK_KEY" to your'
-                    + ' browserstack access key');
+      console.error(
+          'No browserstack access key found. Please set the' +
+          ' environment variable "BROWSERSTACK_KEY" to your' +
+          ' browserstack access key');
     }
     if (!username || !accessKey) {
       process.exit(1);
@@ -173,8 +173,7 @@ module.exports = function(config) {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY,
       timeout: 900,  // Seconds
-      tunnelIdentifier:
-      `tfjs_${Date.now()}_${Math.floor(Math.random() * 1000)}`
+      tunnelIdentifier: `tfjs_${Date.now()}_${Math.floor(Math.random() * 1000)}`
     };
   }
 
@@ -201,7 +200,7 @@ module.exports = function(config) {
       args: TEMPLATE_args,
       jasmine: {
         random: TEMPLATE_jasmine_random,
-        seed: "TEMPLATE_jasmine_seed",
+        seed: 'TEMPLATE_jasmine_seed',
       },
     },
   });

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -83,14 +83,15 @@ const CUSTOM_LAUNCHERS = {
     os_version: 'High Sierra',
     flags: [
       // mandatory flags
-      '--enable-unsafe-webgpu', '--enable-features=Vulkan',
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
       '--use-webgpu-adapter=swiftshader',
 
-      '--use-angle=swiftshader', '--use-vulkan=swiftshader',
+      //'--use-angle=swiftshader',
+      //'--use-vulkan=swiftshader',
 
       // more tests
       '--disable-vulkan-fallback-to-gl-for-testing',
-      //'--disable-features=VaapiVideoDecoder',
 
     ],
   },

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -85,8 +85,6 @@ const CUSTOM_LAUNCHERS = {
       '--enable-unsafe-webgpu',
       '--disable-vulkan-surface',
 
-      '--disable-vulkan-fallback-to-gl-for-testing',
-      '--disable-features=VaapiVideoDecoder',
       '--ignore-gpu-blocklist',
 
       '--enable-features=vulkan',

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -83,16 +83,14 @@ const CUSTOM_LAUNCHERS = {
     os_version: 'High Sierra',
     flags: [
       // mandatory flags
-      '--enable-unsafe-webgpu',
-      '--enable-features=Vulkan',
+      '--enable-unsafe-webgpu', '--enable-features=Vulkan',
       '--use-webgpu-adapter=swiftshader',
 
-      // more tests
-      '--use-angle=swiftshader',
-      '--use-vulkan=swiftshader',
+      '--use-angle=swiftshader', '--use-vulkan=swiftshader',
 
-      '--disable-vulkan-fallback-to-gl-for-testing',
-      '--disable-features=VaapiVideoDecoder',
+      // more tests
+      //'--disable-vulkan-fallback-to-gl-for-testing',
+      //'--disable-features=VaapiVideoDecoder',
 
     ],
   },

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -82,15 +82,17 @@ const CUSTOM_LAUNCHERS = {
     os: 'OS X',
     os_version: 'High Sierra',
     flags: [
+      // mandatory flags
       '--enable-unsafe-webgpu',
-      '--disable-vulkan-surface',
+      '--enable-features=Vulkan',
+      '--use-webgpu-adapter=swiftshader',
 
-      '--ignore-gpu-blocklist',
-
-      '--enable-features=vulkan',
+      // more tests
       '--use-angle=swiftshader',
       '--use-vulkan=swiftshader',
-      '--use-webgpu-adapter=swiftshader',
+
+      '--disable-vulkan-fallback-to-gl-for-testing',
+      '--disable-features=VaapiVideoDecoder',
 
     ],
   },


### PR DESCRIPTION
This is to ensure all the flags are necessary for WebGPU tests in BrowserStack on Chrome macOS based on SwiftShader.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.