### PR TITLE
[gpt2pre 3] Preprocessor Layer

### DIFF
--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/* Original source: keras-nlp/models/preprocessor.py */
+import { serialization } from '@tensorflow/tfjs-core';
+
+import { Layer, LayerArgs } from '../../../engine/topology';
+import { Kwargs } from '../../../types';
+import { Tokenizer } from '../tokenizers';
+import { NotImplementedError } from 'tfjs-layers/src/errors';
+
+export declare interface StartEndPackerArgs extends LayerArgs {
+  /**
+   * Integer. The desired output length.
+   */
+  sequenceLength: number;
+
+  /**
+   * Integer or string. The ID or token that is to be placed at the start of
+   * each sequence. The dtype must match the dtype of the input tensors to the
+   * layer. If undefined, no start value will be added.
+   */
+  startValue?: number|string;
+
+  /**
+   * Integer or string. The ID or token that is to be placed at the end of each
+   * input segment. The dtype must match the dtype of the input tensors to the
+   * layer. If undefined, no end value will be added.
+   */
+  endValue?: number|string;
+
+  /**
+   * Integer or string. The ID or token that is to be placed into the unused
+   * positions after the last segment in the sequence. If undefined, 0 or ''
+   * will be added depending on the dtype of the input tensor.
+   */
+  padValue?: number|string;
+}
+
+export declare interface StartEndPackerOptions {
+  /**
+   * Pass to override the configured `sequenceLength` of the layer.
+   */
+  sequenceLength?: number;
+
+  /**
+   * Pass `false` to not append a start value for this input.
+   * Defaults to true.
+   */
+  addStartValue?: boolean;
+
+  /**
+   * Pass `false` to not append an end value for this input.
+   * Defaults to true.
+   */
+  addEndValue?: boolean;
+}
+
+/**
+ * Base class for model Preprocessors.
+ */
+export class Preprocessor extends Layer {
+  /** @nocollapse */
+  static readonly className = 'Preprocessor';
+
+  private _tokenizer: Tokenizer;
+
+  constructor(args: Kwargs) {
+    super(args);
+  }
+
+  /**
+   * The tokenizer used to tokenize strings.
+   */
+  get tokenizer() {
+    return this._tokenizer;
+  }
+
+  set tokenizer(value: Tokenizer) {
+    this._tokenizer = value;
+  }
+
+  override getConfig(): serialization.ConfigDict {
+    const config = {
+      tokenizer: this._tokenizer.getClassName(),
+    };
+    const baseConfig = super.getConfig();
+    Object.assign(config, baseConfig);
+    return config;
+  }
+
+  static override fromConfig<T extends serialization.Serializable>(
+    cls: serialization.SerializableConstructor<T>,
+    config: serialization.ConfigDict
+  ): T {
+    // TODO(orderique): Find out the correct way to deserialize this.
+    throw new NotImplementedError('Not implemented yet for Preprocessors.');
+  }
+
+  static tokenizerCls<T extends serialization.Serializable>(
+    cls: serialization.SerializableConstructor<T>) {}
+
+  static presets<T extends serialization.Serializable>(
+    cls: serialization.SerializableConstructor<T>) {
+    return {};
+  }
+
+  static fromPreset<T extends serialization.Serializable>(
+    cls: serialization.SerializableConstructor<T>,
+    preset: string,
+    kwargs: Kwargs
+  ) {
+    // TODO(orderique): Discuss the right way to approach this.
+    throw new NotImplementedError('Not implemented yet.');
+  }
+}

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -62,8 +62,10 @@ export class Preprocessor extends Layer {
     if (config.tokenizer != null && !(config.tokenizer instanceof Tokenizer)) {
       const tokenizerConfigDict = config.tokenizer as serialization.ConfigDict;
 
-      kwargs.tokenizer =
-        deserializeKerasObject(tokenizerConfigDict);
+      kwargs.tokenizer = deserializeKerasObject(
+        tokenizerConfigDict,
+        serialization.SerializationMap.getMap().classNameMap,
+        {}, 'preprocessor');
     }
     return new cls(kwargs);
   }

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -18,57 +18,10 @@
 /* Original source: keras-nlp/models/preprocessor.py */
 import { serialization } from '@tensorflow/tfjs-core';
 
-import { Layer, LayerArgs } from '../../../engine/topology';
+import { Layer } from '../../../engine/topology';
 import { Kwargs } from '../../../types';
 import { Tokenizer } from '../tokenizers';
 import { NotImplementedError } from 'tfjs-layers/src/errors';
