### PR TITLE
webgpu: fix: conditionally call deprecated GPUAdapter.requestAdapterInfo

### DIFF
--- a/tfjs-backend-webgpu/src/base.ts
+++ b/tfjs-backend-webgpu/src/base.ts
@@ -57,7 +57,10 @@ if (isWebGPUSupported()) {
     };
 
     const device: GPUDevice = await adapter.requestDevice(deviceDescriptor);
-    const adapterInfo = await adapter.requestAdapterInfo();
+    const adapterInfo =
+      'requestAdapterInfo' in adapter
+        ? await adapter.requestAdapterInfo()
+        : undefined;
     return new WebGPUBackend(device, adapterInfo);
   }, 3 /*priority*/);
 }


### PR DESCRIPTION
## Context

`GPUAdapter.requestAdapterInfo` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/GPUAdapter/requestAdapterInfo) and non-standard.

It's in use by `tfjs-backend-webgpu`, but [the result is optional](https://github.com/tensorflow/tfjs/blob/3daf152cb794f4da58fce5e21e09e8a4f89c8f80/tfjs-backend-webgpu/src/backend_webgpu.ts#L136), and only used for a [single optimization](https://github.com/tensorflow/tfjs/blob/3daf152cb794f4da58fce5e21e09e8a4f89c8f80/tfjs-backend-webgpu/src/backend_webgpu.ts#L149). Yet if called in an environment which doesn't support it, it will throw.

By checking the feature's available before calling it, this unbreaks Deno runtime support for `tfjs-backend-webgpu`, which doesn't support this feature and throws.

## Testing/Verification

`yarn test` and `yarn lint` succeed. Verified basic example now works in Deno.

```ts
import * as tf from "@tensorflow/tfjs-core";
import "@tensorflow/tfjs-backend-webgpu";

await tf.ready();
tf.randomGamma([2, 2], 1).print();
```

## Related

https://github.com/denoland/deno/issues/22029