### PR TITLE
Update broken hyperlink for tf-nightly-2.0-preview

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -24,7 +24,7 @@ __0. Please make sure that you run in a Docker container or a virtual environmen
  The script pulls its own subset of TensorFlow, which might conflict with the
  existing TensorFlow/Keras installation.
 
-__Note__: *Check that [`tf-nightly-2.0-preview`](https://pypi.org/project/tf-nightly-2.0-preview/#files) is available for your platform.*
+__Note__: *Check that [`tf-nightly-cpu-2.0-preview`](https://pypi.org/project/tf-nightly-cpu-2.0-preview/#files) is available for your platform.*
 
 Most of the times, this means that you have to use Python 3.6.8 in your local
 environment. To force Python 3.6.8 in your local project, you can install


### PR DESCRIPTION
I have updated broken hyperlink for [tf-nightly-2.0-preview](https://pypi.org/project/tf-nightly-2.0-preview/#files) from this  [section](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#:~:text=Note%3A%20Check%20that%20tf%2Dnightly%2D2.0%2Dpreview%20is%20available%20for%20your%20platform.) to  [`tf-nightly-cpu-2.0-preview`](https://pypi.org/project/tf-nightly-cpu-2.0-preview/#files) so please do the needful. Thank you!


