### PR TITLE
webgpu: Enable importExternalTexture

### DIFF
--- a/tfjs-backend-webgpu/src/from_pixels_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/from_pixels_webgpu_test.ts
@@ -50,7 +50,6 @@ describeWebGPU('fromPixels', () => {
         document.body.appendChild(video);
         await test_util.play(video);
 
-        // importExternalTexture is temporarily disabled
         {
           tf.env().set('WEBGPU_IMPORT_EXTERNAL_TEXTURE', true);
           const res = tf.browser.fromPixels(video);
@@ -59,7 +58,7 @@ describeWebGPU('fromPixels', () => {
           expect(data.length).toEqual(90 * 160 * 3);
           const freeTexturesAfterFromPixels =
               textureManager.getNumFreeTextures();
-          expect(freeTexturesAfterFromPixels).toEqual(1);
+          expect(freeTexturesAfterFromPixels).toEqual(0);
           const usedTexturesAfterFromPixels =
               textureManager.getNumUsedTextures();
           expect(usedTexturesAfterFromPixels).toEqual(0);

--- a/tfjs-backend-webgpu/src/kernels/FromPixels.ts
+++ b/tfjs-backend-webgpu/src/kernels/FromPixels.ts
@@ -63,10 +63,8 @@ export function fromPixels(args: {
       [pixels.width, pixels.height];
   const outputShape = [height, width, numChannels];
 
-  // Disable importExternalTexture temporarily as it has problem in spec and
-  // browser impl
   const importVideo =
-      false && env().getBool('WEBGPU_IMPORT_EXTERNAL_TEXTURE') && isVideo;
+      env().getBool('WEBGPU_IMPORT_EXTERNAL_TEXTURE') && isVideo;
   const isVideoOrImage = isVideo || isImage;
   if (isImageBitmap || isCanvas || isVideoOrImage) {
     let resource;


### PR DESCRIPTION
Issues related to importExternalTexture were fixed in Chrome, so that we may enable this feature by default again.
Note that its Linux implementation still has problem, and WebGPU support on Linux hasn't been officially released yet.
Bug #7972

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.