### PR TITLE
fix the h5 conversion test

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion_test.py
@@ -25,6 +25,7 @@ import shutil
 import tempfile
 import unittest
 import six
+
 import h5py
 import numpy as np
 import tensorflow.compat.v2 as tf
@@ -182,9 +183,6 @@ class ConvertH5WeightsTest(unittest.TestCase):
         h5py.File(h5_path))
     saved_topology = out['model_config']
 
-    # keys_to_remove = ["module", "registered_name", "date_saved", "build_config"]
-    # conversion._discard_v3_keys(config_json, keys_to_remove)
-    # conversion._discard_v3_keys(saved_topology, keys_to_remove)
     # check the model topology was stored
     self.assertEqual(config_json['class_name'], saved_topology['class_name'])
     self.assertEqual(config_json['config'], saved_topology['config'])
@@ -192,6 +190,7 @@ class ConvertH5WeightsTest(unittest.TestCase):
     # Check the loaded weights.
     # By default, all weights of the model ought to be put in the same group.
     self.assertEqual(1, len(groups))
+
     self.assertEqual(tf.keras.__version__, out['keras_version'])
     self.assertEqual('tensorflow', out['backend'])
     weight_group = groups[0]

--- a/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion_test.py
+++ b/tfjs-converter/python/tensorflowjs/converters/keras_h5_conversion_test.py
@@ -25,7 +25,6 @@ import shutil
 import tempfile
 import unittest
 import six
-import keras
 import h5py
 import numpy as np
 import tensorflow.compat.v2 as tf
@@ -136,7 +135,7 @@ class ConvertH5WeightsTest(unittest.TestCase):
     # Check meta-data in the artifact JSON.
     self.assertEqual(model_json['format'], 'layers-model')
     self.assertEqual(model_json['generatedBy'],
-                     'keras v%s' % keras.__version__)
+                     'keras v%s' % tf.keras.__version__)
     self.assertEqual(
         model_json['convertedBy'],
         'TensorFlow.js Converter v%s' % version.version)
@@ -193,7 +192,7 @@ class ConvertH5WeightsTest(unittest.TestCase):
     # Check the loaded weights.
     # By default, all weights of the model ought to be put in the same group.
     self.assertEqual(1, len(groups))
-    self.assertEqual(keras.__version__, out['keras_version'])
+    self.assertEqual(tf.keras.__version__, out['keras_version'])
     self.assertEqual('tensorflow', out['backend'])
     weight_group = groups[0]
     self.assertEqual(3, len(weight_group))
@@ -246,7 +245,7 @@ class ConvertH5WeightsTest(unittest.TestCase):
     # because the model has two layers.
     self.assertEqual(2, len(groups))
 
-    self.assertEqual(keras.__version__, out['keras_version'])
+    self.assertEqual(tf.keras.__version__, out['keras_version'])
     self.assertEqual('tensorflow', out['backend'])
     self.assertEqual(2, len(groups[0]))
     kernel1 = groups[0][0]


### PR DESCRIPTION
Update the H5 conversion tests. 
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.