### PR TITLE
tfjs model download via http issue

### DIFF
--- a/tfjs-core/src/io/http.ts
+++ b/tfjs-core/src/io/http.ts
@@ -104,7 +104,7 @@ export class HTTPRequest implements IOHandler {
         getModelJSONForModelArtifacts(modelArtifacts, weightsManifest);
 
     init.body.append(
-        'model.json',
+        'model_json',
         new Blob(
             [JSON.stringify(modelTopologyAndWeightManifest)],
             {type: JSON_TYPE}),
@@ -116,7 +116,7 @@ export class HTTPRequest implements IOHandler {
       const weightBuffer = CompositeArrayBuffer.join(modelArtifacts.weightData);
 
       init.body.append(
-          'model.weights.bin',
+          'model_weights_bin',
           new Blob([weightBuffer], {type: OCTET_STREAM_MIME_TYPE}),
           'model.weights.bin');
     }

--- a/tfjs-core/src/io/http_test.ts
+++ b/tfjs-core/src/io/http_test.ts
@@ -243,7 +243,7 @@ describeWithFlags('http-save', CHROME_ENVS, () => {
           const init = requestInits[0];
           expect(init.method).toEqual('POST');
           const body = init.body as FormData;
-          const jsonFile = body.get('model.json') as File;
+          const jsonFile = body.get('model_json') as File;
           const jsonFileReader = new FileReader();
           jsonFileReader.onload = (event: Event) => {
             const modelJSON =
@@ -254,7 +254,7 @@ describeWithFlags('http-save', CHROME_ENVS, () => {
             expect(modelJSON.weightsManifest[0].weights).toEqual(weightSpecs1);
             expect(modelJSON.trainingConfig).toEqual(trainingConfig1);
 
-            const weightsFile = body.get('model.weights.bin') as File;
+            const weightsFile = body.get('model_weights_bin') as File;
             const weightsFileReader = new FileReader();
             weightsFileReader.onload = (event: Event) => {
               // tslint:disable-next-line:no-any


### PR DESCRIPTION
Hi, tfjs.

When downloading a model using tfjs via HTTP, the keys model.json and model.weights.json are not suitable because in FastAPI, there are cases where keys are used as variables.

Therefore, it is advisable to change them to model_json and model_weights_json.


```
@app.post("/upload")
async def upload_files(model_json: UploadFile = File(...), model_weights: UploadFile = File(...)):
    with open("model.json", "wb") as json_file:
        json_content = await model_json.read()
        json_file.write(json_content)

    with open("model.weights.bin", "wb") as weights_file:
        weights_content = await model_weights.read()
        weights_file.write(weights_content)

    return True
 ```