-
-export declare interface StartEndPackerArgs extends LayerArgs {
-  /**
-   * Integer. The desired output length.
-   */
-  sequenceLength: number;
-
-  /**
-   * Integer or string. The ID or token that is to be placed at the start of
-   * each sequence. The dtype must match the dtype of the input tensors to the
-   * layer. If undefined, no start value will be added.
-   */
-  startValue?: number|string;
-
-  /**
-   * Integer or string. The ID or token that is to be placed at the end of each
-   * input segment. The dtype must match the dtype of the input tensors to the
-   * layer. If undefined, no end value will be added.
-   */
-  endValue?: number|string;
-
-  /**
-   * Integer or string. The ID or token that is to be placed into the unused
-   * positions after the last segment in the sequence. If undefined, 0 or ''
-   * will be added depending on the dtype of the input tensor.
-   */
-  padValue?: number|string;
-}
-
-export declare interface StartEndPackerOptions {
-  /**
-   * Pass to override the configured `sequenceLength` of the layer.
-   */
-  sequenceLength?: number;
-
-  /**
-   * Pass `false` to not append a start value for this input.
-   * Defaults to true.
-   */
-  addStartValue?: boolean;
-
-  /**
-   * Pass `false` to not append an end value for this input.
-   * Defaults to true.
-   */
-  addEndValue?: boolean;
-}
 
 /**
  * Base class for model Preprocessors.

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -59,9 +59,11 @@ export class Preprocessor extends Layer {
   ): T {
     const kwargs: Kwargs = config;
 
-    if ('tokenizer' in config && !(config.tokenizer instanceof Tokenizer)) {
+    if (config.tokenizer != null && !(config.tokenizer instanceof Tokenizer)) {
+      const tokenizerConfigDict = config.tokenizer as serialization.ConfigDict;
+
       kwargs.tokenizer =
-        deserializeKerasObject(config.tokenizer as serialization.ConfigDict);
+        deserializeKerasObject(tokenizerConfigDict);
     }
     return new cls(kwargs);
   }
@@ -69,3 +71,4 @@ export class Preprocessor extends Layer {
   static tokenizerCls<T extends serialization.Serializable>(
     cls: serialization.SerializableConstructor<T>) {}
 }
+serialization.registerClass(Preprocessor);

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -21,7 +21,7 @@ import { serialization } from '@tensorflow/tfjs-core';
 import { Layer, LayerArgs } from '../../../engine/topology';
 import { Tokenizer } from '../tokenizers';
 import { Kwargs } from '../../../types';
-import { deserializeKerasObject } from '../../../utils/generic_utils';
+import { deserializeKerasObject, serializeKerasObject } from '../../../utils/generic_utils';
 
 /**
  * Base class for model Preprocessors.
@@ -48,11 +48,8 @@ export class Preprocessor extends Layer {
   }
 
   override getConfig(): serialization.ConfigDict {
-    const config = {
-      tokenizer: this._tokenizer.getClassName(),
-    };
-    const baseConfig = super.getConfig();
-    Object.assign(config, baseConfig);
+    const config = super.getConfig();
+    config.tokenizer = serializeKerasObject(this.tokenizer);
     return config;
   }
 

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -18,7 +18,7 @@
 /* Original source: keras-nlp/models/preprocessor.py */
 import { serialization } from '@tensorflow/tfjs-core';
 
-import { Layer } from '../../../engine/topology';
+import { Layer, LayerArgs } from '../../../engine/topology';
 import { Kwargs } from '../../../types';
 import { Tokenizer } from '../tokenizers';
 import { NotImplementedError } from 'tfjs-layers/src/errors';
