### PR TITLE
Add browser tests for CPU backend

### DIFF
--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -42,7 +42,7 @@ tfjs_web_test(
     headless = False,
     presubmit_browsers = [
         "bs_safari_mac",
-    ]
+    ],
 )
 
 tfjs_bundle(

--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -36,9 +36,16 @@ tfjs_web_test(
         "//tfjs-backend-cpu/src:tfjs-backend-cpu_test_bundle",
     ],
     args = [],
-    browsers = [],
+    browsers = [
+        "bs_chrome_mac",
+        "bs_firefox_mac",
+        "bs_android_10",
+        "win_10_chrome",
+    ],
     headless = False,
-    presubmit_browsers = []
+    presubmit_browsers = [
+        "bs_safari_mac",
+    ]
 )
 
 tfjs_bundle(

--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -16,6 +16,7 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm")
 load("//tools:copy_to_dist.bzl", "copy_to_dist", "copy_ts_library_to_dist")
 load("//tools:tfjs_bundle.bzl", "tfjs_bundle")
+load("//tools:tfjs_web_test.bzl", "tfjs_web_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,6 +28,17 @@ nodejs_test(
     entry_point = "//tfjs-backend-cpu/src:run_tests.ts",
     link_workspace_root = True,
     tags = ["ci"],
+)
+
+tfjs_web_test(
+    name = "tfjs-backend-cpu_browser_test",
+    srcs = [
+        "//tfjs-backend-cpu/src:tfjs-backend-cpu_test_bundle",
+    ],
+    args = [],
+    browsers = [],
+    headless = False,
+    presubmit_browsers = []
 )
 
 tfjs_bundle(

--- a/tfjs-backend-cpu/BUILD.bazel
+++ b/tfjs-backend-cpu/BUILD.bazel
@@ -38,9 +38,6 @@ tfjs_web_test(
     args = [],
     browsers = [
         "bs_chrome_mac",
-        "bs_firefox_mac",
-        "bs_android_10",
-        "win_10_chrome",
     ],
     headless = False,
     presubmit_browsers = [

--- a/tfjs-backend-cpu/src/BUILD.bazel
+++ b/tfjs-backend-cpu/src/BUILD.bazel
@@ -66,7 +66,9 @@ ts_library(
 ts_library(
     name = "tfjs-backend-cpu_test_lib",
     testonly = True,
-    srcs = glob(TEST_SRCS),
+    srcs = glob(TEST_SRCS) + [
+        ":tests",
+    ],
     module_name = "@tensorflow/tfjs-backend-cpu/dist",
     deps = [
         ":tfjs-backend-cpu_lib",

--- a/tfjs-backend-cpu/src/BUILD.bazel
+++ b/tfjs-backend-cpu/src/BUILD.bazel
@@ -13,7 +13,8 @@
 # limitations under the License.
 # =============================================================================
 
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+load("//tools:enumerate_tests.bzl", "enumerate_tests")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,6 +22,23 @@ TEST_SRCS = [
     "**/*_test.ts",
     "run_tests.ts",
 ]
+
+filegroup(
+    name = "all_test_entrypoints",
+    srcs = glob(
+        ["**/*_test.ts"],
+        exclude = [
+            "setup_test.ts",
+        ],
+    ),
+)
+
+# Generates the 'tests.ts' file that imports all test entrypoints.
+enumerate_tests(
+    name = "tests",
+    srcs = [":all_test_entrypoints"],
+    root_path = "tfjs-backend-cpu/src",
+)
 
 ts_library(
     name = "tfjs-backend-cpu_src_lib",
@@ -58,5 +76,24 @@ ts_library(
         "//tfjs-core/src:tfjs-core_test_lib",
         "@npm//@types/jasmine",
         "@npm//jasmine",
+    ],
+)
+
+esbuild(
+    name = "tfjs-backend-cpu_test_bundle",
+    testonly = True,
+    entry_point = "setup_test.ts",
+    external = [
+        # webworker tests call 'require('@tensorflow/tfjs')', which
+        # is external to the test bundle.
+        # Note: This is not a bazel target. It's just a string.
+        "@tensorflow/tfjs",
+        "worker_threads",
+        "util",
+    ],
+    sources_content = True,
+    deps = [
+        ":tfjs-backend-cpu_lib",
+        ":tfjs-backend-cpu_test_lib",
     ],
 )

--- a/tfjs-backend-cpu/src/setup_test.ts
+++ b/tfjs-backend-cpu/src/setup_test.ts
@@ -26,6 +26,8 @@ import '@tensorflow/tfjs-core/dist/register_all_gradients';
 // tslint:disable-next-line: no-imports-from-dist
 import {parseTestEnvFromKarmaFlags, setTestEnvs, setupTestFilters, TEST_ENVS, TestFilter} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
+setTestEnvs([{name: 'cpu', backendName: 'cpu', isDataSync: true}]);
+
 const TEST_FILTERS: TestFilter[] = [];
 const customInclude = (testName: string) => {
   return true;

--- a/tfjs-backend-cpu/src/setup_test.ts
+++ b/tfjs-backend-cpu/src/setup_test.ts
@@ -44,12 +44,6 @@ if (typeof __karma__ !== 'undefined') {
   }
 }
 
-// These use 'require' because they must not be hoisted above
-// the preceding snippet that parses test environments.
-// Import and run tests from core.
-// tslint:disable-next-line:no-imports-from-dist
-// tslint:disable-next-line:no-require-imports
-require('@tensorflow/tfjs-core/dist/tests');
 // Import and run tests from cpu.
 // tslint:disable-next-line:no-imports-from-dist
 // tslint:disable-next-line:no-require-imports

--- a/tfjs-backend-cpu/src/setup_test.ts
+++ b/tfjs-backend-cpu/src/setup_test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import '@tensorflow/tfjs-backend-cpu';
+// Register the backend.
+import './index';
+// tslint:disable-next-line: no-imports-from-dist
+import '@tensorflow/tfjs-core/dist/public/chained_ops/register_all_chained_ops';
+// tslint:disable-next-line: no-imports-from-dist
+import '@tensorflow/tfjs-core/dist/register_all_gradients';
+
+// tslint:disable-next-line: no-imports-from-dist
+import {parseTestEnvFromKarmaFlags, setTestEnvs, setupTestFilters, TEST_ENVS, TestFilter} from '@tensorflow/tfjs-core/dist/jasmine_util';
+
+const TEST_FILTERS: TestFilter[] = [];
+const customInclude = (testName: string) => {
+  return true;
+};
+setupTestFilters(TEST_FILTERS, customInclude);
+
+// Allow flags to override test envs
+// tslint:disable-next-line:no-any
+declare let __karma__: any;
+if (typeof __karma__ !== 'undefined') {
+  const testEnv = parseTestEnvFromKarmaFlags(__karma__.config.args, TEST_ENVS);
+  if (testEnv != null) {
+    setTestEnvs([testEnv]);
+  }
+}
+
+// These use 'require' because they must not be hoisted above
+// the preceding snippet that parses test environments.
+// Import and run tests from core.
+// tslint:disable-next-line:no-imports-from-dist
+// tslint:disable-next-line:no-require-imports
+require('@tensorflow/tfjs-core/dist/tests');
+// Import and run tests from cpu.
+// tslint:disable-next-line:no-imports-from-dist
+// tslint:disable-next-line:no-require-imports
+require('./tests');


### PR DESCRIPTION
This PR adds browser test target for CPU backend. The test target does not include tests in Core, but the test target is added to nightly and presubmit tests.

Only added "bs_chrome_mac" for nightly and presubmit tests, because the CPU tests do not heavily relay on the platform.

Currently, CPU backend only has Node.js tests. We could provide browser tests for CPU backend, even though it does not need to be integrated into CI and nightly tests. eg. this would be helpful for Draw API tests for CPU backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.