### PR TITLE
Add sliceUpdate util

### DIFF
--- a/tfjs-layers/src/layers/nlp/utils.ts
+++ b/tfjs-layers/src/layers/nlp/utils.ts
@@ -36,23 +36,23 @@ export function tensorArrTo2DArr(inputs: Tensor[]): unknown[][] {
  * @returns a new tensor with the modification.
  */
 export function sliceUpdate(
-  inputs: Tensor, startIndices: number[], updates: Tensor): Tensor {
-const indices: number[][] = [];
-function createIndices(idx: number, curr: number[]): void {
-  if (curr.length === startIndices.length) {
-    indices.push(curr.slice());
-    return;
+    inputs: Tensor, startIndices: number[], updates: Tensor): Tensor {
+  const indices: number[][] = [];
+  function createIndices(idx: number, curr: number[]): void {
+    if (curr.length === startIndices.length) {
+      indices.push(curr.slice());
+      return;
+    }
+    const s = startIndices[idx];
+    const e = s + updates.shape[idx];
+    for (let i = s; i < e; i++) {
+      curr.push(i);
+      createIndices(idx + 1, curr);
+      curr.pop();
+    }
   }
-  const s = startIndices[idx];
-  const e = s + updates.shape[idx];
-  for (let i = s; i < e; i++) {
-    curr.push(i);
-    createIndices(idx + 1, curr);
-    curr.pop();
-  }
-}
-createIndices(0, []);
-// Flatten the updates to match length of its update indices.
-updates = updates.reshape([updates.size]);
-return tensorScatterUpdate(inputs, indices, updates);
+  createIndices(0, []);
+  // Flatten the updates to match length of its update indices.
+  updates = updates.reshape([updates.size]);
+  return tensorScatterUpdate(inputs, indices, updates);
 }

--- a/tfjs-layers/src/layers/nlp/utils.ts
+++ b/tfjs-layers/src/layers/nlp/utils.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import { Tensor } from '@tensorflow/tfjs-core';
+import { Tensor, tensorScatterUpdate } from '@tensorflow/tfjs-core';
 
 export function tensorToArr(input: Tensor): unknown[] {
   return Array.from(input.dataSync()) as unknown as unknown[];
@@ -23,4 +23,36 @@ export function tensorToArr(input: Tensor): unknown[] {
 
 export function tensorArrTo2DArr(inputs: Tensor[]): unknown[][] {
   return inputs.map(input => tensorToArr(input));
+}
+
+/**
+ * Returns a new Tensor with `updates` inserted into `inputs` starting at the
+ * index `startIndices`.
+ *
+ * @param inputs Tensor to "modify"
+ * @param startIndices the starting index to insert the slice.
+ *  Length must be equal to `inputs.rank`;
+ * @param updates the update tensor. Shape must fit within `inputs` shape.
+ * @returns a new tensor with the modification.
+ */
+export function sliceUpdate(
+  inputs: Tensor, startIndices: number[], updates: Tensor): Tensor {
+const indices: number[][] = [];
+function createIndices(idx: number, curr: number[]): void {
+  if (curr.length === startIndices.length) {
+    indices.push(curr.slice());
+    return;
+  }
+  const s = startIndices[idx];
+  const e = s + updates.shape[idx];
+  for (let i = s; i < e; i++) {
+    curr.push(i);
+    createIndices(idx + 1, curr);
+    curr.pop();
+  }
+}
+createIndices(0, []);
+// Flatten the updates to match length of its update indices.
+updates = updates.reshape([updates.size]);
+return tensorScatterUpdate(inputs, indices, updates);
 }

--- a/tfjs-layers/src/layers/nlp/utils_test.ts
+++ b/tfjs-layers/src/layers/nlp/utils_test.ts
@@ -15,8 +15,9 @@
  * =============================================================================
  */
 
-import { tensor, test_util } from '@tensorflow/tfjs-core';
-import { tensorArrTo2DArr, tensorToArr } from './utils';
+import { ones, tensor, test_util, zeros } from '@tensorflow/tfjs-core';
+import { sliceUpdate, tensorArrTo2DArr, tensorToArr } from './utils';
+import { expectTensorsClose } from '../../utils/test_utils';
 
 describe('tensor to array functions', () => {
   it('tensorToArr', () => {
@@ -38,5 +39,51 @@ describe('tensor to array functions', () => {
     );
     test_util.expectArraysEqual(
       tensorArrTo2DArr(inputNum) as number[][], [[2, 11], [15]]);
+  });
+});
+
+describe('sliceUpdate', () => {
+  it('1D', () => {
+    const inputs = tensor([1, 2, 3, 4, 5]);
+    const startIndices = [2];
+    const updates = tensor([-1, -2]);
+    const expected = tensor([1, 2, -1, -2, 5]);
+
+    const result = sliceUpdate(inputs, startIndices, updates);
+
+    expectTensorsClose(result, expected, 0);
+  });
+
+  it('2D', () => {
+    const inputs = zeros([2, 5]);
+    const startIndices = [0, 1];
+    const updates = tensor([
+      [-1, -2],
+      [-4, -3],
+    ]);
+    const expected = tensor([
+      [0, -1, -2, 0, 0],
+      [0, -4, -3, 0, 0]
+    ]);
+    const result = sliceUpdate(inputs, startIndices, updates);
+
+    expectTensorsClose(result, expected, 0);
+  });
+
+  it('3D', () => {
+    const inputs = zeros([2, 3, 4]);
+    const startIndices = [0, 0, 0];
+    const updates = ones([2, 1, 4]);
+    const expected = tensor([
+      [[1, 1, 1, 1],
+       [0, 0, 0, 0],
+       [0, 0, 0, 0]],
+      [[1, 1, 1, 1],
+       [0, 0, 0, 0],
+       [0, 0, 0, 0]],
+    ]);
+    const result = sliceUpdate(inputs, startIndices, updates);
+
+    expectTensorsClose(result, expected, 0);
   });
 });


### PR DESCRIPTION
The Keras [implementation ](https://github.com/keras-team/keras-nlp/blob/v0.6.0/keras_nlp/layers/modeling/cached_multi_head_attention.py#L115) of the `CachedMultiHeadAttention` layer uses a non TF op, [slice_update](https://keras.io/keras_core/api/ops/core/#sliceupdate-function), to modify tensors in the `call` method. 

This PR adds this as a util function while we discuss adding this op to TFJS. 