### PR TITLE
Add Tokenizer base class.

### DIFF
--- a/tfjs-layers/src/layers/nlp/tokenizers.ts
+++ b/tfjs-layers/src/layers/nlp/tokenizers.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/**
+ *  Tokenizer layers.
+ */
+
+/* Original source: keras-nlp/tokenizer.py */
+import { Tensor1D, serialization, tensor1d } from '@tensorflow/tfjs-core';
+
+import { Layer } from '../../engine/topology';
+import { NotImplementedError, ValueError } from '../../errors';
+
+export declare interface TokenizerOptions {
+  mode?: 'tokenize' | 'detokenize'
+}
+
+/**
+ * Base class for Tokenizers.
+ *
+ * Subclassers should always implement the `tokenize()` method, which will also
+ * be the default when calling the layer directly on inputs.
+ */
+export abstract class Tokenizer extends Layer {
+  /**
+   * Transform input tensors of strings into output tokens.
+   *
+   * @param inputs Input tensor.
+   * @param kwargs Additional keyword arguments.
+   */
+  abstract tokenize(inputs: Tensor1D): Tensor1D[];
+
+  /**
+   * Transform tokens back into strings.
+   *
+   * @param inputs Input tensor.
+   * @param kwargs Additional keyword arguments.
+   */
+  detokenize(inputs: Tensor1D[]): Tensor1D {
+    throw new NotImplementedError(
+      `No implementation of 'detokenize()' was found for
+      ${this.constructor.name}.`
+    );
+  }
+
+  /**
+   * Get the tokenizer vocabulary as a list of strings terms.
+   */
+  get vocabulary(): string[] {
+    throw new NotImplementedError(
+      `No implementation of 'vocabulary()' was found for
+      ${this.constructor.name}.`
+    );
+  }
+
+  /**
+   * Returns the total size of the token id space.
+   */
+  get vocabularySize(): number {
+    throw new NotImplementedError(
+      `No implementation of 'vocabularySize()' was found for
+      ${this.constructor.name}.`
+    );
+  }
+
+  /**
+   * Convert an integer id to a string token.
+   */
+  idToToken(id: number): string {
+    throw new NotImplementedError(
+      `No implementation of 'idToToken()' was found for
+      ${this.constructor.name}.`
+    );
+  }
+
+  /**
+   * Convert an integer id to a string token.
+   */
+  tokenToId(token: string): number {
+    throw new NotImplementedError(
+      `No implementation of 'tokenToId()' was found for
+      ${this.constructor.name}.`
+    );
+  }
+
+  override call(inputs: Tensor1D|Tensor1D[], kwargs: TokenizerOptions={mode: 'tokenize'}): Tensor1D|Tensor1D[] {
+    if (kwargs.mode === 'tokenize') {
+      if (inputs instanceof Array) {
+        throw new ValueError(`tokenize expects Tensor1D, not Tensor1D[].`);
+      }
+      return this.tokenize(inputs);
+    }
+
+    if (kwargs.mode === 'detokenize') {
+      if (!(inputs instanceof Array)) {
+        throw new ValueError(`detokenize expects Tensor1D[], not Tensor1D.`);
+      }
+      return this.detokenize(inputs);
+    }
+
+    throw new ValueError(`Input mode=${kwargs.mode} is not supported.`)
+  }
+}
+
+export class WhiteSpaceTokenizer extends Tokenizer {
+  /** @nocollapse */
+  static readonly className = 'WhiteSpaceTokenizer';
+
+  tokenize(inputs: Tensor1D): Tensor1D[] {
+    const stringInputs = inputs.dataSync() as unknown as string[];
+    return stringInputs.map(input => tensor1d(input.split(' ')));
+  }
+
+  override detokenize(inputs: Tensor1D[]): Tensor1D {
+    const stringInputs = inputs.map(input => input.dataSync() as unknown as string[]);
+    return tensor1d(stringInputs.map(str => str.join(' ')));
+  }
+}
+
+serialization.registerClass(WhiteSpaceTokenizer);

--- a/tfjs-layers/src/layers/nlp/tokenizers_test.ts
+++ b/tfjs-layers/src/layers/nlp/tokenizers_test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+/**
+ * Unit Tests for Tokenizer Layers.
+ */
+
+import { Tensor1D, tensor1d } from '@tensorflow/tfjs-core';
+
+import { WhiteSpaceTokenizer } from './tokenizers';
+import { expectTensorsClose } from '../../../src/utils/test_utils';
+
+describe('White Space Tokenizer', () => {
+  const tokenizer = new WhiteSpaceTokenizer();
+
+  it('tokenize', () => {
+    const inputData = tensor1d(["the quick brown fox"]);
+    const expectedOutput = [tensor1d(["the", "quick", "brown", "fox"])];
+
+    const tokenizeOutput = tokenizer.tokenize(inputData);
+    const callOutput = tokenizer.call(inputData) as Tensor1D[];
+
+    expect(tokenizeOutput.length).toBe(1);
+    expectTensorsClose(tokenizeOutput[0], expectedOutput[0]);
+
+    expect(callOutput.length).toBe(1);
+    expectTensorsClose(callOutput[0], expectedOutput[0]);
+  });
+
+  it('detokenize', () => {
+    const inputData = [tensor1d(["the", "quick", "brown", "fox"])];
+    const expectedOutput = tensor1d(["the quick brown fox"]);
+
+    const detokenizeOutput = tokenizer.detokenize(inputData);
+    const callOutput = tokenizer.call(inputData, {mode: 'detokenize'}) as Tensor1D;
+
+    expectTensorsClose(detokenizeOutput, expectedOutput);
+    expectTensorsClose(callOutput, expectedOutput);
+  });
+
+  it('detokenize(tokenize) composition', () => {
+    const inputData = tensor1d(["the quick brown fox"]);
+
+    expectTensorsClose(
+      tokenizer.detokenize(tokenizer.tokenize(inputData)), inputData);
+  });
+});


### PR DESCRIPTION
Add the Tokenizer base class from which BytePairEncoding and other future Tokenizers will inherit from.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.