### PR TITLE
webgpu: Fix timestamp query

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -950,28 +950,30 @@ export class WebGPUBackend extends KernelBackend {
     const shouldTimeProgram = this.activeTimers != null;
     this.ensureCommandEncoderReady();
 
-    if (!this.computePassEncoder) {
-      const computePassDescriptor: GPUComputePassDescriptor = {};
-      if (shouldTimeProgram && this.supportTimestampQuery) {
-        if (this.querySet == null) {
-          this.querySet = this.device.createQuerySet({
-            type: 'timestamp',
-            count: this.querySetCount,
-          });
-        }
-        computePassDescriptor.timestampWrites = [
-          {
-            querySet: this.querySet,
-            queryIndex: 0,
-            location: 'beginning',
-          },
-          {
-            querySet: this.querySet,
-            queryIndex: 1,
-            location: 'end',
-          }
-        ];
+    const computePassDescriptor: GPUComputePassDescriptor = {};
+    if (shouldTimeProgram && this.supportTimestampQuery) {
+      this.endComputePassEncoder();
+      if (this.querySet == null) {
+        this.querySet = this.device.createQuerySet({
+          type: 'timestamp',
+          count: this.querySetCount,
+        });
       }
+      computePassDescriptor.timestampWrites = [
+        {
+          querySet: this.querySet,
+          queryIndex: 0,
+          location: 'beginning',
+        },
+        {
+          querySet: this.querySet,
+          queryIndex: 1,
+          location: 'end',
+        }
+      ];
+      this.computePassEncoder =
+          this.commandEncoder.beginComputePass(computePassDescriptor);
+    } else if (!this.computePassEncoder) {
       this.computePassEncoder =
           this.commandEncoder.beginComputePass(computePassDescriptor);
     }


### PR DESCRIPTION
If a pass that needs timestamp query follows a pass without timestamp query, querySet may not be created as expected. This PR fixes this issue.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.