### PR TITLE
Update broken link for tf.keras SavedModel in README.md

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -17,7 +17,7 @@ using an already hosted model (e.g. MobileNet), skip this step.
 2. [JavaScript API](./src/executor/graph_model.ts), for loading and running
 inference.
 
-## Step 1: Converting a [TensorFlow SavedModel](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/saved_model/README.md), [TensorFlow Hub module](https://www.tensorflow.org/hub/), [Keras HDF5](https://keras.io/getting_started/faq/#what-are-my-options-for-saving-models), [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/keras/saving/save_model), or [Flax/JAX model](http://github.com/google/flax) to a web-friendly format
+## Step 1: Converting a [TensorFlow SavedModel](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/saved_model/README.md), [TensorFlow Hub module](https://www.tensorflow.org/hub/), [Keras HDF5](https://keras.io/getting_started/faq/#what-are-my-options-for-saving-models), [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/keras/models/save_model), or [Flax/JAX model](http://github.com/google/flax) to a web-friendly format
 
 __0. Please make sure that you run in a Docker container or a virtual environment.__
 


### PR DESCRIPTION
Hi, Team

This pull request fixes a broken link in the README.md file. The original link to the [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/keras/saving/save_model) documentation was not working. This update replaces the broken link with a functional one ensuring users have access to the correct information so I have updated broken link for hyperlink [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/keras/saving/save_model) on this [page](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#step-1-converting-a-tensorflow-savedmodel-tensorflow-hub-module-keras-hdf5-tfkeras-savedmodel-or-flaxjax-model-to-a-web-friendly-format) to [workable link](https://www.tensorflow.org/api_docs/python/tf/keras/models/save_model) so please do the needful. Thank you