### PR TITLE
Fix for windows installation #7341

### DIFF
--- a/tfjs-node/scripts/deps-stage.js
+++ b/tfjs-node/scripts/deps-stage.js
@@ -22,6 +22,7 @@ const copy = util.promisify(fs.copyFile);
 const os = require('os');
 const rename = util.promisify(fs.rename);
 const symlink = util.promisify(fs.symlink);
+const mkdir = util.promisify(fs.mkdir);
 const {
   depsLibTensorFlowFrameworkPath,
   depsLibTensorFlowPath,
@@ -57,7 +58,7 @@ async function symlinkDepsLib() {
     throw new Error('Destination path not supplied!');
   }
   try {
-    await fs.mkdir(path.dirname(destLibTensorFlowPath), {recursive: true});
+    await mkdir(path.dirname(destLibTensorFlowPath), {recursive: true});
     await symlink(
         path.relative(
             path.dirname(destLibTensorFlowPath), depsLibTensorFlowPath),

--- a/tfjs-node/scripts/deps-stage.js
+++ b/tfjs-node/scripts/deps-stage.js
@@ -57,6 +57,7 @@ async function symlinkDepsLib() {
     throw new Error('Destination path not supplied!');
   }
   try {
+    await fs.mkdir(path.dirname(destLibTensorFlowPath), {recursive: true});
     await symlink(
         path.relative(
             path.dirname(destLibTensorFlowPath), depsLibTensorFlowPath),


### PR DESCRIPTION
**(Edit: Added one more commit, the mkdir function on my patch was misussed on the async call)**

Fix a problem with the installation on windows.
My problem on windows was that `./lib/napi-v9` directory didn't exist and `./scripts/deps-stage.js` on line **60** needed the path to symlink or copy the dll. 

My fix was to make sure that the directory `napi-v9` exists with: `fs.mkdir(path.dirname(destLibTensorFlowPath), {recursive: true})`;

I'm solving the copy issue with this code.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.