### PR TITLE
[webgpu] Fix cast error

### DIFF
--- a/tfjs-backend-webgpu/src/conv2d_mm_webgpu.ts
+++ b/tfjs-backend-webgpu/src/conv2d_mm_webgpu.ts
@@ -31,11 +31,11 @@ function conv2dCommonSnippet(
   const getXSnippet = (innerElementSize: number) => {
     switch (innerElementSize) {
       case 1:
-        return 'resData = x[xIndex];';
+        return 'resData = f32(x[xIndex]);';
       case 3:
         return 'resData = vec3<f32>(x[xIndex], x[xIndex + 1], x[xIndex + 2]);';
       case 4:
-        return 'resData = x[xIndex / 4];';
+        return 'resData = vec4<f32>(x[xIndex / 4]);';
       default:
         throw new Error(
             `innerElementSize ${innerElementSize} is not supported.`);
@@ -44,9 +44,9 @@ function conv2dCommonSnippet(
   const getWSnippet = (innerElementSize: number) => {
     switch (innerElementSize) {
       case 1:
-        return 'return W[row * uniforms.wShape[3] + col];';
+        return 'return f32(W[row * uniforms.wShape[3] + col]);';
       case 4:
-        return 'return W[(row * uniforms.wShape[3] + col) / 4];';
+        return 'return vec4<f32>(W[(row * uniforms.wShape[3] + col) / 4]);';
       default:
         throw new Error(
             `innerElementSize ${innerElementSize} is not supported.`);

--- a/tfjs-backend-webgpu/src/flags_webgpu.ts
+++ b/tfjs-backend-webgpu/src/flags_webgpu.ts
@@ -74,9 +74,10 @@ ENV.registerFlag('WEBGPU_USE_NAIVE_CONV2D_DEBUG', () => false);
 /**
  * Threshold to increase dispatched workgroups for matmul. If too few workgroups
  * are dispatched, it means the hardware may be in low occupancy.
- * 0 means it's not set by the user. A default strategy will be applied.
+ * -1 means it's not set by the user. A default strategy will be applied.
  */
-ENV.registerFlag('WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL', () => 0);
+ENV.registerFlag(
+    'WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL', () => -1);
 
 /**
  * Whether we will run im2col as a separate shader for convolution.

--- a/tfjs-backend-webgpu/src/kernels/Conv2D_impl.ts
+++ b/tfjs-backend-webgpu/src/kernels/Conv2D_impl.ts
@@ -310,10 +310,11 @@ export function conv2DImpl({
     });
   }
 
-  const thresholdFlagValue = env().getNumber(
-    'WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL');
-  const thresholdToIncreaseWorkgroups =  thresholdFlagValue > 0 ?
-      thresholdFlagValue : backend.thresholdToIncreaseWorkgroups;
+  const thresholdFlagValue =
+      env().getNumber('WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL');
+  const thresholdToIncreaseWorkgroups = thresholdFlagValue > -1 ?
+      thresholdFlagValue :
+      backend.thresholdToIncreaseWorkgroups;
   const workgroupsBy32x32 = convInfo.batchSize *
       Math.ceil((convInfo.outHeight * convInfo.outWidth) / 32) *
       Math.ceil(convInfo.outChannels / 32);

--- a/tfjs-backend-webgpu/src/kernels/conv2d_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_webgpu_test.ts
@@ -286,6 +286,19 @@ describeWebGPU('conv2d vec4', () => {
         ]));
   });
 
+  it('bool cast float32 + conv2d', async () => {
+    const a1 = tf.tensor4d([3, 2, 3, 4, 3, 2], [1, 2, 3, 1]);
+    const b1 = tf.tensor4d([2, 2, 2, 1, 4, 1], [1, 2, 3, 1]);
+    // Generate a bool tensor and have data in GPU.
+    const a = tf.greater(a1, b1);
+    // Cast the bool tensor to a float32 tensor.
+    const x = tf.cast(a, 'float32') as tf.Tensor4D;
+    const w = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 1, 2]);
+    const res = tf.conv2d(x, w, 1, 0);
+    const resData = await res.data();
+    test_util.expectArraysClose(resData, new Float32Array([6, 8, 10, 12]));
+  });
+
   it('x=[1,9,9,3] f=[3,3,3,4] s=[2,2] d=1 p=valid NCHW', async () => {
     const inputDepth = 3;
     const xSize = 9;

--- a/tfjs-backend-webgpu/src/kernels/conv2d_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/kernels/conv2d_webgpu_test.ts
@@ -287,6 +287,13 @@ describeWebGPU('conv2d vec4', () => {
   });
 
   it('bool cast float32 + conv2d', async () => {
+    const im2colFlag = tf.env().getBool('WEBGPU_CONV_SEPARATE_IM2COL_SHADER');
+    const thresholdFlag =
+        tf.env().getBool('WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL');
+    tf.env().set('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', false);
+    // Setting the threshold to 0 is like skipping the corresponding
+    // optimization.
+    tf.env().set('WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL', 0);
     const a1 = tf.tensor4d([3, 2, 3, 4, 3, 2], [1, 2, 3, 1]);
     const b1 = tf.tensor4d([2, 2, 2, 1, 4, 1], [1, 2, 3, 1]);
     // Generate a bool tensor and have data in GPU.
@@ -297,6 +304,9 @@ describeWebGPU('conv2d vec4', () => {
     const res = tf.conv2d(x, w, 1, 0);
     const resData = await res.data();
     test_util.expectArraysClose(resData, new Float32Array([6, 8, 10, 12]));
+    tf.env().set('WEBGPU_CONV_SEPARATE_IM2COL_SHADER', im2colFlag);
+    tf.env().set(
+        'WEBGPU_THRESHOLD_TO_INCREASE_WORKGROUPS_FOR_MATMUL', thresholdFlag);
   });
 
   it('x=[1,9,9,3] f=[3,3,3,4] s=[2,2] d=1 p=valid NCHW', async () => {


### PR DESCRIPTION
When cast a bool tensor to a float32 tensor, it's just an identity operation, see [here](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-webgpu/src/kernels/Cast.ts#L67-L68), which adds the underlying tensor data refCount and reuse the same gpu buffer. However, if we use the casted float32 tensor as the conv2d's input, error happens due to that we expect a f32 data but the original buffer data is i32. This PR fixes it by converting the input data to f32 data since our calculation is based on f32.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.