### PR TITLE
Update supported TypedArray data types in tf.tensor in the documentation

### DIFF
--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -172,8 +172,9 @@ import {makeTensor} from './tensor_ops_util';
  * await tf.setBackend(savedBackend);
  * ```
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`, or a `WebGLData` object, or a
- * `WebGPUData` object. If the values are strings, they will be encoded as utf-8
+ *     or a flat array, or a `TypedArray`(At the moment it supports Uint8Array, 
+ * Uint8ClampedArray, Int32Array, Float32Array) data types, or a `WebGLData` object, 
+ * or a `WebGPUData` object. If the values are strings, they will be encoded as utf-8
  * and kept as `Uint8Array[]`. If the values is a `WebGLData` object, the dtype
  * could only be 'float32' or 'int32' and the object has to have: 1. texture, a
  * `WebGLTexture`, the texture must share the same `WebGLRenderingContext` with


### PR DESCRIPTION
Hi, Team

I have updated [tf.tensor](https://js.tensorflow.org/api/latest/#tensor) documentation to accurately reflect its support for `TypedArray` data types. Previously, the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) listed **11 supported TypedArray data types**. However, only `Uint8Array`, `Uint8ClampedArray`, `Int32Array`, and `Float32Array` were actually functional. This pull request updates the documentation to correctly reflect these supported data types for `TypedArray`.

I welcome your feedback and suggestions. Thank you.