### PR TITLE
Replace OffscreenCanvas with HTMLCanvasElement for Draw tests

### DIFF
--- a/tfjs-core/src/ops/draw_test.ts
+++ b/tfjs-core/src/ops/draw_test.ts
@@ -20,15 +20,18 @@ import {BROWSER_ENVS, describeWithFlags} from '../jasmine_util';
 import {expectArraysClose, expectArraysEqual} from '../test_util';
 
 function readPixelsFromCanvas(
-    canvas: OffscreenCanvas, contextType: string, width: number,
+    canvas: HTMLCanvasElement, contextType: string, width: number,
     height: number) {
   let actualData;
   if (contextType === '2d') {
     const ctx = canvas.getContext(contextType);
     actualData = ctx.getImageData(0, 0, width, height).data;
   } else {
-    const offscreenCanvas = new OffscreenCanvas(width, height);
-    const ctx = offscreenCanvas.getContext('2d');
+    const tmpCanvas = document.createElement('canvas');
+    tmpCanvas.width = width;
+    tmpCanvas.height = height;
+    const ctx = tmpCanvas.getContext('2d');
+
     ctx.drawImage(canvas, 0, 0);
     actualData = new Uint8ClampedArray(
         ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height).data);
@@ -93,7 +96,9 @@ function drawAndReadback(
     img = tf.tensor2d(
         data, shape as [number, number], dtype as keyof tf.DataTypeMap);
   }
-  const canvas = new OffscreenCanvas(width, height);
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
   if (canvasUsedAs2d) {
     canvas.getContext('2d');
   }


### PR DESCRIPTION
Old version Safari and Firefox [do not support OffscreenCanvas](https://caniuse.com/?search=OffscreenCanvas), so this PR replaces the usage of OffscreenCanvas with normal canvas for testing.

Alternative considered: Update browser versions to the latest.
Safari currently requires at least 'Big Sur' OS's Safari to support OffscreenCanvas, so we additionally need to update test OS from 'High Sierra' to a  relatively new OS version to fix the error.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.