### PR TITLE
Add ensureShape API

### DIFF
--- a/tfjs-converter/docs/supported_ops.md
+++ b/tfjs-converter/docs/supported_ops.md
@@ -373,6 +373,7 @@
 |Pad|pad|
 |PadV2|PadV2|
 |Reshape|reshape|
+|EnsureShape|ensureShape|
 |SpaceToBatchND|spaceToBatchND|
 |Squeeze|squeeze|
 |Not mapped|setdiff1dAsync|

--- a/tfjs-converter/python/tensorflowjs/op_list/transformation.json
+++ b/tfjs-converter/python/tensorflowjs/op_list/transformation.json
@@ -125,6 +125,22 @@
     ]
   },
   {
+    "tfOpName": "EnsureShape",
+    "category": "transformation",
+    "inputs": [
+      {
+        "start": 0,
+        "name": "x",
+        "type": "tensor"
+      },
+      {
+        "start": 1,
+        "name": "shape",
+        "type": "number[]"
+      }
+    ]
+  },
+  {
     "tfOpName": "Squeeze",
     "category": "transformation",
     "inputs": [

--- a/tfjs-converter/src/operations/executors/transformation_executor.ts
+++ b/tfjs-converter/src/operations/executors/transformation_executor.ts
@@ -26,8 +26,8 @@ import {InternalOpExecutor, Node} from '../types';
 import {getParamValue} from './utils';
 
 export const executeOp: InternalOpExecutor =
-    (node: Node, tensorMap: NamedTensorsMap,
-     context: ExecutionContext, ops = tfOps): Tensor[] => {
+    (node: Node, tensorMap: NamedTensorsMap, context: ExecutionContext,
+     ops = tfOps): Tensor[] => {
       switch (node.op) {
         case 'Cast': {
           return [ops.cast(
@@ -50,6 +50,11 @@ export const executeOp: InternalOpExecutor =
 
         case 'Reshape': {
           return [ops.reshape(
+              getParamValue('x', node, tensorMap, context) as Tensor,
+              getParamValue('shape', node, tensorMap, context) as number[])];
+        }
+        case 'EnsureShape': {
+          return [ops.ensureShape(
               getParamValue('x', node, tensorMap, context) as Tensor,
               getParamValue('shape', node, tensorMap, context) as number[])];
         }

--- a/tfjs-converter/src/operations/executors/transformation_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/transformation_executor_test.ts
@@ -19,9 +19,10 @@ import * as tfOps from '@tensorflow/tfjs-core/dist/ops/ops_for_converter';
 
 import {ExecutionContext} from '../../executor/execution_context';
 import {Node} from '../types';
+
+import {RecursiveSpy, spyOnAllFunctions} from './spy_ops';
 import {createDtypeAttr, createNumberAttr, createNumericArrayAttrFromIndex, createStrAttr, createTensorAttr} from './test_helper';
 import {executeOp} from './transformation_executor';
-import {RecursiveSpy, spyOnAllFunctions} from './spy_ops';
 
 describe('transformation', () => {
   let node: Node;
@@ -119,6 +120,17 @@ describe('transformation', () => {
         executeOp(node, {input1, input2}, context, spyOpsAsTfOps);
 
         expect(spyOps.reshape).toHaveBeenCalledWith(input1[0], [1, 1]);
+      });
+    });
+    describe('EnsureShape', () => {
+      it('should call tfOps.ensureShape', () => {
+        node.op = 'EnsureShape';
+        node.inputParams.shape = createNumericArrayAttrFromIndex(1);
+        node.inputNames = ['input1', 'input2'];
+
+        executeOp(node, {input1, input2}, context, spyOpsAsTfOps);
+
+        expect(spyOps.ensureShape).toHaveBeenCalledWith(input1[0], [1, 1]);
       });
     });
     describe('Squeeze', () => {

--- a/tfjs-converter/src/operations/executors/transformation_executor_test.ts
+++ b/tfjs-converter/src/operations/executors/transformation_executor_test.ts
@@ -126,11 +126,12 @@ describe('transformation', () => {
       it('should call tfOps.ensureShape', () => {
         node.op = 'EnsureShape';
         node.inputParams.shape = createNumericArrayAttrFromIndex(1);
-        node.inputNames = ['input1', 'input2'];
+        node.inputNames = ['input2', 'input3'];
+        const input3 = [tfOps.tensor1d([2])];
 
-        executeOp(node, {input1, input2}, context, spyOpsAsTfOps);
+        executeOp(node, {input2, input3}, context, spyOpsAsTfOps);
 
-        expect(spyOps.ensureShape).toHaveBeenCalledWith(input1[0], [1, 1]);
+        expect(spyOps.ensureShape).toHaveBeenCalledWith(input2[0], [2]);
       });
     });
     describe('Squeeze', () => {

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -50,7 +50,7 @@ import {op} from './operation';
 function ensureShape_<R extends Rank>(x: Tensor, shape: ShapeMap[R]): Tensor {
   const $x = convertToTensor(x, 'x', 'ensureShape', 'string_or_numeric');
   if (!arraysEqualWithNull($x.shape, shape)) {
-    throw new Error(`Invalid argument error. Shape of tensor ${
+    throw new Error(`EnsureShape: Shape of tensor ${
         $x.shape} is not compatible with expected shape ${shape}`);
   }
 

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -41,7 +41,7 @@ import {op} from './operation';
  *
  * @param x The input tensor to be ensured.
  * @param shape A TensorShape representing the shape of this tensor, an array
- *     and null.
+ *     or null.
  *
  * @doc {heading: 'Tensors', subheading: 'Transformations'}
  */

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -40,8 +40,8 @@ import {op} from './operation';
  * ```
  *
  * @param x The input tensor to be ensured.
- * @param shape A TensorShape representing the shape of this tensor, a list, a
- *     tuple, or None.
+ * @param shape A TensorShape representing the shape of this tensor, an array
+ *     and null.
  *
  * @doc {heading: 'Tensors', subheading: 'Transformations'}
  */

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC. All Rights Reserved.
+ * Copyright 2023 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,10 +23,13 @@ import {arraysEqualWithNull} from '../util_base';
 import {op} from './operation';
 
 /**
- * Updates a tensor and checks at runtime that the shape holds.
+ * Checks the input tensor mathes the given shape.
  *
  * Given an input tensor, returns a new tensor with the same values as the
  * input tensor with shape `shape`.
+ *
+ * The method supports the null value in tensor. It will still check the shapes,
+ * and null is a placeholder.
  *
  *
  * ```js

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Tensor} from '../tensor';
+import {convertToTensor} from '../tensor_util_env';
+import {Rank, ShapeMap, TensorLike} from '../types';
+import {arraysEqualWithNull} from '../util_base';
+
+import {op} from './operation';
+
+/**
+ * Updates a tensor and checks at runtime that the shape holds.
+ *
+ * Given an input tensor, returns a new tensor with the same values as the
+ * input tensor with shape `shape`.
+ *
+ *
+ * ```js
+ * const x = tf.tensor1d([1, 2, 3, 4]);
+ * tf.ensureShape(x, [4]).print();
+ * ```
+ *
+ * @param x The input tensor to be ensured.
+ * @param shape A TensorShape representing the shape of this tensor, a list, a
+ *     tuple, or None.
+ *
+ * @doc {heading: 'Tensors', subheading: 'Transformations'}
+ */
+function ensureShape_<R extends Rank>(
+    x: Tensor|TensorLike, shape: ShapeMap[R]): Tensor {
+  const $x = convertToTensor(x, 'x', 'ensure_shape', 'string_or_numeric');
+
+  if (!arraysEqualWithNull($x.shape, shape)) {
+    throw new Error(`Invalid argument error. Shape of tensor ${
+        x} is not compatible with expected shape ${shape}`);
+  }
+
+  return $x;
+}
+export const ensureShape = /* @__PURE__ */ op({ensureShape_});

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -35,8 +35,10 @@ import {op} from './operation';
  * ```js
  * const x = tf.tensor1d([1, 2, 3, 4]);
  * const y = tf.tensor1d([1, null, 3, 4]);
+ * const z = tf.tensor2d([1, 2, 3, 4], [2,2]);
  * tf.ensureShape(x, [4]).print();
  * tf.ensureShape(y, [4]).print();
+ * tf.ensureShape(z, [null, 2]).print();
  * ```
  *
  * @param x The input tensor to be ensured.

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -31,7 +31,9 @@ import {op} from './operation';
  *
  * ```js
  * const x = tf.tensor1d([1, 2, 3, 4]);
+ * const y = tf.tensor1d([1, null, 3, 4]);
  * tf.ensureShape(x, [4]).print();
+ * tf.ensureShape(y, [4]).print();
  * ```
  *
  * @param x The input tensor to be ensured.
@@ -46,7 +48,7 @@ function ensureShape_<R extends Rank>(
 
   if (!arraysEqualWithNull($x.shape, shape)) {
     throw new Error(`Invalid argument error. Shape of tensor ${
-        x} is not compatible with expected shape ${shape}`);
+        $x.shape} is not compatible with expected shape ${shape}`);
   }
 
   return $x;

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -17,7 +17,7 @@
 
 import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
-import {Rank, ShapeMap, TensorLike} from '../types';
+import {Rank, ShapeMap} from '../types';
 import {arraysEqualWithNull} from '../util_base';
 
 import {op} from './operation';
@@ -47,15 +47,13 @@ import {op} from './operation';
  *
  * @doc {heading: 'Tensors', subheading: 'Transformations'}
  */
-function ensureShape_<R extends Rank>(
-    x: Tensor|TensorLike, shape: ShapeMap[R]): Tensor {
-  const $x = convertToTensor(x, 'x', 'ensure_shape', 'string_or_numeric');
-
+function ensureShape_<R extends Rank>(x: Tensor, shape: ShapeMap[R]): Tensor {
+  const $x = convertToTensor(x, 'x', 'ensureShape', 'string_or_numeric');
   if (!arraysEqualWithNull($x.shape, shape)) {
     throw new Error(`Invalid argument error. Shape of tensor ${
         $x.shape} is not compatible with expected shape ${shape}`);
   }
 
-  return $x;
+  return x;
 }
 export const ensureShape = /* @__PURE__ */ op({ensureShape_});

--- a/tfjs-core/src/ops/ensure_shape.ts
+++ b/tfjs-core/src/ops/ensure_shape.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2023 Google LLC. All Rights Reserved.
+ * Copyright 2023 Google LLC.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -35,10 +35,10 @@ describeWithFlags('ensureShape', ALL_ENVS, () => {
     const x = tf.tensor1d([1, 2, 3, 4]);
     expect(() => ensureShape(x, [1, 3]))
         .toThrowError(/Invalid argument error./);
-  })
+  });
 
   it('null shape', () => {
     const x = tf.tensor2d([1, null, 3, 4], [2, 2]);
     expect(ensureShape(x, [2, 2])).toEqual(x);
-  })
+  });
 });

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -19,7 +19,7 @@ import * as tf from '../index';
 import {ALL_ENVS, describeWithFlags} from '../jasmine_util';
 import {ensureShape} from './ensure_shape';
 
-describeWithFlags('ensure_shape', ALL_ENVS, () => {
+describeWithFlags('ensureShape', ALL_ENVS, () => {
   it('basic', () => {
     const x = tf.ones([2, 3]);
     expect(ensureShape(x, [2, 3])).toEqual(x);
@@ -30,4 +30,15 @@ describeWithFlags('ensure_shape', ALL_ENVS, () => {
     expect(() => ensureShape(x, [5, 3]))
         .toThrowError(/Invalid argument error./);
   });
+
+  it('different length', () => {
+    const x = tf.tensor1d([1, 2, 3, 4]);
+    expect(() => ensureShape(x, [1, 3]))
+        .toThrowError(/Invalid argument error./);
+  })
+
+  it('null shape', () => {
+    const x = tf.tensor2d([1, null, 3, 4], [2, 2]);
+    expect(ensureShape(x, [2, 2])).toEqual(x);
+  })
 });

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC. All Rights Reserved.
+ * Copyright 2023 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -27,6 +27,7 @@ describeWithFlags('ensure_shape', ALL_ENVS, () => {
 
   it('different shape', () => {
     const x = tf.ones([2, 3]);
-    expect(() => ensureShape(x, [5, 3])).toThrowError();
+    expect(() => ensureShape(x, [5, 3]))
+        .toThrowError(/Invalid argument error./);
   });
 });

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -27,14 +27,12 @@ describeWithFlags('ensureShape', ALL_ENVS, () => {
 
   it('different shape', () => {
     const x = tf.ones([2, 3]);
-    expect(() => ensureShape(x, [5, 3]))
-        .toThrowError(/Invalid argument error./);
+    expect(() => ensureShape(x, [5, 3])).toThrowError(/EnsureShape:/);
   });
 
   it('different length', () => {
     const x = tf.tensor1d([1, 2, 3, 4]);
-    expect(() => ensureShape(x, [1, 3]))
-        .toThrowError(/Invalid argument error./);
+    expect(() => ensureShape(x, [1, 3])).toThrowError(/EnsureShape:/);
   });
 
   it('null shape', () => {

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2023 Google LLC. All Rights Reserved.
+ * Copyright 2023 Google LLC.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/tfjs-core/src/ops/ensure_shape_test.ts
+++ b/tfjs-core/src/ops/ensure_shape_test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../index';
+import {ALL_ENVS, describeWithFlags} from '../jasmine_util';
+import {ensureShape} from './ensure_shape';
+
+describeWithFlags('ensure_shape', ALL_ENVS, () => {
+  it('basic', () => {
+    const x = tf.ones([2, 3]);
+    expect(ensureShape(x, [2, 3])).toEqual(x);
+  });
+
+  it('different shape', () => {
+    const x = tf.ones([2, 3]);
+    expect(() => ensureShape(x, [5, 3])).toThrowError();
+  });
+});

--- a/tfjs-core/src/ops/ops.ts
+++ b/tfjs-core/src/ops/ops.ts
@@ -71,6 +71,7 @@ export {divNoNan} from './div_no_nan';
 export {dot} from './dot';
 export {einsum} from './einsum';
 export {elu} from './elu';
+export {ensureShape} from './ensure_shape';
 export {equal} from './equal';
 export {erf} from './erf';
 export {euclideanNorm} from './euclidean_norm';

--- a/tfjs-core/src/util_base.ts
+++ b/tfjs-core/src/util_base.ts
@@ -194,6 +194,27 @@ export function isScalarShape(shape: number[]): boolean {
   return shape.length === 0;
 }
 
+export function arraysEqualWithNull(n1: number[], n2: number[]) {
+  if (n1 === n2) {
+    return true;
+  }
+
+  if (n1 == null || n2 == null) {
+    return false;
+  }
+
+  if (n1.length !== n2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < n1.length; i++) {
+    if (n1[i] !== null && n2[i] !== null && n1[i] !== n2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function arraysEqual(n1: FlatVector, n2: FlatVector) {
   if (n1 === n2) {
     return true;


### PR DESCRIPTION
This PR adds the ops for ensureShape() in Core.
We can ensure the input tensor has the same shape as the given shape.
```js
// Construct a 1D tensor with [1, 2, 3, 4]
const x = tf.tensor1d([1, 2, 3, 4]);

// Ensure that x has the same shape with shape: [4]
tf.ensureShape(x, [4]);
```

Fix https://github.com/tensorflow/tfjs/issues/7225