### PR TITLE
Update correct link for TensorFlow SavedModel hyperlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ and <a href="https://js.tensorflow.org/api/latest/">documentation</a> for more d
 ## Importing pre-trained models
 
 We support porting pre-trained models from:
-- [TensorFlow SavedModel](https://github.com/tensorflow/tfjs-converter)
+- [TensorFlow SavedModel](https://www.tensorflow.org/js/tutorials/conversion/import_saved_model)
 - [Keras](https://js.tensorflow.org/tutorials/import-keras.html)
 
 ## Various ops supported in different backends


### PR DESCRIPTION
I have updated correct link for [TensorFlow SavedModel](https://github.com/tensorflow/tfjs-converter) in this [section](https://github.com/tensorflow/tfjs#importing-pre-trained-models) which was pointing to archived repo of tfjs-converter and I see in the same section for **Keras** hyperlink, it was pointing to [Keras](https://js.tensorflow.org/tutorials/import-keras.html) so please do the needful. Thank you!