### PR TITLE
Update broken link for Frozen Model hyperlink in  README.md

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -186,7 +186,7 @@ most cases.
 | `keras_saved_model` | `tfjs_layers_model` | Convert a tf.keras SavedModel model file (from [`tf.contrib.saved_model.save_keras_model`](https://www.tensorflow.org/api_docs/python/tf/contrib/saved_model/save_keras_model)) to TensorFlow.js Layers model format. Use [`tf.loadLayersModel()`](https://js.tensorflow.org/api/latest/#loadLayersModel) to load the model in JavaScript. |
 | `tf_hub` | `tfjs_graph_model` | Convert a [TF-Hub](https://www.tensorflow.org/hub) model file to TensorFlow.js graph model format. Use [`tf.loadGraphModel()`](https://js.tensorflow.org/api/latest/#loadGraphModel) to load the converted model in JavaScript. |
 | `tf_saved_model` | `tfjs_graph_model` | Convert a [TensorFlow SavedModel](https://www.tensorflow.org/guide/saved_model#build_and_load_a_savedmodel) to TensorFlow.js graph model format. Use [`tf.loadGraphModel()`](https://js.tensorflow.org/api/latest/#loadGraphModel) to load the converted model in JavaScript. |
-| `tf_frozen_model` | `tfjs_graph_model` | Convert a [Frozen Model](https://www.tensorflow.org/mobile/prepare_models#how_do_you_get_a_model_you_can_use_on_mobile) to TensorFlow.js graph model format. Use [`tf.loadGraphModel()`](https://js.tensorflow.org/api/latest/#loadGraphModel) to load the converted model in JavaScript. |
+| `tf_frozen_model` | `tfjs_graph_model` | Convert a [Frozen Model](https://medium.com/@sebastingarcaacosta/how-to-export-a-tensorflow-2-x-keras-model-to-a-frozen-and-optimized-graph-39740846d9eb) to TensorFlow.js graph model format. Use [`tf.loadGraphModel()`](https://js.tensorflow.org/api/latest/#loadGraphModel) to load the converted model in JavaScript. |
 
 #### JavaScript-to-Python
 


### PR DESCRIPTION
I have updated broken link for Frozen Model on this [page](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#python-to-javascript) because it was pointing to outdated documentation page which does not exist now and I checked on Tensorflow website there is no official documentation page about Frozen Model if I'm not wrong so I updated broken link with [Medium](https://medium.com/@sebastingarcaacosta/how-to-export-a-tensorflow-2-x-keras-model-to-a-frozen-and-optimized-graph-39740846d9eb) article which will help community users to export a TensorFlow 2.x Keras model to a frozen graph model

I have found similar issue on [Tensorflow Forum](https://discuss.tensorflow.org/t/how-do-you-export-a-frozen-inference-graph-in-tensorflow-2-x-object-detection-api/5928) where user found [workaround](https://github.com/tensorflow/models/issues/8966#issuecomment-1017052562) so either we can update broken link with any one of the below medium articles or we can remove hyperlink for Frozen Model which we did on this [page](https://www.tensorflow.org/js/tutorials/conversion/import_saved_model), at the moment I updated broken link with this [article](https://medium.com/@sebastingarcaacosta/how-to-export-a-tensorflow-2-x-keras-model-to-a-frozen-and-optimized-graph-39740846d9eb) so I need your help on this what should we do here ? Thank you!

1. https://medium.com/@sebastingarcaacosta/how-to-export-a-tensorflow-2-x-keras-model-to-a-frozen-and-optimized-graph-39740846d9eb
2. https://ksingh7.medium.com/part-iii-convert-keras-model-to-tensorflow-frozen-graph-model-a6aa6b1aaeee
3. https://jimmy-shen.medium.com/how-to-freeze-graph-in-tensorflow-2-x-3a3238c70f19