### PR TITLE
Fix indexeddb for 1GB models

### DIFF
--- a/tfjs-core/src/io/indexed_db.ts
+++ b/tfjs-core/src/io/indexed_db.ts
@@ -22,6 +22,7 @@ import {env} from '../environment';
 import {getModelArtifactsInfoForJSON} from './io_utils';
 import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, ModelArtifactsInfo, ModelStoreManager, SaveResult} from './types';
+import {CompositeArrayBuffer} from './composite_array_buffer';
 
 const DATABASE_NAME = 'tensorflowjs';
 const DATABASE_VERSION = 1;
@@ -157,6 +158,13 @@ export class BrowserIndexedDB implements IOHandler {
           modelTx.oncomplete = () => db.close();
         } else {
           // Put model into object store.
+
+          // Concatenate all the model weights into a single ArrayBuffer. Large
+          // models (~1GB) have problems saving if they are not concatenated.
+          // TODO(mattSoulanille): Save large models to multiple indexeddb
+          // records.
+          modelArtifacts.weightData = new CompositeArrayBuffer(
+            modelArtifacts.weightData).slice();
           const modelArtifactsInfo: ModelArtifactsInfo =
               getModelArtifactsInfoForJSON(modelArtifacts);
           // First, put ModelArtifactsInfo into info store.

--- a/tfjs-core/src/io/indexed_db.ts
+++ b/tfjs-core/src/io/indexed_db.ts
@@ -163,8 +163,8 @@ export class BrowserIndexedDB implements IOHandler {
           // models (~1GB) have problems saving if they are not concatenated.
           // TODO(mattSoulanille): Save large models to multiple indexeddb
           // records.
-          modelArtifacts.weightData = new CompositeArrayBuffer(
-            modelArtifacts.weightData).slice();
+          modelArtifacts.weightData = CompositeArrayBuffer.join(
+              modelArtifacts.weightData);
           const modelArtifactsInfo: ModelArtifactsInfo =
               getModelArtifactsInfoForJSON(modelArtifacts);
           // First, put ModelArtifactsInfo into info store.


### PR DESCRIPTION
Fixes #7702 by concatenating model weights into a single ArrayBuffer before sending them to IndexedDB. A better solution would be to store the model as multiple records, but this quick fix is easy to implement solves the issue for most current models (~1GB).

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.