### PR TITLE
Bug fix (tfjs-react-native): fallback to `localUri` when `uri` in unavailable in bundleResourceIO!

### DIFF
--- a/tfjs-react-native/src/bundle_resource_io.ts
+++ b/tfjs-react-native/src/bundle_resource_io.ts
@@ -103,7 +103,7 @@ class BundleResourceHandler implements io.IOHandler {
           if (Platform.OS === 'android') {
             // On android we get a resource id instead of a regular path. We
             // need to load the weights from the res/raw folder using this id.
-            const fileName = `${weightsAsset.uri}.${weightsAsset.type}`;
+            const fileName = weightsAsset.uri ? `${weightsAsset.uri}.${weightsAsset.type}` : weightsAsset.localUri;
             try {
               base64Weights = await RNFS.readFileRes(fileName, 'base64');
             } catch (e) {
@@ -114,7 +114,7 @@ class BundleResourceHandler implements io.IOHandler {
             }
           } else {
             try {
-              base64Weights = await RNFS.readFile(weightsAsset.uri, 'base64');
+              base64Weights = await RNFS.readFile(weightsAsset.uri ?? weightsAsset.localUri, 'base64');
             } catch (e) {
               throw new Error(
                   `Error reading resource ${weightsAsset.uri}.`,


### PR DESCRIPTION
This bug was mentioned in #8501 
This only occurs in development release builds and where `expo-updates` is installed. I fixed the bug in my own app by falling back to `asset.localUri` whenever `asset.uri` is not available.

Hope this helps!