### PR TITLE
Update error handling logic in convolutional.ts

### DIFF
--- a/tfjs-layers/src/layers/convolutional.ts
+++ b/tfjs-layers/src/layers/convolutional.ts
@@ -105,7 +105,7 @@ export function conv1dWithBias(
     if (bias != null && bias.shape.length !== 1) {
       throw new ValueError(
           `The bias for a conv1dWithBias operation should be 1, but is ` +
-          `${kernel.shape.length} instead`);
+          `${bias.shape.length} instead`);
     }
     // TODO(cais): Support CAUSAL padding mode.
     if (dataFormat === 'channelsFirst') {


### PR DESCRIPTION
Hi, Team

I have updated error handling code in this file [tfjs/tfjs-layers/src/layers/convolutional.ts](https://github.com/tensorflow/tfjs/blob/63250eceec9dab31f10345e77722080b17100bc7/tfjs-layers/src/layers/convolutional.ts#L108) the if statement checks if bias is not null and its shape.length (number of dimensions) is not equal to 1. This is the correct check to ensure a valid bias tensor for a 1D convolution.However, the error message incorrectly references `kernel.shape.length` when it should be referencing `bias.shape.length`. If I'm not wrong, it seems like there is typo while writing error handling code logic so please do the needful. 

The following error message would be more accurate and clearly indicates that the issue lies with the number of dimensions in the bias tensor, not the kernel.

```
if (bias != null && bias.shape.length !== 1) {
      throw new ValueError(
          `The bias for a conv1dWithBias operation should be 1, but is ` +
          `${bias.shape.length} instead`);
    }
```

I would request you to please review the changes and if you've any suggestion or feedback please let me know. Thank you.