### PR TITLE
Start verdaccio earlier and keep it alive longer

### DIFF
--- a/scripts/release-util.ts
+++ b/scripts/release-util.ts
@@ -640,7 +640,8 @@ export async function runVerdaccio(): Promise<() => void> {
 
     serverProcess.on('message', (msg: {verdaccio_started: boolean}) => {
       if (msg.verdaccio_started) {
-        console.log('Verdaccio Started.');
+        console.log(chalk.magenta.bold(
+            `Verdaccio Started. Visit http://localhost:4873 to see packages.`));
         clearTimeout(timeout);
         resolve();
       }


### PR DESCRIPTION
Start the verdaccio server immediately when running publish-npm and keep it alive until the first OTP is entered. Also, add a tip for how to access the server from your browser. This makes it easier to verify that all packages will be published correctly to NPM.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.