### PR TITLE
changed path for polyshape import

### DIFF
--- a/tfjs-converter/python/tensorflowjs/converters/jax_conversion.py
+++ b/tfjs-converter/python/tensorflowjs/converters/jax_conversion.py
@@ -17,7 +17,7 @@ import tempfile
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 from jax.experimental import jax2tf
-from jax.experimental.export import shape_poly
+from jax.experimental.jax2tf import PolyShape
 import tensorflow as tf
 from tensorflowjs.converters import tf_saved_model_conversion_v2 as saved_model_conversion
 
@@ -25,7 +25,6 @@ from tensorflowjs.converters import tf_saved_model_conversion_v2 as saved_model_
 _TF_SERVING_KEY = tf.saved_model.DEFAULT_SERVING_SIGNATURE_DEF_KEY
 Array = Any
 DType = Any
-PolyShape = shape_poly.PolyShape
 
 
 class _ReusableSavedModelWrapper(tf.train.Checkpoint):


### PR DESCRIPTION
A bit of a noob with github, apologies if I broke or misunderstood any of the guidelines. There seems to be an issue with the poly_shape import in the jax_conversion.py file that has been preventing others from being able to convert models. There's an ongoing discussion here which I provided a solution that works for me.

[https://github.com/google/jax/issues/18978](https://github.com/google/jax/issues/18978)

Hopefully this is helpful in some way, cheers and happy holidays.