### PR TITLE
Fix webgpu support check failing if globalThis is undefined

### DIFF
--- a/tfjs-backend-webgpu/src/webgpu_util.ts
+++ b/tfjs-backend-webgpu/src/webgpu_util.ts
@@ -155,7 +155,8 @@ export function GPUBytesPerElement(dtype: DataType): number {
 }
 
 export function isWebGPUSupported(): boolean {
-  return !!(globalThis && (globalThis.navigator) && (globalThis.navigator.gpu));
+  return !!(typeof globalThis !== 'undefined' && (globalThis.navigator)
+    && (globalThis.navigator.gpu));
 }
 
 export function assertNotComplex(


### PR DESCRIPTION
Fix WebGPU support check not working on iOS, where globalThis is sometimes not available.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.