### PR TITLE
Infer dtype in wasm fill

### DIFF
--- a/tfjs-backend-wasm/src/kernels/Fill.ts
+++ b/tfjs-backend-wasm/src/kernels/Fill.ts
@@ -15,13 +15,17 @@
  * =============================================================================
  */
 
-import {KernelConfig, KernelFunc} from '@tensorflow/tfjs-core';
+import {KernelConfig, KernelFunc, util} from '@tensorflow/tfjs-core';
 import {Fill, FillAttrs} from '@tensorflow/tfjs-core';
 
 import {BackendWasm} from '../backend_wasm';
 
 export function fill(args: {attrs: FillAttrs, backend: BackendWasm}) {
-  const {attrs: {shape, value, dtype}, backend} = args;
+  const {attrs: {shape, value}, backend} = args;
+  let {attrs: {dtype}} = args;
+
+  dtype = dtype || util.inferDtype(value);
+
   const out = backend.makeOutput(shape, dtype);
   const outVals = backend.typedArrayFromHeap(out);
   outVals.fill(value as number);


### PR DESCRIPTION
This makes the `dtype` handling in `wasm` follow the same codepath as the `webgl` backend.

Originally, I had [this issue](https://github.com/tensorflow/tfjs/issues/7408) but it was fixed by @chunnienc's commit:  https://github.com/tensorflow/tfjs/commit/ff6739dd2b0fd5af59d35a9dbdf698a525b1791f#diff-ec2bd7b410dc39732c6db76ce69e87aa309d69fb0d53d355f5e43aa055dd3b7bR44.  I discovered the fix while testing this PR, but thought I would open it anyway as it may be nice as a sanity check to have both `Fill`s have the same behavior.

Alternatively, I can open a PR that eliminates [the util.inferDtype call](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-webgl/src/kernels/Fill.ts#L29) within the `webgl` backend as it's now a no-op.