### PR TITLE
Check globalThis.navigator before checking for WebGPU support

### DIFF
--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -155,7 +155,7 @@ export function GPUBytesPerElement(dtype: DataType): number {
 }
 
 export function isWebGPUSupported(): boolean {
-  return !!globalThis.navigator.gpu;
+  return !!globalThis.navigator?.gpu;
 }
 
 export function assertNotComplex(


### PR DESCRIPTION
Use the optional chaining operator to check for globalThis.navigator being nullish before checking for globalThis.navigator.gpu. This fixes isWebGPUSupported() so that it works on platforms like Node which don't provide navigator in the global scope.

Fixed #8066.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.