### PR TITLE
Fix: env() does not always return platform

### DIFF
--- a/tfjs-core/src/util.ts
+++ b/tfjs-core/src/util.ts
@@ -136,7 +136,7 @@ export function decodeString(bytes: Uint8Array, encoding = 'utf-8'): string {
 export function isTypedArray(a: {}): a is Float32Array|Int32Array|Uint8Array|
     Uint8ClampedArray {
   // TODO(mattsoulanille): Remove this fallback in 5.0.0
-  if (env().platform.isTypedArray != null) {
+  if (env().platform && env().platform.isTypedArray != null) {
     return env().platform.isTypedArray(a);
   } else {
     return isTypedArrayBrowser(a);


### PR DESCRIPTION
In attempts at running TensorFlow in an `AudioWorklet` (see #4704 ), I ran into the issue where `env().platform` is `undefined`. This is the pragmatic fix, since the fallback is supposed to be removed in the future. (and to actually run TFJS in an AudioWorklet, I needed some more patches to the WASM backend loading, but that's unrelated to this PR).