### PR TITLE
Use bs-local.com for safari browserstack tests

### DIFF
--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -22,11 +22,6 @@ const browserstackConfig = {
   // range of ports (9200 - 9400).
   // https://www.browserstack.com/question/39572
   port: 9200,
-  // This is necessary for non-flaky Safari tests. They usually pass just
-  // fine without it, but sometimes, Safari will fail to connect to Karma.
-  // If you want to remove this, prove that it's not flaky by running
-  // bazel test //tfjs-core/src:bs_safari_mac_from_pixels_worker_test --runs_per_test=100
-  hostname: 'bs-local.com',
 };
 
 // Select Chrome or ChromeHeadless based on the value of the --//:headless flag.
@@ -166,6 +161,13 @@ module.exports = function(config) {
     }
     if (!username || !accessKey) {
       process.exit(1);
+    }
+    if (browserLauncher.browser === 'safari' || browserLauncher.os === 'ios') {
+      // This is necessary for non-flaky Safari tests. They usually pass just
+      // fine without it, but sometimes, Safari will fail to connect to Karma.
+      // If you want to remove this, prove that it's not flaky by running
+      // bazel test //tfjs-core/src:bs_safari_mac_from_pixels_worker_test --runs_per_test=100
+      extraConfig.hostname = 'bs-local.com';
     }
 
     Object.assign(extraConfig, browserstackConfig);

--- a/tools/karma_template.conf.js
+++ b/tools/karma_template.conf.js
@@ -22,6 +22,11 @@ const browserstackConfig = {
   // range of ports (9200 - 9400).
   // https://www.browserstack.com/question/39572
   port: 9200,
+  // This is necessary for non-flaky Safari tests. They usually pass just
+  // fine without it, but sometimes, Safari will fail to connect to Karma.
+  // If you want to remove this, prove that it's not flaky by running
+  // bazel test //tfjs-core/src:bs_safari_mac_from_pixels_worker_test --runs_per_test=100
+  hostname: 'bs-local.com',
 };
 
 // Select Chrome or ChromeHeadless based on the value of the --//:headless flag.


### PR DESCRIPTION
This seems to improve connection stability for Safari tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.