### PR TITLE
Fix SliceUpdate tests

### DIFF
--- a/tfjs-layers/src/layers/nlp/utils_test.ts
+++ b/tfjs-layers/src/layers/nlp/utils_test.ts
@@ -51,7 +51,7 @@ describe('sliceUpdate', () => {
 
     const result = sliceUpdate(inputs, startIndices, updates);
 
-    expectTensorsClose(result, expected, 0);
+    expectTensorsClose(result, expected);
   });
 
   it('2D', () => {
@@ -67,7 +67,7 @@ describe('sliceUpdate', () => {
     ]);
     const result = sliceUpdate(inputs, startIndices, updates);
 
-    expectTensorsClose(result, expected, 0);
+    expectTensorsClose(result, expected);
   });
 
   it('3D', () => {
@@ -84,6 +84,6 @@ describe('sliceUpdate', () => {
     ]);
     const result = sliceUpdate(inputs, startIndices, updates);
 
-    expectTensorsClose(result, expected, 0);
+    expectTensorsClose(result, expected);
   });
 });


### PR DESCRIPTION
After discussion with @Linchenn, I found out that using a zero-value epsilon in `expectTensorsClose` causes some tests for devices with low precision to fail. This PR changes the tests to use the default epsilon value.