### PR TITLE
Fix missing publish tag for non-bazel packages

### DIFF
--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -203,15 +203,15 @@ async function publish(pkg: string, registry: string, otp?: string,
       await retry(() =>
           run(`${login}yarn --registry '${registry}' publish-npm ${dashes} ${otpFlag} --tag=${tag} --force`));
     } else {
-      // Publish the package to the registry.
-      await retry(() =>
-          run(`${login}npm --registry '${registry}' publish ${otpFlag}`));
-
       // Special case for tfjs-node(-gpu), which must upload the node addon
       // to GCP as well. Only do this when publishing to NPM.
       if (registry === NPM_REGISTRY && pkg.startsWith('tfjs-node')) {
         $('yarn build-and-upload-addon publish');
       }
+
+      // Publish the package to the registry.
+      await retry(() =>
+          run(`${login}npm --registry '${registry}' publish --tag=${tag} ${otpFlag}`));
     }
     console.log(`Published ${pkg} to ${registry}.`);
 


### PR DESCRIPTION
Add a missing tag argument to the npm publish script for packages that don't build with Bazel.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.