@@ -32,7 +32,7 @@ export class Preprocessor extends Layer {
 
   private _tokenizer: Tokenizer;
 
-  constructor(args: Kwargs) {
+  constructor(args: LayerArgs) {
     super(args);
   }
 

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -19,9 +19,9 @@
 import { serialization } from '@tensorflow/tfjs-core';
 
 import { Layer, LayerArgs } from '../../../engine/topology';
-import { Kwargs } from '../../../types';
 import { Tokenizer } from '../tokenizers';
-import { NotImplementedError } from '../../../errors';
+import { Kwargs } from '../../../types';
+import { deserializeKerasObject } from '../../../utils/generic_utils';
 
 /**
  * Base class for model Preprocessors.
@@ -60,24 +60,15 @@ export class Preprocessor extends Layer {
     cls: serialization.SerializableConstructor<T>,
     config: serialization.ConfigDict
   ): T {
-    // TODO(orderique): Find out the correct way to deserialize this.
-    throw new NotImplementedError('Not implemented yet for Preprocessors.');
+    const kwargs: Kwargs = config;
+
+    if ('tokenizer' in config && !(config.tokenizer instanceof Tokenizer)) {
+      kwargs.tokenizer =
+        deserializeKerasObject(config.tokenizer as serialization.ConfigDict);
+    }
+    return new cls(kwargs);
   }
 
   static tokenizerCls<T extends serialization.Serializable>(
     cls: serialization.SerializableConstructor<T>) {}
-
-  static presets<T extends serialization.Serializable>(
-    cls: serialization.SerializableConstructor<T>) {
-    return {};
-  }
-
-  static fromPreset<T extends serialization.Serializable>(
-    cls: serialization.SerializableConstructor<T>,
-    preset: string,
-    kwargs: Kwargs
-  ) {
-    // TODO(orderique): Discuss the right way to approach this.
-    throw new NotImplementedError('Not implemented yet.');
-  }
 }

--- a/tfjs-layers/src/layers/nlp/models/preprocessor.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor.ts
@@ -21,7 +21,7 @@ import { serialization } from '@tensorflow/tfjs-core';
 import { Layer, LayerArgs } from '../../../engine/topology';
 import { Kwargs } from '../../../types';
 import { Tokenizer } from '../tokenizers';
-import { NotImplementedError } from 'tfjs-layers/src/errors';
+import { NotImplementedError } from '../../../errors';
 
 /**
  * Base class for model Preprocessors.

--- a/tfjs-layers/src/layers/nlp/models/preprocessor_test.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor_test.ts
@@ -18,7 +18,6 @@
 /**
  * Unit Tests for Preprocessor Layers.
  */
-import { BytePairTokenizer } from '../tokenizers';
 import { Preprocessor } from './preprocessor';
 
 describe('Preprocessor', () => {
@@ -29,15 +28,6 @@ describe('Preprocessor', () => {
   });
 
   it('serialization round-trip with no set tokenizer', () => {
-    const reserialized = Preprocessor.fromConfig(
-      Preprocessor, preprocessor.getConfig());
-    expect(reserialized.getConfig()).toEqual(preprocessor.getConfig());
-  });
-
-  it('serialization round-trip with set tokenizer', () => {
-    preprocessor.tokenizer = new BytePairTokenizer({
-      vocabulary: new Map([['<|endoftext|>', 0]]), merges: ['a b']});
-
     const reserialized = Preprocessor.fromConfig(
       Preprocessor, preprocessor.getConfig());
     expect(reserialized.getConfig()).toEqual(preprocessor.getConfig());

--- a/tfjs-layers/src/layers/nlp/models/preprocessor_test.ts
+++ b/tfjs-layers/src/layers/nlp/models/preprocessor_test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * Unit Tests for Preprocessor Layers.
+ */
+import { BytePairTokenizer } from '../tokenizers';
+import { Preprocessor } from './preprocessor';
+
+describe('Preprocessor', () => {
+  let preprocessor: Preprocessor;
+
+  beforeEach(() => {
+    preprocessor = new Preprocessor({});
+  });
+
+  it('serialization round-trip with no set tokenizer', () => {
+    const reserialized = Preprocessor.fromConfig(
+      Preprocessor, preprocessor.getConfig());
+    expect(reserialized.getConfig()).toEqual(preprocessor.getConfig());
+  });
+
+  it('serialization round-trip with set tokenizer', () => {
+    preprocessor.tokenizer = new BytePairTokenizer({
+      vocabulary: new Map([['<|endoftext|>', 0]]), merges: ['a b']});
+
+    const reserialized = Preprocessor.fromConfig(
+      Preprocessor, preprocessor.getConfig());
+    expect(reserialized.getConfig()).toEqual(preprocessor.getConfig());
+  });
+});

--- a/tfjs-layers/src/layers/nlp/tokenizers.ts
+++ b/tfjs-layers/src/layers/nlp/tokenizers.ts
@@ -331,7 +331,7 @@ export class BytePairTokenizer extends Tokenizer {
 
   override getConfig(): serialization.ConfigDict {
     const config = {
-      vocabulary: this.vocabulary,
+      vocabulary: Array.from(this._vocabulary.entries()),
       merges: this.merges,
       sequenceLength: this.sequenceLength,
       addPrefixSpace: this.addPrefixSpace,


### PR DESCRIPTION
Implements the base layer for processor layers, such as the GPT2 Preprocessor layer.

Update:
~~Some methods were left unimplemented and are pending discussion~~
Based on discussion with @mattsoulanille, `presets` was removed, and `fromConfig` and `getConfig` was implemented instead.