### PR TITLE
webgpu: fix browser check

### DIFF
--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -155,10 +155,7 @@ export function GPUBytesPerElement(dtype: DataType): number {
 }
 
 export function isWebGPUSupported(): boolean {
-  return ((typeof window !== 'undefined') ||
-          //@ts-ignore
-          (typeof WorkerGlobalScope !== 'undefined')) &&
-      !!navigator.gpu;
+  return !!globalThis.navigator.gpu;
 }
 
 export function assertNotComplex(


### PR DESCRIPTION
This change is due to this not working in Deno's NPM compatibility.
