### PR TITLE
chore: change let into const for packageNames variable inside Update …

### DIFF
--- a/link-package/build_deps.ts
+++ b/link-package/build_deps.ts
@@ -57,7 +57,7 @@ parser.add_argument('--bazel_options', {
  */
 async function main() {
   const args = parser.parse_args();
-  let packageNames: string[] = args.tfjs_package;
+  const packageNames: string[] = args.tfjs_package;
 
   let targets: string[];
   if (args.all) {


### PR DESCRIPTION
The variable packageNames is only used in one place and a shallow copy is created there, so shouldn't it be a const instead of a let?
