### PR TITLE
Update hyperlinks to correct hyperlinks for go to section

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -56,9 +56,9 @@ __2. Run the converter script provided by the pip package:__
 
 There are three way to trigger the model conversion, explain below:
 
-- The conversion wizard: `tensorflowjs_wizard` ([go to section](#conversion-wizard-tensorflowjswizard))
-- Regular conversion script: `tensorflowjs_converter` ([go to section](#regular-conversion-script-tensorflowjsconverter))
-- Calling a converter function in Python (Flax/JAX) ([go to section](#calling-a-converter-function-in-python))
+- The conversion wizard: `tensorflowjs_wizard` ([go to section](https://github.com/tensorflow/tfjs/blob/master/tfjs-converter/README.md#conversion-wizard-tensorflowjs_wizard))
+- Regular conversion script: `tensorflowjs_converter` ([go to section](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#regular-conversion-script-tensorflowjs_converter))
+- Calling a converter function in Python (Flax/JAX) ([go to section](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#calling-a-converter-function-in-python-flaxjax))
 
 ## Conversion wizard: `tensorflowjs_wizard`
 


### PR DESCRIPTION
I updated correct hyperlinks for 03 `go to section` which was not pointing to correct section on this [page](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter) for this [section](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#:~:text=2.%20Run%20the%20converter%20script%20provided%20by%20the%20pip%20package%3A) so please do the needful. Thank you!