### PR TITLE
Update hyperlink for tf.keras SavedModel in README.md

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -2,7 +2,7 @@
 
 **TensorFlow.js converter** is an open source library to load a pretrained
 TensorFlow
-[SavedModel](https://www.tensorflow.org/programmers_guide/saved_model#overview_of_saving_and_restoring_models)
+[SavedModel](https://www.tensorflow.org/api_docs/python/tf/keras/saving/save_model)
 or [TensorFlow Hub module](https://www.tensorflow.org/hub/)
 into the browser and run inference through
 [TensorFlow.js](https://js.tensorflow.org).


### PR DESCRIPTION
I have updated correct link for [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/contrib/saved_model/save_keras_model) on this web page https://github.com/tensorflow/tfjs/tree/master/tfjs-converter for this [section](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#:~:text=Step%201%3A%20Converting%20a%20TensorFlow%20SavedModel%2C%20TensorFlow%20Hub%20module%2C%20Keras%20HDF5%2C%20tf.keras%20SavedModel%2C%20or%20Flax/JAX%20model%20to%20a%20web%2Dfriendly%20format) for hyperlink [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/contrib/saved_model/save_keras_model) so please do the needful. Thank you!