### PR TITLE
Disable verdaccio tfjs package forwarding when updating lockfiles

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -430,7 +430,7 @@ export async function getReleaseBranch(name: string): Promise<string> {
 }
 
 export function checkoutReleaseBranch(
-    releaseBranch: string, git_protocol: string, dir: string) {
+    releaseBranch: string, git_protocol: string, dir: string, shallow=true) {
   console.log(chalk.magenta.bold(
       `~~~ Checking out release branch ${releaseBranch} ~~~`));
   $(`rm -f -r ${dir}`);
@@ -442,7 +442,9 @@ export function checkoutReleaseBranch(
   });
 
   const urlBase = git_protocol ? 'git@github.com:' : 'https://github.com/';
-  $(`git clone -b ${releaseBranch} ${urlBase}tensorflow/tfjs ${dir} --depth=1`);
+  const shallowArg = shallow ? '--depth=1' : '';
+  $(`git clone -b ${releaseBranch} ${urlBase}tensorflow/tfjs ${dir} `
+    + `${shallowArg}`);
 }
 
 export function createPR(

--- a/scripts/update-tfjs-lockfiles.ts
+++ b/scripts/update-tfjs-lockfiles.ts
@@ -46,7 +46,8 @@ async function main() {
   console.log();
 
   // ========== Checkout release branch. =======================================
-  checkoutReleaseBranch(releaseBranch, args.git_protocol, TMP_DIR);
+  checkoutReleaseBranch(releaseBranch, args.git_protocol, TMP_DIR,
+                        /*shallow*/ false);
 
   shell.cd(TMP_DIR);
 
@@ -87,9 +88,14 @@ async function main() {
   }
 
   // ========== Send a PR to the release branch =====================
-  const message = `Update lockfiles branch ${lockfilesBranch} lock files.`;
+  const message = `Update ${lockfilesBranch}`;
   createPR(lockfilesBranch, releaseBranch, message);
-
+  // Cherry-pick a patch that disables Verdaccio proxying for
+  // `@tensorflow`-scoped packages.  For details, see #7557.
+  // TODO(mattSoulanille): Find a better solution than this? Or perhaps this is
+  // an acceptable solution.
+  $(`git cherry-pick 740d44448341b1cc78329d85d59156065faaa59e`);
+  $(`git push`);
   console.log('Done.');
 
   process.exit(0);


### PR DESCRIPTION
Disable verdaccio npm forwarding for tfjs packages when updating lockfiles. See #7557 for details.

Fixes #7557

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.