### PR TITLE
Remove --no-site-packages flag from virtualenv command and update the supported python version. 

### DIFF
--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -41,7 +41,7 @@ Now, you can
 a `venv` virtual environment in your current folder:
 
 ```bash
-virtualenv --no-site-packages venv
+virtualenv venv
 . venv/bin/activate
 ```
 

--- a/tfjs-converter/README.md
+++ b/tfjs-converter/README.md
@@ -26,14 +26,14 @@ __0. Please make sure that you run in a Docker container or a virtual environmen
 
 __Note__: *Check that [`tf-nightly-cpu-2.0-preview`](https://pypi.org/project/tf-nightly-cpu-2.0-preview/#files) is available for your platform.*
 
-Most of the times, this means that you have to use Python 3.6.8 in your local
-environment. To force Python 3.6.8 in your local project, you can install
+Most of the times, this means that you have to use Python 3.7.10 in your local
+environment. To force Python 3.7.10 in your local project, you can install
 [`pyenv`](https://github.com/pyenv/pyenv) and proceed as follows in the target
 directory:
 
 ```bash
-pyenv install 3.6.8
-pyenv local 3.6.8
+pyenv install 3.7.10
+pyenv local 3.7.10
 ```
 
 Now, you can


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

Ref. [8541](https://github.com/tensorflow/tfjs/issues/8541). virtualenv has deprecated the flag --no-site-packages. This has been corrected in the tfjs documentation for creating a virtual environment.

Ref. [8540](https://github.com/tensorflow/tfjs/issues/8540) Update the supported python version for `tensorflowjs[wizard]` installation. 

