### PR TITLE
Fix WebGL error with MirrorPadPacked on Safari 18.1

### DIFF
--- a/tfjs-backend-webgl/src/mirror_pad_packed_gpu.ts
+++ b/tfjs-backend-webgl/src/mirror_pad_packed_gpu.ts
@@ -108,7 +108,7 @@ export class MirrorPadPackedProgram implements GPGPUProgram {
         ${dtype} source = rc;
         ${dtype} lt = ${dtype}(lessThan(source, start));
         ${dtype} gte = ${dtype}(greaterThanEqual(source, end));
-        ${dtype} orig = 1 - (lt + gte);
+        ${dtype} orig = ${dtype}(1) - (lt + gte);
         source = orig * source +
                 lt * (start * 2 - source - ${offset}) +
                 gte * ((end - 1) * 2 - source + ${offset});


### PR DESCRIPTION
### Issue

This resolves a shader compiler error with Safari 18.1 when running the `MirrorPadPacked` op with the WebGL backend.

The error that occurs is:
```
WebGL: INVALID_OPERATION: Error: 0x00000502, in /AppleInternal/Library/BuildRoots/f00160a0-8d47-11ef-b394-4a83e32a47e1/Library/Caches/com.apple.xbs/Sources/ANGLE/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm, CreateMslShaderLib:381. Internal error compiling shader with Metal backend.
program_source:44:8: warning: constexpr if is a C++17 extension [-Wc++17-extensions]
    if constexpr (metal::is_signed_v<X>)
       ^
program_source:60:12: error: as_type cast from vector 'metal::make_unsigned_t<int __attribute__((ext_vector_type(4)))>' (aka 'metal::_make_unsigned_impl<int __attribute__((ext_vector_type(4)))>::type') to scalar 'int' of different size
    return as_type<X>(as_type<metal::make_unsigned_t<X>>(x) - as_type<metal::make_unsigned_t<Y>>(y));
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
program_source:321:24: note: in instantiation of function template specialization 'ANGLE_isub<int, int __attribute__((ext_vector_type(4)))>' requested here
  metal::int4 _uorig = ANGLE_isub(1, ANGLE__62);
```

To reproduce the issue, run the following code on Safari 18.1 on iOS or macOS:
```
<html>
  <head>
    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs/dist/tf.min.js"> </script>
    <script>
      const x = tf.range(0, 9).reshape([1, 1, 3, 3]);
      x.mirrorPad([[0, 0], [0, 0], [2, 2], [2, 2]], 'reflect').print();
    </script>
  </head>
  <body>
  </body>
</html>
```

This issue does not happen on older versions of Safari (such as Safari 17.x). It's unclear which version of Safari this issue was first introduced in.

### Investigation

When Safari compiles the shader, it converts the GLSL code to Metal but it appears there is a bug with this conversion process. In particular, it seems that applying an add/sub between a scalar and vector causes the shader compile error to happen, which occurs with the following line: `orig = 1 - (lt + gte)`. The three variables are vectors while the `1` is a scalar.

A bug has been filed with WebKit: https://bugs.webkit.org/show_bug.cgi?id=283576

### Solution

Casting the scalar to the vector before doing the subtraction resolves the error.