### PR TITLE
webgpu: Move the readSync warning position

### DIFF
--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -377,13 +377,6 @@ export class WebGPUBackend extends KernelBackend {
   }
 
   override readSync(dataId: object): BackendValues {
-    if (!this.hasReadSyncWarned) {
-      this.hasReadSyncWarned = true;
-      console.warn(
-          `The performance of synchronously reading data from GPU to CPU is ` +
-          `poor on the webgpu backend, please use asynchronous APIs instead.`);
-    }
-
     const tensorData = this.tensorMap.get(dataId);
     const {values, complexTensorInfos} = tensorData;
 
@@ -401,6 +394,13 @@ export class WebGPUBackend extends KernelBackend {
           'float32');
       this.convertAndCacheOnCPU(dataId, complexVals);
       return complexVals;
+    }
+
+    if (!this.hasReadSyncWarned) {
+      this.hasReadSyncWarned = true;
+      console.warn(
+          `The performance of synchronously reading data from GPU to CPU is ` +
+          `poor on the webgpu backend, please use asynchronous APIs instead.`);
     }
 
     const alphaModes: GPUCanvasAlphaMode[] = ['opaque', 'premultiplied'];


### PR DESCRIPTION
The warning should only happen when there is really data reading back from gpu to cpu.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.