### PR TITLE
Address typos in tfjs-node documentation strings

### DIFF
--- a/tfjs-layers/demos/README.md
+++ b/tfjs-layers/demos/README.md
@@ -15,10 +15,10 @@ Once the development environment is prepared, execute the build script from the 
 ./scripts/build-benchmarks-demo.sh
 ```
 
-The script will construct a number of Keras models in Python and benchmark their training using the TensorFlow backend.  When it is complete, it will bring up a
-local HTTP server.  Navigate to the local URL spcecified in stdout to bring up
-the benchmarks page UI.  There will be a button to begin the JS side of the
-benchmarks.  Clicking the button will run through and time the same models, now
+The script will construct a number of Keras models in Python and benchmark their training using the TensorFlow backend. When it is complete, it will bring up a
+local HTTP server. Navigate to the local URL specified in stdout to bring up
+the benchmarks page UI. There will be a button to begin the JS side of the
+benchmarks. Clicking the button will run through and time the same models, now
 running in the browser.
 
 Once complete, the models' `fit()` and `predict()` costs are listed in a table.

--- a/tfjs-layers/src/base_callbacks.ts
+++ b/tfjs-layers/src/base_callbacks.ts
@@ -518,7 +518,7 @@ export class CallbackConstructorRegistry {
    * callbacks for every tf.LayersModel.fit() call afterwards.
    *
    * @param verbosityLevel Level of verbosity at which the `callbackConstructor`
-   *   is to be reigstered.
+   *   is to be registered.
    * @param callbackConstructor A no-arg constructor for `tf.Callback`.
    * @throws Error, if the same callbackConstructor has been registered before,
    *   either at the same or a different `verbosityLevel`.

--- a/tfjs-layers/src/constraints_test.ts
+++ b/tfjs-layers/src/constraints_test.ts
@@ -125,7 +125,7 @@ describeMathCPU('constraints.get', () => {
 
 describe('Constraints Serialization', () => {
   it('Built-ins', () => {
-    // Test both types of captialization.
+    // Test both types of capitalization.
     const constraints: ConstraintIdentifier[] = [
       'maxNorm', 'nonNeg', 'unitNorm', 'minMaxNorm', 'MaxNorm', 'NonNeg',
       'UnitNorm', 'MinMaxNorm'

--- a/tfjs-layers/src/engine/container.ts
+++ b/tfjs-layers/src/engine/container.ts
@@ -554,7 +554,7 @@ export abstract class Container extends Layer {
       throw new ValueError(
           'Container instance unexpectedly contains _trainableWeights.' +
           'The trainable weights of a Container are a union of the ' +
-          'trainable weights of its consituent Layers. Its own ' +
+          'trainable weights of its constituent Layers. Its own ' +
           '_trainableWeights must remain an empty Array.');
     }
 
@@ -670,7 +670,7 @@ export abstract class Container extends Layer {
       // For keras v3, the weights name are saved based on the folder structure.
       // e.g. _backbone/_layer_checkpoint_dependencies/transformer/_self../
       // _output_dense/vars/0
-      // Therefore we discard the `vars` and `layer_checkpoint_depencies` within
+      // Therefore we discard the `vars` and `layer_checkpoint_dependencies` within
       // the saved name and only keeps the layer name and weights.
       // This can help to mapping the actual name of the layers and load each
       // weight accordingly.

--- a/tfjs-layers/src/engine/dataset_fakes.ts
+++ b/tfjs-layers/src/engine/dataset_fakes.ts
@@ -26,7 +26,7 @@ export interface FakeDatasetArgs {
   xShape: Shape|{[name: string]: Shape};
 
   /**
-   * The shape of the target(s) of a single exapmle.
+   * The shape of the target(s) of a single example.
    */
   yShape: Shape|{[name: string]: Shape};
 

--- a/tfjs-layers/src/engine/dataset_fakes_test.ts
+++ b/tfjs-layers/src/engine/dataset_fakes_test.ts
@@ -19,7 +19,7 @@ describeMathCPUAndGPU('FakeNumericDataset', () => {
     const dataset = new FakeNumericDataset(
         {xShape: [3], yShape: [1], batchSize: 8, numBatches: 5});
     for (let k = 0; k < 2; ++k) {
-      // Run twice to make sure that calling iteartor() multiple times works.
+      // Run twice to make sure that calling iterator() multiple times works.
       const iterator = await dataset.iterator();
       for (let i = 0; i < 5; ++i) {
         const result = await iterator.next();
@@ -39,7 +39,7 @@ describeMathCPUAndGPU('FakeNumericDataset', () => {
     const dataset = new FakeNumericDataset(
         {xShape: [3, 4], yShape: [2], batchSize: 8, numBatches: 5});
     for (let k = 0; k < 2; ++k) {
-      // Run twice to make sure that calling iteartor() multiple times works.
+      // Run twice to make sure that calling iterator() multiple times works.
       const iterator = await dataset.iterator();
       for (let i = 0; i < 5; ++i) {
         const result = await iterator.next();
@@ -63,7 +63,7 @@ describeMathCPUAndGPU('FakeNumericDataset', () => {
       numBatches: 5
     });
     for (let k = 0; k < 2; ++k) {
-      // Run twice to make sure that calling iteartor() multiple times works.
+      // Run twice to make sure that calling iterator() multiple times works.
       const iterator = await dataset.iterator();
       for (let i = 0; i < 5; ++i) {
         const result = await iterator.next();

--- a/tfjs-layers/src/engine/executor.ts
+++ b/tfjs-layers/src/engine/executor.ts
@@ -365,7 +365,7 @@ export function execute(
   }
   // NOTE(cais): Unlike intermediate tensors, we don't discard mask
   // tensors as we go, because these tensors are sometimes passed over a
-  // series of mutliple layers, i.e., not obeying the immediate input
+  // series of multiple layers, i.e., not obeying the immediate input
   // relations in the graph. If this becomes a memory-usage concern,
   // we can improve this in the future.
   internalFeedDict.disposeMasks();

--- a/tfjs-layers/src/engine/topology.ts
+++ b/tfjs-layers/src/engine/topology.ts
@@ -1382,7 +1382,7 @@ export abstract class Layer extends serialization.Serializable {
       // masking not explicitly supported: return null as mask
       return null;
     }
-    // if masking is explictly supported, by default
+    // if masking is explicitly supported, by default
     // carry over the input mask
     return mask;
   }

--- a/tfjs-layers/src/engine/topology_test.ts
+++ b/tfjs-layers/src/engine/topology_test.ts
@@ -1059,7 +1059,7 @@ describeMathCPUAndGPU('Layer-dispose', () => {
     const model = tfl.model({inputs: [input], outputs: [output]});
 
     const result = model.dispose();
-    // This model, consiting of only an input layer and a reshape layer, does
+    // This model, consisting of only an input layer and a reshape layer, does
     // not have any weights to dispose.
     expect(result.numDisposedVariables).toEqual(0);
     expect(() => model.predict(zeros([1, 2, 3])))

--- a/tfjs-layers/src/engine/training.ts
+++ b/tfjs-layers/src/engine/training.ts
@@ -290,7 +290,7 @@ function checkLossAndTargetCompatibility(
  * @param shapes: Expected shapes for the input data, from the model.
  * @param checkBatchAxis: Whether the size along the batch axis (i.e., the
  *   first dimension) will be checked for matching.
- * @param exceptionPrefix: Execption prefix message, used in generating error
+ * @param exceptionPrefix: Exception prefix message, used in generating error
  *   messages.
  * @throws ValueError: on incorrect number of inputs or mismatches in shapes.
  */
@@ -513,7 +513,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
   //   implicit "knowledge" of the outputs it depends on.
   metricsTensors: Array<[LossOrMetricFn, number]>;
 
-  // User defind metadata (if any).
+  // User defined metadata (if any).
   private userDefinedMetadata: {};
 
   constructor(args: ContainerArgs) {
@@ -921,7 +921,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
     } else {
       throw new ValueError(
           `Either the input data should have a defined shape, or ` +
-          `${stepsName} shoud be specified.`);
+          `${stepsName} should be specified.`);
     }
     return numSamples;
   }
@@ -1028,7 +1028,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
    * @param batchSize: integer batch size.
    * @param verbose: verbosity model
    * @returns: Predictions as `tf.Tensor` (if a single output) or an `Array` of
-   *   `tf.Tensor` (if multipe outputs).
+   *   `tf.Tensor` (if multiple outputs).
    */
   private predictLoop(ins: Tensor|Tensor[], batchSize = 32, verbose = false):
       Tensor|Tensor[] {
@@ -1562,7 +1562,7 @@ export class LayersModel extends Container implements tfc.InferenceModel {
       //  through graph placeholders. In tfjs-layers, the data are fed as
       //  function arguments. Since the function are defined below in the
       //  scope, we don't have equivalents of PyKeras's
-      //  `_make_train_funciton`.
+      //  `_make_train_function`.
       const trainFunction = this.makeTrainFunction();
       const outLabels = this.getDedupedMetricsNames();
 

--- a/tfjs-layers/src/engine/training_dataset.ts
+++ b/tfjs-layers/src/engine/training_dataset.ts
@@ -595,7 +595,7 @@ export async function evaluateDataset<T>(
       if (hasBatches) {
         console.warn(
             'Your dataset iterator ran out of data during evaluateDataset(). ' +
-            'Interrupting evalution. Make sure that your ' +
+            'Interrupting evaluation. Make sure that your ' +
             'dataset can generate at least `batches` ' +
             `batches (in this case, ${args.batches} batches). ` +
             'You may need to use the repeat() function when building ' +

--- a/tfjs-layers/src/engine/training_dataset_test.ts
+++ b/tfjs-layers/src/engine/training_dataset_test.ts
@@ -896,7 +896,7 @@ describeMathCPUAndGPU('LayersModel.fitDataset', () => {
        expect(numTensors1).toEqual(numTensors0);
      });
 
-  // Refence Python tf.keras code:
+  // Reference Python tf.keras code:
   //
   // ```py
   // import numpy as np

