### PR TITLE
[Experiment] Improve downloadable cache for WebGPU backend 

### DIFF
--- a/export.html
+++ b/export.html
@@ -1,0 +1,40 @@
+<html>
+  <script src="https://unpkg.com/@tensorflow/tfjs-core@4.6.0"></script>
+  <script src="https://unpkg.com/@tensorflow/tfjs-converter@4.6.0"></script>
+  <script src="./dist/bin/tfjs-backend-webgpu/dist/tf-backend-webgpu.js"></script>
+
+  <script>
+    async function exportCache() {
+      window.localStorage.clear()
+      await tf.setBackend('webgpu');
+      await modelInference();
+      const cache = tf.backend().exportCache();
+      window.localStorage.setItem('webgpuCache', JSON.stringify(cache));
+    }
+
+    function importCache() {
+      const cache = JSON.parse(window.localStorage.getItem('webgpuCache'));
+      tf.backend().importCache(cache);
+    }
+
+    async function modelInference() {
+      const modelUrl = 'https://storage.googleapis.com/tfhub-tfjs-modules/tensorflow/tfjs-model/deeplab/pascal/1/quantized/2/1/model.json';
+      const input = tf.ones([1, 227, 500, 3], 'int32');
+      const model = await tf.loadGraphModel(modelUrl);
+      await model.predict(input).data();
+    }
+
+    async function benchmark(useCache = false) {
+      await tf.setBackend('webgpu');
+
+      const time1 = performance.now();
+      if (useCache) {
+        importCache();
+      }
+      const time2 = performance.now();
+      await modelInference();
+      const time3 = performance.now();
+      console.log(`Cache time: ${time2 - time1}, inference time: ${time3 - time2}`);
+    }
+  </script>
+</html>

--- a/tfjs-backend-webgpu/src/backend_webgpu.ts
+++ b/tfjs-backend-webgpu/src/backend_webgpu.ts
@@ -60,6 +60,15 @@ export interface WebGPUTimingInfo extends TimingInfo {
   downloadWaitMs: number;
 }
 
+export type WebGPUProgramCache = {
+  shader: string,
+  pipeline: GPUComputePipeline|Promise<GPUComputePipeline>
+}
+
+export type ShaderCache = {
+  [key: string]: string
+}
+
 type ProgramUniform = Array<{type: string; data: number[]}>;
 
 // Empirically determined constant used to determine size threshold for handing
