### PR TITLE
Fixing typos in READMEs

### DIFF
--- a/tfjs-backend-wasm/README.md
+++ b/tfjs-backend-wasm/README.md
@@ -47,7 +47,7 @@ tf.setBackend('wasm').then(() => main());
 Starting from Chrome 92 (to be released around July 2021), **cross-origin
 isolation** needs to be set up in your site in order to take advantage of
 the multi-threading support in WASM backend. Without this, the backend
-will fallback to the WASM binary with SIMD-only support (or the vanila version
+will fallback to the WASM binary with SIMD-only support (or the vanilla version
 if SIMD is not enabled). Without multi-threading support, certain models might
 not achieve the best performance.
 

--- a/tfjs-tflite/README.md
+++ b/tfjs-tflite/README.md
@@ -88,7 +88,7 @@ enabled by default. In older versions of Chrome, they can be enabled in
 
 Starting from Chrome 92, **cross-origin isolation** needs to be set up in your
 site in order to take advantage of the multi-threading support. Without this, it
-will fallback to the WASM binary with SIMD-only support (or the vanila version
+will fallback to the WASM binary with SIMD-only support (or the vanilla version
 if SIMD is not enabled). Without multi-threading support, certain models might
 not achieve the best performance. See [here][cross origin setup steps] for the
 high-level steps to set up the cross-origin isolation.


### PR DESCRIPTION
This just fixes 2 typos in 2 Readmes
`vanila` is most likely supposed to be `vanilla` if it is referring to the unchanged software