### PR TITLE
docs:fix to README where the provided example prompts type errors in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ Add the following code to an HTML file:
       model.fit(xs, ys).then(() => {
         // Use the model to do inference on a data point the model hasn't seen before:
         // Open the browser devtools to see the output
-        model.predict(tf.tensor2d([5], [1, 1])).print();
+        const result = model.predict(tf.tensor2d([5], [1, 1]))
+        if (Array.isArray(result)) {
+          result.forEach(item => item.print())
+        } else {
+          result.print()
+        }
       });
     </script>
   </head>
@@ -153,7 +158,12 @@ const ys = tf.tensor2d([1, 3, 5, 7], [4, 1]);
 // Train the model using the data.
 model.fit(xs, ys).then(() => {
   // Use the model to do inference on a data point the model hasn't seen before:
-  model.predict(tf.tensor2d([5], [1, 1])).print();
+  const result = model.predict(tf.tensor2d([5], [1, 1]))
+  if (Array.isArray(result)) {
+    result.forEach(item => item.print())
+  } else {
+    result.print()
+  }
 });
 ```
 


### PR DESCRIPTION
When I first started using `@tensorflow/tfjs`, I first followed the code examples in the `README.md`. But it hints at a type error in `typescript`.

Then I found out that the return type of `model.predict` might be an `array`, but `array` don't have `print` methods. So I made a judgment to resolve the type error.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.