### PR TITLE
Make MultiHeadAttention use masks from query and value tensors

### DIFF
--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -275,6 +275,8 @@ export class Tensor<R extends Rank = Rank> implements TensorInfo {
   kept = false;
   /** The id of the scope this tensor is being tracked in. */
   scopeId: number;
+  /** The keras mask that some keras layers attach to the tensor */
+  keras_mask?: Tensor;
 
   /**
    * Number of elements to skip in each dimension when indexing. See
@@ -441,6 +443,9 @@ export class Tensor<R extends Rank = Rank> implements TensorInfo {
   dispose(): void {
     if (this.isDisposed) {
       return;
+    }
+    if (this.keras_mask) {
+      this.keras_mask.dispose();
     }
     trackerFn().disposeTensor(this);
     this.isDisposedInternal = true;

--- a/tfjs-core/src/tensor.ts
+++ b/tfjs-core/src/tensor.ts
@@ -276,7 +276,7 @@ export class Tensor<R extends Rank = Rank> implements TensorInfo {
   /** The id of the scope this tensor is being tracked in. */
   scopeId: number;
   /** The keras mask that some keras layers attach to the tensor */
-  keras_mask?: Tensor;
+  kerasMask?: Tensor;
 
   /**
    * Number of elements to skip in each dimension when indexing. See
@@ -444,8 +444,8 @@ export class Tensor<R extends Rank = Rank> implements TensorInfo {
     if (this.isDisposed) {
       return;
     }
-    if (this.keras_mask) {
-      this.keras_mask.dispose();
+    if (this.kerasMask) {
+      this.kerasMask.dispose();
     }
     trackerFn().disposeTensor(this);
     this.isDisposedInternal = true;

--- a/tfjs-layers/src/base_callbacks.ts
+++ b/tfjs-layers/src/base_callbacks.ts
@@ -488,7 +488,8 @@ export function standardizeCallbacks(
   }
   // Convert custom callback configs to custom callback objects.
   const callbackConfigs =
-      generic_utils.toList(callbacks) as CustomCallbackArgs[];
+      generic_utils.toList<BaseCallback | CustomCallbackArgs>(
+        callbacks) as CustomCallbackArgs[];
   return callbackConfigs.map(
       callbackConfig => new CustomCallback(callbackConfig, yieldEvery));
 }

--- a/tfjs-layers/src/engine/topology.ts
+++ b/tfjs-layers/src/engine/topology.ts
@@ -1029,18 +1029,18 @@ export abstract class Layer extends serialization.Serializable {
                 + `but ${outputMask.length} masks for those tensors`);
             }
             for (let i = 0; i < output.length; i++) {
-              output[i].keras_mask = outputMask[i];
+              output[i].kerasMask = outputMask[i];
             }
           } else if (outputMask instanceof Array) {
             throw new Error(`{this.name} output a single tensor `
               + `but ${outputMask.length} masks`);
           } else if (output instanceof Array) {
             for (const out of output) {
-              out.keras_mask = outputMask.clone();
+              out.kerasMask = outputMask.clone();
             }
             outputMask.dispose(); // Only keep the clones to avoid leaking
           } else {
-            output.keras_mask = outputMask;
+            output.kerasMask = outputMask;
           }
         }
 

--- a/tfjs-layers/src/layers/nlp/multihead_attention.ts
+++ b/tfjs-layers/src/layers/nlp/multihead_attention.ts
@@ -813,8 +813,8 @@ export class MultiHeadAttention extends Layer {
     return tidy(() => {
       let autoMask: Tensor;
 
-      const queryMask = query.keras_mask;
-      const valueMask = value.keras_mask;
+      const queryMask = query.kerasMask;
+      const valueMask = value.kerasMask;
       if (queryMask != null) {
         autoMask = queryMask.expandDims(2); // Shape is [B, T, 1]
       }

--- a/tfjs-layers/src/layers/nlp/multihead_attention_test.ts
+++ b/tfjs-layers/src/layers/nlp/multihead_attention_test.ts
@@ -203,7 +203,7 @@ describeMathCPUAndGPU('MultiHeadAttention', () => {
     expectTensorsNotClose(trainOut, testOut);
   });
 
-  fdescribe('Causal Mask Value', () => {
+  describe('Causal Mask Value', () => {
     let testLayer: MultiHeadAttention;
     let maskedQuery: Tensor;
     let maskedValue: Tensor;
@@ -214,8 +214,9 @@ describeMathCPUAndGPU('MultiHeadAttention', () => {
       const query = tensor2d([
         [1, 2, 3, 0, 0], [3, 3, 1, 1, 2], [1, 0, 0, 0, 0]
       ]);
-      maskedQuery = new Embedding(
-        {inputDim: 4, outputDim: 8, maskZero: true}).apply(query) as Tensor;
+      const maskedQueryLayer = new Embedding(
+        {inputDim: 4, outputDim: 8, maskZero: true});
+      maskedQuery = maskedQueryLayer.apply(query) as Tensor;
       const value = tensor2d([[5, 4, 0], [3, 0, 0], [2, 1, 1]]);
       maskedValue = new Embedding(
         {inputDim: 6, outputDim: 8, maskZero: true}).apply(value) as Tensor;
@@ -232,9 +233,14 @@ describeMathCPUAndGPU('MultiHeadAttention', () => {
     /**
      * Test that the value and causal masks are taken into account.
      */
-    fit('causal', () => {
+    it('causal', () => {
       const output = testLayer.call(
         maskedQuery, {value: maskedValue, useCausalMask: true});
+
+      mask = mask.logicalAnd(tensor([
+        [[true, false, false], [true, true, false]].concat(
+          [[true, true, true], [true, true, true], [true, true, true]])
+      ]));
 
       const outputWithManualMask = testLayer.call(
         maskedQuery, {value: maskedValue, attentionMask: mask});
@@ -244,12 +250,7 @@ describeMathCPUAndGPU('MultiHeadAttention', () => {
 
     it('not_causal', () => {
       const output = testLayer.call(
-        maskedQuery, {value: maskedValue, useCausalMask: true});
-
-      mask = mask.logicalAnd(tensor([
-        [[true, false, false], [true, true, false]].concat(
-          [[true, true, true], [true, true, true], [true, true, true]])
-      ]));
+        maskedQuery, {value: maskedValue, useCausalMask: false});
 
       const outputWithManualMask = testLayer.call(
         maskedQuery, {value: maskedValue, attentionMask: mask});

--- a/tfjs-layers/src/layers/nlp/multihead_attention_test.ts
+++ b/tfjs-layers/src/layers/nlp/multihead_attention_test.ts
@@ -25,10 +25,10 @@ import { TruncatedNormal } from '../../initializers';
 import { input } from '../../exports';
 import { Shape } from '../../keras_format/common';
 import { MultiHeadAttention } from './multihead_attention';
-import { describeMathCPU, expectTensorsClose, expectTensorsNotClose } from '../../utils/test_utils';
+import { describeMathCPU, describeMathCPUAndGPU, expectTensorsClose, expectTensorsNotClose } from '../../utils/test_utils';
 import { Embedding } from '../embeddings';
 
-describe('MultiHeadAttention', () => {
+describeMathCPUAndGPU('MultiHeadAttention', () => {
 
   describe('Non Masked Attention', () => {
     interface NonMaskedAttentionArgs {
@@ -188,101 +188,6 @@ describe('MultiHeadAttention', () => {
     expectTensorsNotClose(queryKernel, outputKernel, 1e-6);
   });
 
-  describeMathCPU('High Dimensional Attention', () => {
-    interface HighDimAttentionArgs {
-      testcaseName: string;
-      qDims: Shape;
-      vDims: Shape;
-      maskDims: Shape;
-      attentionAxes: number[];
-    }
-    /**
-     * Test with high dimensional inputs.
-     */
-    function testHighDimAttention({
-      testcaseName, qDims, vDims, maskDims, attentionAxes,
-    }: HighDimAttentionArgs) {
-      it(testcaseName, () => {
-        const testLayer = new MultiHeadAttention({
-          numHeads: 2, keyDim: 2, attentionAxes,
-        });
-        const batchSize = 3;
-        const hiddenSize = 8;
-        // Generate data for the input (non-mask) tensors.
-        const queryShape = [batchSize].concat(qDims).concat(hiddenSize);
-        const valueShape = [batchSize].concat(vDims).concat(hiddenSize);
-        const maskShape = [batchSize].concat(maskDims);
-        const query = randomUniform(queryShape, 0, 10);
-        const value = randomUniform(valueShape, 0, 10);
-
-        // Invoke the data with a random set of mask data. This should mask at
-        // least one element.
-        const maskData = randomUniformInt(maskShape, 0, 2).asType('bool');
-
-        // Invoke the same data, but with a null mask (where no elements are
-        // masked).
-        const nullMaskData = ones(maskShape);
-
-        // Because one data is masked and one is not, the outputs should not be
-        // the same.
-
-        const outputWithMask = testLayer.call(
-          query, {value, attentionMask: maskData});
-        const outputWithNullMask = testLayer.call(
-          query, {value, attentionMask: nullMaskData});
-
-        expectTensorsNotClose(outputWithMask, outputWithNullMask);
-      });
-    }
-    const params: HighDimAttentionArgs[] = [
-      {
-        testcaseName: '4d_inputs_1freebatch_mask2',
-        qDims: [3, 4],
-        vDims: [3, 2],
-        maskDims: [4, 2],
-        attentionAxes: [2],
-      },
-      {
-        testcaseName: '4d_inputs_1freebatch_mask3',
-        qDims: [3, 4],
-        vDims: [3, 2],
-        maskDims: [3, 4, 2],
-        attentionAxes: [2],
-      },
-      {
-        testcaseName: '4d_inputs_1freebatch_mask4',
-        qDims: [3, 4],
-        vDims: [3, 2],
-        maskDims: [3, 2, 4, 2],
-        attentionAxes: [2],
-      },
-      {
-        testcaseName: '4D_inputs_2D_attention',
-        qDims: [3, 4],
-        vDims: [3, 2],
-        maskDims: [3, 4, 3, 2],
-        attentionAxes: [1, 2],
-      },
-      {
-        testcaseName: '5D_inputs_2D_attention',
-        qDims: [5, 3, 4],
-        vDims: [5, 3, 2],
-        maskDims: [3, 4, 3, 2],
-        attentionAxes: [2, 3],
-      },
-      {
-        testcaseName: '5D_inputs_2D_attention_fullmask',
-        qDims: [5, 3, 4],
-        vDims: [5, 3, 2],
-        maskDims: [5, 3, 4, 3, 2],
-        attentionAxes: [2, 3],
-      },
-    ];
-    for (const param of params) {
-      testHighDimAttention(param);
-    }
-  });
-
   it('dropout', () => {
     const testLayer = new MultiHeadAttention({
       numHeads: 2,
@@ -298,7 +203,7 @@ describe('MultiHeadAttention', () => {
     expectTensorsNotClose(trainOut, testOut);
   });
 
-  describe('Casual Mask Value', () => {
+  fdescribe('Casual Mask Value', () => {
     /**
      * Test that the value and causal masks are taken into account.
      */
@@ -480,6 +385,101 @@ describe('MultiHeadAttention', () => {
     expect(memory().numTensors).toEqual(numTensors + 1);
   });
   // TODO(pforderique): Test serialization.
+});
+
+describeMathCPU('High Dimensional Attention', () => {
+  interface HighDimAttentionArgs {
+    testcaseName: string;
+    qDims: Shape;
+    vDims: Shape;
+    maskDims: Shape;
+    attentionAxes: number[];
+  }
+  /**
+   * Test with high dimensional inputs.
+   */
+  function testHighDimAttention({
+    testcaseName, qDims, vDims, maskDims, attentionAxes,
+  }: HighDimAttentionArgs) {
+    it(testcaseName, () => {
+      const testLayer = new MultiHeadAttention({
+        numHeads: 2, keyDim: 2, attentionAxes,
+      });
+      const batchSize = 3;
+      const hiddenSize = 8;
+      // Generate data for the input (non-mask) tensors.
+      const queryShape = [batchSize].concat(qDims).concat(hiddenSize);
+      const valueShape = [batchSize].concat(vDims).concat(hiddenSize);
+      const maskShape = [batchSize].concat(maskDims);
+      const query = randomUniform(queryShape, 0, 10);
+      const value = randomUniform(valueShape, 0, 10);
+
+      // Invoke the data with a random set of mask data. This should mask at
+      // least one element.
+      const maskData = randomUniformInt(maskShape, 0, 2).asType('bool');
+
+      // Invoke the same data, but with a null mask (where no elements are
+      // masked).
+      const nullMaskData = ones(maskShape);
+
+      // Because one data is masked and one is not, the outputs should not be
+      // the same.
+
+      const outputWithMask = testLayer.call(
+        query, {value, attentionMask: maskData});
+      const outputWithNullMask = testLayer.call(
+        query, {value, attentionMask: nullMaskData});
+
+      expectTensorsNotClose(outputWithMask, outputWithNullMask);
+    });
+  }
+  const params: HighDimAttentionArgs[] = [
+    {
+      testcaseName: '4d_inputs_1freebatch_mask2',
+      qDims: [3, 4],
+      vDims: [3, 2],
+      maskDims: [4, 2],
+      attentionAxes: [2],
+    },
+    {
+      testcaseName: '4d_inputs_1freebatch_mask3',
+      qDims: [3, 4],
+      vDims: [3, 2],
+      maskDims: [3, 4, 2],
+      attentionAxes: [2],
+    },
+    {
+      testcaseName: '4d_inputs_1freebatch_mask4',
+      qDims: [3, 4],
+      vDims: [3, 2],
+      maskDims: [3, 2, 4, 2],
+      attentionAxes: [2],
+    },
+    {
+      testcaseName: '4D_inputs_2D_attention',
+      qDims: [3, 4],
+      vDims: [3, 2],
+      maskDims: [3, 4, 3, 2],
+      attentionAxes: [1, 2],
+    },
+    {
+      testcaseName: '5D_inputs_2D_attention',
+      qDims: [5, 3, 4],
+      vDims: [5, 3, 2],
+      maskDims: [3, 4, 3, 2],
+      attentionAxes: [2, 3],
+    },
+    {
+      testcaseName: '5D_inputs_2D_attention_fullmask',
+      qDims: [5, 3, 4],
+      vDims: [5, 3, 2],
+      maskDims: [5, 3, 4, 3, 2],
+      attentionAxes: [2, 3],
+    },
+  ];
+  for (const param of params) {
+    testHighDimAttention(param);
+  }
 });
 
 class SubclassAttention extends MultiHeadAttention {

--- a/tfjs-layers/src/utils/generic_utils.ts
+++ b/tfjs-layers/src/utils/generic_utils.ts
@@ -76,7 +76,7 @@ export function singletonOrArray<T>(xs: T[]): T|T[] {
  * @param x target object to be normalized.
  */
 // tslint:disable-next-line:no-any
-export function toList(x: any): any[] {
+export function toList<T>(x: T|T[]): T[] {
   if (Array.isArray(x)) {
     return x;
   }


### PR DESCRIPTION
Add optional [Keras masks](https://www.tensorflow.org/guide/keras/understanding_masking_and_padding) to tfjs tensors. Enable them for tfjs-layers on layers that emit them. Use the masks of query and value input tensors in MultiHeadAttention to compute the correct mask automatically.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.