### PR TITLE
Avoid changing 'action_env' between bazel run and test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,6 +51,7 @@ build:ci --config=bes
 # See https://github.com/angular/angular/issues/27514.
 build --incompatible_strict_action_env
 run --incompatible_strict_action_env
+test --incompatible_strict_action_env
 
 # Use a sandboxed build where available to avoid a possible issue with the rules_nodejs linker for Linux and MacOS. b/250727292
 # Remote builds are sandboxed.
@@ -70,7 +71,9 @@ run --action_env=BROWSERSTACK_USERNAME --action_env=BROWSERSTACK_KEY
 test --action_env=BROWSERSTACK_USERNAME --action_env=BROWSERSTACK_KEY
 
 # Make python debugging refer to the real files instead of symlinks
+build --action_env=PYDEVD_RESOLVE_SYMLINKS=true
 run --action_env=PYDEVD_RESOLVE_SYMLINKS=true
+test --action_env=PYDEVD_RESOLVE_SYMLINKS=true
 
 # Platform specific DISPLAY environment variable for webgl and headless setting
 # for browser tests.


### PR DESCRIPTION
When action_env changes, Bazel needs to recompile everything, since the compilation output may have been changed by the shell variables specified in action_env. This PR avoids changing action_env between build and test commands, which prevents Bazel from re-building everything when switching between `bazel test` and `bazel run` commands.

Tested by running `yarn build` in tfjs-core followed by `yarn test`. It should not have to re-build the targets built in `yarn build`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.