### PR TITLE
[gpt2pre 2] GPT2 Tokenizer Class

### DIFF
--- a/tfjs-layers/src/layers/nlp/models/gpt2/gpt2_tokenizer.ts
+++ b/tfjs-layers/src/layers/nlp/models/gpt2/gpt2_tokenizer.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * GPT-2 tokenizer layer.
+ */
+
+/* Original source: keras-nlp/models/gpt2/gpt2_tokenizer.py */
+import { serialization } from '@tensorflow/tfjs-core';
+
+import { LayerArgs } from '../../../../engine/topology';
+import { BytePairTokenizer } from '../../tokenizers';
+import { ValueError } from '../../../../errors';
+
+export declare interface GPT2TokenizerArgs extends LayerArgs {
+  /**
+   * Maps token to integer ids
+   */
+  vocabulary: Map<string, number>;
+
+  /**
+   * Array. Contains the merge rule.
+   */
+  merges: string[];
+}
+
+/**
+ * A GPT-2 tokenizer using Byte-Pair Encoding subword segmentation.
+ *
+ * This tokenizer class will tokenize raw strings into integer sequences and
+ * is based on `BytePairTokenizer`. Unlike the underlying tokenizer, it will
+ * check for all special tokens needed by GPT-2 models.
+ *
+ * This tokenizer does not provide truncation or padding of inputs.
+ *
+ * When given an input of a batch of strings (`tf.Tensor`), the layer will
+ * output a `tf.Tensor[]`.
+ *
+ * Examples:
+ *
+ * ```js
+ * const vocabulary = new Map([
+ *    ['<|endoftext|>', 0], ['butter', 1], ['fly', 2]]);
+ * const merges = ['b u', 't t', 'e r', 'bu tt', 'butt er', 'f l', 'fl y'];
+ * const tokenizer = new BytePairTokenizer({vocabulary, merges});
+ *
+ * tokenizer.tokenize(tensor(['butterfly']))[0].print();
+ * tokenizer.tokenize(tensor(['butterfly, butter<|endoftext|>']))[1].print();
+ *
+ * tokenizer.detokenize([tensor([1, 2, 0])]).print();
+ */
+export class GPT2Tokenizer extends BytePairTokenizer {
+  private readonly _endTokenId: number;
+  private readonly _startTokenId: number;
+  private readonly _padTokenId: number;
+
+  constructor(args: GPT2TokenizerArgs) {
+
+    // Special tokens.
+    const endToken = '<|endoftext|>';
+
+    super({
+      vocabulary: args.vocabulary,
+      merges: args.merges,
+      unsplittableTokens: [endToken]
+    });
+
+    // Check whether special tokens are present in the vocabulary.
+    if (!this.vocabulary.includes(endToken)) {
+      throw new ValueError(
+        `Cannot find token '${endToken}' in the provided 'vocabulary'. Please` +
+        ` provide '${endToken}' in your 'vocabulary' or use a pretrained` +
+        ` 'vocabulary' name.`
+      );
+    }
+
+    this._endTokenId = this.tokenToId(endToken);
+    this._startTokenId = this._endTokenId;
+    this._padTokenId = 0;
+  }
+
+  get endTokenId() {
+    return this._endTokenId;
+  }
+
+  get startTokenId() {
+    return this._startTokenId;
+  }
+
+  get padTokenId() {
+    return this._padTokenId;
+  }
+
+  override getConfig(): serialization.ConfigDict {
+    const config = super.getConfig();
+    // In the constructor, we pass the list of special tokens to the
+    // `unsplittableTokens` arg of the superclass' constructor. Hence, we
+    // delete it from the config here.
+    delete config.unsplittableTokens;
+    return config;
+  }
+}
+serialization.registerClass(GPT2Tokenizer);

--- a/tfjs-layers/src/layers/nlp/models/gpt2/gpt2_tokenizer_test.ts
+++ b/tfjs-layers/src/layers/nlp/models/gpt2/gpt2_tokenizer_test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * Unit Tests for GPT2Tokenizer.
+ */
+
+import { tensor } from '@tensorflow/tfjs-core';
+
+import { expectTensorsClose } from '../../../../utils/test_utils';
+import { GPT2Tokenizer } from './gpt2_tokenizer';
+
+describe('GPT2Tokenizer', () => {
+  let vocabulary: Map<string, number>;
+  let merges: string[];
+  let tokenizer: GPT2Tokenizer;
+
+  beforeEach(() => {
+    vocabulary = new Map([
+      ['<|endoftext|>', 0],
+      ['Ġair', 1],
+      ['plane', 2],
+      ['Ġat', 3],
+      ['port', 4],
+      ['Ġkoh', 5],
+      ['li', 6],
+      ['Ġis', 7],
+      ['Ġthe', 8],
+      ['Ġbest', 9],
+    ]);
+
+    merges = ['Ġ a', 'Ġ t', 'Ġ k', 'Ġ i', 'Ġ b', 'Ġa i', 'p l', 'n e'].concat(
+      ['Ġa t', 'p o', 'r t', 'o h', 'l i', 'Ġi s', 'Ġb e', 's t'],
+      ['Ġt h', 'Ġai r', 'pl a', 'Ġk oh', 'Ġth e', 'Ġbe st', 'po rt'],
+      ['pla ne']);
+
+    tokenizer = new GPT2Tokenizer({vocabulary, merges});
+  });
+
+  it('tokenize', () => {
+    const inputData = tensor([' airplane at airport']);
+    const expectedOutput = [tensor([1, 2, 3, 1, 4])];
+
+    const output = tokenizer.tokenize(inputData);
+
+    expect(output.length).toBe(1);
+    expectTensorsClose(output[0], expectedOutput[0]);
+  });
+
+  it('tokenize end token', () => {
+    const inputData = tensor([' airplane at airport<|endoftext|>']);
+    const expectedOutput = [tensor([1, 2, 3, 1, 4, 0])];
+
+    const output = tokenizer.tokenize(inputData);
+
+    expect(output.length).toBe(1);
+    expectTensorsClose(output[0], expectedOutput[0]);
+  });
+
+  it('tokenize batch', () => {
+    const inputData = tensor([' airplane at airport', ' kohli is the best']);
+    const expectedOutput = [tensor([1, 2, 3, 1, 4]), tensor([5, 6, 7, 8, 9])];
+
+    const output = tokenizer.tokenize(inputData);
+
+    expect(output.length).toBe(2);
+    expectTensorsClose(output[0], expectedOutput[0]);
+    expectTensorsClose(output[1], expectedOutput[1]);
+  });
+
+  it('detokenize', () => {
+    const inputData = [tensor([1, 2, 3, 1, 4])];
+    const expectedOutput = tensor([' airplane at airport']);
+
+    const output = tokenizer.detokenize(inputData);
+
+    expectTensorsClose(output, expectedOutput);
+  });
+
+  it('vocabulary size', () => {
+    expect(tokenizer.vocabularySize).toBe(10);
+  });
+
+  it('errors with missing special tokens', () => {
+    vocabulary = new Map([['a', 1], ['b', 2], ['c', 3]]);
+    merges = [];
+    expect(() => new GPT2Tokenizer({vocabulary, merges})).toThrowError();
+  });
+});


### PR DESCRIPTION
Implements the `GPT2Tokenizer` that extends `BytePairEncoding`.

This is a standalone PR with no dependencies or implementation followups.

 `GPT2Tokenizer` will be used by ` GPT2Preprocessor` in a future PR.

NOTE:
This class does not implement `presets()` as discussed earlier this week.
 