### PR TITLE
Add size to dataset generator

### DIFF
--- a/tfjs-data/src/readers.ts
+++ b/tfjs-data/src/readers.ts
@@ -198,11 +198,12 @@ export function func<T extends TensorContainer>(
  */
 export function generator<T extends TensorContainer>(
   generator: () => Iterator<T> | Promise<Iterator<T>> | AsyncIterator<T>,
+  size: number = null,
 ): Dataset<T> {
   return datasetFromIteratorFn(async () => {
     const gen = await generator();
     return iteratorFromFunction(() => gen.next());
-  });
+  }, size);
 }
 
 /**


### PR DESCRIPTION
Solves #8529.

Add an optional size parameter to tf.data.generator function to be able to specify size when creating dataset with a generator function.