--- a/tfjs-layers/src/engine/training_test.ts
+++ b/tfjs-layers/src/engine/training_test.ts
@@ -457,7 +457,7 @@ describeMathCPUAndWebGL2('LayersModel.fit long', () => {
   it('Return sequences; Fit with metric', async () => {
     // The golden values for history used in the assertion below can be obtained
     // with the following Python Keras code.
-    // Ran with Python Keras verion 2.1.2 and TensorFlow (CPU) version
+    // Ran with Python Keras version 2.1.2 and TensorFlow (CPU) version
     // 1.7.0-dev20180226.
     // ```python
     // import keras
@@ -500,7 +500,7 @@ describeMathCPUAndWebGL2('LayersModel.fit long', () => {
     const dataSize = 16;
     const validationSplit = 0.5;
     const batchSize = 3;
-    // So there are 8 examples for train and validation, respectivly. The actual
+    // So there are 8 examples for train and validation, respectively. The actual
     // batches during training and validation will be 3, 3 and 2. This tests the
     // correct averaging of the loss values happens without broadcasting.
     const outputSize = 2;
@@ -2286,7 +2286,7 @@ describeMathGPU('LayersModel.fit: yieldEvery', () => {
       yieldEvery + 1,  // Should call.
       yieldEvery + 1,  // Should call.
       1,
-      yieldEvery + 1,  // SHould call.
+      yieldEvery + 1,  // Should call.
       yieldEvery + 1,  // Should call.
       1,
       1,

--- a/tfjs-layers/src/exports.ts
+++ b/tfjs-layers/src/exports.ts
@@ -22,7 +22,7 @@ import {Sequential, SequentialArgs} from './models';
 export {loadLayersModel} from './models';
 
 // TODO(cais): Add doc string to all the public static functions in this
-//   class; include exectuable JavaScript code snippets where applicable
+//   class; include executable JavaScript code snippets where applicable
 //   (b/74074458).
 
 // LayersModel and related factory methods.

--- a/tfjs-layers/src/exports_layers.ts
+++ b/tfjs-layers/src/exports_layers.ts
@@ -31,7 +31,7 @@ import {Resizing, ResizingArgs} from './layers/preprocessing/image_resizing';
 import {RandomWidth, RandomWidthArgs} from './layers/preprocessing/random_width';
 
 // TODO(cais): Add doc string to all the public static functions in this
-//   class; include exectuable JavaScript code snippets where applicable
+//   class; include executable JavaScript code snippets where applicable
 //   (b/74074458).
 
 // Input Layer.
@@ -1772,7 +1772,7 @@ export function centerCrop(args?: CenterCropArgs) {
  * This layer resizes an image input to a target height and width. The input
  * should be a 4D (batched) or 3D (unbatched) tensor in `"channels_last"`
  * format.  Input pixel values can be of any range (e.g. `[0., 1.)` or `[0,
- * 255]`) and of interger or floating point dtype. By default, the layer will
+ * 255]`) and of integer or floating point dtype. By default, the layer will
  * output floats.
  *
  * Arguments:

--- a/tfjs-layers/src/initializers_test.ts
+++ b/tfjs-layers/src/initializers_test.ts
@@ -702,7 +702,7 @@ describeMathCPU('initializers.get', () => {
   });
 });
 
-describe('Invalid intializer identifier', () => {
+describe('Invalid initializer identifier', () => {
   it('Throws exception', () => {
     expect(() => {
       getInitializer('invalid_initializer_id');

--- a/tfjs-layers/src/layers/convolutional.ts
+++ b/tfjs-layers/src/layers/convolutional.ts
@@ -401,7 +401,7 @@ export abstract class BaseConv extends Layer {
   protected readonly dilationRate: number[];
 
   // Bias-related members are here because all convolution subclasses use the
-  // same configuration parmeters to control bias.  Kernel-related members
+  // same configuration parameters to control bias.  Kernel-related members
   // are in subclass `Conv` because some subclasses use different parameters to
   // control kernel properties, for instance, `DepthwiseConv2D` uses
   // `depthwiseInitializer` instead of `kernelInitializer`.

--- a/tfjs-layers/src/layers/core.ts
+++ b/tfjs-layers/src/layers/core.ts
@@ -496,7 +496,7 @@ export class Reshape extends Layer {
         if (unknown === null) {
           unknown = i;
         } else {
-          throw new ValueError('Can only specifiy one unknown dimension.');
+          throw new ValueError('Can only specify one unknown dimension.');
         }
       } else {
         known *= dim;

--- a/tfjs-layers/src/layers/core_test.ts
+++ b/tfjs-layers/src/layers/core_test.ts
@@ -605,7 +605,7 @@ describe('Reshape Layer: Symbolic', () => {
     const targetShape: number[] = [null, null];
     const flattenLayer = tfl.layers.reshape({targetShape});
     expect(() => flattenLayer.apply(symbolicInput))
-        .toThrowError(/Can only specifiy one unknown dimension/);
+        .toThrowError(/Can only specify one unknown dimension/);
   });
 
   it('One unknown with indivisible size.', () => {

--- a/tfjs-layers/src/layers/merge.ts
+++ b/tfjs-layers/src/layers/merge.ts
@@ -742,7 +742,7 @@ export class Concatenate extends Merge {
     if (mask.length !== inputs.length) {
       throw new ValueError(
           `Mismatch in the length of mask (${mask.length}) ` +
-          `and the legnth of inputs (${inputs.length})`);
+          `and the length of inputs (${inputs.length})`);
     }
     return tfc.tidy(() => {
       let allNullMasks = true;

--- a/tfjs-layers/src/layers/merge_test.ts
+++ b/tfjs-layers/src/layers/merge_test.ts
@@ -687,7 +687,7 @@ describeMathCPU('Deserialize Merge Layers', () => {
 });
 
 describeMathCPU('Dot-Layer: Symbolic', () => {
-  // Example refernce Python Keras code:
+  // Example reference Python Keras code:
   //
   // ```py
   // import keras

--- a/tfjs-layers/src/layers/nlp/modeling/transformer_decoder_test.ts
+++ b/tfjs-layers/src/layers/nlp/modeling/transformer_decoder_test.ts
@@ -106,7 +106,7 @@ describe('TransformerDecoder', () => {
     const config = testLayer.getConfig();
     const restored = TransformerDecoder.fromConfig(TransformerDecoder, config);
 
-    // Initializers don't get serailized with customObjects.
+    // Initializers don't get serialized with customObjects.
     delete ((config['kernelInitializer'] as serialization.ConfigDict
       )['config'] as serialization.ConfigDict)['customObjects'];
     delete ((config['biasInitializer'] as serialization.ConfigDict
@@ -167,5 +167,5 @@ describe('TransformerDecoder', () => {
     expectTensorsClose(outputCache, noLoopCache);
   });
 
-  // TODO(pforderique): Test mask propogation once supported.
+  // TODO(pforderique): Test mask propagation once supported.
 });

--- a/tfjs-layers/src/layers/nlp/models/gpt2/gpt2_causal_lm.ts
+++ b/tfjs-layers/src/layers/nlp/models/gpt2/gpt2_causal_lm.ts
@@ -70,7 +70,7 @@ export declare interface GPT2CausalLMArgs extends PipelineModelArgs {
 }
 
 /**
- * An end-to-end GPT2 model for causal langauge modeling.
+ * An end-to-end GPT2 model for causal language modeling.
  *
  * A causal language model (LM) predicts the next token based on previous
  * tokens. This task setup can be used to train the model unsupervised on

--- a/tfjs-layers/src/layers/nlp/multihead_attention.ts
+++ b/tfjs-layers/src/layers/nlp/multihead_attention.ts
@@ -703,7 +703,7 @@ export class MultiHeadAttention extends Layer {
 
     newInputs = [inputs, kwargs['value']].concat(kwargs['key'] ?? []);
 
-    // TODO(pforderique): Support mask propogation.
+    // TODO(pforderique): Support mask propagation.
     return super.apply(newInputs, kwargs);
   }
 

--- a/tfjs-layers/src/layers/nlp/multihead_attention_test.ts
+++ b/tfjs-layers/src/layers/nlp/multihead_attention_test.ts
@@ -313,7 +313,7 @@ describeMathCPUAndGPU('MultiHeadAttention', () => {
         outputShape: null
       },
       {
-        testcaseName: 'wihtout_key_different_proj',
+        testcaseName: 'without_key_different_proj',
         queryDims: [40, 80],
         valueDims: [20, 80],
         keyDims: null,

--- a/tfjs-layers/src/layers/normalization.ts
+++ b/tfjs-layers/src/layers/normalization.ts
@@ -430,7 +430,7 @@ export interface LayerNormalizationLayerArgs extends LayerArgs {
   axis?: number|number[];
 
   /**
-   * A small positive float added to variance to avoid divison by zero.
+   * A small positive float added to variance to avoid division by zero.
    * Defaults to 1e-3.
    */
   epsilon?: number;

--- a/tfjs-layers/src/layers/normalization_test.ts
+++ b/tfjs-layers/src/layers/normalization_test.ts
@@ -353,7 +353,7 @@ describeMathCPUAndWebGL2('BatchNormalization Layers: Tensor', () => {
     const x = tensor2d([[1, 2], [3, 4]], [2, 2]);
     expectTensorsClose(layer.apply(x) as Tensor, x, 0.01);
     expect(layer.getWeights().length).toEqual(3);
-    // Firt weight is gamma.
+    // First weight is gamma.
     expectTensorsClose(layer.getWeights()[0], onesLike(layer.getWeights()[0]));
     // Second weight is moving mean.
     expectTensorsClose(layer.getWeights()[1], zerosLike(layer.getWeights()[1]));
@@ -366,7 +366,7 @@ describeMathCPUAndWebGL2('BatchNormalization Layers: Tensor', () => {
     const x = tensor2d([[1, 2], [3, 4]], [2, 2]);
     expectTensorsClose(layer.apply(x) as Tensor, x, 0.01);
     expect(layer.getWeights().length).toEqual(3);
-    // Firt weight is beta.
+    // First weight is beta.
     expectTensorsClose(layer.getWeights()[0], zerosLike(layer.getWeights()[0]));
     // Second weight is moving mean.
     expectTensorsClose(layer.getWeights()[1], zerosLike(layer.getWeights()[1]));
@@ -529,7 +529,7 @@ describeMathCPUAndWebGL2('BatchNormalization Layers: Tensor', () => {
   // h = model.fit(xs, ys, epochs=3)
   // print(h.history)
   // ```
-  it('Fit: Wtih conv2d layer', async () => {
+  it('Fit: With conv2d layer', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.conv2d({
       filters: 4,
@@ -587,7 +587,7 @@ describeMathCPUAndWebGL2('BatchNormalization Layers: Tensor', () => {
   // print(h.history)
   // print(model.layers[1].get_weights())
   // ```
-  it('Fit: Wtih conv2dTranspose layer', async () => {
+  it('Fit: With conv2dTranspose layer', async () => {
     const model = tfl.sequential();
     model.add(tfl.layers.conv2dTranspose({
       filters: 4,

--- a/tfjs-layers/src/layers/preprocessing/image_resizing_test.ts
+++ b/tfjs-layers/src/layers/preprocessing/image_resizing_test.ts
@@ -88,7 +88,7 @@ describeMathCPUAndGPU('Resizing Layer', () => {
   });
 
   it('Returns a tensor of the correct dtype', () => {
-    // do a same resizing operation, cheeck tensors dtypes and content
+    // do a same resizing operation, check tensors dtypes and content
     const height = 40;
     const width = 60;
     const numChannels = 3;

--- a/tfjs-layers/src/layers/preprocessing/preprocessing_utils_test.ts
+++ b/tfjs-layers/src/layers/preprocessing/preprocessing_utils_test.ts
@@ -54,7 +54,7 @@ describeMathCPUAndGPU('Preprocessing Utils', () => {
     expectTensorsClose(outputs, expectedOutput);
   });
 
-  it('Thows an error if input rank > 2', () => {
+  it('Throws an error if input rank > 2', () => {
     const inputs = tensor([[[1], [2]], [[3], [1]]]);
     expect(() =>utils.encodeCategoricalInputs(inputs, 'multiHot', 4))
     .toThrowError(`When outputMode is not int, maximum output rank is 2`
@@ -62,7 +62,7 @@ describeMathCPUAndGPU('Preprocessing Utils', () => {
     + ` which would result in output rank ${inputs.rank}.`);
   });
 
-  it('Thows an error if weights are not supplied for tfIdf', () => {
+  it('Throws an error if weights are not supplied for tfIdf', () => {
     const inputs = tensor([0, 1, 1, 2, 2, 2]);
     expect(() =>utils.encodeCategoricalInputs(inputs, 'tfIdf', 4)).
     toThrowError(`When outputMode is 'tfIdf', weights must be provided.`);

--- a/tfjs-layers/src/layers/preprocessing/random_height.ts
+++ b/tfjs-layers/src/layers/preprocessing/random_height.ts
@@ -35,7 +35,7 @@ type InterpolationType = typeof INTERPOLATION_KEYS[number];
  *
  * The input should be a 3D (unbatched) or
  * 4D (batched) tensor in the `"channels_last"` image data format. Input pixel
- * values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and of interger
+ * values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and of integer
  * or floating point dtype. By default, the layer will output floats.
  *
  * tf methods implemented in tfjs: 'bilinear', 'nearest',
@@ -48,7 +48,7 @@ export class RandomHeight extends BaseRandomLayer {
   /** @nocollapse */
   static override className = 'RandomHeight';
   private readonly factor: number | [number, number];
-  private readonly interpolation?: InterpolationType;  // defualt = 'bilinear
+  private readonly interpolation?: InterpolationType;  // default = 'bilinear
   private heightLower: number;
   private heightUpper: number;
   private imgWidth: number;

--- a/tfjs-layers/src/layers/preprocessing/random_width.ts
+++ b/tfjs-layers/src/layers/preprocessing/random_width.ts
@@ -35,7 +35,7 @@ type InterpolationType = typeof INTERPOLATION_KEYS[number];
  *
  * The input should be a 3D (unbatched) or
  * 4D (batched) tensor in the `"channels_last"` image data format. Input pixel
- * values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and of interger
+ * values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and of integer
  * or floating point dtype. By default, the layer will output floats.
  *
  * tf methods implemented in tfjs: 'bilinear', 'nearest',
@@ -48,7 +48,7 @@ export class RandomWidth extends BaseRandomLayer {
   /** @nocollapse */
   static override className = 'RandomWidth';
   private readonly factor: number | [number, number];
-  private readonly interpolation?: InterpolationType;  // defualt = 'bilinear
+  private readonly interpolation?: InterpolationType;  // default = 'bilinear
   private widthLower: number;
   private widthUpper: number;
   private imgHeight: number;

--- a/tfjs-layers/src/layers/recurrent.ts
+++ b/tfjs-layers/src/layers/recurrent.ts
@@ -127,7 +127,7 @@ export function standardizeArgs(
  *   the stepwise outputs need to be kept (e.g., for an LSTM layer of which
  *   `returnSequence` is `true`.)
  * @returns An Array: `[lastOutput, outputs, newStates]`.
- *   lastOutput: the lastest output of the RNN, of shape `[samples, ...]`.
+ *   lastOutput: the latest output of the RNN, of shape `[samples, ...]`.
  *   outputs: tensor with shape `[samples, time, ...]` where each entry
  *     `output[s, t]` is the output of the step function at time `t` for sample
  *     `s`. This return value is provided if and only if the
@@ -252,7 +252,7 @@ export declare interface BaseRNNLayerArgs extends LayerArgs {
    *     see section "Note on passing external constants" below.
    *     Porting Node: PyKeras overrides the `call()` signature of RNN cells,
    *       which are Layer subtypes, to accept two arguments. tfjs-layers does
-   *       not do such overriding. Instead we preseve the `call()` signature,
+   *       not do such overriding. Instead we preserve the `call()` signature,
    *       which due to its `Tensor|Tensor[]` argument and return value is
    *       flexible enough to handle the inputs and states.
    *   - a `stateSize` attribute. This can be a single integer (single state)
@@ -757,7 +757,7 @@ export class RNN extends Layer {
 
       const output = this.returnSequences ? outputs : lastOutput;
 
-      // TODO(cais): Porperty set learning phase flag.
+      // TODO(cais): Property set learning phase flag.
 
       if (this.returnState) {
         return [output].concat(states);
@@ -1568,7 +1568,7 @@ export class GRU extends RNN {
   static override fromConfig<T extends serialization.Serializable>(
       cls: serialization.SerializableConstructor<T>,
       config: serialization.ConfigDict): T {
-    if (config['implmentation'] === 0) {
+    if (config['implementation'] === 0) {
       config['implementation'] = 1;
     }
     return new cls(config);
@@ -1906,7 +1906,7 @@ export class LSTM extends RNN {
   static override fromConfig<T extends serialization.Serializable>(
       cls: serialization.SerializableConstructor<T>,
       config: serialization.ConfigDict): T {
-    if (config['implmentation'] === 0) {
+    if (config['implementation'] === 0) {
       config['implementation'] = 1;
     }
     return new cls(config);
@@ -1933,7 +1933,7 @@ export class StackedRNNCells extends RNNCell {
 
   get stateSize(): number[] {
     // States are a flat list in reverse order of the cell stack.
-    // This allows perserving the requirement `stack.statesize[0] ===
+    // This allows preserving the requirement `stack.statesize[0] ===
     // outputDim`. E.g., states of a 2-layer LSTM would be `[h2, c2, h1, c1]`,
     // assuming one LSTM has states `[h, c]`.
     const stateSize: number[] = [];
@@ -2098,7 +2098,7 @@ export class StackedRNNCells extends RNNCell {
     batchSetValue(tuples);
   }
 
-  // TODO(cais): Maybe implemnt `losses` and `getLossesFor`.
+  // TODO(cais): Maybe implement `losses` and `getLossesFor`.
 }
 serialization.registerClass(StackedRNNCells);
 

--- a/tfjs-layers/src/layers/serialization_test.ts
+++ b/tfjs-layers/src/layers/serialization_test.ts
@@ -14,14 +14,14 @@ import {Initializer, Ones, Zeros} from '../initializers';
 import {deserialize} from './serialization';
 
 describe('Deserialization', () => {
-  it('Zeros Initialzer', () => {
+  it('Zeros Initializer', () => {
     const config: serialization.ConfigDict = {};
     config['className'] = 'Zeros';
     config.config = {};
     const initializer: Zeros = deserialize(config) as Initializer;
     expect(initializer instanceof (Zeros)).toEqual(true);
   });
-  it('Ones Initialzer', () => {
+  it('Ones Initializer', () => {
     const config: serialization.ConfigDict = {};
     config['className'] = 'Ones';
     config.config = {};

--- a/tfjs-layers/src/models.ts
+++ b/tfjs-layers/src/models.ts
@@ -110,7 +110,7 @@ export interface ModelAndWeightsConfig {
    * A JSON object or JSON string containing the model config.
    *
    * This can be either of the following two formats:
-   *   - A model archiecture-only config,  i.e., a format consistent with the
+   *   - A model architecture-only config,  i.e., a format consistent with the
    *     return value of`keras.Model.to_json()`.
    *   - A full model config, containing not only model architecture, but also
    *     training options and state, i.e., a format consistent with the return

--- a/tfjs-layers/src/models_test.ts
+++ b/tfjs-layers/src/models_test.ts
@@ -2019,7 +2019,7 @@ describeMathCPUAndGPU('Sequential', () => {
       dataFormat: 'channelsLast',
       inputShape: [4, 4, 1]
     });
-    // Adding the layer would result in a shpae of [null, -5, -5, 1]
+    // Adding the layer would result in a shape of [null, -5, -5, 1]
     expect(() => model.add(layer)).toThrowError(/Negative dimension size/);
   });
 
@@ -2034,7 +2034,7 @@ describeMathCPUAndGPU('Sequential', () => {
       padding: 'valid',
       dataFormat: 'channelsLast',
     });
-    // Adding the layer would result in a shpae of [null, -5, -5, 1]
+    // Adding the layer would result in a shape of [null, -5, -5, 1]
     expect(() => model.add(layer)).toThrowError(/Negative dimension size/);
   });
 

--- a/tfjs-layers/src/user_defined_metadata.ts
+++ b/tfjs-layers/src/user_defined_metadata.ts
@@ -23,7 +23,7 @@ export const MAX_USER_DEFINED_METADATA_SERIALIZED_LENGTH = 1 * 1024 * 1024;
  *   Used during construction of error messages.
  * @param checkSize Whether to check the size of the metadata is under
  *   recommended limit. Default: `false`. If `true`, will try stringify the
- *   JSON object and print a console warning if the serialzied size is above the
+ *   JSON object and print a console warning if the serialized size is above the
  *   limit.
  * @throws Error if `userDefinedMetadata` is not a plain JSON object.
  */

--- a/tfjs-layers/src/utils/conv_utils.ts
+++ b/tfjs-layers/src/utils/conv_utils.ts
@@ -80,7 +80,7 @@ export function deconvLength(
   } else if (padding === 'same') {
     dimSize = dimSize * strideSize;
   } else {
-    throw new ValueError(`Unsupport padding mode: ${padding}.`);
+    throw new ValueError(`Unsupported padding mode: ${padding}.`);
   }
   return dimSize;
 }

--- a/tfjs-layers/src/utils/executor_utils_test.ts
+++ b/tfjs-layers/src/utils/executor_utils_test.ts
@@ -14,7 +14,7 @@ import {describeMathCPU} from '../utils/test_utils';
 // tslint:enable
 
 describeMathCPU('LruCache', () => {
-  it('Delete the leaset recent used entry when exceeding the size', () => {
+  it('Delete the least recent used entry when exceeding the size', () => {
     const maxEntries = 3;
     const cache = new LruCache<number>(maxEntries);
     cache.put('1', 1);  // Caching [1]

--- a/tfjs-layers/src/utils/generic_utils.ts
+++ b/tfjs-layers/src/utils/generic_utils.ts
@@ -333,7 +333,7 @@ export function stringToDType(dtype: string): DataType {
  * Test the element-by-element equality of two Arrays of strings.
  * @param xs First array of strings.
  * @param ys Second array of strings.
- * @returns Wether the two arrays are all equal, element by element.
+ * @returns Whether the two arrays are all equal, element by element.
  */
 export function stringsEqual(xs: string[], ys: string[]): boolean {
   if (xs == null || ys == null) {
@@ -456,7 +456,7 @@ export function assertPositiveInteger(value: number|number[], name: string) {
  * Format a value into a display-friendly, human-readable fashion.
  *
  * - `null` is formatted as `'null'`
- * - Strings are formated with flanking pair of quotes.
+ * - Strings are formatted with flanking pair of quotes.
  * - Arrays are formatted with flanking pair of square brackets.
  *
  * @param value The value to display.

--- a/tfjs-layers/src/utils/math_utils_test.ts
+++ b/tfjs-layers/src/utils/math_utils_test.ts
@@ -47,7 +47,7 @@ describe('arrayProd', () => {
     expect(math_utils.arrayProd([2, 3, 4], 1, 3)).toEqual(12);
   });
 
-  it('Partial no beginninng no end', () => {
+  it('Partial no beginnings no end', () => {
     expect(math_utils.arrayProd([2, 3, 4, 5], 1, 3)).toEqual(12);
   });
 

--- a/tfjs-layers/src/utils/serialization_utils_test.ts
+++ b/tfjs-layers/src/utils/serialization_utils_test.ts
@@ -69,7 +69,7 @@ describe('convertPythonToTs', () => {
       inboundNodes: ['DoNotChange_Me', 0, null]
     });
   });
-  // We promote certan fields to enums
+  // We promote certain fields to enums
   it('enum promotion', () => {
     expect(convertPythonicToTs({mode: 'fan_out'})).toEqual({mode: 'fanOut'});
     expect(convertPythonicToTs({distribution: 'normal'})).toEqual({

--- a/tfjs-layers/src/utils/test_utils.ts
+++ b/tfjs-layers/src/utils/test_utils.ts
@@ -170,6 +170,6 @@ export function expectNoLeakedTensors(
         `Created an unexpected number of new ` +
         `Tensors.  Expected: ${numNewTensors}, created : ${
             actualNewTensors}. ` +
-        `Please investigate the discrepency and/or use tidy.`);
+        `Please investigate the discrepancy and/or use tidy.`);
   }
 }

--- a/tfjs-layers/src/variables.ts
+++ b/tfjs-layers/src/variables.ts
@@ -297,7 +297,7 @@ export function update(x: LayerVariable, xNew: Tensor): LayerVariable {
 /**
  * Update the value of a Variable by adding an increment.
  * @param x The Variable to be updated.
- * @param increment The incrment to add to `x`.
+ * @param increment The increment to add to `x`.
  * @return The Variable updated.
  */
 export function updateAdd(x: LayerVariable, increment: Tensor): LayerVariable {

--- a/tfjs-layers/src/variables_test.ts
+++ b/tfjs-layers/src/variables_test.ts
@@ -393,7 +393,7 @@ describeMathCPUAndGPU('Variable update', () => {
 });
 
 describeMathCPUAndGPU('batchGetValue', () => {
-  it('Legnth-3 Array, Mixed Tensor and Variable', () => {
+  it('Length-3 Array, Mixed Tensor and Variable', () => {
     const v1 = V.variable(zeros([]));
     const v2 = V.variable(zeros([2]));
     const v3 = V.variable(zeros([2, 2]));

--- a/tfjs-node/WINDOWS_TROUBLESHOOTING.md
+++ b/tfjs-node/WINDOWS_TROUBLESHOOTING.md
@@ -2,12 +2,11 @@
 
 The tfjs-node package uses the [node-gyp](https://github.com/nodejs/node-gyp) package to handle cross-compiling the C++ code required to bind TensorFlow to Node.js. This cross platform solution can be somewhat tricky on Windows platforms. This guide helps reference solutions that have been triaged through Issues on the main [tfjs repo](https://github.com/tensorflow/tfjs).
 
-
 ## 'The system cannot find the patch specified' Exceptions
 
 This can happen for a variety of reasons. First, to inspect what is missing either `cd node_modules/@tensorflow/tfjs-node` or clone the [tensorflow/tfjs repo](https://github.com/tensorflow/tfjs).
 
-After `cd`'ing or cloning, run the following command (you might need node-gyp installed globablly `npm install -g node-gyp`):
+After `cd`'ing or cloning, run the following command (you might need node-gyp installed globally `npm install -g node-gyp`):
 
 ```sh
 node-gyp configure --verbose
@@ -22,9 +21,9 @@ gyp verb check python checking for Python executable "python2" in the PATH
 gyp verb `which` failed Error: not found: python2
 ```
 
-This means that node-gyp expects a 'python2' exe somewhere in `%PATH%`. Try running this command from an Admin (elevated privilaged prompt):
+This means that node-gyp expects a 'python2' exe somewhere in `%PATH%`. Try running this command from an Admin (elevated privileged prompt):
 
-You can try running this from an Adminstrative prompt:
+You can try running this from an Administrative prompt:
 
 ```sh
 $ npm --add-python-to-path='true' --debug install --global windows-build-tools

--- a/tfjs-node/binding/tfjs_backend.cc
+++ b/tfjs-node/binding/tfjs_backend.cc
@@ -135,7 +135,7 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromTypedArray(napi_env env,
   if (dtype == TF_INT64) {
     // Currently, int64-type Tensors are represented as Int32Arrays.
     // To represent a int64-type Tensor of `n` elements, an Int32Array of
-    // length `2 * n` is requried. This is why the length-match checking
+    // length `2 * n` is required. This is why the length-match checking
     // logic is special-cased for int64.
     if (array_length != num_elements * 2) {
       NAPI_THROW_ERROR(
@@ -379,7 +379,7 @@ void CopyTFE_TensorHandleDataToResourceArray(
 
   TF_AutoStatus status;
 
-  // Create a JS string to stash the resouce handle into.
+  // Create a JS string to stash the resource handle into.
   napi_status nstatus;
   size_t byte_length = TF_TensorByteSize(tensor.tensor);
   nstatus = napi_create_array_with_length(env, byte_length, result);

--- a/tfjs-node/binding/tfjs_backend.h
+++ b/tfjs-node/binding/tfjs_backend.h
@@ -36,7 +36,7 @@ class TFJSBackend {
   static TFJSBackend *Create(napi_env env);
 
   // Creates a new Tensor with given shape and data and returns an ID that
-  // refernces the new Tensor.
+  // references the new Tensor.
   // - shape_value (number[])
   // - dtype_value (number)
   // - array_value (TypedArray|Array)

--- a/tfjs-node/scripts/make-version
+++ b/tfjs-node/scripts/make-version
@@ -33,5 +33,5 @@ fs.writeFile('src/version.ts', versionCode, err => {
   if (err) {
     throw new Error(`Could not save version file ${version}: ${err}`);
   }
-  console.log(`Version file for version ${version} saved sucessfully.`);
+  console.log(`Version file for version ${version} saved successfully.`);
 });

--- a/tfjs-node/src/callbacks.ts
+++ b/tfjs-node/src/callbacks.ts
@@ -46,7 +46,7 @@ export class ProgbarLogger extends CustomCallback {
   private readonly RENDER_THROTTLE_MS = 50;
 
   /**
-   * Construtor of LoggingCallback.
+   * Constructor of LoggingCallback.
    */
   constructor() {
     super({
@@ -150,7 +150,7 @@ const BASE_NUM_DIGITS = 2;
 const MAX_NUM_DECIMAL_PLACES = 4;
 
 /**
- * Get a succint string representation of a number.
+ * Get a succinct string representation of a number.
  *
  * Uses decimal notation if the number isn't too small.
  * Otherwise, use engineering notation.

--- a/tfjs-node/src/io/file_system_test.ts
+++ b/tfjs-node/src/io/file_system_test.ts
@@ -445,7 +445,7 @@ describe('File system IOHandler', () => {
     const history2 =
         await model2.fit(xs, ys, {epochs: 2, shuffle: false, verbose: 0});
     // The final loss value from training the model twice, 2 epochs
-    // at a time, should be equal to the final loss of trainig the
+    // at a time, should be equal to the final loss of training the
     // model only once with 4 epochs.
     expect(history2.history.loss[1]).toBeCloseTo(18.603);
   });

--- a/tfjs-node/src/nodejs_kernel_backend.ts
+++ b/tfjs-node/src/nodejs_kernel_backend.ts
@@ -235,7 +235,7 @@ export class NodeJSKernelBackend extends KernelBackend {
    * Dispose the memory if the dataId has 0 refCount. Return true if the memory
    * is released, false otherwise.
    * @param dataId
-   * @oaram force Optional, remove the data regardless of refCount
+   * @param force Optional, remove the data regardless of refCount
    */
   disposeData(dataId: DataId, force = false): boolean {
     // No-op if already disposed.

--- a/tfjs-node/src/run_tests.ts
+++ b/tfjs-node/src/run_tests.ts
@@ -122,7 +122,7 @@ const IGNORE_LIST: string[] = [
   // Node backend which uses TF 2.4.0 doesn't support explicit padding
   'pool test-tensorflow {} max x=[3,3,1] f=[3,3] s=1 d=1 p=explicit',
   // tslint:disable-next-line:max-line-length
-  'pool test-tensorflow {} max x=[3,3,1] f=[3,3] s=3 d=1 p=explicit defualt dimRoundingMode',
+  'pool test-tensorflow {} max x=[3,3,1] f=[3,3] s=3 d=1 p=explicit default dimRoundingMode',
   // tslint:disable-next-line:max-line-length
   'pool test-tensorflow {} max x=[3,3,1] f=[3,3] s=3 d=1 p=explicit dimRoundingMode=floor',
   // tslint:disable-next-line:max-line-length
@@ -130,7 +130,7 @@ const IGNORE_LIST: string[] = [
   // tslint:disable-next-line:max-line-length
   'pool test-tensorflow {} max x=[3,3,1] f=[3,3] s=3 d=1 p=explicit dimRoundingMode=ceil',
   // tslint:disable-next-line:max-line-length
-  'pool test-tensorflow {} avg x=[3,3,1] f=[3,3] s=3 d=1 p=explicit defualt dimRoundingMode',
+  'pool test-tensorflow {} avg x=[3,3,1] f=[3,3] s=3 d=1 p=explicit default dimRoundingMode',
   // tslint:disable-next-line:max-line-length
   'pool test-tensorflow {} avg x=[3,3,1] f=[3,3] s=3 d=1 p=explicit dimRoundingMode=floor',
   // tslint:disable-next-line:max-line-length

--- a/tfjs-node/src/tfjs_binding_test.ts
+++ b/tfjs-node/src/tfjs_binding_test.ts
@@ -141,7 +141,7 @@ describe('executeOp', () => {
       binding.executeOp('Equal', null, [] as number[], null);
     }).toThrowError();
   });
-  it('throws excpetion with invalid inputs', () => {
+  it('throws exception with invalid inputs', () => {
     expect(() => {
       binding.executeOp(name, matMulOpAttrs, [] as number[], null);
     }).toThrowError();


### PR DESCRIPTION
Hi, Team
I've identified and corrected several typos within the documentation strings (code comments) of `.ts` files in the `tfjs-node `folder. I believe these corrections will improve the clarity and accuracy of the documentation for users. I appreciate your time and look forward to your feedback. Thank you.