### PR TITLE
[WebGPU] Ensure tf.any and tf.all return bool tensors

### DIFF
--- a/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
+++ b/tfjs-backend-webgpu/src/kernel_utils/reduce.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {backend_util, sumOutType, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
+import {backend_util, DataType, sumOutType, TensorInfo, TypedArray, util} from '@tensorflow/tfjs-core';
 
 import {WebGPUBackend} from '../backend_webgpu';
 import {reshape} from '../kernels/Reshape';
@@ -26,6 +26,11 @@ import {maxImplCPU} from './shared';
 import {prodImplCPU} from './shared';
 
 type ReduceTypes = 'all'|'any'|'max'|'mean'|'min'|'prod'|'sum';
+const ReturnTypes: {[key in ReduceTypes]?: DataType} = {
+  'mean': 'float32',
+  'all': 'bool',
+  'any': 'bool',
+};
 
 export function reduce(
     x: TensorInfo, axis: number|number[], keepDims: boolean,
@@ -79,7 +84,7 @@ export function reduce(
     const batchSize = xSize / inSize;
 
     const reduceInfo = {windowSize: inSize, inSize, batchSize, outSize: 1};
-    const dtype = reduceType === 'mean' ? 'float32' : sumOutType(x.dtype);
+    const dtype = ReturnTypes[reduceType] || sumOutType(x.dtype);
     const uniformData = [
       {type: 'int32', data: [inSize]},
     ];

--- a/tfjs-core/src/.#tensor.ts
+++ b/tfjs-core/src/.#tensor.ts
@@ -1,0 +1,1 @@
+msoulanille@starbridge.mtv.corp.google.com.51379:1673371177

--- a/tfjs-core/src/foo_test.ts
+++ b/tfjs-core/src/foo_test.ts
@@ -1,0 +1,5 @@
+describe('foo', () => {
+  it('array.at works', () => {
+    expect([1,2,3,4,5].at(-2)).toEqual(4);
+  });
+});

--- a/tfjs-core/src/ops/.#all_test.ts
+++ b/tfjs-core/src/ops/.#all_test.ts
@@ -1,0 +1,1 @@
+msoulanille@starbridge.mtv.corp.google.com.74934:1692721976

--- a/tfjs-core/src/ops/all_test.ts
+++ b/tfjs-core/src/ops/all_test.ts
@@ -107,4 +107,10 @@ describeWithFlags('all', ALL_ENVS, () => {
         .toThrowError(
             /Argument 'x' passed to 'all' must be bool tensor, but got string/);
   });
+
+  it('returns a boolean tensor', () => {
+    const a = tf.tensor1d([1, 0], 'bool');
+    const r = tf.all(a);
+    expect(r.dtype).toEqual('bool');
+  });
 });

--- a/tfjs-core/src/ops/any_test.ts
+++ b/tfjs-core/src/ops/any_test.ts
@@ -106,4 +106,10 @@ describeWithFlags('any', ALL_ENVS, () => {
     expect(() => tf.any(['a']))
         .toThrowError(/Argument 'x' passed to 'any' must be bool tensor/);
   });
+
+  it('returns a boolean tensor', () => {
+    const a = tf.tensor1d([1, 0], 'bool');
+    const r = tf.any(a);
+    expect(r.dtype).toEqual('bool');
+  });
 });


### PR DESCRIPTION
Fix a bug where tf.all and tf.any return int tensors instead of bool tensors.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.