### PR TITLE
Fix isWebGPUSupported throwing an error in node

### DIFF
--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -155,7 +155,7 @@ export function GPUBytesPerElement(dtype: DataType): number {
 }
 
 export function isWebGPUSupported(): boolean {
-  return !!globalThis.navigator.gpu;
+  return !!(globalThis && (globalThis.navigator) && (globalThis.navigator.gpu));
 }
 
 export function assertNotComplex(


### PR DESCRIPTION
While node is not supported, 'isWebGPUSupported' should return false instead of throwing an error. This fixes pose-detection node tests, which use the same files as the browser tests.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.