### PR TITLE
[tfjs-core] fix gather gradient when batchDims is 1

### DIFF
--- a/tfjs-core/src/gradients/GatherV2_grad.ts
+++ b/tfjs-core/src/gradients/GatherV2_grad.ts
@@ -36,18 +36,7 @@ export const gatherGradConfig: GradConfig = {
 
     const derX = () => {
       const paramsShape = x.shape;
-      console.log("TCL ~ x:", x.shape, x.arraySync())
-      // console.log("TCL ~ dy:", dy.shape, dy.arraySync())
-      // console.log("TCL ~ batchDims, parsedAxis:", batchDims, parsedAxis)
       const indicesSize = indices.size;
-      // console.log("TCL ~ indicesSize:", indicesSize)
-
-      let $batchDims = batchDims;
-
-      if (batchDims == null) {
-        $batchDims = 0;
-      }
-      console.log("TCL ~ $batchDims:", $batchDims)
 
       const outerShape = paramsShape.slice(0, parsedAxis);
       const outerDims = outerShape.length;
@@ -68,15 +57,12 @@ export const gatherGradConfig: GradConfig = {
       const valuesTranspose = transpose(values, transposeDims);
       let paramsGrad = unsortedSegmentSum(
           valuesTranspose, reshapedIndices as Tensor1D, x.shape[parsedAxis]);
-      console.log("TCL ~ paramsGrad:", paramsGrad.shape, paramsGrad.dataSync())
       const invertTransposeDims = getUndoAxesPermutation(transposeDims);
       paramsGrad = transpose(paramsGrad, invertTransposeDims);
-      console.log("TCL ~ paramsGrad:", paramsGrad.shape, paramsGrad.dataSync())
       return paramsGrad;
     };
 
     const derXIndividual = (x: Tensor, indices: Tensor, dy: Tensor) => {
-      console.log("TCL ~ dy:", dy, dy.shape, dy.dataSync())
       return function(): Tensor {
         const paramsShape = x.shape;
         const indicesSize = indices.size;
@@ -107,7 +93,6 @@ export const gatherGradConfig: GradConfig = {
     };
 
     if(batchDims === 1) {
-      console.log("TCL ~ dy:", dy, dy.shape, dy.dataSync())
       const batchSize = x.shape[0];
       const xBatch = x.split(batchSize, 0);
       const derXBatched = () => {

--- a/tfjs-core/src/gradients/GatherV2_grad.ts
+++ b/tfjs-core/src/gradients/GatherV2_grad.ts
@@ -57,8 +57,10 @@ export const gatherGradConfig: GradConfig = {
       const valuesTranspose = transpose(values, transposeDims);
       let paramsGrad = unsortedSegmentSum(
           valuesTranspose, reshapedIndices as Tensor1D, x.shape[parsedAxis]);
+
       const invertTransposeDims = getUndoAxesPermutation(transposeDims);
       paramsGrad = transpose(paramsGrad, invertTransposeDims);
+
       return paramsGrad;
     };
 
@@ -98,7 +100,7 @@ export const gatherGradConfig: GradConfig = {
       const derXBatched = () => {
         const stacked = stack(
           xBatch.map((x, i) => {
-            return derXIndividual(x, indices.slice(i,1).reshape([1]), dy.slice(i,1))();
+            return derXIndividual(x, indices.slice(i,1), dy.slice(i,1))();
           }))
         return stacked.reshape(x.shape);
     };

--- a/tfjs-core/src/ops/gather_test.ts
+++ b/tfjs-core/src/ops/gather_test.ts
@@ -312,67 +312,20 @@ describeWithFlags('gather', ALL_ENVS, (env) => {
     expectArraysClose(await gradients.data(), [26, 36, 0, 0]);
   });
 
-  fit('test', async () => {
+  it('gradient 2D (gather) axis=1 shape=[4, 2] 1D indices batchDims 1', async () => {
     const t = tf.variable(tf.tensor([[0, 1],
       [1, 2],
       [2, 3],
       [3, 4]]));
-    console.log("TCL ~ t:", t.shape, t.arraySync());
     const indices = tf.tensor([0, 1, 0, 1], [4, 1], 'int32');
     const dy = tf.tensor([1, 1, 1, 1], [4, 1]);
-    console.log("TCL ~ indices:", indices.shape, indices.arraySync());
     const axis = 1;
-    const gathered = tf.gather(t, indices, axis, 1);
-    console.log("TCL ~ gathered:", gathered.shape, gathered.arraySync());
-    expect(gathered.shape).toEqual([4, 1]);
-    expect(gathered.arraySync()).toEqual([[0], [2], [2], [4]]);
-
-    function gatherOwn(input: tf.Tensor, indices: tf.Tensor): tf.Tensor {
-      const batchSize = input.shape[0];
-      const tensors = input.split(batchSize, 0);
-      const output = tf.stack(
-        tensors.map((tensor, i) => tensor.squeeze().gather((indices.arraySync() as any)[i]))
-      );
-      return output;
-    }
-
-    const gatheredOwn = gatherOwn(t, indices);
-    console.log("TCL ~ gatheredOwn:", gatheredOwn.shape, gatheredOwn.arraySync());
-    expect(gatheredOwn.shape).toEqual([4, 1]);
-    expect(gatheredOwn.arraySync()).toEqual([[0], [2], [2], [4]]);
-
-    // const gradientsOwn = tf.grad(t => gatherOwn(t, indices))(t);
-    // console.log("TCL ~ gradientsOwn:", gradientsOwn.shape, gradientsOwn.arraySync());
-    // const gradientsOwnTransposed = gradientsOwn.transpose();
-    // console.log("TCL ~ gradientsOwnTransposed:", gradientsOwnTransposed.shape, gradientsOwnTransposed.arraySync());
-    // // we want [ 4, 2 ] [ [ 1, 0 ], [ 0, 1 ], [ 1, 0 ], [ 0, 1 ] ]
-    // expect(gradientsOwn.shape).toEqual(t.shape);
-    // expectArraysClose(await gradientsOwn.data(), [1, 0, 0, 1, 1, 0, 0, 1]);
 
     const gradients = tf.grad(t => tf.gather(t, indices, axis, 1))(t, dy);
-    console.log("TCL ~ gradients:", gradients.shape, gradients.arraySync());
-    // [0, 1, 0, 1]
-    // transposed: [ 2, 4 ] [ [ 1, 0, 1, 0 ], [ 0, 1, 0, 1 ] ]
-    // we want     [ 4, 2 ] [ [ 1, 0 ], [ 0, 1 ], [ 1, 0 ], [ 0, 1 ] ]
+
     expect(gradients.shape).toEqual(t.shape);
     expectArraysClose(await gradients.data(), [1, 0, 0, 1, 1, 0, 0, 1]);
   });
-
-  // fit('gradient 2D (gather) axis=1 shape=[2, 2] 1D indices no dy', async () => {
-  //   const t = tf.tensor2d([1, 11, 2, 22], [2, 2]);
-  //   console.log("TCL ~ t:", t.shape, t.arraySync())
-  //   const indices = tf.tensor1d([1, 0, 0, 1], 'int32');
-  //   const axis = 1;
-
-  //   const gathered = tf.gather(t, indices, axis);
-  //   console.log("TCL ~ gathered:", gathered.shape, gathered.arraySync());
-
-  //   const gradients = tf.grad(t => tf.gather(t, indices, axis))(t);
-  //   console.log("TCL ~ gradients:", gradients.shape, gradients.arraySync());
-
-  //   expect(gradients.shape).toEqual(t.shape);
-  //   expectArraysClose(await gradients.data(), [9, 9, 17, 17]);
-  // });
 
   it('gradient 2D (gather) axis=1 shape=[2, 2] 1D indices', async () => {
     const t = tf.tensor2d([1, 11, 2, 22], [2, 2]);

--- a/tfjs-core/src/ops/gather_test.ts
+++ b/tfjs-core/src/ops/gather_test.ts
@@ -312,20 +312,21 @@ describeWithFlags('gather', ALL_ENVS, (env) => {
     expectArraysClose(await gradients.data(), [26, 36, 0, 0]);
   });
 
-  it('gradient 2D (gather) axis=1 shape=[4, 2] 1D indices batchDims 1', async () => {
-    const t = tf.variable(tf.tensor([[0, 1],
-      [1, 2],
-      [2, 3],
-      [3, 4]]));
-    const indices = tf.tensor([0, 1, 0, 1], [4, 1], 'int32');
-    const dy = tf.tensor([1, 1, 1, 1], [4, 1]);
-    const axis = 1;
+  it('gradient 2D (gather) axis=1 shape=[4, 2] 1D indices batchDims 1',
+     async () => {
+       const t = tf.variable(tf.tensor([[0, 1],
+                                        [1, 2],
+                                        [2, 3],
+                                        [3, 4]]));
+       const indices = tf.tensor([0, 1, 0, 1], [4, 1], 'int32');
+       const dy = tf.tensor([1, 1, 1, 1], [4, 1]);
+       const axis = 1;
 
-    const gradients = tf.grad(t => tf.gather(t, indices, axis, 1))(t, dy);
+       const gradients = tf.grad(t => tf.gather(t, indices, axis, 1))(t, dy);
 
-    expect(gradients.shape).toEqual(t.shape);
-    expectArraysClose(await gradients.data(), [1, 0, 0, 1, 1, 0, 0, 1]);
-  });
+       expect(gradients.shape).toEqual(t.shape);
+       expectArraysClose(await gradients.data(), [1, 0, 0, 1, 1, 0, 0, 1]);
+     });
 
   it('gradient 2D (gather) axis=1 shape=[2, 2] 1D indices', async () => {
     const t = tf.tensor2d([1, 11, 2, 22], [2, 2]);


### PR DESCRIPTION
This PR fixes #7494, where error is encountered when computing gradient of `tf.gather` with `batchDims=1`.

I am opening a PR with a naive and unoptimized fix first to see if the CI passes, and gather feedback on the direction of the fix.

If the CI passes, I will work on optimizing the logic if needed.

I am not really familiar with the maths behind the original implementation in `derX` of `gatherGradConfig`, and I couldn't get it to work within the `derX` function, I am open to suggestions on better and more optimized way to fix the issue.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.