### PR TITLE
Update weights loading

### DIFF
--- a/tfjs-layers/src/engine/container.ts
+++ b/tfjs-layers/src/engine/container.ts
@@ -596,6 +596,7 @@ export abstract class Container extends Layer {
     let totalWeightsCount = 0;
     // get weights key from tensor map in order to check if it is from keras v3.
     // e.g. dense/0
+    this.parseWeights(weights);
     const key = Object.keys(weights)[0].split('/');
     const isKerasSavedModelFormat = !isNaN(parseInt(key[key.length - 1], 10));
     // Check if weights from keras v3.
@@ -650,6 +651,25 @@ export abstract class Container extends Layer {
     }
 
     batchSetValue(weightValueTuples);
+  }
+
+  protected parseWeights(weights: NamedTensorMap) {
+    Object.keys(weights).forEach(function(key) {
+      const listParts = key.split('/');
+      const list = ['vars', 'layer_checkpoint_dependencies'];
+      const newKey = listParts
+                         .map(str => {
+                           if (str.startsWith('_')) {
+                             return str.slice(1);
+                           }
+                           return str;
+                         })
+                         .filter(str => !list.includes(str))
+                         .join('/');
+
+      weights[newKey] = weights[key];
+      delete weights[key];
+    })
   }
 
   /**

--- a/tfjs-layers/src/engine/container.ts
+++ b/tfjs-layers/src/engine/container.ts
@@ -656,9 +656,16 @@ export abstract class Container extends Layer {
   }
 
   protected parseWeights(weights: NamedTensorMap) {
-    Object.keys(weights).forEach((key) => {
+    for (let key in Object.keys(weights)) {
       const listParts = key.split('/');
       const list = ['vars', 'layer_checkpoint_dependencies'];
+      // For keras v3, the weights name are saved based on the folder structure.
+      // e.g. _backbone/_layer_checkpoint_dependencies/transformer/_self../
+      // _output_dense/vars/0
+      // Therefore we discard the `vars` and `layer_checkpoint_depencies` within
+      // the saved name and only keeps the layer name and weights.
+      // This can help to mapping the actual name of the layers and load each
+      // weight accordingly.
       const newKey = listParts
                          .map(str => {
                            if (str.startsWith('_')) {
@@ -672,7 +679,7 @@ export abstract class Container extends Layer {
         weights[newKey] = weights[key];
         delete weights[key];
       }
-    });
+    }
   }
 
   /**

--- a/tfjs-layers/src/engine/container.ts
+++ b/tfjs-layers/src/engine/container.ts
@@ -596,9 +596,11 @@ export abstract class Container extends Layer {
     let totalWeightsCount = 0;
     // get weights key from tensor map in order to check if it is from keras v3.
     // e.g. dense/0
-    this.parseWeights(weights);
     const key = Object.keys(weights)[0].split('/');
     const isKerasSavedModelFormat = !isNaN(parseInt(key[key.length - 1], 10));
+    if (isKerasSavedModelFormat) {
+      this.parseWeights(weights);
+    }
     // Check if weights from keras v3.
     for (const layer of this.layers) {
       for (const [index, weight] of layer.weights.entries()) {
@@ -654,7 +656,7 @@ export abstract class Container extends Layer {
   }
 
   protected parseWeights(weights: NamedTensorMap) {
-    Object.keys(weights).forEach(function(key) {
+    Object.keys(weights).forEach((key) => {
       const listParts = key.split('/');
       const list = ['vars', 'layer_checkpoint_dependencies'];
       const newKey = listParts
@@ -666,10 +668,11 @@ export abstract class Container extends Layer {
                          })
                          .filter(str => !list.includes(str))
                          .join('/');
-
-      weights[newKey] = weights[key];
-      delete weights[key];
-    })
+      if (newKey !== key) {
+        weights[newKey] = weights[key];
+        delete weights[key];
+      }
+    });
   }
 
   /**

--- a/tfjs-layers/src/engine/container.ts
+++ b/tfjs-layers/src/engine/container.ts
@@ -656,7 +656,7 @@ export abstract class Container extends Layer {
   }
 
   protected parseWeights(weights: NamedTensorMap) {
-    for (let key in Object.keys(weights)) {
+    for (const key in Object.keys(weights)) {
       const listParts = key.split('/');
       const list = ['vars', 'layer_checkpoint_dependencies'];
       // For keras v3, the weights name are saved based on the folder structure.

--- a/tfjs-layers/src/model_save_test.ts
+++ b/tfjs-layers/src/model_save_test.ts
@@ -16,7 +16,6 @@ import {describeMathCPUAndGPU, describeMathCPUAndWebGL2, expectTensorsClose} fro
 import {version} from './version';
 
 describeMathCPUAndGPU('LayersModel.save', () => {
-  let originalTimeout: number;
   class IOHandlerForTest implements io.IOHandler {
     savedArtifacts: io.ModelArtifacts;
 
@@ -27,14 +26,6 @@ describeMathCPUAndGPU('LayersModel.save', () => {
   }
 
   class EmptyIOHandler implements io.IOHandler {}
-  beforeEach(() => {
-    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
-  });
-
-  afterEach(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-  });
   it('Model artifacts contains meta-information: Sequential', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.dense({units: 3, inputShape: [5]}));

--- a/tfjs-layers/src/model_save_test.ts
+++ b/tfjs-layers/src/model_save_test.ts
@@ -26,6 +26,7 @@ describeMathCPUAndGPU('LayersModel.save', () => {
   }
 
   class EmptyIOHandler implements io.IOHandler {}
+
   it('Model artifacts contains meta-information: Sequential', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.dense({units: 3, inputShape: [5]}));

--- a/tfjs-layers/src/model_save_test.ts
+++ b/tfjs-layers/src/model_save_test.ts
@@ -16,6 +16,7 @@ import {describeMathCPUAndGPU, describeMathCPUAndWebGL2, expectTensorsClose} fro
 import {version} from './version';
 
 describeMathCPUAndGPU('LayersModel.save', () => {
+  let originalTimeout: number;
   class IOHandlerForTest implements io.IOHandler {
     savedArtifacts: io.ModelArtifacts;
 
@@ -26,7 +27,14 @@ describeMathCPUAndGPU('LayersModel.save', () => {
   }
 
   class EmptyIOHandler implements io.IOHandler {}
+  beforeEach(() => {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
+  });
 
+  afterEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
   it('Model artifacts contains meta-information: Sequential', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.dense({units: 3, inputShape: [5]}));


### PR DESCRIPTION
Reflect the changes for saving weight to bin files [PR](https://github.com/tensorflow/tfjs/pull/7848).
This PR updates the way to parse the weights name.
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.