### PR TITLE
Use new Chrome headless

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -20,7 +20,10 @@ const browserstackConfig = {
 };
 
 // Select Chrome or ChromeHeadless based on the value of the --//:headless flag.
-const CHROME = TEMPLATE_headless ? 'ChromeHeadless' : 'Chrome';
+const HEADLESS = TEMPLATE_headless ? [
+  '--headless=new',
+  '--use-mock-keychain', // For MacOS
+] : [];
 
 const CUSTOM_LAUNCHERS = {
   // For browserstack configs see:
@@ -90,29 +93,38 @@ const CUSTOM_LAUNCHERS = {
     ],
   },
   chrome_with_swift_shader: {
-    base: CHROME,
-    flags: ['--blacklist-accelerated-compositing', '--blacklist-webgl']
+    base: 'Chrome',
+    flags: [
+      '--blacklist-accelerated-compositing',
+      '--blacklist-webgl',
+      ...HEADLESS
+    ],
   },
   chrome_autoplay: {
-    base: CHROME,
+    base: 'Chrome',
     flags: [
       '--autoplay-policy=no-user-gesture-required',
       '--no-sandbox',
+      ...HEADLESS,
     ],
   },
   chrome_webgpu_linux: {
-    base: 'ChromeCanary',
+    base: 'Chrome',
     flags: [
       '--enable-features=Vulkan',
       '--enable-unsafe-webgpu',
       '--disable-dawn-features=disallow_unsafe_apis',
+      ...HEADLESS,
     ]
   },
   chrome_webgpu: {
-    base: 'ChromeCanary',
+    base: 'Chrome',
     flags: [
+      '--use-mock-keychain',
+      '--enable-unsafe-webgpu',
       '--disable-dawn-features=disallow_unsafe_apis',
       '--no-sandbox',
+      ...HEADLESS,
     ]
   },
   chrome_debugging: {
@@ -120,8 +132,21 @@ const CUSTOM_LAUNCHERS = {
     flags: ['--remote-debugging-port=9333'],
   },
   chrome_no_sandbox: {
-    base: CHROME,
-    flags: ['--no-sandbox'],
+    base: 'Chrome',
+    flags: [
+      '--no-sandbox',
+      ...HEADLESS,
+    ],
+  },
+  chrome_new_headless: {
+    base: "Chrome",
+    flags: [
+      '--use-mock-keychain',
+      '--enable-unsafe-webgpu',
+      '--no-sandbox',
+      '--headless=new',
+      '--use-webgpu-adapter=swiftshader',
+    ],
   }
 };
 


### PR DESCRIPTION
Use the [new Chrome headless mode](https://developer.chrome.com/articles/new-headless/) with `--headless=new`. The new mode more accurately represents what Chrome does and allows us to run WebGPU tests headlessly.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.