### PR TITLE
Build node addon before running tests

### DIFF
--- a/scripts/cloudbuild_tfjs_node_expected.yml
+++ b/scripts/cloudbuild_tfjs_node_expected.yml
@@ -150,6 +150,7 @@ steps:
       - test-ci
     waitFor:
       - yarn-tfjs-node
+      - build-addon-tfjs-node
       - lint-tfjs-node
       - yarn-common
       - yarn-link-package-build

--- a/tfjs-node-gpu/cloudbuild.yml
+++ b/tfjs-node-gpu/cloudbuild.yml
@@ -59,7 +59,7 @@ steps:
   entrypoint: 'yarn'
   id: 'test'
   args: ['test-ci']
-  waitFor: ['yarn', 'build-deps', 'lint']
+  waitFor: ['yarn', 'build-addon', 'build-deps', 'lint']
 
 # CPU / GPU package alignment.
 - name: 'gcr.io/learnjs-174218/release'

--- a/tfjs-node/cloudbuild.yml
+++ b/tfjs-node/cloudbuild.yml
@@ -51,7 +51,7 @@ steps:
   entrypoint: 'yarn'
   id: 'test'
   args: ['test-ci']
-  waitFor: ['yarn', 'build-deps', 'lint']
+  waitFor: ['yarn', 'build-addon', 'build-deps', 'lint']
 
 # CPU / GPU package alignment.
 - name: 'gcr.io/learnjs-174218/release'


### PR DESCRIPTION
Fix a race condition in CI where the tests may be run before the node addon is built.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.