### PR TITLE
Fix typos in the documentation strings of the tfjs-node directory

### DIFF
--- a/tfjs-node/WINDOWS_TROUBLESHOOTING.md
+++ b/tfjs-node/WINDOWS_TROUBLESHOOTING.md
@@ -7,7 +7,7 @@ The tfjs-node package uses the [node-gyp](https://github.com/nodejs/node-gyp) pa
 
 This can happen for a variety of reasons. First, to inspect what is missing either `cd node_modules/@tensorflow/tfjs-node` or clone the [tensorflow/tfjs repo](https://github.com/tensorflow/tfjs).
 
-After `cd`'ing or cloning, run the following command (you might need node-gyp installed globablly `npm install -g node-gyp`):
+After `cd`'ing or cloning, run the following command (you might need node-gyp installed globally `npm install -g node-gyp`):
 
 ```sh
 node-gyp configure --verbose
@@ -22,9 +22,9 @@ gyp verb check python checking for Python executable "python2" in the PATH
 gyp verb `which` failed Error: not found: python2
 ```
 
-This means that node-gyp expects a 'python2' exe somewhere in `%PATH%`. Try running this command from an Admin (elevated privilaged prompt):
+This means that node-gyp expects a 'python2' exe somewhere in `%PATH%`. Try running this command from an Admin (elevated privileged prompt):
 
-You can try running this from an Adminstrative prompt:
+You can try running this from an Administrative prompt:
 
 ```sh
 $ npm --add-python-to-path='true' --debug install --global windows-build-tools

--- a/tfjs-node/binding/tfjs_backend.cc
+++ b/tfjs-node/binding/tfjs_backend.cc
@@ -135,7 +135,7 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromTypedArray(napi_env env,
   if (dtype == TF_INT64) {
     // Currently, int64-type Tensors are represented as Int32Arrays.
     // To represent a int64-type Tensor of `n` elements, an Int32Array of
-    // length `2 * n` is requried. This is why the length-match checking
+    // length `2 * n` is required. This is why the length-match checking
     // logic is special-cased for int64.
     if (array_length != num_elements * 2) {
       NAPI_THROW_ERROR(
@@ -379,7 +379,7 @@ void CopyTFE_TensorHandleDataToResourceArray(
 
   TF_AutoStatus status;
 
-  // Create a JS string to stash the resouce handle into.
+  // Create a JS string to stash the resource handle into.
   napi_status nstatus;
   size_t byte_length = TF_TensorByteSize(tensor.tensor);
   nstatus = napi_create_array_with_length(env, byte_length, result);

--- a/tfjs-node/binding/tfjs_backend.h
+++ b/tfjs-node/binding/tfjs_backend.h
@@ -36,7 +36,7 @@ class TFJSBackend {
   static TFJSBackend *Create(napi_env env);
 
   // Creates a new Tensor with given shape and data and returns an ID that
-  // refernces the new Tensor.
+  // references the new Tensor.
   // - shape_value (number[])
   // - dtype_value (number)
   // - array_value (TypedArray|Array)

--- a/tfjs-node/scripts/make-version
+++ b/tfjs-node/scripts/make-version
@@ -33,5 +33,5 @@ fs.writeFile('src/version.ts', versionCode, err => {
   if (err) {
     throw new Error(`Could not save version file ${version}: ${err}`);
   }
-  console.log(`Version file for version ${version} saved sucessfully.`);
+  console.log(`Version file for version ${version} saved successfully.`);
 });

--- a/tfjs-node/src/callbacks.ts
+++ b/tfjs-node/src/callbacks.ts
@@ -46,7 +46,7 @@ export class ProgbarLogger extends CustomCallback {
   private readonly RENDER_THROTTLE_MS = 50;
 
   /**
-   * Construtor of LoggingCallback.
+   * Constructor of LoggingCallback.
    */
   constructor() {
     super({
@@ -150,7 +150,7 @@ const BASE_NUM_DIGITS = 2;
 const MAX_NUM_DECIMAL_PLACES = 4;
 
 /**
- * Get a succint string representation of a number.
+ * Get a succinct string representation of a number.
  *
  * Uses decimal notation if the number isn't too small.
  * Otherwise, use engineering notation.

--- a/tfjs-node/src/io/file_system_test.ts
+++ b/tfjs-node/src/io/file_system_test.ts
@@ -445,7 +445,7 @@ describe('File system IOHandler', () => {
     const history2 =
         await model2.fit(xs, ys, {epochs: 2, shuffle: false, verbose: 0});
     // The final loss value from training the model twice, 2 epochs
-    // at a time, should be equal to the final loss of trainig the
+    // at a time, should be equal to the final loss of training the
     // model only once with 4 epochs.
     expect(history2.history.loss[1]).toBeCloseTo(18.603);
   });


### PR DESCRIPTION
Hi, Team
I've identified and corrected several typos within the documentation strings (code comments) of .ts files in the tfjs-node folder. I believe these corrections will improve the clarity and accuracy of the documentation for users. I appreciate your time and look forward to your feedback. Thank you.