### PR TITLE
Fix unexpected extraporation cropAndResize

### DIFF
--- a/tfjs-backend-cpu/src/kernels/CropAndResize.ts
+++ b/tfjs-backend-cpu/src/kernels/CropAndResize.ts
@@ -32,7 +32,7 @@ class ImageScaler {
     this.t2 = t2;
     this.t1 = t1;
     this.imageLength = imageLength;
-    this.cropLength = cropLength
+    this.cropLength = cropLength;
   }
 
   scaling(x: number): number {
@@ -85,8 +85,8 @@ export function cropAndResize(args: {
       continue;
     }
 
-    const heightScaler = new ImageScaler(y2, y1, imageHeight, cropHeight)
-    const widthScaler = new ImageScaler(x2, x1, imageWidth, cropWidth)
+    const heightScaler = new ImageScaler(y2, y1, imageHeight, cropHeight);
+    const widthScaler = new ImageScaler(x2, x1, imageWidth, cropWidth);
 
     for (let y = 0; y < cropHeight; y++) {
       const yInd: number = (cropHeight > 1) ?

--- a/tfjs-core/src/ops/image/crop_and_resize_test.ts
+++ b/tfjs-core/src/ops/image/crop_and_resize_test.ts
@@ -33,7 +33,7 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
   });
 
   it('halving-nearest', async () => {
-    const baseSize = 28
+    const baseSize = 28;
     const image: tf.Tensor4D = tf.ones([1, 2 * baseSize, 1, 1]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);
     const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');

--- a/tfjs-core/src/ops/image/crop_and_resize_test.ts
+++ b/tfjs-core/src/ops/image/crop_and_resize_test.ts
@@ -32,6 +32,21 @@ describeWithFlags('cropAndResize', ALL_ENVS, () => {
     expectArraysClose(await output.data(), [2.5]);
   });
 
+  it('halving-nearest', async () => {
+    const baseSize = 28
+    const image: tf.Tensor4D = tf.ones([1, 2 * baseSize, 1, 1]);
+    const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);
+    const boxInd: tf.Tensor1D = tf.tensor1d([0], 'int32');
+
+    const output = tf.image.cropAndResize(
+        image, boxes, boxInd, [baseSize, 1], 'nearest', -1000);
+    const expected = Array(baseSize).fill(1);
+
+    expect(output.shape).toEqual([1, baseSize, 1, 1]);
+    expect(output.dtype).toBe('float32');
+    expectArraysClose(await output.data(), expected);
+  });
+
   it('5x5-bilinear, no change in shape', async () => {
     const image: tf.Tensor4D = tf.ones([1, 5, 5, 3]);
     const boxes: tf.Tensor2D = tf.tensor2d([0, 0, 1, 1], [1, 4]);


### PR DESCRIPTION
As shown in the issue below, when halving the width of a certain image, the corners are filled with black. That's even if the original image width is an even number. We determined that this was due to a rounding error. I made a pull request for the code that reflects the results.
ref: https://github.com/tensorflow/tfjs/issues/6624