### PR TITLE
Update supported TypedArray data types in tf.tensor in the documentation

### DIFF
--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -207,4 +207,3 @@ export function tensor<R extends Rank>(
   const inferredShape = inferShape(values, dtype);
   return makeTensor(values, shape, inferredShape, dtype) as Tensor<R>;
 }
-

--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -172,29 +172,25 @@ import {makeTensor} from './tensor_ops_util';
  * await tf.setBackend(savedBackend);
  * ```
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`(At the moment it supports Uint8Array, 
- * Uint8ClampedArray, Int32Array, Float32Array) data types, or a `WebGLData` object, 
- * or a `WebGPUData` object. If the values are strings, they will be encoded as 
- * utf-8 and kept as `Uint8Array[]`. If the values is a `WebGLData` object,the dtype
- * could only be 'float32' or 'int32' and the object has to have: 1. texture, a
- * `WebGLTexture`, the texture must share the same `WebGLRenderingContext` with
- * TFJS's WebGL backend (you could create a custom WebGL backend from your
- * texture's canvas) and the internal texture format for the input texture must
- * be floating point or normalized integer; 2. height, the height of the
- * texture; 3. width, the width of the texture; 4. channels, a non-empty subset
- * of 'RGBA', indicating the values of which channels will be passed to the
- * tensor, such as 'R' or 'BR' (The order of the channels affect the order of
- * tensor values. ). (If the values passed from texture is less than the tensor
- * size, zeros will be padded at the rear.). If the values is a `WebGPUData`
- * object, the dtype could only be 'float32' or 'int32 and the object has to
- * have: buffer, a `GPUBuffer`. The buffer must: 1. share the same `GPUDevice`
- * with TFJS's WebGPU backend; 2. buffer.usage should at least support
- * GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC; 3. buffer.size should not
- * be smaller than the byte size of tensor shape. WebGPUData optionally supports
- * zero copy by flag zeroCopy. When zeroCopy is false or undefined(default),
- * this passing GPUBuffer can be destroyed after tensor is created. When
- * zeroCopy is true, this GPUBuffer is bound directly by the tensor, so do not
- * destroy this GPUBuffer until all access is done.
+ * or a flat array, or a `TypedArray`(At the moment it supports Uint8Array,
+ * Uint8ClampedArray, Int32Array, Float32Array) data types, or a `WebGLData`
+ * object, or a `WebGPUData` object. If the values are strings, they will be
+ * encoded as utf-8 and kept as `Uint8Array[]`. If the values is a `WebGLData`
+ * object, the dtype could only be 'float32' or 'int32' and the object has to
+ * have: 1. texture, a `WebGLTexture`, the texture must share the same
+ * `WebGLRenderingContext` with TFJS's WebGL backend (you could create a custom * WebGL backend from your texture's canvas) and the internal texture format
+ * for the input texture must be floating point or normalized integer; 2.
+ * height, the height of the texture; 3. width, the width of the texture; 4.
+ * channels, a non-empty subset of 'RGBA', indicating the values of which
+ * channels will be passed to the tensor, such as 'R' or 'BR' (The order of the * channels affect the order of tensor values. ). (If the values passed from
+ * texture is less than the tensor size, zeros will be padded at the rear.). If * the values is a `WebGPUData` object, the dtype could only be 'float32' or
+ * 'int32 and the object has to have: buffer, a `GPUBuffer`. The buffer must:
+ * 1. share the same `GPUDevice` with TFJS's WebGPU backend; 2. buffer.usage
+ * should at least support GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC; 3. * buffer.size should not be smaller than the byte size of tensor shape.
+ * WebGPUData optionally supports zero copy by flag zeroCopy. When zeroCopy is
+ * false or undefined(default),this passing GPUBuffer can be destroyed after
+ * tensor is created. When zeroCopy is true, this GPUBuffer is bound directly
+ * by the tensor, so do not destroy this GPUBuffer until all access is done.
  * @param shape The shape of the tensor. Optional. If not provided,
  *   it is inferred from `values`.
  * @param dtype The data type.
