### PR TITLE
Fix worker tests using the wrong paths in importScripts

### DIFF
--- a/tfjs-core/src/worker_test.ts
+++ b/tfjs-core/src/worker_test.ts
@@ -26,8 +26,8 @@ const str2workerURL = (str: string): string => {
 
 // The source code of a web worker.
 const workerTest = `
-importScripts(location.origin + '/base/tfjs/tfjs-core/tf-core.min.js');
-importScripts(location.origin
+importScripts('${location.origin}/base/tfjs/tfjs-core/tf-core.min.js');
+importScripts('${location.origin}'
   + '/base/tfjs/tfjs-backend-cpu/tf-backend-cpu.min.js');
 
 let a = tf.tensor1d([1, 2, 3]);

--- a/tfjs-tflite/src/worker_test.ts
+++ b/tfjs-tflite/src/worker_test.ts
@@ -25,18 +25,18 @@ const str2workerURL = (str: string): string => {
 
 // The source code of a web worker.
 const workerTest = `
-importScripts(location.origin + '/base/tfjs/tfjs-core/tf-core.min.js');
-importScripts(location.origin
+importScripts('${location.origin}/base/tfjs/tfjs-core/tf-core.min.js');
+importScripts('${location.origin}'
   + '/base/tfjs/tfjs-backend-cpu/tf-backend-cpu.min.js');
 // Import order matters. TFLite must be imported after tfjs core.
-importScripts(location.origin + '/base/tfjs/tfjs-tflite/tf-tflite.min.js');
+importScripts('${location.origin}/base/tfjs/tfjs-tflite/tf-tflite.min.js');
 
 // Setting wasm path is required. It can be set to CDN if needed,
 // but that's not a good idea for a test.
-tflite.setWasmPath('/base/tfjs/tfjs-tflite/wasm/');
+tflite.setWasmPath('${location.origin}/base/tfjs/tfjs-tflite/wasm/');
 async function main() {
   // This is a test model that adds two tensors of shape [1, 4].
-  const model = await tflite.loadTFLiteModel(location.origin + '/base/tfjs/tfjs-tflite/test_files/add4.tflite');
+  const model = await tflite.loadTFLiteModel('${location.origin}/base/tfjs/tfjs-tflite/test_files/add4.tflite');
 
   const a = tf.tensor2d([[1, 2, 3, 4]]);
   const b = tf.tensor2d([[5, 6, 7, 8]]);


### PR DESCRIPTION
Worker tests were getting the path for `importScripts` by referencing `location.origin`, but this is `blob://` when accessed from the worker context.

Template `location.origin` from the main context into the worker source code instead of accessing the worker's version of `location.origin`.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.