@@ -116,8 +125,7 @@ export class WebGPUBackend extends KernelBackend {
   private dummyContext: GPUCanvasContext;
   private tensorDataPendingDisposal: DataId[] = [];
   private static nextDataId = 0;
-  private pipelineCache:
-      {[key: string]: GPUComputePipeline|Promise<GPUComputePipeline>};
+  private pipelineCache: {[key: string]: WebGPUProgramCache};
   private programTimersStack: TimerNode[];
   private queryResolveBuffer: GPUBuffer = null;
   private querySet: GPUQuerySet = null;
@@ -325,13 +333,14 @@ export class WebGPUBackend extends KernelBackend {
   async checkCompileCompletionAsync() {
     let pipelines: GPUComputePipeline[];
     try {
-      pipelines = await Promise.all(Object.values(this.pipelineCache));
+      pipelines = await Promise.all(
+          Object.values(this.pipelineCache).map(e => e.pipeline));
     } catch (e) {
       // TODO: Add test case to catch this exception.
       throw new Error(e.message);
     }
     Object.keys(this.pipelineCache).map((key, i) => {
-      this.pipelineCache[key] = pipelines[i];
+      this.pipelineCache[key].pipeline = pipelines[i];
     });
   }
 
@@ -847,6 +856,22 @@ export class WebGPUBackend extends KernelBackend {
     return {offset: 0, size: currentOffset, buffer: uniformBuffer};
   }
 
+  public exportCache(): ShaderCache {
+    const shaderCache: ShaderCache = {};
+    for (const [key, value] of Object.entries(this.pipelineCache)) {
+      shaderCache[key] = value.shader;
+    }
+    return shaderCache;
+  }
+
+  public importCache(shaderCache: ShaderCache) {
+    for (const [key, value] of Object.entries(shaderCache)) {
+      if (!(key in this.pipelineCache)) {
+        this.pipelineCache[key] = {shader: value, pipeline: null};
+      }
+    }
+  }
+
   public runWebGPUProgram(
       program: webgpu_program.WebGPUProgram, inputs: TensorInfo[],
       outputDtype: DataType, programDefinedUniform?: ProgramUniform,
@@ -886,11 +911,22 @@ export class WebGPUBackend extends KernelBackend {
         webgpu_program.makeShaderKey(program, inputsData, output);
 
     const parallelCompilation = env().getBool('WEBGPU_ENGINE_COMPILE_ONLY');
+    let cachedProgram: WebGPUProgramCache;
     if (!(program.shaderKey in this.pipelineCache)) {
-      this.pipelineCache[program.shaderKey] = webgpu_program.compileProgram(
-          this.device, program, inputsData, output, parallelCompilation);
+      cachedProgram = {
+        shader: webgpu_program.buildProgram(program, inputsData, output),
+        pipeline: null
+      };
+      this.pipelineCache[program.shaderKey] = cachedProgram;
+    } else {
+      cachedProgram = this.pipelineCache[program.shaderKey];
     }
-    program.pipeline = this.pipelineCache[program.shaderKey];
+
+    if (cachedProgram.pipeline == null) {
+      cachedProgram.pipeline = webgpu_program.compileProgram(
+          this.device, program, cachedProgram.shader, parallelCompilation);
+    }
+    program.pipeline = cachedProgram.pipeline;
 
     if (!parallelCompilation) {
       this.recordAndSubmit(program, output, inputs, programDefinedUniform);

--- a/tfjs-backend-webgpu/src/webgpu_program.ts
+++ b/tfjs-backend-webgpu/src/webgpu_program.ts
@@ -53,12 +53,16 @@ export interface WebGPUProgram {
   getUserCode: () => string;
 }
 
+export function buildProgram(
+    program: WebGPUProgram, inputsData: InputInfo[], output: TensorInfo) {
+  const outputData = {dtype: output.dtype, shape: output.shape};
+  return makeShader(inputsData, outputData, program);
+}
+
 export const compileProgram =
-    (device: GPUDevice, program: WebGPUProgram, inputsData: InputInfo[],
-     output: TensorInfo, parallelCompilation: boolean): GPUComputePipeline|
+    (device: GPUDevice, program: WebGPUProgram, source: string,
+     parallelCompilation: boolean): GPUComputePipeline|
     Promise<GPUComputePipeline> => {
-      const outputData = {dtype: output.dtype, shape: output.shape};
-      const source = makeShader(inputsData, outputData, program);
       const module = device.createShaderModule(
           {code: source, label: program.constructor.name});
 


### PR DESCRIPTION
## Background
### Use Case
We want to improve a use case: users want to run one large model and they want to download a cache after the first model inference. Then they want to use the cache to speed up the first model inference in another environment.

## Approach
From my perspective, one downloadable cache is the shader strings, so we could save the map of shaderKey->fullShader and add 'exportCache' and 'importCache' API to export/import the map. This cache could reduce the time for `makeShader` (the string interpolation).

## Experiment
I took a relative large model, DeepLabV3, to prove the improvement. (A large model spends relatively more time in `makeShader`) 

### MakeShader time
I found `makeShader` takes 5.9ms of 572ms (first inference). (ran a couple times of this, `makeShader` takes 3~11ms).
![image](https://github.com/tensorflow/tfjs/assets/40653845/65605165-492b-4e06-b086-c62224c3f0f8)

### ImportCache time
I am using the `export.html` in this PR:
* Open the file and call `exportCache()`;
* Refresh the file and call `importCache()`;

Found the time to import shaders (copy the strings to the pipelineCache) is 4.4ms.

Even `importCache` is free, I feel this improvement may be trivial. What do you think? @qjia7 

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.