@@ -207,3 +203,4 @@ export function tensor<R extends Rank>(
   const inferredShape = inferShape(values, dtype);
   return makeTensor(values, shape, inferredShape, dtype) as Tensor<R>;
 }
+

--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -172,9 +172,10 @@ import {makeTensor} from './tensor_ops_util';
  * await tf.setBackend(savedBackend);
  * ```
  * @param values The values of the tensor. Can be nested array of numbers,
- *     or a flat array, or a `TypedArray`, or a `WebGLData` object, or a
- * `WebGPUData` object. If the values are strings, they will be encoded as utf-8
- * and kept as `Uint8Array[]`. If the values is a `WebGLData` object, the dtype
+ *     or a flat array, or a `TypedArray`(At the moment it supports Uint8Array, 
+ * Uint8ClampedArray, Int32Array, Float32Array) data types, or a `WebGLData` object, 
+ * or a `WebGPUData` object. If the values are strings, they will be encoded as 
+ * utf-8 and kept as `Uint8Array[]`. If the values is a `WebGLData` object,the dtype
  * could only be 'float32' or 'int32' and the object has to have: 1. texture, a
  * `WebGLTexture`, the texture must share the same `WebGLRenderingContext` with
  * TFJS's WebGL backend (you could create a custom WebGL backend from your

--- a/tfjs-core/src/ops/tensor.ts
+++ b/tfjs-core/src/ops/tensor.ts
@@ -178,15 +178,19 @@ import {makeTensor} from './tensor_ops_util';
  * encoded as utf-8 and kept as `Uint8Array[]`. If the values is a `WebGLData`
  * object, the dtype could only be 'float32' or 'int32' and the object has to
  * have: 1. texture, a `WebGLTexture`, the texture must share the same
- * `WebGLRenderingContext` with TFJS's WebGL backend (you could create a custom * WebGL backend from your texture's canvas) and the internal texture format
+ * `WebGLRenderingContext` with TFJS's WebGL backend (you could create a custom
+ * WebGL backend from your texture's canvas) and the internal texture format
  * for the input texture must be floating point or normalized integer; 2.
  * height, the height of the texture; 3. width, the width of the texture; 4.
  * channels, a non-empty subset of 'RGBA', indicating the values of which
- * channels will be passed to the tensor, such as 'R' or 'BR' (The order of the * channels affect the order of tensor values. ). (If the values passed from
- * texture is less than the tensor size, zeros will be padded at the rear.). If * the values is a `WebGPUData` object, the dtype could only be 'float32' or
+ * channels will be passed to the tensor, such as 'R' or 'BR' (The order of the 
+ * channels affect the order of tensor values. ). (If the values passed from 
+ * texture is less than the tensor size, zeros will be padded at the rear.). If 
+ * the values is a `WebGPUData` object, the dtype could only be 'float32' or
  * 'int32 and the object has to have: buffer, a `GPUBuffer`. The buffer must:
  * 1. share the same `GPUDevice` with TFJS's WebGPU backend; 2. buffer.usage
- * should at least support GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC; 3. * buffer.size should not be smaller than the byte size of tensor shape.
+ * should at least support GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC; 3.
+ * buffer.size should not be smaller than the byte size of tensor shape.
  * WebGPUData optionally supports zero copy by flag zeroCopy. When zeroCopy is
  * false or undefined(default),this passing GPUBuffer can be destroyed after
  * tensor is created. When zeroCopy is true, this GPUBuffer is bound directly


### PR DESCRIPTION
Hi, Team

I have updated [tf.tensor](https://js.tensorflow.org/api/latest/#tensor) documentation to accurately reflect its support for `TypedArray` data types. Previously, the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) listed **11 supported TypedArray data types**. However, only `Uint8Array`, `Uint8ClampedArray`, `Int32Array`, and `Float32Array` were actually functional. This pull request updates the documentation to correctly reflect these supported data types for `TypedArray`.

Please refer issue https://github.com/tensorflow/tfjs/issues/8257 for more information

I welcome your feedback and suggestions. Thank you.