### PR TITLE
Recover the default backend

### DIFF
--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -55,6 +55,7 @@ import {makeTensor} from './tensor_ops_util';
  *   const customBackend = new tf.MathBackendWebGL(customCanvas);
  *   tf.registerBackend('custom-webgl', () => customBackend);
  * }
+ * const savedBackend = tf.getBackend();
  * await tf.setBackend('custom-webgl');
  * const gl = tf.backend().gpgpu.gl;
  * const texture = gl.createTexture();
@@ -94,6 +95,7 @@ import {makeTensor} from './tensor_ops_util';
  * // so:
  *
  * const tex = a.dataToGPU();
+ * await tf.setBackend(savedBackend);
  * ```
  *
  * ```js
@@ -146,6 +148,7 @@ import {makeTensor} from './tensor_ops_util';
  *   return gpuReadBuffer;
  * }
  *
+ * const savedBackend = tf.getBackend();
  * await tf.setBackend('webgpu').catch(
  *     () => {throw new Error(
  *         'Failed to use WebGPU backend. Please use Chrome Canary to run.')});
@@ -166,6 +169,7 @@ import {makeTensor} from './tensor_ops_util';
  * b.dispose();
  * result.dispose();
  * aBuffer.destroy();
+ * await tf.setBackend(savedBackend);
  * ```
  * @param values The values of the tensor. Can be nested array of numbers,
  *     or a flat array, or a `TypedArray`, or a `WebGLData` object, or a


### PR DESCRIPTION
Creating tensor from WebGLData|WebGPUData is specific for webgl/webgpu backend. We should save the default backend and recover it at the end of the case. Otherwise, all other cases will switch to, for example `custom-webgl` backend.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.