### PR TITLE
webgpu: Optimize depthwise conv2d

### DIFF
--- a/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
@@ -91,7 +91,7 @@ export class DepthwiseConv2DVec4Program implements WebGPUProgram {
       }
 
       ${main('index')} {
-      if (index < uniforms.size) {
+      if (index * ${this.workPerThread} < uniforms.size) {
         let width0 = uniforms.outShape[3] / 4;
         let d1 = (index % width0) * 4;
         var index1 = index / width0;

--- a/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
+++ b/tfjs-backend-webgpu/src/depthwise_conv2d_vec4_webgpu.ts
@@ -50,7 +50,7 @@ export class DepthwiseConv2DVec4Program implements WebGPUProgram {
 
     this.dispatch = computeDispatch(
         this.dispatchLayout, virtualOutputShape, this.workgroupSize,
-        [4 * this.workPerThread, 1, 1]);
+        [this.outputComponent * this.workPerThread, 1, 1]);
 
     util.assert(
         convInfo.dataFormat === 'channelsLast',
@@ -91,11 +91,11 @@ export class DepthwiseConv2DVec4Program implements WebGPUProgram {
       }
 
       ${main('index')} {
-        let width0 = uniforms.outShape[3] / 4;
-        let d1 = (index % width0) * 4;
+        let width0 = uniforms.outShape[3] / ${this.outputComponent};
+        let d1 = (index % width0) * ${this.outputComponent};
         var index1 = index / width0;
         let width1 = uniforms.virtualWidth / ${this.workPerThread};
-        let c = (index1 %  width1) * ${this.workPerThread};
+        let c = (index1 % width1) * ${this.workPerThread};
         index1 = index1 / width1;
         let r = index1 % uniforms.outShape[1];
         let batch = index1 / uniforms.outShape[1];

--- a/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
+++ b/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
@@ -55,8 +55,7 @@ export function depthwiseConv2dNative(args: {
     program = new DepthwiseConv2DNCHWSharedProgram(
         convInfo.outShape, convInfo.filterHeight, convInfo.filterWidth);
   } else if (
-      isChannelsLast && convInfo.outHeight > 4 && convInfo.outWidth > 4 &&
-      convInfo.strideWidth <= 2 &&
+      isChannelsLast && convInfo.strideWidth <= 2 &&
       convInfo.inChannels === convInfo.outChannels &&
       convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
       convInfo.inChannels % 4 === 0) {

--- a/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
+++ b/tfjs-backend-webgpu/src/kernels/DepthwiseConv2dNative.ts
@@ -55,11 +55,13 @@ export function depthwiseConv2dNative(args: {
     program = new DepthwiseConv2DNCHWSharedProgram(
         convInfo.outShape, convInfo.filterHeight, convInfo.filterWidth);
   } else if (
-      isChannelsLast && convInfo.strideWidth <= 2 &&
+      isChannelsLast && convInfo.outHeight > 4 && convInfo.outWidth > 4 &&
+      convInfo.strideWidth <= 2 &&
       convInfo.inChannels === convInfo.outChannels &&
       convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
       convInfo.inChannels % 4 === 0) {
     program = new DepthwiseConv2DVec4Program(convInfo);
+    dimensions.push({type: 'int32', data: [program.virtualWidth]});
   } else {
     program = new DepthwiseConv2DProgram(convInfo);
     dimensions.push(

--- a/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
@@ -64,8 +64,7 @@ export function fusedDepthwiseConv2D(args: {
   ];
 
   let program: DepthwiseConv2DProgram|DepthwiseConv2DVec4Program;
-  if (convInfo.outHeight > 4 && convInfo.outWidth > 4 &&
-      convInfo.strideWidth <= 2 &&
+  if (convInfo.strideWidth <= 2 &&
       convInfo.inChannels === convInfo.outChannels &&
       convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
       convInfo.inChannels % 4 === 0) {

--- a/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
+++ b/tfjs-backend-webgpu/src/kernels/FusedDepthwiseConv2D.ts
@@ -64,12 +64,14 @@ export function fusedDepthwiseConv2D(args: {
   ];
 
   let program: DepthwiseConv2DProgram|DepthwiseConv2DVec4Program;
-  if (convInfo.strideWidth <= 2 &&
+  if (convInfo.outHeight > 4 && convInfo.outWidth > 4 &&
+      convInfo.strideWidth <= 2 &&
       convInfo.inChannels === convInfo.outChannels &&
       convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
       convInfo.inChannels % 4 === 0) {
     program = new DepthwiseConv2DVec4Program(
         convInfo, hasBias, activation, hasPreluActivationWeights);
+    dimensions.push({type: 'int32', data: [program.virtualWidth]});
   } else {
     program = new DepthwiseConv2DProgram(
         convInfo, hasBias, activation, hasPreluActivationWeights);


### PR DESCRIPTION
This PR uses linear workgroup size to optimize depthwise conv2d vec4.

See 150% improvement for the time of FusedDepthwiseConv2D on
BlazePoseDetector.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.