### PR TITLE
Disable e2e WebGPU golden model tests

### DIFF
--- a/e2e/integration_tests/graph_model_golden_tests.ts
+++ b/e2e/integration_tests/graph_model_golden_tests.ts
@@ -20,7 +20,7 @@ import '@tensorflow/tfjs-backend-webgl';
 import * as tfconverter from '@tensorflow/tfjs-converter';
 import * as tfc from '@tensorflow/tfjs-core';
 // tslint:disable-next-line: no-imports-from-dist
-import {ALL_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
+import {Constraints, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 
 import {GOLDEN, KARMA_SERVER} from './constants';
 import * as GOLDEN_MODEL_DATA_FILENAMES from './graph_model_golden_data/filenames.json';
@@ -30,7 +30,14 @@ import {GraphModeGoldenData, TensorDetail} from './types';
 const DATA_URL = 'graph_model_golden_data';
 const INTERMEDIATE_NODE_TESTS_NUM = 5;
 
-describeWithFlags(`${GOLDEN} graph_model_golden`, ALL_ENVS, (env) => {
+// WebGPU freezes when running mobilenet on BrowserStack, so disable it for
+// automated tests until it's working.
+// TODO(mattSoulanille); Enable WebGPU golden file tests.
+const NO_WEBGPU: Constraints = {
+  predicate: env => env.backendName !== 'webgpu'
+}
+
+describeWithFlags(`${GOLDEN} graph_model_golden`, NO_WEBGPU, (env) => {
   let originalTimeout: number;
 
   beforeAll(async () => {
@@ -40,7 +47,7 @@ describeWithFlags(`${GOLDEN} graph_model_golden`, ALL_ENVS, (env) => {
     // https://jasmine.github.io/2.0/introduction.html#section-42
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
-    await tfc.setBackend(env.name);
+    await tfc.setBackend(env.backendName);
   });
 
   afterAll(() => jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout);


### PR DESCRIPTION
WebGPU golden model tests are freezing on BrowserStack for unknown reasons (they work locally). Disable them for now to unblock presubmits.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.