### PR TITLE
Update tar package version for tfjs-node & tfjs-node-gpu

### DIFF
--- a/tfjs-node-gpu/package.json
+++ b/tfjs-node-gpu/package.json
@@ -70,7 +70,7 @@
     "https-proxy-agent": "^2.2.1",
     "progress": "^2.0.0",
     "rimraf": "^2.6.2",
-    "tar": "^4.4.6"
+    "tar": "^6.2.1"
   },
   "binary": {
     "module_name": "tfjs_binding",

--- a/tfjs-node/package.json
+++ b/tfjs-node/package.json
@@ -68,7 +68,7 @@
     "https-proxy-agent": "^2.2.1",
     "progress": "^2.0.0",
     "rimraf": "^2.6.2",
-    "tar": "^4.4.6"
+    "tar": "^6.2.1"
   },
   "binary": {
     "module_name": "tfjs_binding",


### PR DESCRIPTION
Hi, Team

We've identified that the [@tensorflow/tfjs-node](https://www.npmjs.com/package/@tensorflow/tfjs-node/v/4.18.0?activeTab=code) package currently specifies a dependency on `"tar": "^4.4.6"`. To address a known security vulnerability detailed in this GitHub security advisory: [GHSA-f5x3-32g6-xq36](https://github.com/isaacs/node-tar/security/advisories/GHSA-f5x3-32g6-xq36), I've updated the tar dependency to a version `"tar": "^6.2.1"` to take care of this issue and I believe we'll have to release a patched version to npm. Thank you.