### PR TITLE
[benchmark] support string dtype input generation

### DIFF
--- a/e2e/benchmarks/benchmark_util.js
+++ b/e2e/benchmarks/benchmark_util.js
@@ -107,6 +107,11 @@ function generateInputFromDef(inputDefs, isForGraphModel = false) {
         // the data generated maybe outside of [min, max].
         inputTensor = tf.clipByValue(generatedRaw, min, max);
         generatedRaw.dispose();
+      } else if (inputDef.dtype === 'string') {
+        size = tf.util.sizeFromShape(inputDef.shape);
+        data = [...Array(size)].map(
+            () => Math.random().toString(36).substring(2, 7));
+        inputTensor = tf.tensor(data, inputShape, inputDef.dtype);
       } else {
         throw new Error(
             `The ${inputDef.dtype} dtype of '${inputDef.name}' input ` +


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.