### PR TITLE
webgpu: Remove bufSize from GPUData

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -632,7 +632,7 @@ export class WebGPUBackend extends KernelBackend {
     tensorData
         .resourceInfo = {size, usage: this.defaultGpuBufferUsage(), buffer};
 
-    return {tensorRef, buffer, bufSize: size};
+    return {tensorRef, buffer};
   }
 
   bufferSync<R extends Rank, D extends DataType>(t: TensorInfo):

--- a/tfjs-backend-webgpu/src/backend_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu_test.ts
@@ -250,13 +250,14 @@ describeWebGPU('keeping data on gpu ', () => {
     const a = tf.tensor(data, [1, 3, 4]);
     const b = tf.add(a, 0);
     const res = b.dataToGPU();
-    expectArraysEqual(res.bufSize, size);
+    expectArraysEqual(res.buffer.size, size);
     if (res.tensorRef.dtype !== 'float32') {
       throw new Error(
           `Unexpected type. Actual: ${res.tensorRef.dtype}. ` +
           `Expected: float32`);
     }
-    const resData = await webGPUBackend.getBufferData(res.buffer, res.bufSize);
+    const resData =
+        await webGPUBackend.getBufferData(res.buffer, res.buffer.size);
     const values = tf.util.convertBackendValuesAndArrayBuffer(
         resData, res.tensorRef.dtype);
     expectArraysEqual(values, data);
@@ -270,13 +271,14 @@ describeWebGPU('keeping data on gpu ', () => {
     const b = tf.tensor([0], [1], 'int32');
     const c = tf.add(a, b);
     const res = c.dataToGPU();
-    expectArraysEqual(res.bufSize, size);
+    expectArraysEqual(res.buffer.size, size);
     if (res.tensorRef.dtype !== 'int32') {
       throw new Error(
           `Unexpected type. Actual: ${res.tensorRef.dtype}. ` +
           `Expected: float32`);
     }
-    const resData = await webGPUBackend.getBufferData(res.buffer, res.bufSize);
+    const resData =
+        await webGPUBackend.getBufferData(res.buffer, res.buffer.size);
     const values = tf.util.convertBackendValuesAndArrayBuffer(
         resData, res.tensorRef.dtype);
     expectArraysEqual(values, data);
@@ -322,7 +324,8 @@ describeWebGPU('keeping data on gpu ', () => {
     expect(endDataBuckets).toEqual(startDataBuckets + 1);
 
     const res = result as unknown as GPUData;
-    const resData = await webGPUBackend.getBufferData(res.buffer, res.bufSize);
+    const resData =
+        await webGPUBackend.getBufferData(res.buffer, res.buffer.size);
     const values = tf.util.convertBackendValuesAndArrayBuffer(
         resData, res.tensorRef.dtype);
     expectArraysEqual(values, data);

--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -19,8 +19,8 @@
 /// <reference types="@webgpu/types/dist" />
 
 import {getGlobal} from './global_util';
-import {TensorInfo, DataId} from './tensor_info';
 import {tensorToString} from './tensor_format';
+import {DataId, TensorInfo} from './tensor_info';
 import {ArrayMap, BackendValues, DataType, DataTypeMap, DataValues, NumericDataType, Rank, ShapeMap, SingleValueMap, TypedArray} from './types';
 import * as util from './util';
 import {computeStrides, toNestedArray} from './util';
@@ -171,7 +171,6 @@ export interface GPUData {
   texture?: WebGLTexture;
   buffer?: GPUBuffer;
   texShape?: [number, number];
-  bufSize?: number;
 }
 
 export interface TensorTracker {
@@ -385,12 +384,10 @@ export class Tensor<R extends Rank = Rank> implements TensorInfo {
    *        texShape: [number, number] // [height, width]
    *     }
    *
-   *     For WebGPU backend, a GPUData contains the new buffer and
-   *     its information.
+   *     For WebGPU backend, a GPUData contains the new buffer.
    *     {
    *        tensorRef: The tensor that is associated with this buffer,
    *        buffer: GPUBuffer,
-   *        bufSize: number
    *     }
    *
    *     Remember to dispose the GPUData after it is used by


### PR DESCRIPTION
The buffer size and usage are the attributes of GPUBuffer. So bufSize doesn't need to be provided extra in GPUData.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.